### PR TITLE
Add network state collector (internal/netstate)

### DIFF
--- a/internal/netstate/netstate.go
+++ b/internal/netstate/netstate.go
@@ -1,0 +1,257 @@
+// Package netstate captures a point-in-time snapshot of the machine's
+// network configuration: default route, DNS resolvers, proxy settings,
+// /etc/hosts overrides, and current listening ports.
+//
+// All collection is user-privilege, read-only, no network I/O.
+// See docs/design/system-inventory.md#networkstate.
+package netstate
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// State is the NetworkState slice of a Spectra snapshot.
+type State struct {
+	DefaultRouteIface string            `json:"default_route_iface,omitempty"`
+	DefaultRouteGW    string            `json:"default_route_gw,omitempty"`
+	DNSServers        []string          `json:"dns_servers,omitempty"`
+	Proxy             ProxyConfig       `json:"proxy"`
+	HostsOverrides    []HostsEntry      `json:"hosts_overrides,omitempty"`
+	ListeningPorts    []ListeningPort   `json:"listening_ports,omitempty"`
+}
+
+// ProxyConfig is the system HTTP/HTTPS/SOCKS proxy configuration.
+type ProxyConfig struct {
+	HTTP  string `json:"http,omitempty"`
+	HTTPS string `json:"https,omitempty"`
+	SOCKS string `json:"socks,omitempty"`
+}
+
+// HostsEntry is one non-default line from /etc/hosts.
+type HostsEntry struct {
+	IP      string   `json:"ip"`
+	Names   []string `json:"names"`
+}
+
+// ListeningPort is one TCP/UDP socket currently bound on the machine.
+type ListeningPort struct {
+	Port    int    `json:"port"`
+	Proto   string `json:"proto"` // "tcp", "udp"
+	PID     int    `json:"pid,omitempty"`
+	AppPath string `json:"app_path,omitempty"`
+}
+
+// CmdRunner abstracts shell-out for testability.
+type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// DefaultRunner runs the real command.
+func DefaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// Collect gathers network state. Any sub-command failure is silently
+// absorbed; partial results are still valid.
+func Collect(run CmdRunner) State {
+	var s State
+	if out, err := run("route", "-n", "get", "default"); err == nil {
+		s.DefaultRouteIface, s.DefaultRouteGW = parseRoute(string(out))
+	}
+	if out, err := run("scutil", "--dns"); err == nil {
+		s.DNSServers = parseDNS(string(out))
+	}
+	if out, err := run("scutil", "--proxy"); err == nil {
+		s.Proxy = parseProxy(string(out))
+	}
+	s.HostsOverrides = readHostsOverrides("/etc/hosts")
+	if out, err := run("lsof", "-i", "-P", "-n", "-sTCP:LISTEN"); err == nil {
+		s.ListeningPorts = parseLSOFListen(string(out))
+	}
+	return s
+}
+
+// parseRoute extracts interface and gateway from `route -n get default`.
+//
+// Example:
+//
+//	interface: en0
+//	gateway: 192.168.1.1
+func parseRoute(out string) (iface, gw string) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if k, v, ok := strings.Cut(line, ":"); ok {
+			k = strings.TrimSpace(k)
+			v = strings.TrimSpace(v)
+			switch k {
+			case "interface":
+				iface = v
+			case "gateway":
+				gw = v
+			}
+		}
+	}
+	return
+}
+
+// parseDNS extracts unique nameserver addresses from `scutil --dns`.
+//
+// Example relevant lines: "nameserver[0] : 8.8.8.8"
+func parseDNS(out string) []string {
+	seen := map[string]bool{}
+	var result []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "nameserver") {
+			continue
+		}
+		_, v, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		ip := strings.TrimSpace(v)
+		if ip != "" && !seen[ip] {
+			seen[ip] = true
+			result = append(result, ip)
+		}
+	}
+	return result
+}
+
+// parseProxy extracts HTTP/HTTPS/SOCKS proxy settings from `scutil --proxy`.
+//
+// Example:
+//
+//	HTTPSEnable : 1
+//	HTTPSProxy : proxy.example.com
+//	HTTPSPort  : 8080
+func parseProxy(out string) ProxyConfig {
+	kv := scutilKV(out)
+	var pc ProxyConfig
+	if kv["HTTPEnable"] == "1" {
+		pc.HTTP = kv["HTTPProxy"] + portSuffix(kv["HTTPPort"])
+	}
+	if kv["HTTPSEnable"] == "1" {
+		pc.HTTPS = kv["HTTPSProxy"] + portSuffix(kv["HTTPSPort"])
+	}
+	if kv["SOCKSEnable"] == "1" {
+		pc.SOCKS = kv["SOCKSProxy"] + portSuffix(kv["SOCKSPort"])
+	}
+	return pc
+}
+
+func portSuffix(port string) string {
+	if port == "" || port == "0" {
+		return ""
+	}
+	return ":" + port
+}
+
+// scutilKV parses "Key : Value" lines from scutil output into a map.
+func scutilKV(out string) map[string]string {
+	m := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		k, v, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		m[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return m
+}
+
+// readHostsOverrides reads /etc/hosts and returns non-default, non-comment
+// lines. hostsPath is parameterised for testing.
+func readHostsOverrides(hostsPath string) []HostsEntry {
+	// Default macOS /etc/hosts entries — skip these.
+	defaults := map[string]bool{
+		"127.0.0.1":   true,
+		"255.255.255.255": true,
+		"::1":         true,
+		"fe80::1%lo0": true,
+	}
+
+	f, err := os.Open(hostsPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var entries []HostsEntry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		ip := fields[0]
+		if defaults[ip] {
+			continue
+		}
+		entries = append(entries, HostsEntry{IP: ip, Names: fields[1:]})
+	}
+	return entries
+}
+
+// parseLSOFListen parses `lsof -i -P -n -sTCP:LISTEN` for listening ports.
+//
+// Relevant line format:
+//
+//	com.apple.WebKit  412   alice  29u  IPv4  ...  TCP *:8080 (LISTEN)
+func parseLSOFListen(out string) []ListeningPort {
+	var ports []ListeningPort
+	seen := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		// Need at least: command pid user fd type ... name(LISTEN)
+		if len(fields) < 9 {
+			continue
+		}
+		addrField := fields[8]
+		if !strings.HasSuffix(addrField, "(LISTEN)") {
+			// Some lsof versions put (LISTEN) in a separate column.
+			found := false
+			for _, f := range fields {
+				if f == "(LISTEN)" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		// Address is the field before (LISTEN): "TCP *:8080" or "*:8080"
+		addr := strings.TrimSuffix(addrField, "(LISTEN)")
+		addr = strings.TrimSpace(addr)
+		if idx := strings.LastIndex(addr, ":"); idx >= 0 {
+			portStr := addr[idx+1:]
+			if seen[portStr] {
+				continue
+			}
+			seen[portStr] = true
+			port := parsePort(portStr)
+			if port > 0 {
+				ports = append(ports, ListeningPort{Port: port, Proto: "tcp"})
+			}
+		}
+	}
+	return ports
+}
+
+func parsePort(s string) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/internal/netstate/netstate_test.go
+++ b/internal/netstate/netstate_test.go
@@ -1,0 +1,176 @@
+package netstate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRoute(t *testing.T) {
+	out := `   route to: default
+destination: default
+       mask: default
+    gateway: 192.168.1.1
+  interface: en0
+      flags: <UP,GATEWAY,DONE,STATIC,PRCLONING,GLOBAL>
+`
+	iface, gw := parseRoute(out)
+	if iface != "en0" {
+		t.Errorf("iface = %q, want en0", iface)
+	}
+	if gw != "192.168.1.1" {
+		t.Errorf("gw = %q, want 192.168.1.1", gw)
+	}
+}
+
+func TestParseDNS(t *testing.T) {
+	out := `DNS configuration
+
+resolver #1
+  nameserver[0] : 8.8.8.8
+  nameserver[1] : 8.8.4.4
+  flags    : Request A records, Request AAAA records
+  reach    : 0x00000002 (Reachable)
+
+resolver #2
+  nameserver[0] : 8.8.8.8
+  flags    : ...
+`
+	dns := parseDNS(out)
+	// 8.8.8.8 appears twice but should be deduped.
+	if len(dns) != 2 {
+		t.Fatalf("dns = %v, want [8.8.8.8 8.8.4.4]", dns)
+	}
+	if dns[0] != "8.8.8.8" || dns[1] != "8.8.4.4" {
+		t.Errorf("dns = %v", dns)
+	}
+}
+
+func TestParseProxy(t *testing.T) {
+	out := `<dictionary> {
+  HTTPEnable : 1
+  HTTPProxy : proxy.example.com
+  HTTPPort : 8080
+  HTTPSEnable : 0
+  SOCKSEnable : 0
+}`
+	pc := parseProxy(out)
+	if pc.HTTP != "proxy.example.com:8080" {
+		t.Errorf("HTTP = %q, want proxy.example.com:8080", pc.HTTP)
+	}
+	if pc.HTTPS != "" {
+		t.Errorf("HTTPS should be empty (disabled)")
+	}
+}
+
+func TestParseProxySOCKS(t *testing.T) {
+	out := `SOCKSEnable : 1
+SOCKSProxy : socks.example.com
+SOCKSPort : 1080
+`
+	pc := parseProxy(out)
+	if pc.SOCKS != "socks.example.com:1080" {
+		t.Errorf("SOCKS = %q, want socks.example.com:1080", pc.SOCKS)
+	}
+}
+
+func TestReadHostsOverrides(t *testing.T) {
+	content := `# default /etc/hosts
+127.0.0.1       localhost
+::1             localhost
+255.255.255.255 broadcasthost
+
+# custom entries
+10.0.0.5        internal.corp.example.com
+192.168.50.10   dev-db.local devdb
+`
+	path := filepath.Join(t.TempDir(), "hosts")
+	os.WriteFile(path, []byte(content), 0o644)
+
+	entries := readHostsOverrides(path)
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(entries), entries)
+	}
+	if entries[0].IP != "10.0.0.5" {
+		t.Errorf("entries[0].IP = %q", entries[0].IP)
+	}
+	if entries[1].IP != "192.168.50.10" {
+		t.Errorf("entries[1].IP = %q", entries[1].IP)
+	}
+	if len(entries[1].Names) != 2 {
+		t.Errorf("entries[1] names = %v, want 2", entries[1].Names)
+	}
+}
+
+func TestReadHostsOverridesMissing(t *testing.T) {
+	entries := readHostsOverrides("/nonexistent/hosts")
+	if entries != nil {
+		t.Error("expected nil for missing hosts file")
+	}
+}
+
+const lsofOutput = `COMMAND    PID   USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
+Slack      412   alice  29u  IPv4  12345      0t0  TCP *:8080 (LISTEN)
+Google     999   alice  12u  IPv4  99999      0t0  TCP *:9090 (LISTEN)
+Slack      412   alice  30u  IPv4  12346      0t0  TCP *:8080 (LISTEN)
+`
+
+func TestParseLSOFListen(t *testing.T) {
+	ports := parseLSOFListen(lsofOutput)
+	if len(ports) != 2 {
+		t.Fatalf("got %d ports, want 2 (8080 and 9090, deduped): %+v", len(ports), ports)
+	}
+	found := map[int]bool{}
+	for _, p := range ports {
+		found[p.Port] = true
+	}
+	if !found[8080] || !found[9090] {
+		t.Errorf("ports = %+v, want 8080 and 9090", ports)
+	}
+}
+
+func TestParseLSOFListenEmpty(t *testing.T) {
+	ports := parseLSOFListen("")
+	if len(ports) != 0 {
+		t.Errorf("expected empty for blank input")
+	}
+}
+
+func TestCollect(t *testing.T) {
+	stub := func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "route":
+			return []byte("interface: en0\ngateway: 10.0.0.1\n"), nil
+		case "scutil":
+			if len(args) > 0 && args[0] == "--dns" {
+				return []byte("nameserver[0] : 1.1.1.1\n"), nil
+			}
+			return []byte("HTTPEnable : 0\n"), nil
+		case "lsof":
+			return []byte(lsofOutput), nil
+		}
+		return nil, errors.New("unexpected command")
+	}
+
+	s := Collect(stub)
+	if s.DefaultRouteIface != "en0" {
+		t.Errorf("DefaultRouteIface = %q", s.DefaultRouteIface)
+	}
+	if len(s.DNSServers) != 1 || s.DNSServers[0] != "1.1.1.1" {
+		t.Errorf("DNSServers = %v", s.DNSServers)
+	}
+	if len(s.ListeningPorts) != 2 {
+		t.Errorf("ListeningPorts = %d", len(s.ListeningPorts))
+	}
+}
+
+func TestCollectAllFail(t *testing.T) {
+	stub := func(name string, args ...string) ([]byte, error) {
+		return nil, errors.New("not available")
+	}
+	s := Collect(stub)
+	if s.DefaultRouteIface != "" || len(s.DNSServers) != 0 {
+		t.Errorf("expected zero value on all-fail: %+v", s)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/sysinfo"
 	"github.com/kaeawc/spectra/internal/toolchain"
@@ -35,11 +36,11 @@ type Snapshot struct {
 	Toolchains toolchain.Toolchains `json:"toolchains"`
 	Power      sysinfo.PowerState   `json:"power"`
 	Sysctls    map[string]string    `json:"sysctls,omitempty"`
+	Network    netstate.State       `json:"network"`
 
 	// Placeholders for upcoming collectors. Empty until implemented.
 	// See docs/design/system-inventory.md.
 	// JVMs    []JVMInfo
-	// Network *NetworkState
 	// Storage *StorageState
 }
 
@@ -69,6 +70,10 @@ type Options struct {
 	// SysinfoCmdRunner is forwarded to sysinfo collectors (sysctls + power).
 	// Zero value uses the real commands.
 	SysinfoCmdRunner sysinfo.CmdRunner
+
+	// NetCmdRunner is forwarded to the network state collector.
+	// Zero value uses the real commands.
+	NetCmdRunner netstate.CmdRunner
 }
 
 // Build assembles a Snapshot by running every collector in parallel and
@@ -85,11 +90,15 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	if siRun == nil {
 		siRun = sysinfo.DefaultRunner
 	}
+	netRun := opts.NetCmdRunner
+	if netRun == nil {
+		netRun = netstate.DefaultRunner
+	}
 
 	var wg sync.WaitGroup
-	collectors := 5 // host, apps, toolchains, power, sysctls
+	collectors := 6 // host, apps, toolchains, power, sysctls, network
 	if !opts.SkipProcesses {
-		collectors = 6
+		collectors = 7
 	}
 	wg.Add(collectors)
 
@@ -112,6 +121,10 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	go func() {
 		defer wg.Done()
 		s.Sysctls = sysinfo.CollectSysctls(siRun)
+	}()
+	go func() {
+		defer wg.Done()
+		s.Network = netstate.Collect(netRun)
 	}()
 
 	if !opts.SkipProcesses {


### PR DESCRIPTION
## Summary

- `internal/netstate`: single-pass network state snapshot
- **Default route** — interface + gateway via `route -n get default`
- **DNS** — deduplicated nameserver list from `scutil --dns`
- **Proxy** — HTTP/HTTPS/SOCKS from `scutil --proxy`; only populated when `*Enable=1`
- **`/etc/hosts` overrides** — skips standard macOS defaults (127.0.0.1, ::1, etc.)
- **Listening ports** — `lsof -i -P -n -sTCP:LISTEN`; deduped by port number
- `CmdRunner` injected for all collectors; `/etc/hosts` path parameterised for testing
- `Snapshot.Network` wired into `Build()`; `NetCmdRunner` forwarded from `Options`

## Test plan

- [ ] 10 tests: route/DNS/proxy parsing, hosts overrides, lsof dedup, all-fail graceful
- [ ] `go test ./... -race` passes