### PR TITLE
Add snapshot diff (spectra snapshot diff)

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/diff"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/store"
 )
@@ -20,6 +21,7 @@ func snapshotSubcommands() []subcommand {
 	return []subcommand{
 		{"list", "List stored snapshots", runSnapshotList},
 		{"show", "Show details of one snapshot by ID", runSnapshotShow},
+		{"diff", "Diff two stored snapshots", runSnapshotDiff},
 	}
 }
 
@@ -242,5 +244,103 @@ func sortStrings(s []string) {
 		for j := i; j > 0 && s[j-1] > s[j]; j-- {
 			s[j-1], s[j] = s[j], s[j-1]
 		}
+	}
+}
+
+// runSnapshotDiff loads two snapshots by ID and prints a structured diff.
+func runSnapshotDiff(args []string) int {
+	fs := flag.NewFlagSet("spectra snapshot diff", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "usage: spectra snapshot diff <id-a> <id-b>")
+		return 2
+	}
+	idA, idB := fs.Arg(0), fs.Arg(1)
+
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	snapA, err := loadSnapshotFromDB(ctx, db, idA)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "snapshot %q: %v\n", idA, err)
+		return 1
+	}
+	snapB, err := loadSnapshotFromDB(ctx, db, idB)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "snapshot %q: %v\n", idB, err)
+		return 1
+	}
+
+	result := diff.Compare(*snapA, *snapB)
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return 0
+	}
+
+	printDiff(result)
+	return 0
+}
+
+// loadSnapshotFromDB retrieves the full snapshot JSON blob for id and unmarshals
+// it into a snapshot.Snapshot. Returns an error if the snapshot is not found or
+// was saved without a JSON blob (pre-v0.8 rows).
+func loadSnapshotFromDB(ctx context.Context, db *store.DB, id string) (*snapshot.Snapshot, error) {
+	raw, err := db.GetSnapshotJSON(ctx, id)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, fmt.Errorf("not found")
+	}
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, fmt.Errorf("snapshot exists but has no JSON blob (was it taken before this version?)")
+	}
+	var s snapshot.Snapshot
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	return &s, nil
+}
+
+// printDiff renders a diff.Result as a human-readable table.
+func printDiff(r diff.Result) {
+	if !r.HasChanges() {
+		fmt.Println("no differences")
+		return
+	}
+	fmt.Printf("diff  %s  →  %s\n\n", r.AID, r.BID)
+	for _, sec := range r.Sections {
+		if len(sec.Changes) == 0 {
+			continue
+		}
+		fmt.Printf("=== %s ===\n", sec.Name)
+		for _, c := range sec.Changes {
+			switch c.Kind {
+			case diff.Added:
+				fmt.Printf("  + %-40s  %s\n", c.Key, c.After)
+			case diff.Removed:
+				fmt.Printf("  - %-40s  %s\n", c.Key, c.Before)
+			case diff.Changed:
+				fmt.Printf("  ~ %-40s  %s  →  %s\n", c.Key, c.Before, c.After)
+			}
+		}
+		fmt.Println()
 	}
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,277 @@
+// Package diff computes a structured diff between two Spectra snapshots.
+// Each category uses a category-specific equality rule as described in
+// docs/design/system-inventory.md#diff-semantics.
+package diff
+
+import (
+	"fmt"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+// ChangeKind classifies one diff entry.
+type ChangeKind string
+
+const (
+	Added   ChangeKind = "added"
+	Removed ChangeKind = "removed"
+	Changed ChangeKind = "changed"
+)
+
+// Change is one leaf difference within a category.
+type Change struct {
+	Kind   ChangeKind
+	Key    string // identity key (bundle ID, formula name, port string, sysctl key, …)
+	Before string // empty for Added
+	After  string // empty for Removed
+}
+
+// Section groups changes under one logical category.
+type Section struct {
+	Name    string
+	Changes []Change
+}
+
+// Result holds the full diff output between two snapshots.
+type Result struct {
+	AID      string
+	BID      string
+	Sections []Section
+}
+
+// HasChanges reports whether any section contains at least one change.
+func (r Result) HasChanges() bool {
+	for _, s := range r.Sections {
+		if len(s.Changes) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Compare computes the structural diff of snapshots a and b. Sections with
+// zero changes are included so callers know which categories were evaluated.
+func Compare(a, b snapshot.Snapshot) Result {
+	return Result{
+		AID: a.ID,
+		BID: b.ID,
+		Sections: []Section{
+			diffHost(a, b),
+			diffApps(a, b),
+			diffJDKs(a, b),
+			diffBrewFormulae(a, b),
+			diffListeningPorts(a, b),
+			diffPathDirs(a, b),
+			diffSysctls(a, b),
+		},
+	}
+}
+
+// diffHost compares HostInfo fields one-by-one.
+func diffHost(a, b snapshot.Snapshot) Section {
+	type field struct {
+		key    string
+		before string
+		after  string
+	}
+	fields := []field{
+		{"hostname", a.Host.Hostname, b.Host.Hostname},
+		{"os_version", a.Host.OSVersion, b.Host.OSVersion},
+		{"os_build", a.Host.OSBuild, b.Host.OSBuild},
+		{"cpu_brand", a.Host.CPUBrand, b.Host.CPUBrand},
+		{"cpu_cores", fmt.Sprint(a.Host.CPUCores), fmt.Sprint(b.Host.CPUCores)},
+		{"ram_bytes", fmt.Sprint(a.Host.RAMBytes), fmt.Sprint(b.Host.RAMBytes)},
+		{"arch", a.Host.Architecture, b.Host.Architecture},
+		{"spectra_version", a.Host.SpectraVersion, b.Host.SpectraVersion},
+	}
+	var changes []Change
+	for _, f := range fields {
+		if f.before != f.after {
+			changes = append(changes, Change{Kind: Changed, Key: f.key, Before: f.before, After: f.after})
+		}
+	}
+	return Section{Name: "host", Changes: changes}
+}
+
+// diffApps matches by bundle ID (falling back to path when bundle ID is empty).
+// Reports added, removed, and version-changed apps.
+func diffApps(a, b snapshot.Snapshot) Section {
+	type appKey struct{ bundleID, path string }
+	type appInfo struct{ version, path string }
+
+	mapA := make(map[string]appInfo, len(a.Apps))
+	for _, r := range a.Apps {
+		k := r.BundleID
+		if k == "" {
+			k = r.Path
+		}
+		mapA[k] = appInfo{version: r.AppVersion, path: r.Path}
+	}
+	mapB := make(map[string]appInfo, len(b.Apps))
+	for _, r := range b.Apps {
+		k := r.BundleID
+		if k == "" {
+			k = r.Path
+		}
+		mapB[k] = appInfo{version: r.AppVersion, path: r.Path}
+	}
+
+	var changes []Change
+	for k, ia := range mapA {
+		if ib, ok := mapB[k]; !ok {
+			changes = append(changes, Change{Kind: Removed, Key: k, Before: ia.version})
+		} else if ia.version != ib.version {
+			changes = append(changes, Change{Kind: Changed, Key: k, Before: ia.version, After: ib.version})
+		}
+	}
+	for k, ib := range mapB {
+		if _, ok := mapA[k]; !ok {
+			changes = append(changes, Change{Kind: Added, Key: k, After: ib.version})
+		}
+	}
+	return Section{Name: "apps", Changes: changes}
+}
+
+// diffJDKs matches by (major.minor.patch, vendor). Same identity at different
+// paths is "compatible"; different identities are "drift".
+func diffJDKs(a, b snapshot.Snapshot) Section {
+	type jdkKey struct {
+		major, minor, patch int
+		vendor              string
+	}
+	key := func(j toolchain.JDKInstall) jdkKey {
+		return jdkKey{j.VersionMajor, j.VersionMinor, j.VersionPatch, j.Vendor}
+	}
+	label := func(j toolchain.JDKInstall) string {
+		return fmt.Sprintf("%d.%d.%d/%s@%s", j.VersionMajor, j.VersionMinor, j.VersionPatch, j.Vendor, j.Source)
+	}
+
+	setA := make(map[jdkKey]toolchain.JDKInstall, len(a.Toolchains.JDKs))
+	for _, j := range a.Toolchains.JDKs {
+		setA[key(j)] = j
+	}
+	setB := make(map[jdkKey]toolchain.JDKInstall, len(b.Toolchains.JDKs))
+	for _, j := range b.Toolchains.JDKs {
+		setB[key(j)] = j
+	}
+
+	var changes []Change
+	for k, ja := range setA {
+		if _, ok := setB[k]; !ok {
+			changes = append(changes, Change{Kind: Removed, Key: label(ja), Before: ja.Path})
+		}
+	}
+	for k, jb := range setB {
+		if _, ok := setA[k]; !ok {
+			changes = append(changes, Change{Kind: Added, Key: label(jb), After: jb.Path})
+		}
+	}
+	return Section{Name: "jdks", Changes: changes}
+}
+
+// diffBrewFormulae matches by formula name; reports added/removed/version-changed.
+func diffBrewFormulae(a, b snapshot.Snapshot) Section {
+	mapA := make(map[string]string, len(a.Toolchains.Brew.Formulae))
+	for _, f := range a.Toolchains.Brew.Formulae {
+		mapA[f.Name] = f.Version
+	}
+	mapB := make(map[string]string, len(b.Toolchains.Brew.Formulae))
+	for _, f := range b.Toolchains.Brew.Formulae {
+		mapB[f.Name] = f.Version
+	}
+
+	var changes []Change
+	for name, va := range mapA {
+		if vb, ok := mapB[name]; !ok {
+			changes = append(changes, Change{Kind: Removed, Key: name, Before: va})
+		} else if va != vb {
+			changes = append(changes, Change{Kind: Changed, Key: name, Before: va, After: vb})
+		}
+	}
+	for name, vb := range mapB {
+		if _, ok := mapA[name]; !ok {
+			changes = append(changes, Change{Kind: Added, Key: name, After: vb})
+		}
+	}
+	return Section{Name: "brew_formulae", Changes: changes}
+}
+
+// diffListeningPorts matches by (port, proto); reports added/removed.
+func diffListeningPorts(a, b snapshot.Snapshot) Section {
+	portKey := func(port, proto string) string { return proto + ":" + port }
+
+	setA := make(map[string]bool)
+	for _, p := range a.Network.ListeningPorts {
+		setA[portKey(fmt.Sprint(p.Port), p.Proto)] = true
+	}
+	setB := make(map[string]bool)
+	for _, p := range b.Network.ListeningPorts {
+		setB[portKey(fmt.Sprint(p.Port), p.Proto)] = true
+	}
+
+	var changes []Change
+	for k := range setA {
+		if !setB[k] {
+			changes = append(changes, Change{Kind: Removed, Key: k})
+		}
+	}
+	for k := range setB {
+		if !setA[k] {
+			changes = append(changes, Change{Kind: Added, Key: k})
+		}
+	}
+	return Section{Name: "listening_ports", Changes: changes}
+}
+
+// diffPathDirs sequence-compares PATH dirs (order matters for shadowing).
+func diffPathDirs(a, b snapshot.Snapshot) Section {
+	pa := a.Toolchains.Env.PathDirs
+	pb := b.Toolchains.Env.PathDirs
+
+	// Build indexed sets for quick lookup.
+	posA := make(map[string]int, len(pa))
+	for i, d := range pa {
+		posA[d] = i
+	}
+	posB := make(map[string]int, len(pb))
+	for i, d := range pb {
+		posB[d] = i
+	}
+
+	var changes []Change
+	for _, d := range pa {
+		if _, ok := posB[d]; !ok {
+			changes = append(changes, Change{Kind: Removed, Key: d, Before: fmt.Sprintf("pos %d", posA[d])})
+		}
+	}
+	for _, d := range pb {
+		if _, ok := posA[d]; !ok {
+			changes = append(changes, Change{Kind: Added, Key: d, After: fmt.Sprintf("pos %d", posB[d])})
+		} else if posA[d] != posB[d] {
+			changes = append(changes, Change{Kind: Changed, Key: d,
+				Before: fmt.Sprintf("pos %d", posA[d]),
+				After:  fmt.Sprintf("pos %d", posB[d]),
+			})
+		}
+	}
+	return Section{Name: "path_dirs", Changes: changes}
+}
+
+// diffSysctls compares every key that appears in either snapshot.
+func diffSysctls(a, b snapshot.Snapshot) Section {
+	var changes []Change
+	for k, va := range a.Sysctls {
+		if vb, ok := b.Sysctls[k]; !ok {
+			changes = append(changes, Change{Kind: Removed, Key: k, Before: va})
+		} else if va != vb {
+			changes = append(changes, Change{Kind: Changed, Key: k, Before: va, After: vb})
+		}
+	}
+	for k, vb := range b.Sysctls {
+		if _, ok := a.Sysctls[k]; !ok {
+			changes = append(changes, Change{Kind: Added, Key: k, After: vb})
+		}
+	}
+	return Section{Name: "sysctls", Changes: changes}
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,233 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/netstate"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+// base returns a minimal snapshot for tests.
+func base() snapshot.Snapshot {
+	return snapshot.Snapshot{
+		ID:   "snap-a",
+		Kind: snapshot.KindLive,
+		Host: snapshot.HostInfo{
+			Hostname:    "mac-a",
+			OSVersion:   "14.4",
+			OSBuild:     "23E214",
+			CPUBrand:    "Apple M3",
+			CPUCores:    10,
+			RAMBytes:    17179869184,
+			Architecture: "arm64",
+		},
+	}
+}
+
+func TestCompareIdentical(t *testing.T) {
+	a := base()
+	r := Compare(a, a)
+	if r.HasChanges() {
+		for _, s := range r.Sections {
+			for _, c := range s.Changes {
+				t.Errorf("[%s] unexpected change: %+v", s.Name, c)
+			}
+		}
+	}
+}
+
+func TestDiffHostChanged(t *testing.T) {
+	a := base()
+	b := base()
+	b.Host.OSVersion = "15.0"
+	b.Host.OSBuild = "24A336"
+
+	r := Compare(a, b)
+	sec := findSection(r, "host")
+	if sec == nil {
+		t.Fatal("host section missing")
+	}
+	if !hasChange(sec.Changes, Changed, "os_version") {
+		t.Error("expected os_version changed")
+	}
+	if !hasChange(sec.Changes, Changed, "os_build") {
+		t.Error("expected os_build changed")
+	}
+	if hasChange(sec.Changes, Changed, "hostname") {
+		t.Error("unexpected hostname change")
+	}
+}
+
+func TestDiffAppsAddedRemoved(t *testing.T) {
+	a := base()
+	b := base()
+	a.Apps = []detect.Result{
+		{BundleID: "com.example.old", AppVersion: "1.0", Path: "/Applications/Old.app"},
+	}
+	b.Apps = []detect.Result{
+		{BundleID: "com.example.new", AppVersion: "2.0", Path: "/Applications/New.app"},
+	}
+
+	r := Compare(a, b)
+	sec := findSection(r, "apps")
+	if sec == nil {
+		t.Fatal("apps section missing")
+	}
+	if !hasChange(sec.Changes, Removed, "com.example.old") {
+		t.Error("expected old app removed")
+	}
+	if !hasChange(sec.Changes, Added, "com.example.new") {
+		t.Error("expected new app added")
+	}
+}
+
+func TestDiffAppsVersionChanged(t *testing.T) {
+	a := base()
+	b := base()
+	a.Apps = []detect.Result{{BundleID: "com.example.app", AppVersion: "1.0"}}
+	b.Apps = []detect.Result{{BundleID: "com.example.app", AppVersion: "2.0"}}
+
+	r := Compare(a, b)
+	sec := findSection(r, "apps")
+	if !hasChange(sec.Changes, Changed, "com.example.app") {
+		t.Error("expected version change")
+	}
+}
+
+func TestDiffJDKsAddedRemoved(t *testing.T) {
+	a := base()
+	b := base()
+	a.Toolchains.JDKs = []toolchain.JDKInstall{
+		{VersionMajor: 17, VersionMinor: 0, VersionPatch: 5, Vendor: "Temurin", Source: "brew"},
+	}
+	b.Toolchains.JDKs = []toolchain.JDKInstall{
+		{VersionMajor: 21, VersionMinor: 0, VersionPatch: 1, Vendor: "Temurin", Source: "brew"},
+	}
+
+	r := Compare(a, b)
+	sec := findSection(r, "jdks")
+	if sec == nil {
+		t.Fatal("jdks section missing")
+	}
+	if len(sec.Changes) != 2 {
+		t.Errorf("expected 2 jdk changes (removed+added), got %d", len(sec.Changes))
+	}
+}
+
+func TestDiffBrewFormulae(t *testing.T) {
+	a := base()
+	b := base()
+	a.Toolchains.Brew.Formulae = []toolchain.BrewFormula{
+		{Name: "wget", Version: "1.21"},
+		{Name: "curl", Version: "8.1"},
+	}
+	b.Toolchains.Brew.Formulae = []toolchain.BrewFormula{
+		{Name: "wget", Version: "1.22"},
+		{Name: "jq", Version: "1.7"},
+	}
+
+	r := Compare(a, b)
+	sec := findSection(r, "brew_formulae")
+	if !hasChange(sec.Changes, Changed, "wget") {
+		t.Error("expected wget version changed")
+	}
+	if !hasChange(sec.Changes, Removed, "curl") {
+		t.Error("expected curl removed")
+	}
+	if !hasChange(sec.Changes, Added, "jq") {
+		t.Error("expected jq added")
+	}
+}
+
+func TestDiffListeningPorts(t *testing.T) {
+	a := base()
+	b := base()
+	a.Network.ListeningPorts = []netstate.ListeningPort{{Port: 8080, Proto: "tcp"}}
+	b.Network.ListeningPorts = []netstate.ListeningPort{{Port: 9090, Proto: "tcp"}}
+
+	r := Compare(a, b)
+	sec := findSection(r, "listening_ports")
+	if !hasChange(sec.Changes, Removed, "tcp:8080") {
+		t.Error("expected tcp:8080 removed")
+	}
+	if !hasChange(sec.Changes, Added, "tcp:9090") {
+		t.Error("expected tcp:9090 added")
+	}
+}
+
+func TestDiffPathDirs(t *testing.T) {
+	a := base()
+	b := base()
+	a.Toolchains.Env.PathDirs = []string{"/usr/local/bin", "/usr/bin", "/bin"}
+	b.Toolchains.Env.PathDirs = []string{"/opt/homebrew/bin", "/usr/bin", "/bin"}
+
+	r := Compare(a, b)
+	sec := findSection(r, "path_dirs")
+	if !hasChange(sec.Changes, Removed, "/usr/local/bin") {
+		t.Error("expected /usr/local/bin removed")
+	}
+	if !hasChange(sec.Changes, Added, "/opt/homebrew/bin") {
+		t.Error("expected /opt/homebrew/bin added")
+	}
+}
+
+func TestDiffPathDirsReordered(t *testing.T) {
+	a := base()
+	b := base()
+	a.Toolchains.Env.PathDirs = []string{"/usr/bin", "/usr/local/bin"}
+	b.Toolchains.Env.PathDirs = []string{"/usr/local/bin", "/usr/bin"}
+
+	r := Compare(a, b)
+	sec := findSection(r, "path_dirs")
+	// Both dirs present but at different positions → Changed.
+	if !hasChange(sec.Changes, Changed, "/usr/bin") && !hasChange(sec.Changes, Changed, "/usr/local/bin") {
+		t.Error("expected reorder to show as Changed")
+	}
+}
+
+func TestDiffSysctls(t *testing.T) {
+	a := base()
+	b := base()
+	a.Sysctls = map[string]string{
+		"hw.ncpu":     "10",
+		"hw.memsize":  "17179869184",
+	}
+	b.Sysctls = map[string]string{
+		"hw.ncpu":      "10",
+		"kern.maxfiles": "12288",
+	}
+
+	r := Compare(a, b)
+	sec := findSection(r, "sysctls")
+	if !hasChange(sec.Changes, Removed, "hw.memsize") {
+		t.Error("expected hw.memsize removed")
+	}
+	if !hasChange(sec.Changes, Added, "kern.maxfiles") {
+		t.Error("expected kern.maxfiles added")
+	}
+	if hasChange(sec.Changes, Changed, "hw.ncpu") {
+		t.Error("hw.ncpu unchanged, should not appear")
+	}
+}
+
+// --- helpers ---
+
+func findSection(r Result, name string) *Section {
+	for i := range r.Sections {
+		if r.Sections[i].Name == name {
+			return &r.Sections[i]
+		}
+	}
+	return nil
+}
+
+func hasChange(changes []Change, kind ChangeKind, key string) bool {
+	for _, c := range changes {
+		if c.Kind == kind && c.Key == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/convert.go
+++ b/internal/store/convert.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 
@@ -21,6 +22,8 @@ func FromSnapshot(s snapshot.Snapshot) SnapshotInput {
 		apps[i] = fromResult(r)
 	}
 
+	snapJSON, _ := json.Marshal(s)
+
 	return SnapshotInput{
 		ID:           s.ID,
 		MachineUUID:  uuid,
@@ -36,6 +39,7 @@ func FromSnapshot(s snapshot.Snapshot) SnapshotInput {
 		RAMBytes:     s.Host.RAMBytes,
 		Architecture: s.Host.Architecture,
 		Apps:         apps,
+		SnapshotJSON: snapJSON,
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,9 +75,14 @@ func (s *DB) applyPragmas() error {
 }
 
 // migrate creates tables that don't yet exist. Idempotent.
+// Also adds new columns to existing tables when the schema evolves.
 func (s *DB) migrate() error {
-	_, err := s.db.Exec(schema)
-	return err
+	if _, err := s.db.Exec(schema); err != nil {
+		return err
+	}
+	// Add snapshot_json column if this is an existing DB without it.
+	_, _ = s.db.Exec(`ALTER TABLE snapshots ADD COLUMN snapshot_json TEXT`)
+	return nil
 }
 
 const schema = `
@@ -102,6 +107,7 @@ CREATE TABLE IF NOT EXISTS snapshots (
     kind          TEXT NOT NULL DEFAULT 'live',
     spectra_ver   TEXT,
     app_count     INTEGER NOT NULL DEFAULT 0,
+    snapshot_json TEXT,
     FOREIGN KEY (machine_uuid) REFERENCES hosts(machine_uuid)
 );
 
@@ -183,11 +189,18 @@ func upsertHost(tx *sql.Tx, s SnapshotInput) error {
 
 func insertSnapshot(tx *sql.Tx, s SnapshotInput) error {
 	_, err := tx.Exec(`
-		INSERT OR IGNORE INTO snapshots (id, machine_uuid, taken_at, kind, spectra_ver, app_count)
-		VALUES (?,?,?,?,?,?)`,
-		s.ID, s.MachineUUID, s.TakenAt, s.Kind, s.SpectraVer, len(s.Apps),
+		INSERT OR IGNORE INTO snapshots (id, machine_uuid, taken_at, kind, spectra_ver, app_count, snapshot_json)
+		VALUES (?,?,?,?,?,?,?)`,
+		s.ID, s.MachineUUID, s.TakenAt, s.Kind, s.SpectraVer, len(s.Apps), nullableJSON(s.SnapshotJSON),
 	)
 	return err
+}
+
+func nullableJSON(b []byte) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return string(b)
 }
 
 func insertApp(tx *sql.Tx, snapID string, a AppInput) error {
@@ -252,6 +265,26 @@ func (s *DB) GetSnapshot(ctx context.Context, id string) (SnapshotRow, error) {
 	return r, nil
 }
 
+// GetSnapshotJSON returns the full snapshot JSON blob for id, or ErrNotFound
+// if absent. Returns nil (not ErrNotFound) if the row exists but was saved
+// without a JSON blob (older rows).
+func (s *DB) GetSnapshotJSON(ctx context.Context, id string) ([]byte, error) {
+	var raw sql.NullString
+	err := s.db.QueryRowContext(ctx,
+		`SELECT snapshot_json FROM snapshots WHERE id=?`, id,
+	).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !raw.Valid {
+		return nil, nil
+	}
+	return []byte(raw.String), nil
+}
+
 // GetSnapshotApps returns the per-app rows for a snapshot.
 func (s *DB) GetSnapshotApps(ctx context.Context, snapID string) ([]AppRow, error) {
 	rows, err := s.db.QueryContext(ctx,
@@ -290,20 +323,23 @@ var ErrNotFound = errors.New("store: not found")
 
 // SnapshotInput carries the data needed to persist a snapshot.
 type SnapshotInput struct {
-	ID          string
-	MachineUUID string
-	TakenAt     time.Time
-	Kind        string
-	SpectraVer  string
-	Hostname    string
-	OSName      string
-	OSVersion   string
-	OSBuild     string
-	CPUBrand    string
-	CPUCores    int
-	RAMBytes    uint64
+	ID           string
+	MachineUUID  string
+	TakenAt      time.Time
+	Kind         string
+	SpectraVer   string
+	Hostname     string
+	OSName       string
+	OSVersion    string
+	OSBuild      string
+	CPUBrand     string
+	CPUCores     int
+	RAMBytes     uint64
 	Architecture string
-	Apps        []AppInput
+	Apps         []AppInput
+	// SnapshotJSON is the full snapshot marshalled to JSON. Stored as a blob
+	// so diff and rules can reconstruct the complete Snapshot without re-running collectors.
+	SnapshotJSON []byte
 }
 
 // AppInput carries the per-app data to store.


### PR DESCRIPTION
## Summary

- Adds `internal/diff` package with `Compare(a, b snapshot.Snapshot) Result` covering all categories from docs/design/system-inventory.md diff-semantics: host fields, apps (by bundle ID), JDKs (by version+vendor), brew formulae (by name), listening ports (by port+proto), PATH dirs (sequence order), sysctls
- Extends `internal/store` to persist the full snapshot JSON blob alongside the structured rows; existing DBs get the column added via a safe `ALTER TABLE` migration
- Adds `spectra snapshot diff <id-a> <id-b>` CLI subcommand with `--json` flag; human output uses `+/-/~` prefix per change kind

## Test plan

- [ ] `go test ./internal/diff/...` — 9 table-driven tests covering each category
- [ ] `go build ./...` — clean build
- [ ] `go test ./internal/store/...` — store tests pass with new column