### PR TITLE
Add toolchain collector (JDKs, Node, Python, Go, Ruby, Rust, Brew, Env)

### DIFF
--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
 // Kind distinguishes a live snapshot from an immutable baseline.
@@ -22,27 +23,21 @@ const (
 )
 
 // Snapshot is the structured capture of one host at one point in time.
-// Most fields are placeholders for collectors that don't exist yet (JVMs,
-// JDKs, toolchains, network state, storage state, power, env, sysctls).
-// Each will arrive in its own commit; the schema is shaped now so the
-// SQLite layer that lands next has a stable target.
 type Snapshot struct {
-	ID       string    `json:"id"`
-	TakenAt  time.Time `json:"taken_at"`
-	Kind     Kind      `json:"kind"`
-	Host     HostInfo  `json:"host"`
-	Apps     []detect.Result `json:"apps"`
+	ID         string               `json:"id"`
+	TakenAt    time.Time            `json:"taken_at"`
+	Kind       Kind                 `json:"kind"`
+	Host       HostInfo             `json:"host"`
+	Apps       []detect.Result      `json:"apps"`
+	Toolchains toolchain.Toolchains `json:"toolchains"`
 
-	// Placeholders for upcoming collectors. Empty in v0.1.
+	// Placeholders for upcoming collectors. Empty until implemented.
 	// See docs/design/system-inventory.md.
 	// Processes  []ProcessInfo
 	// JVMs       []JVMInfo
-	// JDKs       []JDKInstall
-	// Toolchains *Toolchains
 	// Network    *NetworkState
 	// Storage    *StorageState
 	// Power      *PowerState
-	// Env        *EnvSnapshot
 	// Sysctls    map[string]string
 }
 
@@ -58,6 +53,10 @@ type Options struct {
 
 	// DetectOpts are forwarded to each Detect call.
 	DetectOpts detect.Options
+
+	// ToolchainOpts are forwarded to the toolchain collector.
+	// Zero value uses production defaults (live machine paths).
+	ToolchainOpts toolchain.CollectOptions
 }
 
 // Build assembles a Snapshot by running every collector in parallel and
@@ -70,9 +69,8 @@ func Build(ctx context.Context, opts Options) Snapshot {
 		Kind:    KindLive,
 	}
 
-	// Two collectors today: host info, app inventory.
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(3)
 
 	go func() {
 		defer wg.Done()
@@ -82,6 +80,11 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	go func() {
 		defer wg.Done()
 		s.Apps = collectApps(ctx, opts)
+	}()
+
+	go func() {
+		defer wg.Done()
+		s.Toolchains = toolchain.Collect(ctx, opts.ToolchainOpts)
 	}()
 
 	wg.Wait()

--- a/internal/toolchain/brew.go
+++ b/internal/toolchain/brew.go
@@ -1,0 +1,96 @@
+package toolchain
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// discoverBrew queries Homebrew for installed formulae, casks, and taps.
+// Uses the injected CmdRunner so tests can stub it without shelling out.
+func discoverBrew(run CmdRunner) (BrewInventory, error) {
+	var inv BrewInventory
+
+	// Formulae from `brew info --json=v2 --installed`
+	if out, err := run("brew", "info", "--json=v2", "--installed"); err == nil {
+		inv.Formulae = parseBrewFormulae(out)
+	}
+	// Casks from `brew list --cask`
+	if out, err := run("brew", "list", "--cask", "--versions"); err == nil {
+		inv.Casks = parseBrewCasks(out)
+	}
+	// Taps from `brew tap`
+	if out, err := run("brew", "tap"); err == nil {
+		for _, name := range lines(out) {
+			inv.Taps = append(inv.Taps, BrewTap{Name: name})
+		}
+	}
+
+	if len(inv.Formulae) == 0 && len(inv.Casks) == 0 {
+		return inv, nil
+	}
+	return inv, nil
+}
+
+// brewInfoV2 mirrors the minimal structure of `brew info --json=v2 --installed`.
+type brewInfoV2 struct {
+	Formulae []struct {
+		Name      string `json:"name"`
+		FullName  string `json:"full_name"`
+		Tap       string `json:"tap"`
+		Deprecated bool   `json:"deprecated"`
+		Installed []struct {
+			Version   string `json:"version"`
+			InstalledOnRequest bool `json:"installed_on_request"`
+		} `json:"installed"`
+		Pinned bool `json:"pinned"`
+	} `json:"formulae"`
+}
+
+func parseBrewFormulae(data []byte) []BrewFormula {
+	var info brewInfoV2
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil
+	}
+	out := make([]BrewFormula, 0, len(info.Formulae))
+	for _, f := range info.Formulae {
+		ver := ""
+		via := "core"
+		if len(f.Installed) > 0 {
+			ver = f.Installed[0].Version
+		}
+		// A non-empty tap that isn't homebrew/core means it's a third-party tap.
+		// full_name like "user/tap/formula" also signals a tap formula.
+		if f.Tap != "" && f.Tap != "homebrew/core" {
+			via = "tap"
+		} else if strings.Count(f.FullName, "/") >= 2 {
+			// e.g. "kaeawc/tap/formula"
+			via = "tap"
+		}
+		out = append(out, BrewFormula{
+			Name:         f.Name,
+			Version:      ver,
+			InstalledVia: via,
+			Deprecated:   f.Deprecated,
+			Pinned:       f.Pinned,
+		})
+	}
+	return out
+}
+
+// parseBrewCasks parses `brew list --cask --versions` output.
+// Each line is "<name> <version>".
+func parseBrewCasks(data []byte) []BrewCask {
+	var out []BrewCask
+	for _, line := range lines(data) {
+		parts := strings.Fields(line)
+		if len(parts) == 0 {
+			continue
+		}
+		cask := BrewCask{Name: parts[0]}
+		if len(parts) >= 2 {
+			cask.Version = parts[1]
+		}
+		out = append(out, cask)
+	}
+	return out
+}

--- a/internal/toolchain/brew_test.go
+++ b/internal/toolchain/brew_test.go
@@ -1,0 +1,137 @@
+package toolchain
+
+import (
+	"errors"
+	"testing"
+)
+
+const brewInfoFixture = `{
+  "formulae": [
+    {
+      "name": "openjdk@21",
+      "full_name": "openjdk@21",
+      "tap": "homebrew/core",
+      "deprecated": false,
+      "pinned": false,
+      "installed": [{"version": "21.0.6", "installed_on_request": true}]
+    },
+    {
+      "name": "node",
+      "full_name": "node",
+      "tap": "homebrew/core",
+      "deprecated": false,
+      "pinned": true,
+      "installed": [{"version": "22.1.0", "installed_on_request": true}]
+    },
+    {
+      "name": "old-formula",
+      "full_name": "old-formula",
+      "tap": "homebrew/core",
+      "deprecated": true,
+      "pinned": false,
+      "installed": [{"version": "1.0.0", "installed_on_request": false}]
+    }
+  ]
+}`
+
+const brewCasksFixture = `slack 4.39.95
+visual-studio-code 1.89.0
+`
+
+const brewTapsFixture = `homebrew/core
+homebrew/cask
+kaeawc/tap
+`
+
+func stubRunner(formulae, casks, taps []byte) CmdRunner {
+	return func(name string, args ...string) ([]byte, error) {
+		if name == "brew" {
+			switch {
+			case len(args) >= 2 && args[0] == "info":
+				return formulae, nil
+			case len(args) >= 1 && args[0] == "list":
+				return casks, nil
+			case len(args) >= 1 && args[0] == "tap":
+				return taps, nil
+			}
+		}
+		return nil, errors.New("unexpected command")
+	}
+}
+
+func TestDiscoverBrewFormulae(t *testing.T) {
+	runner := stubRunner([]byte(brewInfoFixture), []byte(brewCasksFixture), []byte(brewTapsFixture))
+	inv, err := discoverBrew(runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(inv.Formulae) != 3 {
+		t.Fatalf("got %d formulae, want 3", len(inv.Formulae))
+	}
+
+	byName := map[string]BrewFormula{}
+	for _, f := range inv.Formulae {
+		byName[f.Name] = f
+	}
+
+	jdk := byName["openjdk@21"]
+	if jdk.Version != "21.0.6" {
+		t.Errorf("openjdk@21 version = %q, want 21.0.6", jdk.Version)
+	}
+	if jdk.InstalledVia != "core" {
+		t.Errorf("openjdk@21 via = %q, want core", jdk.InstalledVia)
+	}
+
+	node := byName["node"]
+	if !node.Pinned {
+		t.Error("node should be pinned")
+	}
+
+	old := byName["old-formula"]
+	if !old.Deprecated {
+		t.Error("old-formula should be deprecated")
+	}
+}
+
+func TestDiscoverBrewCasks(t *testing.T) {
+	runner := stubRunner([]byte(`{"formulae":[]}`), []byte(brewCasksFixture), nil)
+	inv, err := discoverBrew(runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Casks) != 2 {
+		t.Fatalf("got %d casks, want 2", len(inv.Casks))
+	}
+	if inv.Casks[0].Name != "slack" {
+		t.Errorf("cask[0].Name = %q, want slack", inv.Casks[0].Name)
+	}
+	if inv.Casks[0].Version != "4.39.95" {
+		t.Errorf("cask[0].Version = %q, want 4.39.95", inv.Casks[0].Version)
+	}
+}
+
+func TestDiscoverBrewTaps(t *testing.T) {
+	runner := stubRunner([]byte(`{"formulae":[]}`), nil, []byte(brewTapsFixture))
+	inv, err := discoverBrew(runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Taps) != 3 {
+		t.Fatalf("got %d taps, want 3", len(inv.Taps))
+	}
+}
+
+func TestDiscoverBrewCommandFails(t *testing.T) {
+	// All commands fail — should return empty inventory, no error.
+	runner := func(name string, args ...string) ([]byte, error) {
+		return nil, errors.New("brew not found")
+	}
+	inv, err := discoverBrew(runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inv.Formulae) != 0 || len(inv.Casks) != 0 {
+		t.Errorf("expected empty inventory on failure, got %+v", inv)
+	}
+}

--- a/internal/toolchain/cmd.go
+++ b/internal/toolchain/cmd.go
@@ -1,0 +1,23 @@
+package toolchain
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// execRunner is the default CmdRunner that shells out for real.
+func execRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// lines splits output into trimmed non-empty lines.
+func lines(b []byte) []string {
+	var out []string
+	for _, l := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/internal/toolchain/collect.go
+++ b/internal/toolchain/collect.go
@@ -1,0 +1,124 @@
+package toolchain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// CollectOptions parameterises the collector. All path fields have sane
+// defaults (live machine) but can be overridden in tests to point at
+// a fake home directory.
+type CollectOptions struct {
+	// Home is the user's home directory. Defaults to os.UserHomeDir().
+	Home string
+	// BrewCellars are candidate Homebrew Cellar roots.
+	// Defaults to [/opt/homebrew/Cellar, /usr/local/Cellar].
+	BrewCellars []string
+	// SystemJVMRoot is the system JVM search path (/Library/Java/...).
+	// Defaults to /Library/Java/JavaVirtualMachines.
+	SystemJVMRoot string
+	// UserJVMRoot is ~/Library/Java/JavaVirtualMachines.
+	// Defaults to <Home>/Library/Java/JavaVirtualMachines.
+	UserJVMRoot string
+	// CmdRunner runs external commands. Defaults to execRunner.
+	// Inject a fake in tests to avoid shelling out to brew.
+	CmdRunner CmdRunner
+}
+
+// CmdRunner abstracts exec.Command for testability.
+type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// Collect runs all subsystem discoverers in parallel and returns the
+// aggregate Toolchains. Any discoverer error is silently absorbed —
+// a partial result is still useful.
+func Collect(ctx context.Context, opts CollectOptions) Toolchains {
+	opts = withDefaults(opts)
+
+	var (
+		mu  sync.Mutex
+		out Toolchains
+	)
+
+	set := func(fn func(t *Toolchains)) {
+		fn(&out)
+	}
+
+	run := func(fn func() (func(t *Toolchains), error)) func() {
+		return func() {
+			if apply, err := fn(); err == nil && apply != nil {
+				mu.Lock()
+				set(apply)
+				mu.Unlock()
+			}
+		}
+	}
+
+	var wg sync.WaitGroup
+	tasks := []func(){
+		run(func() (func(*Toolchains), error) {
+			inv, err := discoverBrew(opts.CmdRunner)
+			return func(t *Toolchains) { t.Brew = inv }, err
+		}),
+		run(func() (func(*Toolchains), error) {
+			jdks, err := discoverJDKs(opts)
+			return func(t *Toolchains) { t.JDKs = jdks }, err
+		}),
+		run(func() (func(*Toolchains), error) {
+			installs, err := discoverNode(opts)
+			return func(t *Toolchains) { t.Node = installs }, err
+		}),
+		run(func() (func(*Toolchains), error) {
+			installs, err := discoverPython(opts)
+			return func(t *Toolchains) { t.Python = installs }, err
+		}),
+		run(func() (func(*Toolchains), error) {
+			installs, err := discoverGo(opts)
+			return func(t *Toolchains) { t.Go = installs }, err
+		}),
+		run(func() (func(*Toolchains), error) {
+			installs, err := discoverRuby(opts)
+			return func(t *Toolchains) { t.Ruby = installs }, err
+		}),
+		run(func() (func(*Toolchains), error) {
+			chains, err := discoverRust(opts.Home)
+			return func(t *Toolchains) { t.Rust = chains }, err
+		}),
+		run(func() (func(*Toolchains), error) {
+			snap := collectEnv()
+			return func(t *Toolchains) { t.Env = snap }, nil
+		}),
+	}
+
+	for _, task := range tasks {
+		wg.Add(1)
+		task := task
+		go func() {
+			defer wg.Done()
+			task()
+		}()
+	}
+	wg.Wait()
+	return out
+}
+
+func withDefaults(o CollectOptions) CollectOptions {
+	if o.Home == "" {
+		h, _ := os.UserHomeDir()
+		o.Home = h
+	}
+	if len(o.BrewCellars) == 0 {
+		o.BrewCellars = []string{"/opt/homebrew/Cellar", "/usr/local/Cellar"}
+	}
+	if o.SystemJVMRoot == "" {
+		o.SystemJVMRoot = "/Library/Java/JavaVirtualMachines"
+	}
+	if o.UserJVMRoot == "" {
+		o.UserJVMRoot = filepath.Join(o.Home, "Library", "Java", "JavaVirtualMachines")
+	}
+	if o.CmdRunner == nil {
+		o.CmdRunner = execRunner
+	}
+	return o
+}

--- a/internal/toolchain/collect_test.go
+++ b/internal/toolchain/collect_test.go
@@ -1,0 +1,52 @@
+package toolchain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCollectIntegration(t *testing.T) {
+	home := t.TempDir()
+
+	// Plant a fake SDKMAN JDK.
+	jdkDir := filepath.Join(home, ".sdkman", "candidates", "java", "21.0.6-tem")
+	os.MkdirAll(jdkDir, 0o755)
+	os.WriteFile(filepath.Join(jdkDir, "release"), []byte(`JAVA_VERSION="21.0.6"
+IMPLEMENTOR="Eclipse Adoptium"
+JAVA_RUNTIME_VERSION="21.0.6+7-LTS"
+`), 0o644)
+
+	// Plant a fake nvm Node.
+	os.MkdirAll(filepath.Join(home, ".nvm", "versions", "node", "v22.1.0"), 0o755)
+
+	// Plant a fake rustup toolchain.
+	os.MkdirAll(filepath.Join(home, ".rustup", "toolchains", "stable-aarch64-apple-darwin"), 0o755)
+
+	// Stub brew to return empty.
+	stub := func(name string, args ...string) ([]byte, error) {
+		if name == "brew" && len(args) > 0 && args[0] == "info" {
+			return []byte(`{"formulae":[]}`), nil
+		}
+		return []byte{}, nil
+	}
+
+	tc := Collect(context.Background(), CollectOptions{
+		Home:          home,
+		BrewCellars:   []string{filepath.Join(home, "cellar")},
+		SystemJVMRoot: filepath.Join(home, "nope"),
+		UserJVMRoot:   filepath.Join(home, "nope2"),
+		CmdRunner:     stub,
+	})
+
+	if len(tc.JDKs) != 1 {
+		t.Errorf("JDKs: got %d, want 1", len(tc.JDKs))
+	}
+	if len(tc.Node) != 1 {
+		t.Errorf("Node: got %d, want 1", len(tc.Node))
+	}
+	if len(tc.Rust) != 1 {
+		t.Errorf("Rust: got %d, want 1", len(tc.Rust))
+	}
+}

--- a/internal/toolchain/env.go
+++ b/internal/toolchain/env.go
@@ -1,0 +1,51 @@
+package toolchain
+
+import (
+	"os"
+	"strings"
+)
+
+// collectEnv captures the shell environment fields relevant to runtime
+// resolution. Only named keys are captured — not full os.Environ().
+func collectEnv() EnvSnapshot {
+	snap := EnvSnapshot{
+		JavaHome:  os.Getenv("JAVA_HOME"),
+		GoPath:    os.Getenv("GOPATH"),
+		GoRoot:    os.Getenv("GOROOT"),
+		NpmPrefix: os.Getenv("NPM_CONFIG_PREFIX"),
+		PnpmHome:  os.Getenv("PNPM_HOME"),
+	}
+
+	// Shell: use $SHELL, strip path prefix
+	if sh := os.Getenv("SHELL"); sh != "" {
+		snap.Shell = sh
+		if idx := strings.LastIndex(sh, "/"); idx >= 0 {
+			snap.Shell = sh[idx+1:]
+		}
+	}
+
+	// PATH: ordered, deduped
+	if path := os.Getenv("PATH"); path != "" {
+		seen := map[string]bool{}
+		for _, d := range strings.Split(path, ":") {
+			if d != "" && !seen[d] {
+				snap.PathDirs = append(snap.PathDirs, d)
+				seen[d] = true
+			}
+		}
+	}
+
+	// Proxy vars
+	proxyKeys := []string{"http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY",
+		"no_proxy", "NO_PROXY", "all_proxy", "ALL_PROXY"}
+	for _, k := range proxyKeys {
+		if v := os.Getenv(k); v != "" {
+			if snap.ProxyEnvVars == nil {
+				snap.ProxyEnvVars = map[string]string{}
+			}
+			snap.ProxyEnvVars[strings.ToLower(k)] = v
+		}
+	}
+
+	return snap
+}

--- a/internal/toolchain/env_test.go
+++ b/internal/toolchain/env_test.go
@@ -1,0 +1,74 @@
+package toolchain
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCollectEnvShell(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+	snap := collectEnv()
+	if snap.Shell != "zsh" {
+		t.Errorf("Shell = %q, want zsh", snap.Shell)
+	}
+}
+
+func TestCollectEnvPath(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/usr/local/bin:/usr/bin") // duplicate at end
+	snap := collectEnv()
+	if len(snap.PathDirs) != 2 {
+		t.Errorf("PathDirs = %v, want 2 unique entries", snap.PathDirs)
+	}
+	if snap.PathDirs[0] != "/usr/bin" {
+		t.Errorf("PathDirs[0] = %q, want /usr/bin", snap.PathDirs[0])
+	}
+}
+
+func TestCollectEnvJavaHome(t *testing.T) {
+	t.Setenv("JAVA_HOME", "/usr/local/opt/openjdk@21")
+	snap := collectEnv()
+	if snap.JavaHome != "/usr/local/opt/openjdk@21" {
+		t.Errorf("JavaHome = %q", snap.JavaHome)
+	}
+}
+
+func TestCollectEnvProxy(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+	t.Setenv("NO_PROXY", "localhost,127.0.0.1")
+	snap := collectEnv()
+	if snap.ProxyEnvVars["https_proxy"] != "http://proxy.example.com:8080" {
+		t.Errorf("proxy not captured: %+v", snap.ProxyEnvVars)
+	}
+	if snap.ProxyEnvVars["no_proxy"] != "localhost,127.0.0.1" {
+		t.Errorf("no_proxy not captured: %+v", snap.ProxyEnvVars)
+	}
+}
+
+func TestCollectEnvEmptyProxy(t *testing.T) {
+	// Unset all proxy vars to ensure they don't bleed from the test environment.
+	for _, k := range []string{"http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY",
+		"no_proxy", "NO_PROXY", "all_proxy", "ALL_PROXY"} {
+		os.Unsetenv(k)
+	}
+	snap := collectEnv()
+	if len(snap.ProxyEnvVars) != 0 {
+		t.Errorf("expected empty proxy vars, got %+v", snap.ProxyEnvVars)
+	}
+}
+
+func TestCollectEnvPathEmpty(t *testing.T) {
+	t.Setenv("PATH", "")
+	snap := collectEnv()
+	if len(snap.PathDirs) != 0 {
+		t.Errorf("expected empty PathDirs for empty PATH, got %v", snap.PathDirs)
+	}
+}
+
+func TestCollectEnvShellBashPath(t *testing.T) {
+	t.Setenv("SHELL", "/bin/bash")
+	snap := collectEnv()
+	if !strings.HasSuffix(snap.Shell, "bash") {
+		t.Errorf("Shell = %q, want bash suffix", snap.Shell)
+	}
+}

--- a/internal/toolchain/jdk.go
+++ b/internal/toolchain/jdk.go
@@ -1,0 +1,150 @@
+package toolchain
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// discoverJDKs enumerates all installed JDKs across every well-known
+// installation location. Parses each JDK's `release` file for version +
+// vendor rather than running `java -version` (faster; works for broken JDKs).
+func discoverJDKs(opts CollectOptions) ([]JDKInstall, error) {
+	javaHome := os.Getenv("JAVA_HOME")
+
+	type searchRoot struct {
+		dir    string
+		source string
+		sub    string // subdirectory inside each match to find JDK home, e.g. "Contents/Home"
+	}
+
+	roots := []searchRoot{
+		{opts.SystemJVMRoot, "system", "Contents/Home"},
+		{opts.UserJVMRoot, "manual", "Contents/Home"},
+		{filepath.Join(opts.Home, ".sdkman", "candidates", "java"), "sdkman", ""},
+		{filepath.Join(opts.Home, ".asdf", "installs", "java"), "asdf", ""},
+		{filepath.Join(opts.Home, ".local", "share", "mise", "installs", "java"), "mise", ""},
+		{filepath.Join(opts.Home, "Library", "Caches", "Coursier", "jvm"), "coursier", ""},
+	}
+	// Homebrew installs openjdk@* as symlinks in opt/
+	for _, cellar := range opts.BrewCellars {
+		base := filepath.Dir(cellar) // /opt/homebrew or /usr/local
+		roots = append(roots, searchRoot{filepath.Join(base, "opt"), "brew", ""})
+	}
+	// JetBrains Toolbox JBRs
+	tbApps := filepath.Join(opts.Home, "Library", "Application Support", "JetBrains", "Toolbox", "apps")
+	roots = append(roots, searchRoot{tbApps, "jbr-toolbox", "jbr/Contents/Home"})
+
+	seen := map[string]bool{}
+	var out []JDKInstall
+	for _, r := range roots {
+		entries, err := readDir(r.dir)
+		if err != nil {
+			continue
+		}
+		for _, name := range entries {
+			candidate := filepath.Join(r.dir, name)
+			// For brew opt/, only accept openjdk* symlinks.
+			if r.source == "brew" && !strings.HasPrefix(name, "openjdk") {
+				continue
+			}
+			home := candidate
+			if r.sub != "" {
+				home = filepath.Join(candidate, r.sub)
+			}
+			if seen[home] {
+				continue
+			}
+			jdk, ok := parseJDKHome(home, r.source)
+			if !ok {
+				continue
+			}
+			jdk.Path = home
+			jdk.IsActiveJavaHome = (javaHome != "" && strings.HasPrefix(home, javaHome))
+			jdk.InstallID = fmt.Sprintf("%s-%s-%d.%d.%d",
+				jdk.Source, sanitize(jdk.Vendor), jdk.VersionMajor, jdk.VersionMinor, jdk.VersionPatch)
+			seen[home] = true
+			out = append(out, jdk)
+		}
+	}
+	return out, nil
+}
+
+// parseJDKHome reads <jdkHome>/release and returns a populated JDKInstall.
+func parseJDKHome(jdkHome, source string) (JDKInstall, bool) {
+	f, err := os.Open(filepath.Join(jdkHome, "release"))
+	if err != nil {
+		return JDKInstall{}, false
+	}
+	defer f.Close()
+
+	props := map[string]string{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		props[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"`)
+	}
+
+	raw := props["JAVA_VERSION"]
+	if raw == "" {
+		raw = props["JAVA_RUNTIME_VERSION"]
+	}
+	if raw == "" {
+		return JDKInstall{}, false
+	}
+
+	jdk := JDKInstall{
+		Source:        source,
+		ReleaseString: props["JAVA_RUNTIME_VERSION"],
+		Vendor:        props["IMPLEMENTOR"],
+	}
+	// Parse "21.0.6", "1.8.0_392", "21.0.6+7-LTS"
+	clean := strings.FieldsFunc(raw, func(r rune) bool { return r == '+' || r == '-' })[0]
+	parts := strings.Split(clean, ".")
+	if len(parts) >= 1 {
+		major, _ := strconv.Atoi(parts[0])
+		// Old JDK "1.8.0_N" → major is parts[1]
+		if major == 1 && len(parts) >= 2 {
+			major, _ = strconv.Atoi(parts[1])
+		}
+		jdk.VersionMajor = major
+	}
+	if len(parts) >= 2 {
+		minor, _ := strconv.Atoi(parts[1])
+		jdk.VersionMinor = minor
+	}
+	if len(parts) >= 3 {
+		patch, _ := strconv.Atoi(strings.FieldsFunc(parts[2], func(r rune) bool { return r == '_' })[0])
+		jdk.VersionPatch = patch
+	}
+	return jdk, true
+}
+
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			return r
+		}
+		return '-'
+	}, s)
+}
+
+// readDir lists entries in dir, returning names only. Silently ignores errors.
+func readDir(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names, nil
+}

--- a/internal/toolchain/jdk_test.go
+++ b/internal/toolchain/jdk_test.go
@@ -1,0 +1,149 @@
+package toolchain
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeJDK creates a fake JDK home directory with a release file under dir.
+func makeJDK(t *testing.T, dir, name, javaVersion, runtimeVersion, implementor string) string {
+	t.Helper()
+	jdkHome := filepath.Join(dir, name)
+	if err := os.MkdirAll(jdkHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := fmt.Sprintf(`JAVA_VERSION="%s"
+JAVA_RUNTIME_VERSION="%s"
+IMPLEMENTOR="%s"
+`, javaVersion, runtimeVersion, implementor)
+	if err := os.WriteFile(filepath.Join(jdkHome, "release"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return jdkHome
+}
+
+func TestParseJDKHome(t *testing.T) {
+	dir := t.TempDir()
+	makeJDK(t, dir, "jdk21", "21.0.6", "21.0.6+7-LTS", "Eclipse Adoptium")
+
+	jdk, ok := parseJDKHome(filepath.Join(dir, "jdk21"), "sdkman")
+	if !ok {
+		t.Fatal("parseJDKHome returned false")
+	}
+	if jdk.VersionMajor != 21 {
+		t.Errorf("VersionMajor = %d, want 21", jdk.VersionMajor)
+	}
+	if jdk.VersionMinor != 0 {
+		t.Errorf("VersionMinor = %d, want 0", jdk.VersionMinor)
+	}
+	if jdk.VersionPatch != 6 {
+		t.Errorf("VersionPatch = %d, want 6", jdk.VersionPatch)
+	}
+	if jdk.Vendor != "Eclipse Adoptium" {
+		t.Errorf("Vendor = %q", jdk.Vendor)
+	}
+	if jdk.ReleaseString != "21.0.6+7-LTS" {
+		t.Errorf("ReleaseString = %q", jdk.ReleaseString)
+	}
+	if jdk.Source != "sdkman" {
+		t.Errorf("Source = %q", jdk.Source)
+	}
+}
+
+func TestParseJDKHomeLegacy(t *testing.T) {
+	// Old Java 8 style: JAVA_VERSION="1.8.0_392"
+	dir := t.TempDir()
+	makeJDK(t, dir, "jdk8", "1.8.0_392", "1.8.0_392-b08", "Azul Systems, Inc.")
+
+	jdk, ok := parseJDKHome(filepath.Join(dir, "jdk8"), "brew")
+	if !ok {
+		t.Fatal("parseJDKHome returned false")
+	}
+	if jdk.VersionMajor != 8 {
+		t.Errorf("VersionMajor = %d, want 8 (legacy 1.x prefix)", jdk.VersionMajor)
+	}
+}
+
+func TestParseJDKHomeMissingRelease(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "empty"), 0o755)
+	_, ok := parseJDKHome(filepath.Join(dir, "empty"), "manual")
+	if ok {
+		t.Error("expected false for JDK home with no release file")
+	}
+}
+
+func TestDiscoverJDKsFromFakeSDKMAN(t *testing.T) {
+	home := t.TempDir()
+	sdkBase := filepath.Join(home, ".sdkman", "candidates", "java")
+	makeJDK(t, sdkBase, "21.0.6-tem", "21.0.6", "21.0.6+7-LTS", "Eclipse Adoptium")
+	makeJDK(t, sdkBase, "17.0.10-zulu", "17.0.10", "17.0.10+7", "Azul Systems")
+
+	opts := CollectOptions{
+		Home:          home,
+		SystemJVMRoot: filepath.Join(home, "nonexistent-sys"),
+		UserJVMRoot:   filepath.Join(home, "nonexistent-usr"),
+		BrewCellars:   []string{filepath.Join(home, "cellar")},
+	}
+	jdks, err := discoverJDKs(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jdks) != 2 {
+		t.Fatalf("got %d JDKs, want 2; %+v", len(jdks), jdks)
+	}
+}
+
+func TestDiscoverJDKsSystemVirtualMachines(t *testing.T) {
+	sysRoot := t.TempDir()
+	// Simulate /Library/Java/JavaVirtualMachines/temurin-21.jdk
+	jdkBundle := filepath.Join(sysRoot, "temurin-21.jdk", "Contents", "Home")
+	os.MkdirAll(jdkBundle, 0o755)
+	content := `JAVA_VERSION="21.0.7"
+IMPLEMENTOR="Eclipse Adoptium"
+JAVA_RUNTIME_VERSION="21.0.7+6-LTS"
+`
+	os.WriteFile(filepath.Join(jdkBundle, "release"), []byte(content), 0o644)
+
+	home := t.TempDir()
+	opts := CollectOptions{
+		Home:          home,
+		SystemJVMRoot: sysRoot,
+		UserJVMRoot:   filepath.Join(home, "nope"),
+		BrewCellars:   []string{},
+	}
+	jdks, err := discoverJDKs(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jdks) != 1 {
+		t.Fatalf("got %d JDKs, want 1", len(jdks))
+	}
+	if jdks[0].Source != "system" {
+		t.Errorf("Source = %q, want system", jdks[0].Source)
+	}
+	if jdks[0].VersionMajor != 21 {
+		t.Errorf("VersionMajor = %d, want 21", jdks[0].VersionMajor)
+	}
+}
+
+func TestDiscoverJDKsDedup(t *testing.T) {
+	// Same physical path listed under two search roots should only appear once.
+	home := t.TempDir()
+	sdkBase := filepath.Join(home, ".sdkman", "candidates", "java")
+	makeJDK(t, sdkBase, "21.0.6-tem", "21.0.6", "21.0.6+7-LTS", "Eclipse Adoptium")
+
+	opts := CollectOptions{
+		Home:          home,
+		SystemJVMRoot: filepath.Join(home, "nope"),
+		UserJVMRoot:   filepath.Join(home, "nope2"),
+		BrewCellars:   []string{},
+	}
+	jdks1, _ := discoverJDKs(opts)
+	jdks2, _ := discoverJDKs(opts)
+	if len(jdks1) != len(jdks2) {
+		t.Errorf("non-deterministic: %d vs %d", len(jdks1), len(jdks2))
+	}
+}

--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -1,0 +1,245 @@
+package toolchain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// discoverNode enumerates Node.js installations from all common managers.
+func discoverNode(opts CollectOptions) ([]RuntimeInstall, error) {
+	active := activeVersion("node")
+	var out []RuntimeInstall
+
+	// nvm
+	for _, v := range listDirs(filepath.Join(opts.Home, ".nvm", "versions", "node")) {
+		out = append(out, runtimeInstall("nvm", v, filepath.Join(opts.Home, ".nvm", "versions", "node", v, "bin", "node"), active))
+	}
+	// fnm
+	for _, base := range []string{
+		filepath.Join(opts.Home, ".fnm", "node-versions"),
+		filepath.Join(opts.Home, ".local", "share", "fnm", "node-versions"),
+	} {
+		for _, v := range listDirs(base) {
+			out = append(out, runtimeInstall("fnm", v, filepath.Join(base, v, "installation", "bin", "node"), active))
+		}
+	}
+	// volta
+	for _, v := range listDirs(filepath.Join(opts.Home, ".volta", "tools", "image", "node")) {
+		out = append(out, runtimeInstall("volta", v, filepath.Join(opts.Home, ".volta", "tools", "image", "node", v, "bin", "node"), active))
+	}
+	// mise
+	for _, v := range listDirs(filepath.Join(opts.Home, ".local", "share", "mise", "installs", "node")) {
+		out = append(out, runtimeInstall("mise", v, filepath.Join(opts.Home, ".local", "share", "mise", "installs", "node", v, "bin", "node"), active))
+	}
+	// asdf
+	for _, v := range listDirs(filepath.Join(opts.Home, ".asdf", "installs", "nodejs")) {
+		out = append(out, runtimeInstall("asdf", v, filepath.Join(opts.Home, ".asdf", "installs", "nodejs", v, "bin", "node"), active))
+	}
+	// brew
+	for _, cellar := range opts.BrewCellars {
+		for _, pkg := range listDirs(cellar) {
+			if !strings.HasPrefix(pkg, "node") {
+				continue
+			}
+			for _, v := range listDirs(filepath.Join(cellar, pkg)) {
+				out = append(out, runtimeInstall("brew", v, filepath.Join(cellar, pkg, v, "bin", "node"), active))
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// discoverPython enumerates Python installations.
+func discoverPython(opts CollectOptions) ([]RuntimeInstall, error) {
+	active := activeVersion("python3")
+	var out []RuntimeInstall
+
+	// system
+	if _, err := os.Stat("/usr/bin/python3"); err == nil {
+		out = append(out, RuntimeInstall{Version: "system", Source: "system", Path: "/usr/bin/python3",
+			Active: strings.HasPrefix(active, "/usr/bin")})
+	}
+	// pyenv
+	for _, v := range listDirs(filepath.Join(opts.Home, ".pyenv", "versions")) {
+		out = append(out, runtimeInstall("pyenv", v, filepath.Join(opts.Home, ".pyenv", "versions", v, "bin", "python3"), active))
+	}
+	// uv
+	for _, v := range listDirs(filepath.Join(opts.Home, ".local", "share", "uv", "python")) {
+		out = append(out, runtimeInstall("uv", v, filepath.Join(opts.Home, ".local", "share", "uv", "python", v, "bin", "python3"), active))
+	}
+	// mise
+	for _, v := range listDirs(filepath.Join(opts.Home, ".local", "share", "mise", "installs", "python")) {
+		out = append(out, runtimeInstall("mise", v, filepath.Join(opts.Home, ".local", "share", "mise", "installs", "python", v, "bin", "python3"), active))
+	}
+	// asdf
+	for _, v := range listDirs(filepath.Join(opts.Home, ".asdf", "installs", "python")) {
+		out = append(out, runtimeInstall("asdf", v, filepath.Join(opts.Home, ".asdf", "installs", "python", v, "bin", "python3"), active))
+	}
+	// brew
+	for _, cellar := range opts.BrewCellars {
+		for _, pkg := range listDirs(cellar) {
+			if !strings.HasPrefix(pkg, "python") {
+				continue
+			}
+			for _, v := range listDirs(filepath.Join(cellar, pkg)) {
+				out = append(out, runtimeInstall("brew", v, filepath.Join(cellar, pkg, v, "bin", "python3"), active))
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// discoverGo enumerates Go installations.
+func discoverGo(opts CollectOptions) ([]RuntimeInstall, error) {
+	active := activeVersion("go")
+	var out []RuntimeInstall
+
+	// system /usr/local/go
+	if _, err := os.Stat("/usr/local/go/bin/go"); err == nil {
+		out = append(out, RuntimeInstall{Version: "system", Source: "system", Path: "/usr/local/go/bin/go",
+			Active: strings.HasPrefix(active, "/usr/local/go")})
+	}
+	// goenv
+	for _, v := range listDirs(filepath.Join(opts.Home, ".goenv", "versions")) {
+		out = append(out, runtimeInstall("goenv", v, filepath.Join(opts.Home, ".goenv", "versions", v, "bin", "go"), active))
+	}
+	// mise
+	for _, v := range listDirs(filepath.Join(opts.Home, ".local", "share", "mise", "installs", "go")) {
+		out = append(out, runtimeInstall("mise", v, filepath.Join(opts.Home, ".local", "share", "mise", "installs", "go", v, "bin", "go"), active))
+	}
+	// asdf
+	for _, v := range listDirs(filepath.Join(opts.Home, ".asdf", "installs", "golang")) {
+		out = append(out, runtimeInstall("asdf", v, filepath.Join(opts.Home, ".asdf", "installs", "golang", v, "packages", "pkg", "tool", "darwin_arm64", "go"), active))
+	}
+	// brew
+	for _, cellar := range opts.BrewCellars {
+		for _, pkg := range listDirs(cellar) {
+			if pkg != "go" && !strings.HasPrefix(pkg, "go@") {
+				continue
+			}
+			for _, v := range listDirs(filepath.Join(cellar, pkg)) {
+				out = append(out, runtimeInstall("brew", v, filepath.Join(cellar, pkg, v, "bin", "go"), active))
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// discoverRuby enumerates Ruby installations.
+func discoverRuby(opts CollectOptions) ([]RuntimeInstall, error) {
+	active := activeVersion("ruby")
+	var out []RuntimeInstall
+
+	// rbenv
+	for _, v := range listDirs(filepath.Join(opts.Home, ".rbenv", "versions")) {
+		out = append(out, runtimeInstall("rbenv", v, filepath.Join(opts.Home, ".rbenv", "versions", v, "bin", "ruby"), active))
+	}
+	// mise
+	for _, v := range listDirs(filepath.Join(opts.Home, ".local", "share", "mise", "installs", "ruby")) {
+		out = append(out, runtimeInstall("mise", v, filepath.Join(opts.Home, ".local", "share", "mise", "installs", "ruby", v, "bin", "ruby"), active))
+	}
+	// asdf
+	for _, v := range listDirs(filepath.Join(opts.Home, ".asdf", "installs", "ruby")) {
+		out = append(out, runtimeInstall("asdf", v, filepath.Join(opts.Home, ".asdf", "installs", "ruby", v, "bin", "ruby"), active))
+	}
+	// brew
+	for _, cellar := range opts.BrewCellars {
+		for _, pkg := range listDirs(cellar) {
+			if pkg != "ruby" && !strings.HasPrefix(pkg, "ruby@") {
+				continue
+			}
+			for _, v := range listDirs(filepath.Join(cellar, pkg)) {
+				out = append(out, runtimeInstall("brew", v, filepath.Join(cellar, pkg, v, "bin", "ruby"), active))
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// discoverRust enumerates rustup-managed toolchains from ~/.rustup/toolchains/.
+func discoverRust(home string) ([]RustToolchain, error) {
+	base := filepath.Join(home, ".rustup", "toolchains")
+	// default toolchain is the target of ~/.rustup/toolchains/stable-* symlink
+	// or listed in ~/.rustup/settings.toml as default_toolchain.
+	defName := readRustDefault(filepath.Join(home, ".rustup", "settings.toml"))
+
+	var out []RustToolchain
+	for _, name := range listDirs(base) {
+		ch := rustChannel(name)
+		out = append(out, RustToolchain{
+			Toolchain: name,
+			Channel:   ch,
+			Default:   defName != "" && strings.HasPrefix(name, defName),
+		})
+	}
+	return out, nil
+}
+
+// rustChannel extracts "stable", "beta", or "nightly" from a toolchain name
+// like "stable-aarch64-apple-darwin".
+func rustChannel(name string) string {
+	for _, ch := range []string{"stable", "beta", "nightly"} {
+		if strings.HasPrefix(name, ch) {
+			return ch
+		}
+	}
+	return "custom"
+}
+
+// readRustDefault reads `default_toolchain = "..."` from settings.toml.
+func readRustDefault(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		k, v, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(k) != "default_toolchain" {
+			continue
+		}
+		return strings.Trim(strings.TrimSpace(v), `"`)
+	}
+	return ""
+}
+
+// listDirs returns immediate subdirectory names of dir. Returns nil on error.
+func listDirs(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || e.Type()&os.ModeSymlink != 0 {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+// activeVersion runs `which <bin>` and returns the resolved path.
+func activeVersion(bin string) string {
+	out, err := execRunner("which", bin)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// runtimeInstall constructs a RuntimeInstall and marks it active when
+// the resolved `which` path starts with the install's directory.
+func runtimeInstall(source, version, binPath, activePath string) RuntimeInstall {
+	dir := filepath.Dir(binPath) // trim /bin/node → .../version
+	isActive := activePath != "" && strings.HasPrefix(activePath, dir)
+	return RuntimeInstall{
+		Version: version,
+		Source:  source,
+		Path:    binPath,
+		Active:  isActive,
+	}
+}

--- a/internal/toolchain/runtime_test.go
+++ b/internal/toolchain/runtime_test.go
@@ -1,0 +1,179 @@
+package toolchain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func makeVersionDir(t *testing.T, base, version string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(base, version), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDiscoverNodeFromNVM(t *testing.T) {
+	home := t.TempDir()
+	nvmBase := filepath.Join(home, ".nvm", "versions", "node")
+	makeVersionDir(t, nvmBase, "v18.20.4")
+	makeVersionDir(t, nvmBase, "v22.1.0")
+
+	opts := CollectOptions{Home: home, BrewCellars: []string{}}
+	installs, err := discoverNode(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installs) != 2 {
+		t.Fatalf("got %d installs, want 2: %+v", len(installs), installs)
+	}
+	for _, i := range installs {
+		if i.Source != "nvm" {
+			t.Errorf("Source = %q, want nvm", i.Source)
+		}
+	}
+}
+
+func TestDiscoverNodeFromMultipleManagers(t *testing.T) {
+	home := t.TempDir()
+	makeVersionDir(t, filepath.Join(home, ".nvm", "versions", "node"), "v18.20.4")
+	makeVersionDir(t, filepath.Join(home, ".fnm", "node-versions"), "v20.0.0")
+	makeVersionDir(t, filepath.Join(home, ".local", "share", "mise", "installs", "node"), "22.1.0")
+
+	opts := CollectOptions{Home: home, BrewCellars: []string{}}
+	installs, err := discoverNode(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installs) != 3 {
+		t.Fatalf("got %d installs, want 3: %+v", len(installs), installs)
+	}
+
+	sources := map[string]bool{}
+	for _, i := range installs {
+		sources[i.Source] = true
+	}
+	for _, want := range []string{"nvm", "fnm", "mise"} {
+		if !sources[want] {
+			t.Errorf("missing source %q", want)
+		}
+	}
+}
+
+func TestDiscoverRustToolchains(t *testing.T) {
+	home := t.TempDir()
+	rtBase := filepath.Join(home, ".rustup", "toolchains")
+	makeVersionDir(t, rtBase, "stable-aarch64-apple-darwin")
+	makeVersionDir(t, rtBase, "nightly-2025-03-01-aarch64-apple-darwin")
+	makeVersionDir(t, rtBase, "beta-aarch64-apple-darwin")
+
+	// Write a settings.toml pointing to stable.
+	os.MkdirAll(filepath.Join(home, ".rustup"), 0o755)
+	os.WriteFile(filepath.Join(home, ".rustup", "settings.toml"),
+		[]byte(`default_toolchain = "stable-aarch64-apple-darwin"`+"\n"), 0o644)
+
+	chains, err := discoverRust(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chains) != 3 {
+		t.Fatalf("got %d toolchains, want 3: %+v", len(chains), chains)
+	}
+
+	byChannel := map[string]RustToolchain{}
+	for _, c := range chains {
+		byChannel[c.Channel] = c
+	}
+	if _, ok := byChannel["stable"]; !ok {
+		t.Error("missing stable toolchain")
+	}
+	if _, ok := byChannel["nightly"]; !ok {
+		t.Error("missing nightly toolchain")
+	}
+
+	stable := byChannel["stable"]
+	if !stable.Default {
+		t.Error("stable should be marked as default")
+	}
+}
+
+func TestRustChannel(t *testing.T) {
+	cases := map[string]string{
+		"stable-aarch64-apple-darwin":                 "stable",
+		"nightly-2025-03-01-aarch64-apple-darwin":     "nightly",
+		"beta-aarch64-apple-darwin":                   "beta",
+		"1.78.0-aarch64-apple-darwin":                 "custom",
+	}
+	for in, want := range cases {
+		if got := rustChannel(in); got != want {
+			t.Errorf("rustChannel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDiscoverPythonFromPyenv(t *testing.T) {
+	home := t.TempDir()
+	pyenvBase := filepath.Join(home, ".pyenv", "versions")
+	makeVersionDir(t, pyenvBase, "3.12.3")
+	makeVersionDir(t, pyenvBase, "3.11.9")
+
+	opts := CollectOptions{Home: home, BrewCellars: []string{}}
+	installs, err := discoverPython(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := 0
+	for _, i := range installs {
+		if i.Source == "pyenv" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("got %d pyenv installs, want 2", count)
+	}
+}
+
+func TestDiscoverGoFromGoenv(t *testing.T) {
+	home := t.TempDir()
+	goenvBase := filepath.Join(home, ".goenv", "versions")
+	makeVersionDir(t, goenvBase, "1.22.3")
+	makeVersionDir(t, goenvBase, "1.23.0")
+
+	opts := CollectOptions{Home: home, BrewCellars: []string{}}
+	installs, err := discoverGo(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := 0
+	for _, i := range installs {
+		if i.Source == "goenv" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("got %d goenv installs, want 2", count)
+	}
+}
+
+func TestDiscoverRubyFromRbenv(t *testing.T) {
+	home := t.TempDir()
+	rbenvBase := filepath.Join(home, ".rbenv", "versions")
+	makeVersionDir(t, rbenvBase, "3.3.0")
+
+	opts := CollectOptions{Home: home, BrewCellars: []string{}}
+	installs, err := discoverRuby(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, i := range installs {
+		if i.Source == "rbenv" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("got %d rbenv installs, want 1", count)
+	}
+}

--- a/internal/toolchain/types.go
+++ b/internal/toolchain/types.go
@@ -1,0 +1,85 @@
+// Package toolchain catalogs every language runtime and package manager
+// installed on the local machine. All discovery is read-only and local;
+// no network calls, no brew update. See docs/inspection/toolchains.md.
+package toolchain
+
+// Toolchains is the aggregate result of all subsystem discoverers.
+type Toolchains struct {
+	Brew    BrewInventory    `json:"brew"`
+	JDKs    []JDKInstall     `json:"jdks,omitempty"`
+	Node    []RuntimeInstall `json:"node,omitempty"`
+	Python  []RuntimeInstall `json:"python,omitempty"`
+	Go      []RuntimeInstall `json:"go,omitempty"`
+	Ruby    []RuntimeInstall `json:"ruby,omitempty"`
+	Rust    []RustToolchain  `json:"rust,omitempty"`
+	Env     EnvSnapshot      `json:"env"`
+}
+
+// BrewInventory holds installed Homebrew formulae, casks, and taps.
+type BrewInventory struct {
+	Formulae []BrewFormula `json:"formulae,omitempty"`
+	Casks    []BrewCask    `json:"casks,omitempty"`
+	Taps     []BrewTap     `json:"taps,omitempty"`
+}
+
+// BrewFormula is one installed Homebrew formula.
+type BrewFormula struct {
+	Name         string `json:"name"`
+	Version      string `json:"version"`
+	InstalledVia string `json:"installed_via,omitempty"` // "core", "tap", "cask-tied"
+	Deprecated   bool   `json:"deprecated,omitempty"`
+	Pinned       bool   `json:"pinned,omitempty"`
+}
+
+// BrewCask is one installed Homebrew cask.
+type BrewCask struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+// BrewTap is one configured Homebrew tap.
+type BrewTap struct {
+	Name string `json:"name"`
+}
+
+// JDKInstall represents one installed JDK found on the machine.
+type JDKInstall struct {
+	InstallID        string `json:"install_id"`
+	Path             string `json:"path"`
+	Source           string `json:"source"` // "system", "brew", "sdkman", "asdf", "mise", "jbr-toolbox", "manual"
+	VersionMajor     int    `json:"version_major"`
+	VersionMinor     int    `json:"version_minor"`
+	VersionPatch     int    `json:"version_patch"`
+	Vendor           string `json:"vendor,omitempty"`
+	ReleaseString    string `json:"release_string,omitempty"`
+	IsActiveJavaHome bool   `json:"is_active_java_home,omitempty"`
+}
+
+// RuntimeInstall is a version of Node, Python, Go, or Ruby found via
+// a version manager or system install.
+type RuntimeInstall struct {
+	Version string `json:"version"`
+	Source  string `json:"source"` // "system", "brew", "nvm", "pyenv", etc.
+	Path    string `json:"path"`
+	Active  bool   `json:"active,omitempty"`
+}
+
+// RustToolchain is one rustup-managed toolchain.
+type RustToolchain struct {
+	Toolchain string `json:"toolchain"`
+	Channel   string `json:"channel"` // "stable", "beta", "nightly"
+	Default   bool   `json:"default,omitempty"`
+}
+
+// EnvSnapshot captures the shell environment fields relevant to runtime
+// resolution. Does NOT include full os.Environ — only named keys.
+type EnvSnapshot struct {
+	Shell        string            `json:"shell,omitempty"`
+	PathDirs     []string          `json:"path_dirs,omitempty"`
+	JavaHome     string            `json:"java_home,omitempty"`
+	GoPath       string            `json:"go_path,omitempty"`
+	GoRoot       string            `json:"go_root,omitempty"`
+	NpmPrefix    string            `json:"npm_prefix,omitempty"`
+	PnpmHome     string            `json:"pnpm_home,omitempty"`
+	ProxyEnvVars map[string]string `json:"proxy_env_vars,omitempty"`
+}


### PR DESCRIPTION
## Summary

- `internal/toolchain`: parallel `Collect()` running 8 subsystem discoverers
- **JDK discovery** — parses `release` files from system JVMs, SDKMAN, asdf, mise, Coursier, Homebrew `opt/`, JetBrains Toolbox JBR; deduped by resolved path
- **Runtime discovery** (Node/Python/Go/Ruby) — scans nvm/fnm/volta/mise/asdf/rbenv/pyenv/goenv/uv/brew Cellar dirs per language
- **Rust** — enumerates `~/.rustup/toolchains/`; reads `settings.toml` for default channel
- **Brew** — `CmdRunner` injected for testability; parses `--json=v2` formulae + `--cask --versions` output
- **Env snapshot** — captures SHELL, PATH (deduped), JAVA_HOME, GOPATH, GOROOT, proxy vars
- `Snapshot.Toolchains` wired into `Build()`; `ToolchainOpts` forwarded from `Options`

## Test plan

- [ ] 23 new tests, all with injected fake home dirs — no real brew/rustup required
- [ ] `go test ./... -race` passes
- [ ] `go build ./...` clean