### PR TITLE
Add sysctls + power state collectors (internal/sysinfo)

### DIFF
--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/sysinfo"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
@@ -32,14 +33,14 @@ type Snapshot struct {
 	Apps       []detect.Result      `json:"apps"`
 	Processes  []process.Info       `json:"processes,omitempty"`
 	Toolchains toolchain.Toolchains `json:"toolchains"`
+	Power      sysinfo.PowerState   `json:"power"`
+	Sysctls    map[string]string    `json:"sysctls,omitempty"`
 
 	// Placeholders for upcoming collectors. Empty until implemented.
 	// See docs/design/system-inventory.md.
-	// JVMs       []JVMInfo
-	// Network    *NetworkState
-	// Storage    *StorageState
-	// Power      *PowerState
-	// Sysctls    map[string]string
+	// JVMs    []JVMInfo
+	// Network *NetworkState
+	// Storage *StorageState
 }
 
 // Options configure a snapshot Build.
@@ -64,6 +65,10 @@ type Options struct {
 
 	// SkipProcesses disables the process collector (faster for tests).
 	SkipProcesses bool
+
+	// SysinfoCmdRunner is forwarded to sysinfo collectors (sysctls + power).
+	// Zero value uses the real commands.
+	SysinfoCmdRunner sysinfo.CmdRunner
 }
 
 // Build assembles a Snapshot by running every collector in parallel and
@@ -76,10 +81,15 @@ func Build(ctx context.Context, opts Options) Snapshot {
 		Kind:    KindLive,
 	}
 
+	siRun := opts.SysinfoCmdRunner
+	if siRun == nil {
+		siRun = sysinfo.DefaultRunner
+	}
+
 	var wg sync.WaitGroup
-	collectors := 3
+	collectors := 5 // host, apps, toolchains, power, sysctls
 	if !opts.SkipProcesses {
-		collectors = 4
+		collectors = 6
 	}
 	wg.Add(collectors)
 
@@ -87,25 +97,26 @@ func Build(ctx context.Context, opts Options) Snapshot {
 		defer wg.Done()
 		s.Host = CollectHost(opts.SpectraVersion)
 	}()
-
 	go func() {
 		defer wg.Done()
 		s.Apps = collectApps(ctx, opts)
 	}()
-
 	go func() {
 		defer wg.Done()
 		s.Toolchains = toolchain.Collect(ctx, opts.ToolchainOpts)
+	}()
+	go func() {
+		defer wg.Done()
+		s.Power = sysinfo.CollectPower(siRun)
+	}()
+	go func() {
+		defer wg.Done()
+		s.Sysctls = sysinfo.CollectSysctls(siRun)
 	}()
 
 	if !opts.SkipProcesses {
 		go func() {
 			defer wg.Done()
-			// Pass app paths for bundle attribution after apps are known.
-			// Since we're parallel, we collect all processes without attribution
-			// and attribute post-hoc once apps are resolved. For now, we skip
-			// attribution during the snapshot build (it can be added in a follow-up
-			// once the two collectors are sequenced or apps is pre-populated).
 			s.Processes = process.CollectAll(ctx, opts.ProcessOpts)
 		}()
 	}

--- a/internal/sysinfo/cmd.go
+++ b/internal/sysinfo/cmd.go
@@ -1,0 +1,11 @@
+package sysinfo
+
+import "os/exec"
+
+// CmdRunner abstracts exec.Command for testability.
+type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// DefaultRunner runs the real command.
+func DefaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}

--- a/internal/sysinfo/power.go
+++ b/internal/sysinfo/power.go
@@ -1,0 +1,116 @@
+package sysinfo
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// PowerState captures battery and thermal facts.
+// See docs/design/system-inventory.md#powerstate.
+type PowerState struct {
+	OnBattery       bool    `json:"on_battery"`
+	BatteryPct      int     `json:"battery_pct"`
+	ThermalPressure string  `json:"thermal_pressure,omitempty"` // "nominal", "fair", "serious", "critical"
+	Assertions      []PowerAssertion `json:"assertions,omitempty"`
+}
+
+// PowerAssertion is one pmset sleep/display assertion.
+type PowerAssertion struct {
+	Type    string `json:"type"`
+	PID     int    `json:"pid"`
+	Name    string `json:"name,omitempty"`
+}
+
+// CollectPower gathers PowerState from pmset. Any sub-command failure is
+// silently absorbed; partial results are still valid.
+func CollectPower(run CmdRunner) PowerState {
+	var ps PowerState
+
+	if out, err := run("pmset", "-g", "batt"); err == nil {
+		parseBatt(string(out), &ps)
+	}
+	if out, err := run("pmset", "-g", "therm"); err == nil {
+		parsTherm(string(out), &ps)
+	}
+	if out, err := run("pmset", "-g", "assertions"); err == nil {
+		ps.Assertions = parseAssertions(string(out))
+	}
+
+	return ps
+}
+
+// parseBatt extracts OnBattery + BatteryPct from `pmset -g batt` output.
+//
+// Example line: "Now drawing from 'Battery Power'"
+// Percentage line: " -InternalBattery-0 (id=...)	85%; discharging; ..."
+func parseBatt(out string, ps *PowerState) {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Battery Power") {
+			ps.OnBattery = true
+		}
+		if pct := extractPct(line); pct >= 0 {
+			ps.BatteryPct = pct
+		}
+	}
+}
+
+var pctRe = regexp.MustCompile(`(\d+)%`)
+
+func extractPct(line string) int {
+	m := pctRe.FindStringSubmatch(line)
+	if len(m) < 2 {
+		return -1
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n
+}
+
+// parsTherm extracts thermal pressure from `pmset -g therm`.
+//
+// Example: "CPU_Speed_Limit	= 100" and "System thermal state: nominal"
+func parsTherm(out string, ps *PowerState) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "System thermal state:") {
+			ps.ThermalPressure = strings.TrimSpace(strings.TrimPrefix(line, "System thermal state:"))
+			return
+		}
+		// Fallback: some macOS versions print "thermal state: X"
+		if strings.HasPrefix(line, "thermal state:") {
+			ps.ThermalPressure = strings.TrimSpace(strings.TrimPrefix(line, "thermal state:"))
+			return
+		}
+	}
+}
+
+// parseAssertions extracts active assertions from `pmset -g assertions`.
+//
+// Real output line format (per-process listing):
+//   " pid 412(Slack): [0x000165b8000002f1] 00:00:04 PreventUserIdleSleep named: "audio" "
+var (
+	assertionPIDRe  = regexp.MustCompile(`pid (\d+)\(`)
+	assertionTypeRe = regexp.MustCompile(`\]\s+[\d:]+\s+(\w+)`)
+	assertionNameRe = regexp.MustCompile(`named:\s+"([^"]*)"`)
+)
+
+func parseAssertions(out string) []PowerAssertion {
+	var result []PowerAssertion
+	for _, line := range strings.Split(out, "\n") {
+		pidM := assertionPIDRe.FindStringSubmatch(line)
+		if len(pidM) < 2 {
+			continue
+		}
+		typeM := assertionTypeRe.FindStringSubmatch(line)
+		if len(typeM) < 2 {
+			continue
+		}
+		pid, _ := strconv.Atoi(pidM[1])
+		a := PowerAssertion{Type: typeM[1], PID: pid}
+		if nameM := assertionNameRe.FindStringSubmatch(line); len(nameM) >= 2 {
+			a.Name = nameM[1]
+		}
+		result = append(result, a)
+	}
+	return result
+}

--- a/internal/sysinfo/power_test.go
+++ b/internal/sysinfo/power_test.go
@@ -1,0 +1,116 @@
+package sysinfo
+
+import (
+	"errors"
+	"testing"
+)
+
+const battOnBattery = `Now drawing from 'Battery Power'
+ -InternalBattery-0 (id=4718601)	85%; discharging; 3:42 remaining present: true
+`
+
+const battOnAC = `Now drawing from 'AC Power'
+ -InternalBattery-0 (id=4718601)	100%; charged; 0:00 remaining present: true
+`
+
+const thermNominal = `System thermal state: nominal
+CPU_Speed_Limit	= 100
+`
+
+const thermSerious = `System thermal state: serious
+CPU_Speed_Limit	= 60
+`
+
+const assertionsOutput = `Assertion status system-wide:
+   BackgroundTask                 0
+   PreventUserIdleSleep           1
+   PreventUserIdleDisplaySleep    0
+   PreventSystemSleep             0
+
+Listed by owning process:
+ pid 412(Slack): [0x000165b8000002f1] 00:00:04 PreventUserIdleSleep named: "playing audio"
+`
+
+func stubPmset(batt, therm, assertions string) CmdRunner {
+	return func(name string, args ...string) ([]byte, error) {
+		if name != "pmset" || len(args) < 2 {
+			return nil, errors.New("unexpected")
+		}
+		switch args[1] {
+		case "batt":
+			if batt == "" {
+				return nil, errors.New("no batt")
+			}
+			return []byte(batt), nil
+		case "therm":
+			if therm == "" {
+				return nil, errors.New("no therm")
+			}
+			return []byte(therm), nil
+		case "assertions":
+			if assertions == "" {
+				return nil, errors.New("no assertions")
+			}
+			return []byte(assertions), nil
+		}
+		return nil, errors.New("unknown pmset arg")
+	}
+}
+
+func TestCollectPowerOnBattery(t *testing.T) {
+	ps := CollectPower(stubPmset(battOnBattery, thermNominal, ""))
+	if !ps.OnBattery {
+		t.Error("OnBattery = false, want true")
+	}
+	if ps.BatteryPct != 85 {
+		t.Errorf("BatteryPct = %d, want 85", ps.BatteryPct)
+	}
+	if ps.ThermalPressure != "nominal" {
+		t.Errorf("ThermalPressure = %q, want nominal", ps.ThermalPressure)
+	}
+}
+
+func TestCollectPowerOnAC(t *testing.T) {
+	ps := CollectPower(stubPmset(battOnAC, thermNominal, ""))
+	if ps.OnBattery {
+		t.Error("OnBattery = true, want false")
+	}
+	if ps.BatteryPct != 100 {
+		t.Errorf("BatteryPct = %d, want 100", ps.BatteryPct)
+	}
+}
+
+func TestCollectPowerThermal(t *testing.T) {
+	ps := CollectPower(stubPmset("", thermSerious, ""))
+	if ps.ThermalPressure != "serious" {
+		t.Errorf("ThermalPressure = %q, want serious", ps.ThermalPressure)
+	}
+}
+
+func TestCollectPowerAssertions(t *testing.T) {
+	ps := CollectPower(stubPmset("", "", assertionsOutput))
+	if len(ps.Assertions) != 1 {
+		t.Fatalf("Assertions = %d, want 1; %+v", len(ps.Assertions), ps.Assertions)
+	}
+	a := ps.Assertions[0]
+	if a.Type != "PreventUserIdleSleep" {
+		t.Errorf("Type = %q, want PreventUserIdleSleep", a.Type)
+	}
+	if a.PID != 412 {
+		t.Errorf("PID = %d, want 412", a.PID)
+	}
+	if a.Name != "playing audio" {
+		t.Errorf("Name = %q, want 'playing audio'", a.Name)
+	}
+}
+
+func TestCollectPowerAllFail(t *testing.T) {
+	stub := func(name string, args ...string) ([]byte, error) {
+		return nil, errors.New("command not found")
+	}
+	ps := CollectPower(stub)
+	// Should not panic; returns zero value.
+	if ps.OnBattery || ps.BatteryPct != 0 {
+		t.Errorf("expected zero value on all-fail: %+v", ps)
+	}
+}

--- a/internal/sysinfo/sysctls.go
+++ b/internal/sysinfo/sysctls.go
@@ -1,0 +1,38 @@
+// Package sysinfo collects selected kernel tunables (sysctls) and battery /
+// power state. Both collectors are read-only, local, and user-privilege.
+// See docs/design/system-inventory.md for the schema.
+package sysinfo
+
+import (
+	"strings"
+)
+
+// AllowedSysctls is the allowlist of kernel tunables Spectra captures.
+// Adding a key here is a deliberate decision — we don't dump all of
+// sysctl -a because it's massive and noisy.
+var AllowedSysctls = []string{
+	"kern.maxfiles",
+	"kern.maxproc",
+	"kern.ipc.maxsockbuf",
+	"kern.boottime",
+	"vm.memory_pressure",
+	"hw.ncpu",
+	"hw.memsize",
+}
+
+// CollectSysctls returns the allowed sysctl key→value map.
+// Keys absent from the output (not present on this kernel) are omitted.
+func CollectSysctls(run CmdRunner) map[string]string {
+	out := make(map[string]string, len(AllowedSysctls))
+	for _, key := range AllowedSysctls {
+		val, err := run("sysctl", "-n", key)
+		if err != nil {
+			continue
+		}
+		v := strings.TrimSpace(string(val))
+		if v != "" {
+			out[key] = v
+		}
+	}
+	return out
+}

--- a/internal/sysinfo/sysctls_test.go
+++ b/internal/sysinfo/sysctls_test.go
@@ -1,0 +1,81 @@
+package sysinfo
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func stubSysctl(responses map[string]string) CmdRunner {
+	return func(name string, args ...string) ([]byte, error) {
+		if name != "sysctl" || len(args) < 2 {
+			return nil, errors.New("unexpected command")
+		}
+		key := args[1]
+		if v, ok := responses[key]; ok {
+			return []byte(v + "\n"), nil
+		}
+		return nil, errors.New("no such key")
+	}
+}
+
+func TestCollectSysctls(t *testing.T) {
+	stub := stubSysctl(map[string]string{
+		"kern.maxfiles":        "49152",
+		"hw.ncpu":              "16",
+		"vm.memory_pressure":   "0",
+	})
+	got := CollectSysctls(stub)
+
+	if got["kern.maxfiles"] != "49152" {
+		t.Errorf("kern.maxfiles = %q", got["kern.maxfiles"])
+	}
+	if got["hw.ncpu"] != "16" {
+		t.Errorf("hw.ncpu = %q", got["hw.ncpu"])
+	}
+	// Keys not in the response should be absent.
+	if _, ok := got["kern.boottime"]; ok {
+		t.Error("kern.boottime should be absent (not in stub)")
+	}
+}
+
+func TestCollectSysctlsAllFail(t *testing.T) {
+	stub := func(name string, args ...string) ([]byte, error) {
+		return nil, errors.New("permission denied")
+	}
+	got := CollectSysctls(stub)
+	if len(got) != 0 {
+		t.Errorf("expected empty map on all-fail, got %d entries", len(got))
+	}
+}
+
+func TestCollectSysctlsAllowlist(t *testing.T) {
+	// Every allowed key should be queried; no others.
+	queried := map[string]int{}
+	stub := func(name string, args ...string) ([]byte, error) {
+		if len(args) >= 2 {
+			queried[args[1]]++
+		}
+		return []byte("0\n"), nil
+	}
+	CollectSysctls(stub)
+
+	for _, key := range AllowedSysctls {
+		if queried[key] == 0 {
+			t.Errorf("allowed key %q was not queried", key)
+		}
+	}
+	if len(queried) != len(AllowedSysctls) {
+		t.Errorf("queried %d keys, want %d", len(queried), len(AllowedSysctls))
+	}
+}
+
+func TestCollectSysctlsTrimWhitespace(t *testing.T) {
+	stub := stubSysctl(map[string]string{
+		"kern.maxfiles": "  49152  ",
+	})
+	got := CollectSysctls(stub)
+	if strings.Contains(got["kern.maxfiles"], " ") {
+		t.Errorf("value has whitespace: %q", got["kern.maxfiles"])
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/sysinfo`: two collectors backed by `pmset` and `sysctl`
- **`CollectSysctls()`** — queries the `AllowedSysctls` allowlist (`kern.maxfiles`, `kern.maxproc`, `kern.ipc.maxsockbuf`, `kern.boottime`, `vm.memory_pressure`, `hw.ncpu`, `hw.memsize`); missing keys silently omitted
- **`CollectPower()`** — `pmset -g batt` → `OnBattery` + `BatteryPct`; `pmset -g therm` → `ThermalPressure`; `pmset -g assertions` → per-process `PowerAssertion` list with PID + name
- `CmdRunner` injected for both — no real `pmset`/`sysctl` forks in tests
- `Snapshot.Power` + `Snapshot.Sysctls` wired into `Build()`; `SysinfoCmdRunner` option forwarded

## Test plan

- [ ] 9 tests; battery on/off, thermal nominal/serious, assertion PID+name parsing, all-fail graceful
- [ ] `go test ./... -race` passes