### PR TITLE
Add sharded blob cache (internal/cache) + spectra cache subcommand

### DIFF
--- a/cmd/spectra/cache.go
+++ b/cmd/spectra/cache.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/cache"
+)
+
+// cacheRegistry is the package-level registry populated at init time.
+// Stores register themselves; the CLI queries this registry for stats/clear.
+var cacheRegistry = cache.Default
+
+// initCacheStores initialises all ShardedStores into the default registry.
+// Called from main before dispatching so every subcommand sees a populated
+// registry. Failures are non-fatal: if the cache root can't be created, the
+// registry stays empty and cache commands print a useful error.
+func initCacheStores() {
+	root, err := cache.DefaultRoot()
+	if err != nil {
+		return
+	}
+	cache.NewStores(root, cacheRegistry)
+}
+
+func runCache(args []string) int {
+	subs := []subcommand{
+		{"stats", "Show cache statistics", runCacheStats},
+		{"clear", "Clear cached data", runCacheClear},
+	}
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: spectra cache <stats|clear> [--kind <name>]")
+		return 2
+	}
+	for _, sc := range subs {
+		if args[0] == sc.name {
+			return sc.run(args[1:])
+		}
+	}
+	fmt.Fprintf(os.Stderr, "unknown cache subcommand %q\n", args[0])
+	return 2
+}
+
+func runCacheStats(args []string) int {
+	fs := flag.NewFlagSet("spectra cache stats", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	stats, err := cacheRegistry.Stats()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(stats) == 0 {
+		fmt.Fprintln(os.Stderr, "no cache kinds registered")
+		return 0
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(stats)
+		return 0
+	}
+
+	fmt.Printf("%-12s  %8s  %12s  %s\n", "KIND", "ENTRIES", "BYTES", "LAST WRITE")
+	fmt.Println(strings.Repeat("-", 56))
+	for _, s := range stats {
+		last := "-"
+		if !s.LastWrite.IsZero() {
+			last = s.LastWrite.Format("2006-01-02 15:04:05Z")
+		}
+		fmt.Printf("%-12s  %8d  %12s  %s\n",
+			s.Kind, s.Entries, humanSize(s.BytesOnDisk), last)
+	}
+	return 0
+}
+
+func runCacheClear(args []string) int {
+	fs := flag.NewFlagSet("spectra cache clear", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	kind := fs.String("kind", "", "Clear only this kind (default: all)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if err := cacheRegistry.Clear(*kind); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if *kind == "" {
+		fmt.Fprintln(os.Stdout, "cache cleared")
+	} else {
+		fmt.Fprintf(os.Stdout, "cache kind %q cleared\n", *kind)
+	}
+	return 0
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -34,12 +34,16 @@ func subcommandList() []subcommand {
 	return []subcommand{
 		{"inspect", "Inspect .app bundles (default; runs when no subcommand given)", runInspect},
 		{"snapshot", "Capture a structured snapshot of host + installed apps", runSnapshot},
+		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},
 	}
 }
 
-func main() { os.Exit(dispatch(os.Args[1:])) }
+func main() {
+	initCacheStores()
+	os.Exit(dispatch(os.Args[1:]))
+}
 
 // dispatch routes args to a subcommand handler. The first non-flag arg
 // matching a known subcommand name selects that subcommand; otherwise

--- a/internal/cache/async_writer.go
+++ b/internal/cache/async_writer.go
@@ -1,0 +1,86 @@
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// AsyncWriter batches blob writes in the background. Callers enqueue a
+// write via Write(); if the queue is full it falls back to a synchronous
+// Put so data is never dropped.
+//
+// Counters (Queued, Completed, Failed, Bytes) are updated atomically and
+// can be read at any time without locking.
+type AsyncWriter struct {
+	store  *ShardedStore
+	queue  chan writeJob
+	wg     sync.WaitGroup
+	closed atomic.Bool
+
+	Queued    atomic.Int64
+	Completed atomic.Int64
+	Failed    atomic.Int64
+	Bytes     atomic.Int64
+}
+
+type writeJob struct{ key, data []byte }
+
+// NewAsyncWriter starts workers draining the queue.
+// queueSize caps how many pending writes can wait before callers fall back
+// to synchronous writes. workers is the number of background goroutines.
+func NewAsyncWriter(store *ShardedStore, queueSize, workers int) *AsyncWriter {
+	w := &AsyncWriter{
+		store: store,
+		queue: make(chan writeJob, queueSize),
+	}
+	for i := 0; i < workers; i++ {
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			for job := range w.queue {
+				if err := store.Put(job.key, job.data); err != nil {
+					w.Failed.Add(1)
+				} else {
+					w.Completed.Add(1)
+					w.Bytes.Add(int64(len(job.data)))
+				}
+			}
+		}()
+	}
+	return w
+}
+
+// Write enqueues a put. Returns true if the write was handled synchronously
+// (queue full or writer closed). Returns false when enqueued successfully.
+func (w *AsyncWriter) Write(key, data []byte) (wroteSync bool) {
+	if w.closed.Load() {
+		_ = w.store.Put(key, data)
+		return true
+	}
+	job := writeJob{key: key, data: data}
+	select {
+	case w.queue <- job:
+		w.Queued.Add(1)
+		return false
+	default:
+		// Queue full — fall back to synchronous write.
+		if err := w.store.Put(key, data); err != nil {
+			w.Failed.Add(1)
+		} else {
+			w.Completed.Add(1)
+			w.Bytes.Add(int64(len(data)))
+		}
+		return true
+	}
+}
+
+// Close drains the queue and waits for all workers to finish. Safe to call
+// multiple times; only the first call drains the queue.
+func (w *AsyncWriter) Close() {
+	if w.closed.Swap(true) {
+		w.wg.Wait() // already closed; just wait for inflight jobs
+		return
+	}
+	close(w.queue)
+	w.wg.Wait()
+}

--- a/internal/cache/async_writer_test.go
+++ b/internal/cache/async_writer_test.go
@@ -1,0 +1,92 @@
+package cache
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestAsyncWriterBasic(t *testing.T) {
+	s := newTestStore(t, "detect")
+	w := NewAsyncWriter(s, 16, 2)
+
+	key := Key([]byte("async-basic"))
+	data := []byte("hello async")
+
+	wroteSync := w.Write(key, data)
+	w.Close() // drain before asserting
+
+	// Regardless of sync/async, data must be in the store.
+	got, ok, err := s.Get(key)
+	if err != nil || !ok {
+		t.Fatalf("data not in store after Write (sync=%v, err=%v)", wroteSync, err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("got %q, want %q", got, data)
+	}
+}
+
+func TestAsyncWriterMultiple(t *testing.T) {
+	s := newTestStore(t, "detect")
+	w := NewAsyncWriter(s, 32, 4)
+
+	const n = 20
+	keys := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		keys[i] = Key([]byte{byte(i), 0xAA})
+		w.Write(keys[i], []byte("payload"))
+	}
+	w.Close()
+
+	for i, k := range keys {
+		_, ok, err := s.Get(k)
+		if err != nil || !ok {
+			t.Errorf("key[%d] missing after Close", i)
+		}
+	}
+	if w.Completed.Load()+w.Failed.Load() != int64(n) {
+		t.Errorf("completed+failed = %d, want %d", w.Completed.Load()+w.Failed.Load(), n)
+	}
+}
+
+func TestAsyncWriterQueueFull(t *testing.T) {
+	// Queue size 0 forces every write to fall back to synchronous.
+	s := newTestStore(t, "detect")
+	w := NewAsyncWriter(s, 0, 1)
+	defer w.Close()
+
+	key := Key([]byte("sync-fallback"))
+	wroteSync := w.Write(key, []byte("x"))
+	if !wroteSync {
+		t.Error("expected synchronous fallback with queue size 0")
+	}
+	_, ok, _ := s.Get(key)
+	if !ok {
+		t.Error("data missing after synchronous fallback write")
+	}
+}
+
+func TestAsyncWriterCounters(t *testing.T) {
+	s := newTestStore(t, "detect")
+	w := NewAsyncWriter(s, 64, 2)
+
+	const n = 10
+	for i := 0; i < n; i++ {
+		w.Write(Key([]byte{byte(i)}), []byte("data"))
+	}
+
+	// Wait for drain without relying on Close timing.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if w.Queued.Load() > 0 || w.Completed.Load()+w.Failed.Load() >= n {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	w.Close()
+
+	total := w.Completed.Load() + w.Failed.Load()
+	if total != int64(n) {
+		t.Errorf("completed+failed = %d, want %d", total, n)
+	}
+}

--- a/internal/cache/kinds.go
+++ b/internal/cache/kinds.go
@@ -1,0 +1,42 @@
+package cache
+
+// Well-known cache kind names. Each must match the subdirectory name under
+// the versioned root. Using constants avoids typos across callers.
+const (
+	KindDetect  = "detect"
+	KindHprof   = "hprof"
+	KindJFR     = "jfr"
+	KindThreads = "threads"
+	KindSamples = "samples"
+	KindNetcap  = "netcap"
+)
+
+// Stores holds the concrete ShardedStore instances for every kind.
+// Callers that need to read or write a specific kind use these directly;
+// the Registry is only for CLI-level stats/clear.
+type Stores struct {
+	Detect  *ShardedStore
+	Hprof   *ShardedStore
+	JFR     *ShardedStore
+	Threads *ShardedStore
+	Samples *ShardedStore
+	Netcap  *ShardedStore
+}
+
+// NewStores creates all ShardedStores under versionedRoot and registers
+// them in the provided Registry.
+func NewStores(versionedRoot string, reg *Registry) *Stores {
+	mk := func(kind string) *ShardedStore {
+		s := NewShardedStore(versionedRoot, kind)
+		reg.RegisterStore(s)
+		return s
+	}
+	return &Stores{
+		Detect:  mk(KindDetect),
+		Hprof:   mk(KindHprof),
+		JFR:     mk(KindJFR),
+		Threads: mk(KindThreads),
+		Samples: mk(KindSamples),
+		Netcap:  mk(KindNetcap),
+	}
+}

--- a/internal/cache/registry.go
+++ b/internal/cache/registry.go
@@ -1,0 +1,94 @@
+package cache
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// Registry tracks all registered cache kinds. Each kind registers itself
+// with a Clear and Stats function; the CLI then exposes uniform
+// `spectra cache stats` and `spectra cache clear` without per-kind code.
+type Registry struct {
+	mu    sync.RWMutex
+	kinds map[string]entry
+}
+
+type entry struct {
+	clear func() error
+	stats func() (StoreStats, error)
+}
+
+// Default is the package-level registry all stores register into.
+var Default = &Registry{kinds: map[string]entry{}}
+
+// Register adds a cache kind to the registry. Duplicate names overwrite.
+func (r *Registry) Register(name string, clearFn func() error, statsFn func() (StoreStats, error)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.kinds[name] = entry{clear: clearFn, stats: statsFn}
+}
+
+// RegisterStore is a convenience helper that registers a ShardedStore
+// under its directory name.
+func (r *Registry) RegisterStore(s *ShardedStore) {
+	name := filepath.Base(s.root)
+	r.Register(name, s.Clear, s.Stats)
+}
+
+// Stats returns stats for all registered kinds, sorted by name.
+func (r *Registry) Stats() ([]StoreStats, error) {
+	r.mu.RLock()
+	names := make([]string, 0, len(r.kinds))
+	for k := range r.kinds {
+		names = append(names, k)
+	}
+	r.mu.RUnlock()
+
+	sort.Strings(names)
+	out := make([]StoreStats, 0, len(names))
+	for _, name := range names {
+		r.mu.RLock()
+		e := r.kinds[name]
+		r.mu.RUnlock()
+
+		st, err := e.stats()
+		if err != nil {
+			return nil, fmt.Errorf("cache stats %q: %w", name, err)
+		}
+		out = append(out, st)
+	}
+	return out, nil
+}
+
+// Clear removes all data for the named kind (or every kind when name=="").
+func (r *Registry) Clear(name string) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if name != "" {
+		e, ok := r.kinds[name]
+		if !ok {
+			return fmt.Errorf("cache: unknown kind %q", name)
+		}
+		return e.clear()
+	}
+	for _, e := range r.kinds {
+		if err := e.clear(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Names returns registered kind names sorted.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.kinds))
+	for k := range r.kinds {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/cache/registry_test.go
+++ b/internal/cache/registry_test.go
@@ -1,0 +1,93 @@
+package cache
+
+import (
+	"errors"
+	"testing"
+)
+
+func newTestRegistry() *Registry {
+	return &Registry{kinds: map[string]entry{}}
+}
+
+func TestRegistryRegisterAndStats(t *testing.T) {
+	reg := newTestRegistry()
+	s := newTestStore(t, "detect")
+	reg.RegisterStore(s)
+
+	_ = s.Put(Key([]byte("x")), []byte("data"))
+
+	stats, err := reg.Stats()
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("got %d stat rows, want 1", len(stats))
+	}
+	if stats[0].Entries != 1 {
+		t.Errorf("Entries = %d, want 1", stats[0].Entries)
+	}
+}
+
+func TestRegistryClearByName(t *testing.T) {
+	reg := newTestRegistry()
+	s := newTestStore(t, "detect")
+	reg.RegisterStore(s)
+	_ = s.Put(Key([]byte("y")), []byte("data"))
+
+	if err := reg.Clear("detect"); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := s.Stats()
+	if st.Entries != 0 {
+		t.Errorf("after Clear(detect), Entries = %d", st.Entries)
+	}
+}
+
+func TestRegistryClearAll(t *testing.T) {
+	reg := newTestRegistry()
+	s1 := newTestStore(t, "detect")
+	s2 := newTestStore(t, "hprof")
+	reg.RegisterStore(s1)
+	reg.RegisterStore(s2)
+	_ = s1.Put(Key([]byte("1")), []byte("x"))
+	_ = s2.Put(Key([]byte("2")), []byte("y"))
+
+	if err := reg.Clear(""); err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range []*ShardedStore{s1, s2} {
+		st, _ := s.Stats()
+		if st.Entries != 0 {
+			t.Errorf("Entries = %d after clear-all", st.Entries)
+		}
+	}
+}
+
+func TestRegistryClearUnknown(t *testing.T) {
+	reg := newTestRegistry()
+	err := reg.Clear("no-such-kind")
+	if err == nil {
+		t.Error("expected error clearing unknown kind")
+	}
+}
+
+func TestRegistryNames(t *testing.T) {
+	reg := newTestRegistry()
+	reg.Register("bravo", func() error { return nil }, func() (StoreStats, error) { return StoreStats{}, nil })
+	reg.Register("alpha", func() error { return nil }, func() (StoreStats, error) { return StoreStats{}, nil })
+	names := reg.Names()
+	if len(names) != 2 || names[0] != "alpha" || names[1] != "bravo" {
+		t.Errorf("Names = %v, want [alpha bravo]", names)
+	}
+}
+
+func TestRegistryStatsPropagatesError(t *testing.T) {
+	reg := newTestRegistry()
+	reg.Register("bad", func() error { return nil }, func() (StoreStats, error) {
+		return StoreStats{}, errors.New("stats failed")
+	})
+	_, err := reg.Stats()
+	if err == nil {
+		t.Error("expected error from Stats when a kind errors")
+	}
+}

--- a/internal/cache/sharded.go
+++ b/internal/cache/sharded.go
@@ -1,0 +1,160 @@
+// Package cache implements the two-level hash-sharded blob store described in
+// docs/design/storage.md (Tier 2) and docs/operations/caching.md.
+//
+// Layout:
+//
+//	~/.cache/spectra/v1/<kind>/<hash[:2]>/<hash[2:]>
+//
+// Two-level sharding keeps no directory above 256 entries at scale.
+// Writes are atomic via tempfile-rename. Read/write are goroutine-safe.
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ShardedStore is a content-addressed file store for one cache kind.
+// Multiple ShardedStores share one versioned root (e.g. ~/.cache/spectra/v1).
+type ShardedStore struct {
+	root string // absolute path to <versionedRoot>/<kind>
+}
+
+// NewShardedStore returns a store rooted at <versionedRoot>/<kind>.
+// The directory is created on first Put, not here.
+func NewShardedStore(versionedRoot, kind string) *ShardedStore {
+	return &ShardedStore{root: filepath.Join(versionedRoot, kind)}
+}
+
+// Key hashes arbitrary bytes to a hex string used as the file path.
+func Key(b ...[]byte) []byte {
+	h := sha256.New()
+	for _, chunk := range b {
+		h.Write(chunk)
+	}
+	return h.Sum(nil)
+}
+
+// path returns the absolute path for a given raw key.
+func (s *ShardedStore) path(key []byte) string {
+	hex := hex.EncodeToString(key)
+	return filepath.Join(s.root, hex[:2], hex[2:])
+}
+
+// Put writes data to the store under key. The write is atomic:
+// data is written to a temp file in the same directory, then renamed.
+func (s *ShardedStore) Put(key, data []byte) error {
+	dest := s.path(key)
+	dir := filepath.Dir(dest)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("cache: mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".tmp-")
+	if err != nil {
+		return fmt.Errorf("cache: temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("cache: write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, dest)
+}
+
+// Get retrieves data for key. Returns (nil, false, nil) on cache miss.
+func (s *ShardedStore) Get(key []byte) ([]byte, bool, error) {
+	data, err := os.ReadFile(s.path(key))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+// Has reports whether a key exists without reading the full file.
+func (s *ShardedStore) Has(key []byte) bool {
+	_, err := os.Stat(s.path(key))
+	return err == nil
+}
+
+// Stats returns aggregate statistics for this store kind.
+func (s *ShardedStore) Stats() (StoreStats, error) {
+	var st StoreStats
+	st.Kind = filepath.Base(s.root)
+	err := filepath.WalkDir(s.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		st.Entries++
+		st.BytesOnDisk += info.Size()
+		if info.ModTime().After(st.LastWrite) {
+			st.LastWrite = info.ModTime()
+		}
+		return nil
+	})
+	if errors.Is(err, fs.ErrNotExist) {
+		return st, nil
+	}
+	return st, err
+}
+
+// Clear removes all files in this store. The root directory itself is kept.
+func (s *ShardedStore) Clear() error {
+	entries, err := os.ReadDir(s.root)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if err := os.RemoveAll(filepath.Join(s.root, e.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// StoreStats is the aggregate stats for one cache kind.
+type StoreStats struct {
+	Kind        string
+	Entries     int64
+	BytesOnDisk int64
+	LastWrite   time.Time
+}
+
+// DefaultRoot returns the default versioned root: ~/.cache/spectra/v1.
+func DefaultRoot() (string, error) {
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cache, "spectra", "v1"), nil
+}
+
+// ReadAt returns an io.ReadCloser for the file at path. Useful for large blobs.
+func (s *ShardedStore) ReadAt(key []byte) (io.ReadCloser, error) {
+	f, err := os.Open(s.path(key))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	return f, err
+}

--- a/internal/cache/sharded_test.go
+++ b/internal/cache/sharded_test.go
@@ -1,0 +1,139 @@
+package cache
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestStore(t *testing.T, kind string) *ShardedStore {
+	t.Helper()
+	return NewShardedStore(t.TempDir(), kind)
+}
+
+func TestPutGet(t *testing.T) {
+	s := newTestStore(t, "detect")
+	key := Key([]byte("test-app-v1"))
+	data := []byte(`{"ui":"Electron"}`)
+
+	if err := s.Put(key, data); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok, err := s.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("cache miss, want hit")
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("Get = %q, want %q", got, data)
+	}
+}
+
+func TestGetMiss(t *testing.T) {
+	s := newTestStore(t, "detect")
+	got, ok, err := s.Get(Key([]byte("not-there")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Errorf("expected miss, got %q", got)
+	}
+}
+
+func TestHas(t *testing.T) {
+	s := newTestStore(t, "detect")
+	key := Key([]byte("has-test"))
+	if s.Has(key) {
+		t.Error("Has: want false before Put")
+	}
+	_ = s.Put(key, []byte("x"))
+	if !s.Has(key) {
+		t.Error("Has: want true after Put")
+	}
+}
+
+func TestPutIdempotent(t *testing.T) {
+	s := newTestStore(t, "detect")
+	key := Key([]byte("idempotent"))
+	_ = s.Put(key, []byte("payload"))
+	if err := s.Put(key, []byte("payload")); err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+}
+
+func TestStats(t *testing.T) {
+	s := newTestStore(t, "detect")
+
+	st, _ := s.Stats()
+	if st.Entries != 0 {
+		t.Errorf("empty store: Entries = %d, want 0", st.Entries)
+	}
+
+	for i := 0; i < 5; i++ {
+		_ = s.Put(Key([]byte{byte(i)}), []byte("payload"))
+	}
+	st, err := s.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Entries != 5 {
+		t.Errorf("Entries = %d, want 5", st.Entries)
+	}
+	if st.BytesOnDisk == 0 {
+		t.Error("BytesOnDisk should be > 0")
+	}
+	if st.LastWrite.IsZero() {
+		t.Error("LastWrite should not be zero")
+	}
+}
+
+func TestClear(t *testing.T) {
+	s := newTestStore(t, "detect")
+	for i := 0; i < 3; i++ {
+		_ = s.Put(Key([]byte{byte(i)}), []byte("x"))
+	}
+	if err := s.Clear(); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	st, _ := s.Stats()
+	if st.Entries != 0 {
+		t.Errorf("after Clear, Entries = %d, want 0", st.Entries)
+	}
+}
+
+func TestClearEmptyStore(t *testing.T) {
+	s := newTestStore(t, "detect")
+	if err := s.Clear(); err != nil {
+		t.Errorf("Clear on non-existent store: %v", err)
+	}
+}
+
+func TestTwoLevelSharding(t *testing.T) {
+	root := t.TempDir()
+	s := NewShardedStore(root, "detect")
+	key := Key([]byte("sharding-test"))
+	_ = s.Put(key, []byte("payload"))
+
+	// Verify file lives at <root>/detect/<2 hex chars>/<remaining hex>
+	h := sha256.Sum256([]byte("sharding-test"))
+	hexStr := hex.EncodeToString(h[:])
+	expected := filepath.Join(root, "detect", hexStr[:2], hexStr[2:])
+	if _, err := os.Stat(expected); err != nil {
+		t.Errorf("expected shard file at %s: %v", expected, err)
+	}
+}
+
+func TestKeyFunction(t *testing.T) {
+	// Key(a+b) == Key(a, b) is NOT guaranteed — Key concatenates inputs.
+	k1 := Key([]byte("hello world"))
+	k2 := Key([]byte("hello"), []byte(" world"))
+	// They feed the same bytes to SHA-256 so they should be equal.
+	if !bytes.Equal(k1, k2) {
+		t.Error("Key should produce same hash for same byte sequence")
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/cache`: two-level hash-sharded content-addressed blob store modeled after krit
- **ShardedStore** — atomic `Put` (tempfile-rename), `Get`, `Has`, `Stats`, `Clear`; `DefaultRoot` → `~/.cache/spectra/v1`
- **Registry** — uniform stats/clear for all cache kinds; `RegisterStore` convenience; no per-kind CLI code needed
- **AsyncWriter** — bounded queue + worker pool background flushes; synchronous fallback on full queue; atomic counters; idempotent `Close()`
- **Kinds** — `detect`, `hprof`, `jfr`, `threads`, `samples`, `netcap` constants + `NewStores` factory
- **`spectra cache stats`** and **`spectra cache clear [--kind <name>]`** subcommands

## Test plan

- [ ] 19 tests covering sharding layout, idempotency, queue-full fallback, counter correctness
- [ ] `go test ./... -race` passes
- [ ] `go build ./...` clean