### PR TITLE
Add storage state collector (internal/storagestate)

### DIFF
--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/storagestate"
 	"github.com/kaeawc/spectra/internal/sysinfo"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
@@ -34,14 +35,14 @@ type Snapshot struct {
 	Apps       []detect.Result      `json:"apps"`
 	Processes  []process.Info       `json:"processes,omitempty"`
 	Toolchains toolchain.Toolchains `json:"toolchains"`
-	Power      sysinfo.PowerState   `json:"power"`
-	Sysctls    map[string]string    `json:"sysctls,omitempty"`
-	Network    netstate.State       `json:"network"`
+	Power      sysinfo.PowerState    `json:"power"`
+	Sysctls    map[string]string     `json:"sysctls,omitempty"`
+	Network    netstate.State        `json:"network"`
+	Storage    storagestate.State    `json:"storage"`
 
 	// Placeholders for upcoming collectors. Empty until implemented.
 	// See docs/design/system-inventory.md.
-	// JVMs    []JVMInfo
-	// Storage *StorageState
+	// JVMs []JVMInfo
 }
 
 // Options configure a snapshot Build.
@@ -67,6 +68,10 @@ type Options struct {
 	// SkipProcesses disables the process collector (faster for tests).
 	SkipProcesses bool
 
+	// SkipStorage disables the storage state collector (faster for tests;
+	// walking ~/Library can take seconds on a full machine).
+	SkipStorage bool
+
 	// SysinfoCmdRunner is forwarded to sysinfo collectors (sysctls + power).
 	// Zero value uses the real commands.
 	SysinfoCmdRunner sysinfo.CmdRunner
@@ -74,6 +79,10 @@ type Options struct {
 	// NetCmdRunner is forwarded to the network state collector.
 	// Zero value uses the real commands.
 	NetCmdRunner netstate.CmdRunner
+
+	// StorageOpts are forwarded to the storage state collector.
+	// Zero value uses live filesystem paths.
+	StorageOpts storagestate.CollectOptions
 }
 
 // Build assembles a Snapshot by running every collector in parallel and
@@ -98,7 +107,10 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	var wg sync.WaitGroup
 	collectors := 6 // host, apps, toolchains, power, sysctls, network
 	if !opts.SkipProcesses {
-		collectors = 7
+		collectors++
+	}
+	if !opts.SkipStorage {
+		collectors++
 	}
 	wg.Add(collectors)
 
@@ -126,6 +138,12 @@ func Build(ctx context.Context, opts Options) Snapshot {
 		defer wg.Done()
 		s.Network = netstate.Collect(netRun)
 	}()
+	if !opts.SkipStorage {
+		go func() {
+			defer wg.Done()
+			s.Storage = storagestate.Collect(opts.StorageOpts)
+		}()
+	}
 
 	if !opts.SkipProcesses {
 		go func() {

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -10,9 +10,12 @@ import (
 
 func TestBuildHostOnly(t *testing.T) {
 	// Use a sentinel non-existent path so collectApps does no real work.
+	// Skip slow collectors (process list, ~/Library walk) for test speed.
 	snap := Build(context.Background(), Options{
 		SpectraVersion: "test",
 		AppPaths:       []string{"/dev/null/__skip__"},
+		SkipProcesses:  true,
+		SkipStorage:    true,
 	})
 
 	if snap.ID == "" {

--- a/internal/storagestate/disk_darwin.go
+++ b/internal/storagestate/disk_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package storagestate
+
+import (
+	"os"
+	"syscall"
+)
+
+// diskBytes returns the actual on-disk allocation for fi using
+// Stat_t.Blocks (512-byte units) so sparse files (Docker thin volumes)
+// report actual usage, not apparent size.
+func diskBytes(fi os.FileInfo) int64 {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return st.Blocks * 512
+	}
+	return fi.Size()
+}

--- a/internal/storagestate/disk_other.go
+++ b/internal/storagestate/disk_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package storagestate
+
+import "os"
+
+func diskBytes(fi os.FileInfo) int64 { return fi.Size() }

--- a/internal/storagestate/exec.go
+++ b/internal/storagestate/exec.go
@@ -1,0 +1,7 @@
+package storagestate
+
+import "os/exec"
+
+func execRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}

--- a/internal/storagestate/storagestate.go
+++ b/internal/storagestate/storagestate.go
@@ -1,0 +1,157 @@
+// Package storagestate captures a point-in-time snapshot of disk volumes
+// and the user's ~/Library directory. All sizing is sparse-file-aware
+// (Stat_t.Blocks * 512) so Docker-style thin containers don't inflate
+// the numbers. See docs/design/system-inventory.md#storagestate.
+package storagestate
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// State is the StorageState slice of a Spectra snapshot.
+type State struct {
+	Volumes         []Volume   `json:"volumes,omitempty"`
+	UserLibraryBytes int64     `json:"user_library_bytes"`
+	AppCachesBytes  int64      `json:"app_caches_bytes"`
+	LargestApps     []AppSize  `json:"largest_apps,omitempty"`
+}
+
+// Volume is one mounted filesystem.
+type Volume struct {
+	MountPoint    string `json:"mount_point"`
+	FSType        string `json:"fs_type,omitempty"`
+	TotalBytes    int64  `json:"total_bytes"`
+	UsedBytes     int64  `json:"used_bytes"`
+	AvailBytes    int64  `json:"avail_bytes"`
+}
+
+// AppSize is one app bundle's on-disk footprint.
+type AppSize struct {
+	Path         string `json:"path"`
+	OnDiskBytes  int64  `json:"on_disk_bytes"`
+}
+
+// CmdRunner abstracts shell-out for testability.
+type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// DefaultRunner runs the real command.
+func DefaultRunner(name string, args ...string) ([]byte, error) {
+	return os.ReadFile("/dev/null") // never called directly; overridden per-use
+}
+
+// CollectOptions parameterises the collector.
+type CollectOptions struct {
+	// Home is the user's home directory. Defaults to os.UserHomeDir().
+	Home string
+	// AppPaths is the list of .app bundles to include in LargestApps.
+	// Typically populated from Snapshot.Apps[i].Path.
+	AppPaths []string
+	// LargestAppsN is how many top apps to report (default 10).
+	LargestAppsN int
+	// CmdRunner overrides exec.Command for testing.
+	CmdRunner CmdRunner
+}
+
+// Collect gathers StorageState.
+func Collect(opts CollectOptions) State {
+	if opts.Home == "" {
+		opts.Home, _ = os.UserHomeDir()
+	}
+	if opts.LargestAppsN == 0 {
+		opts.LargestAppsN = 10
+	}
+	run := opts.CmdRunner
+	if run == nil {
+		run = execRunner
+	}
+
+	var s State
+	if out, err := run("df", "-Pk"); err == nil {
+		s.Volumes = parseDF(string(out))
+	}
+	s.UserLibraryBytes = dirBytes(filepath.Join(opts.Home, "Library"))
+	s.AppCachesBytes = dirBytes(filepath.Join(opts.Home, "Library", "Caches"))
+	if len(opts.AppPaths) > 0 {
+		s.LargestApps = topApps(opts.AppPaths, opts.LargestAppsN)
+	}
+	return s
+}
+
+// parseDF converts `df -Pk` output to Volume slices.
+// POSIX df output: Filesystem 1024-blocks Used Available Capacity% Mounted-on
+func parseDF(out string) []Volume {
+	var volumes []Volume
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 6 || fields[0] == "Filesystem" {
+			continue
+		}
+		mount := fields[5]
+		// Skip pseudo filesystems.
+		if strings.HasPrefix(fields[0], "devfs") ||
+			strings.HasPrefix(fields[0], "map ") ||
+			strings.HasPrefix(mount, "/dev") ||
+			strings.HasPrefix(mount, "/System/Volumes/Preboot") ||
+			strings.HasPrefix(mount, "/System/Volumes/Recovery") ||
+			strings.HasPrefix(mount, "/System/Volumes/VM") ||
+			strings.HasPrefix(mount, "/System/Volumes/xarts") {
+			continue
+		}
+		total := parseInt64(fields[1]) * 1024
+		used := parseInt64(fields[2]) * 1024
+		avail := parseInt64(fields[3]) * 1024
+		volumes = append(volumes, Volume{
+			MountPoint: mount,
+			TotalBytes: total,
+			UsedBytes:  used,
+			AvailBytes: avail,
+		})
+	}
+	return volumes
+}
+
+// dirBytes returns the total on-disk size of all files under dir using
+// sparse-file-aware block counting. Returns 0 if dir doesn't exist.
+func dirBytes(dir string) int64 {
+	var total int64
+	filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error { //nolint:errcheck
+		if err != nil || fi.IsDir() {
+			return nil
+		}
+		total += diskBytes(fi)
+		return nil
+	})
+	return total
+}
+
+// topApps returns the top-N app paths by on-disk size, sorted descending.
+func topApps(paths []string, n int) []AppSize {
+	sizes := make([]AppSize, 0, len(paths))
+	for _, p := range paths {
+		b := dirBytes(p)
+		if b > 0 {
+			sizes = append(sizes, AppSize{Path: p, OnDiskBytes: b})
+		}
+	}
+	sort.Slice(sizes, func(i, j int) bool {
+		return sizes[i].OnDiskBytes > sizes[j].OnDiskBytes
+	})
+	if len(sizes) > n {
+		sizes = sizes[:n]
+	}
+	return sizes
+}
+
+func parseInt64(s string) int64 {
+	var n int64
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			break
+		}
+		n = n*10 + int64(c-'0')
+	}
+	return n
+}

--- a/internal/storagestate/storagestate_test.go
+++ b/internal/storagestate/storagestate_test.go
@@ -1,0 +1,133 @@
+package storagestate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const dfOutput = `Filesystem                       1024-blocks      Used Available Capacity Mounted on
+/dev/disk3s1s1                   971309944 413876292 444843444    49% /
+devfs                                  386       386         0   100% /dev
+/dev/disk3s6                     971309944    753792 444843444     1% /System/Volumes/VM
+/dev/disk3s2                     971309944  13285364 444843444     3% /System/Volumes/Preboot
+/dev/disk3s4                     971309944   1107516 444843444     1% /System/Volumes/Recovery
+/dev/disk3s5                     971309944   5312168 444843444     2% /data
+`
+
+func TestParseDF(t *testing.T) {
+	vols := parseDF(dfOutput)
+	// Should include /, /data but skip devfs and /System/Volumes/*
+	if len(vols) != 2 {
+		t.Fatalf("got %d volumes, want 2: %+v", len(vols), vols)
+	}
+	mounts := map[string]Volume{}
+	for _, v := range vols {
+		mounts[v.MountPoint] = v
+	}
+	if _, ok := mounts["/"]; !ok {
+		t.Error("/ should be included")
+	}
+	if _, ok := mounts["/data"]; !ok {
+		t.Error("/data should be included")
+	}
+	if _, ok := mounts["/dev"]; ok {
+		t.Error("/dev (devfs) should be excluded")
+	}
+}
+
+func TestParseDFBytes(t *testing.T) {
+	vols := parseDF(dfOutput)
+	root := vols[0] // "/"
+	// 971309944 * 1024
+	if root.TotalBytes != 971309944*1024 {
+		t.Errorf("TotalBytes = %d, want %d", root.TotalBytes, 971309944*1024)
+	}
+}
+
+func TestParseDFEmpty(t *testing.T) {
+	vols := parseDF("")
+	if len(vols) != 0 {
+		t.Errorf("expected empty for blank input")
+	}
+}
+
+func TestDirBytes(t *testing.T) {
+	dir := t.TempDir()
+	// Write a few files.
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o644)
+	os.WriteFile(filepath.Join(dir, "b.txt"), make([]byte, 1024), 0o644)
+
+	bytes := dirBytes(dir)
+	if bytes == 0 {
+		t.Error("dirBytes should be > 0 for non-empty dir")
+	}
+}
+
+func TestDirBytesMissing(t *testing.T) {
+	b := dirBytes("/nonexistent/path")
+	if b != 0 {
+		t.Errorf("expected 0 for missing dir, got %d", b)
+	}
+}
+
+func TestTopApps(t *testing.T) {
+	dir := t.TempDir()
+	// Create two fake "app" dirs with different sizes.
+	big := filepath.Join(dir, "Big.app")
+	small := filepath.Join(dir, "Small.app")
+	os.MkdirAll(big, 0o755)
+	os.MkdirAll(small, 0o755)
+	os.WriteFile(filepath.Join(big, "exec"), make([]byte, 4096), 0o755)
+	os.WriteFile(filepath.Join(small, "exec"), make([]byte, 128), 0o755)
+
+	apps := topApps([]string{big, small}, 10)
+	if len(apps) != 2 {
+		t.Fatalf("got %d apps, want 2", len(apps))
+	}
+	// Big should be first.
+	if apps[0].Path != big {
+		t.Errorf("largest app = %q, want Big.app", apps[0].Path)
+	}
+}
+
+func TestTopAppsLimit(t *testing.T) {
+	dir := t.TempDir()
+	var paths []string
+	for i := 0; i < 20; i++ {
+		p := filepath.Join(dir, "App.app")
+		os.MkdirAll(p, 0o755)
+		os.WriteFile(filepath.Join(p, "x"), []byte("x"), 0o644)
+		paths = append(paths, p)
+	}
+	apps := topApps(paths, 5)
+	if len(apps) > 5 {
+		t.Errorf("topApps(n=5) returned %d, want ≤5", len(apps))
+	}
+}
+
+func TestCollect(t *testing.T) {
+	home := t.TempDir()
+	// Create ~/Library/Caches with one file.
+	cacheDir := filepath.Join(home, "Library", "Caches")
+	os.MkdirAll(cacheDir, 0o755)
+	os.WriteFile(filepath.Join(cacheDir, "test.dat"), make([]byte, 2048), 0o644)
+
+	stub := func(name string, args ...string) ([]byte, error) {
+		return []byte(dfOutput), nil
+	}
+
+	s := Collect(CollectOptions{
+		Home:      home,
+		CmdRunner: stub,
+	})
+	if len(s.Volumes) == 0 {
+		t.Error("expected volumes from stubbed df")
+	}
+	if s.AppCachesBytes == 0 {
+		t.Error("AppCachesBytes should be > 0")
+	}
+	if s.UserLibraryBytes == 0 {
+		t.Error("UserLibraryBytes should be > 0")
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/storagestate`: sparse-file-aware disk volume + ~/Library usage snapshot
- **Volumes** — `df -Pk` parsed; pseudo filesystems filtered (devfs, /System/Volumes/Preboot/Recovery/VM/xarts)
- **`~/Library` bytes** — `filepath.Walk` + `Stat_t.Blocks * 512` on darwin (same pattern as `detect.go`); fallback to `fi.Size()` on other platforms
- **`~/Library/Caches` bytes** — sub-total for app caches
- **Largest apps** — top-N `.app` bundles ranked by on-disk size; sorted descending
- `SkipStorage` option added to `snapshot.Options` (avoids 132s `~/Library` walk in tests)
- `TestBuildHostOnly` updated with `SkipProcesses + SkipStorage` to stay within 1-minute assertion

## Test plan

- [ ] 8 tests: df parsing, volume filtering, dirBytes non-zero/missing, topApps sort+limit
- [ ] `go test ./... -race -timeout 60s` passes