### PR TITLE
Add JVM inspector (spectra jvm)

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+func runJVM(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	ctx := context.Background()
+	var infos []jvm.Info
+
+	if fs.NArg() == 0 {
+		// List all running JVMs.
+		infos = jvm.CollectAll(ctx, jvm.CollectOptions{})
+		if len(infos) == 0 {
+			fmt.Fprintln(os.Stderr, "no running JVMs found (is jps in your PATH?)")
+			return 0
+		}
+	} else {
+		// Inspect a specific PID.
+		pidStr := fs.Arg(0)
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid PID %q\n", pidStr)
+			return 2
+		}
+		info := jvm.InspectPID(ctx, pid, jvm.CollectOptions{})
+		if info == nil {
+			fmt.Fprintf(os.Stderr, "could not inspect PID %d (process not found or jcmd unavailable)\n", pid)
+			return 1
+		}
+		infos = []jvm.Info{*info}
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(infos)
+		return 0
+	}
+
+	if fs.NArg() == 0 {
+		printJVMList(infos)
+	} else {
+		printJVMDetail(infos[0])
+	}
+	return 0
+}
+
+func printJVMList(infos []jvm.Info) {
+	// Sort by PID for stable output.
+	sort.Slice(infos, func(i, j int) bool { return infos[i].PID < infos[j].PID })
+
+	fmt.Printf("%-7s  %-12s  %-8s  %s\n", "PID", "VERSION", "THREADS", "MAIN CLASS")
+	fmt.Println(strings.Repeat("-", 70))
+	for _, info := range infos {
+		ver := info.JDKVersion
+		if ver == "" {
+			ver = "?"
+		}
+		threads := "-"
+		if info.ThreadCount > 0 {
+			threads = strconv.Itoa(info.ThreadCount)
+		}
+		mc := info.MainClass
+		if mc == "" {
+			mc = "(unknown)"
+		}
+		fmt.Printf("%-7d  %-12s  %-8s  %s\n", info.PID, truncate(ver, 12), threads, mc)
+	}
+}
+
+func printJVMDetail(info jvm.Info) {
+	fmt.Printf("PID           %d\n", info.PID)
+	fmt.Printf("Main class    %s\n", strOrDash(info.MainClass))
+	fmt.Printf("JDK vendor    %s\n", strOrDash(info.JDKVendor))
+	fmt.Printf("JDK version   %s\n", strOrDash(info.JDKVersion))
+	fmt.Printf("Java home     %s\n", strOrDash(info.JavaHome))
+	fmt.Printf("VM args       %s\n", strOrDash(info.VMArgs))
+	fmt.Printf("VM flags      %s\n", strOrDash(info.VMFlags))
+	fmt.Printf("Threads       %s\n", intOrDash(info.ThreadCount))
+
+	if len(info.SysProps) > 0 {
+		fmt.Println("\nSystem properties:")
+		keys := make([]string, 0, len(info.SysProps))
+		for k := range info.SysProps {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Printf("  %-30s  %s\n", k, info.SysProps[k])
+		}
+	}
+}
+
+func strOrDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func intOrDash(n int) string {
+	if n == 0 {
+		return "-"
+	}
+	return strconv.Itoa(n)
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -34,6 +34,7 @@ func subcommandList() []subcommand {
 	return []subcommand{
 		{"inspect", "Inspect .app bundles (default; runs when no subcommand given)", runInspect},
 		{"snapshot", "Capture a structured snapshot of host + installed apps", runSnapshot},
+		{"jvm", "List or inspect running JVM processes", runJVM},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},

--- a/internal/jvm/collect.go
+++ b/internal/jvm/collect.go
@@ -1,0 +1,79 @@
+package jvm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// CollectOptions configure the JVM collector.
+type CollectOptions struct {
+	// CmdRunner is used for all subprocess calls. Nil means DefaultRunner.
+	CmdRunner CmdRunner
+}
+
+// CollectAll discovers all running JVM processes and collects per-process
+// metadata via jcmd. Returns nil if jps is not on PATH (no JDK installed).
+// Any per-process collection failure is silently absorbed.
+func CollectAll(ctx context.Context, opts CollectOptions) []Info {
+	run := opts.CmdRunner
+	if run == nil {
+		run = DefaultRunner
+	}
+
+	pids := discoverPIDs(run)
+	if len(pids) == 0 {
+		return nil
+	}
+
+	results := make([]Info, 0, len(pids))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for pid, main := range pids {
+		pid, main := pid, main
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			info := collectOne(ctx, pid, main, run)
+			mu.Lock()
+			results = append(results, info)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// InspectPID collects Info for a specific PID without running jps.
+// Returns nil if jcmd is not available or the process doesn't exist.
+func InspectPID(_ context.Context, pid int, opts CollectOptions) *Info {
+	run := opts.CmdRunner
+	if run == nil {
+		run = DefaultRunner
+	}
+	// Quick sanity check: jcmd with the PID; if it errors the process is gone.
+	if _, err := run("jcmd", fmt.Sprint(pid), "VM.version"); err != nil {
+		return nil
+	}
+	info := collectOne(context.Background(), pid, "", run)
+	return &info
+}
+
+// collectOne gathers Info for a single PID.
+func collectOne(_ context.Context, pid int, main string, run CmdRunner) Info {
+	info := Info{PID: pid, MainClass: main}
+
+	props := collectSysProps(pid, run)
+	info.SysProps = props
+	if props != nil {
+		info.JavaHome = props["java.home"]
+		info.JDKVendor = props["java.vendor"]
+		info.JDKVersion = props["java.version"]
+	}
+
+	info.VMFlags, info.VMArgs = collectCommandLine(pid, run)
+	info.ThreadCount = collectThreadCount(pid, run)
+
+	return info
+}

--- a/internal/jvm/jcmd.go
+++ b/internal/jvm/jcmd.go
@@ -1,0 +1,112 @@
+package jvm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// collectSysProps runs `jcmd <pid> VM.system_properties` and returns the
+// filtered set of properties from the selectedProps allowlist.
+func collectSysProps(pid int, run CmdRunner) map[string]string {
+	out, err := run("jcmd", fmt.Sprint(pid), "VM.system_properties")
+	if err != nil {
+		return nil
+	}
+	return parseSysProps(string(out))
+}
+
+// parseSysProps parses `jcmd VM.system_properties` output.
+//
+// Each property is printed as "key=value" with multi-line values escaped as
+// literal \n. Only keys in selectedProps are returned.
+//
+// Example:
+//
+//	java.home=/Library/Java/JavaVirtualMachines/temurin-21.jdk/...
+//	java.vendor=Eclipse Adoptium
+func parseSysProps(out string) map[string]string {
+	m := make(map[string]string)
+	for _, line := range strings.Split(out, "\n") {
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		if !selectedProps[k] {
+			continue
+		}
+		// Unescape literal \n sequences jcmd emits for multi-line values.
+		v = strings.ReplaceAll(v, `\n`, "\n")
+		m[k] = strings.TrimSpace(v)
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+// collectCommandLine runs `jcmd <pid> VM.command_line` and returns the
+// VM flags and arguments strings.
+func collectCommandLine(pid int, run CmdRunner) (vmFlags, vmArgs string) {
+	out, err := run("jcmd", fmt.Sprint(pid), "VM.command_line")
+	if err != nil {
+		return "", ""
+	}
+	return parseCommandLine(string(out))
+}
+
+// parseCommandLine parses `jcmd VM.command_line` output.
+//
+// Example output:
+//
+//	VM Arguments:
+//	jvm_args: -Xmx4g -Xms256m -XX:+UseG1GC
+//	java_command: com.example.Main
+//	java_class_path (initial): /path/to/app.jar
+//	Launcher Type: SUN_STANDARD
+func parseCommandLine(out string) (vmFlags, vmArgs string) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if k, v, ok := strings.Cut(line, ":"); ok {
+			k = strings.TrimSpace(k)
+			v = strings.TrimSpace(v)
+			switch k {
+			case "jvm_args":
+				vmArgs = v
+			case "VM Flags":
+				vmFlags = v
+			}
+		}
+	}
+	return
+}
+
+// collectThreadCount runs `jcmd <pid> Thread.print` and returns the number
+// of threads by counting thread header lines (lines starting with a quote or
+// daemon/thread marker).
+func collectThreadCount(pid int, run CmdRunner) int {
+	out, err := run("jcmd", fmt.Sprint(pid), "Thread.print")
+	if err != nil {
+		return 0
+	}
+	return countThreads(string(out))
+}
+
+// countThreads counts threads in `jcmd Thread.print` output.
+//
+// Thread entries begin with a line like:
+//
+//	"main" #1 prio=5 os_prio=31 cpu=... elapsed=... tid=... nid=... waiting [...]
+//
+// We count lines that start with `"` followed by a non-whitespace char
+// (thread name in quotes) as one thread entry.
+func countThreads(out string) int {
+	count := 0
+	for _, line := range strings.Split(out, "\n") {
+		// Thread name lines start with a double-quote.
+		if len(line) > 0 && line[0] == '"' {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/jvm/jps.go
+++ b/internal/jvm/jps.go
@@ -1,0 +1,52 @@
+package jvm
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// DefaultRunner runs the real command.
+func DefaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// discoverPIDs runs `jps -l` and returns a map of PID → main class.
+// Returns nil if jps is not found or returns an error (no JDK in PATH).
+func discoverPIDs(run CmdRunner) map[int]string {
+	out, err := run("jps", "-l")
+	if err != nil {
+		return nil
+	}
+	return parseJPS(string(out))
+}
+
+// parseJPS parses `jps -l` output into a PID → main-class map.
+//
+// Format (one process per line):
+//
+//	12345 com.example.Main
+//	23456 org.gradle.launcher.daemon.bootstrap.GradleDaemon
+//	34567
+//	56789 sun.tools.jps.Jps   ← jps itself; excluded
+func parseJPS(out string) map[int]string {
+	result := make(map[int]string)
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pid, rest, _ := strings.Cut(line, " ")
+		pidN, err := strconv.Atoi(pid)
+		if err != nil {
+			continue
+		}
+		main := strings.TrimSpace(rest)
+		// Skip jps itself and the Jstat internal tools.
+		if strings.HasPrefix(main, "sun.tools.") {
+			continue
+		}
+		result[pidN] = main
+	}
+	return result
+}

--- a/internal/jvm/jvm_test.go
+++ b/internal/jvm/jvm_test.go
@@ -1,0 +1,199 @@
+package jvm
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// --- jps parsing ---
+
+func TestParseJPS(t *testing.T) {
+	out := `12345 com.example.Main
+23456 org.gradle.launcher.daemon.bootstrap.GradleDaemon
+34567
+56789 sun.tools.jps.Jps
+`
+	got := parseJPS(out)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries (jps itself excluded), got %d: %v", len(got), got)
+	}
+	if got[12345] != "com.example.Main" {
+		t.Errorf("12345: got %q", got[12345])
+	}
+	if got[23456] != "org.gradle.launcher.daemon.bootstrap.GradleDaemon" {
+		t.Errorf("23456: got %q", got[23456])
+	}
+	if got[34567] != "" {
+		t.Errorf("34567 (no main): got %q", got[34567])
+	}
+	if _, ok := got[56789]; ok {
+		t.Error("sun.tools.jps.Jps should be excluded")
+	}
+}
+
+func TestParseJPSEmpty(t *testing.T) {
+	if got := parseJPS(""); len(got) != 0 {
+		t.Errorf("expected empty map, got %v", got)
+	}
+}
+
+// --- system properties parsing ---
+
+func TestParseSysProps(t *testing.T) {
+	out := `java.home=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
+java.vendor=Eclipse Adoptium
+java.version=21.0.6
+java.runtime.version=21.0.6+7-LTS
+os.arch=aarch64
+user.home=/Users/alice
+java.class.path=/some/long/path  <- not in allowlist
+ignored.key=value
+`
+	got := parseSysProps(out)
+	if got["java.home"] != "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home" {
+		t.Errorf("java.home: %q", got["java.home"])
+	}
+	if got["java.vendor"] != "Eclipse Adoptium" {
+		t.Errorf("java.vendor: %q", got["java.vendor"])
+	}
+	if got["java.version"] != "21.0.6" {
+		t.Errorf("java.version: %q", got["java.version"])
+	}
+	if _, ok := got["java.class.path"]; ok {
+		t.Error("java.class.path should be filtered out (not in allowlist)")
+	}
+	if _, ok := got["ignored.key"]; ok {
+		t.Error("ignored.key should be filtered out")
+	}
+}
+
+func TestParseSysPropsNilOnEmpty(t *testing.T) {
+	if got := parseSysProps("no matching lines here"); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+// --- command line parsing ---
+
+func TestParseCommandLine(t *testing.T) {
+	out := `VM Arguments:
+jvm_args: -Xmx4g -Xms256m -XX:+UseG1GC
+java_command: com.example.Main arg1
+java_class_path (initial): /path/to/app.jar
+Launcher Type: SUN_STANDARD
+`
+	flags, args := parseCommandLine(out)
+	if args != "-Xmx4g -Xms256m -XX:+UseG1GC" {
+		t.Errorf("vmArgs: %q", args)
+	}
+	if flags != "" {
+		t.Errorf("vmFlags expected empty, got %q", flags)
+	}
+}
+
+func TestParseCommandLineWithFlags(t *testing.T) {
+	out := `VM Arguments:
+jvm_args: -Xmx2g
+VM Flags: -XX:InitialHeapSize=268435456 -XX:MaxHeapSize=2147483648
+java_command: some.App
+`
+	flags, args := parseCommandLine(out)
+	if args != "-Xmx2g" {
+		t.Errorf("vmArgs: %q", args)
+	}
+	if flags != "-XX:InitialHeapSize=268435456 -XX:MaxHeapSize=2147483648" {
+		t.Errorf("vmFlags: %q", flags)
+	}
+}
+
+// --- thread count ---
+
+func TestCountThreads(t *testing.T) {
+	out := `2024-05-04 00:00:00
+Full thread dump OpenJDK 64-Bit Server VM (21.0.6+7-LTS mixed mode, sharing):
+
+"main" #1 prio=5 os_prio=31 cpu=320.93ms elapsed=3723.12s tid=0x00007f... nid=0x203 waiting on condition [0x70000...]
+   java.lang.Thread.State: TIMED_WAITING (sleeping)
+
+"Reference Handler" #2 daemon prio=10 os_prio=31 cpu=0.09ms elapsed=3723.11s tid=0x... nid=0x... waiting on condition [0x...]
+   java.lang.Thread.State: RUNNABLE
+
+"Finalizer" #3 daemon prio=8 os_prio=31 cpu=0.16ms elapsed=3723.11s tid=... nid=... in Object.wait() [...]
+
+JNI global refs: 42, weak refs: 1
+`
+	n := countThreads(out)
+	if n != 3 {
+		t.Errorf("expected 3 threads, got %d", n)
+	}
+}
+
+// --- CollectAll with fake runner ---
+
+func TestCollectAllNoJPS(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("command not found: %s", name)
+	}
+	got := CollectAll(context.Background(), CollectOptions{CmdRunner: run})
+	if got != nil {
+		t.Errorf("expected nil when jps not found, got %v", got)
+	}
+}
+
+func TestCollectAllSingleProcess(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "jps":
+			return []byte("4012 com.example.Server\n"), nil
+		case "jcmd":
+			if len(args) < 2 {
+				return nil, fmt.Errorf("jcmd needs args")
+			}
+			switch args[1] {
+			case "VM.system_properties":
+				return []byte(`java.home=/usr/lib/jvm/temurin-21
+java.vendor=Eclipse Adoptium
+java.version=21.0.6
+`), nil
+			case "VM.command_line":
+				return []byte(`VM Arguments:
+jvm_args: -Xmx2g
+java_command: com.example.Server
+`), nil
+			case "Thread.print":
+				return []byte(`"main" #1 prio=5
+"GC Thread" #2
+`), nil
+			}
+		}
+		return nil, fmt.Errorf("unexpected: %s %v", name, args)
+	}
+
+	got := CollectAll(context.Background(), CollectOptions{CmdRunner: run})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 JVM info, got %d", len(got))
+	}
+	info := got[0]
+	if info.PID != 4012 {
+		t.Errorf("PID = %d, want 4012", info.PID)
+	}
+	if info.MainClass != "com.example.Server" {
+		t.Errorf("MainClass = %q", info.MainClass)
+	}
+	if info.JDKVendor != "Eclipse Adoptium" {
+		t.Errorf("JDKVendor = %q", info.JDKVendor)
+	}
+	if info.JDKVersion != "21.0.6" {
+		t.Errorf("JDKVersion = %q", info.JDKVersion)
+	}
+	if info.VMArgs != "-Xmx2g" {
+		t.Errorf("VMArgs = %q", info.VMArgs)
+	}
+	if info.ThreadCount != 2 {
+		t.Errorf("ThreadCount = %d, want 2", info.ThreadCount)
+	}
+	if info.SysProps["java.home"] != "/usr/lib/jvm/temurin-21" {
+		t.Errorf("java.home = %q", info.SysProps["java.home"])
+	}
+}

--- a/internal/jvm/types.go
+++ b/internal/jvm/types.go
@@ -1,0 +1,37 @@
+// Package jvm discovers and inspects running JVM processes using the JDK
+// shell tools jps and jcmd. No Java code is embedded; all inspection is
+// done by forking bundled JDK commands already present on the machine.
+//
+// See docs/inspection/jvm.md for the full design.
+package jvm
+
+// CmdRunner abstracts shell-out for testability.
+type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// Info is the snapshot of one running JVM process.
+type Info struct {
+	PID        int               `json:"pid"`
+	MainClass  string            `json:"main_class,omitempty"`  // from jps -l
+	JavaHome   string            `json:"java_home,omitempty"`   // java.home system property
+	JDKVendor  string            `json:"jdk_vendor,omitempty"`  // java.vendor
+	JDKVersion string            `json:"jdk_version,omitempty"` // java.version
+	VMArgs     string            `json:"vm_args,omitempty"`     // from jcmd VM.command_line
+	VMFlags    string            `json:"vm_flags,omitempty"`    // JVM flags (XX: flags)
+	ThreadCount int              `json:"thread_count,omitempty"`
+	SysProps   map[string]string `json:"sys_props,omitempty"` // selected system properties
+}
+
+// selectedProps is the allowlist of java system properties captured in SysProps.
+// Full java.class.path would be huge; we capture only the diagnostically useful subset.
+var selectedProps = map[string]bool{
+	"java.home":            true,
+	"java.version":         true,
+	"java.vendor":          true,
+	"java.runtime.version": true,
+	"os.arch":              true,
+	"os.name":              true,
+	"os.version":           true,
+	"user.home":            true,
+	"user.dir":             true,
+	"java.io.tmpdir":       true,
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/storagestate"
@@ -40,9 +41,7 @@ type Snapshot struct {
 	Network    netstate.State        `json:"network"`
 	Storage    storagestate.State    `json:"storage"`
 
-	// Placeholders for upcoming collectors. Empty until implemented.
-	// See docs/design/system-inventory.md.
-	// JVMs []JVMInfo
+	JVMs []jvm.Info `json:"jvms,omitempty"`
 }
 
 // Options configure a snapshot Build.
@@ -83,6 +82,14 @@ type Options struct {
 	// StorageOpts are forwarded to the storage state collector.
 	// Zero value uses live filesystem paths.
 	StorageOpts storagestate.CollectOptions
+
+	// JVMOpts are forwarded to the JVM collector.
+	// Zero value uses the real jps/jcmd commands.
+	JVMOpts jvm.CollectOptions
+
+	// SkipJVMs disables JVM process discovery (faster for tests; requires jps
+	// in PATH for real collection).
+	SkipJVMs bool
 }
 
 // Build assembles a Snapshot by running every collector in parallel and
@@ -110,6 +117,9 @@ func Build(ctx context.Context, opts Options) Snapshot {
 		collectors++
 	}
 	if !opts.SkipStorage {
+		collectors++
+	}
+	if !opts.SkipJVMs {
 		collectors++
 	}
 	wg.Add(collectors)
@@ -149,6 +159,12 @@ func Build(ctx context.Context, opts Options) Snapshot {
 		go func() {
 			defer wg.Done()
 			s.Processes = process.CollectAll(ctx, opts.ProcessOpts)
+		}()
+	}
+	if !opts.SkipJVMs {
+		go func() {
+			defer wg.Done()
+			s.JVMs = jvm.CollectAll(ctx, opts.JVMOpts)
 		}()
 	}
 

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -16,6 +16,7 @@ func TestBuildHostOnly(t *testing.T) {
 		AppPaths:       []string{"/dev/null/__skip__"},
 		SkipProcesses:  true,
 		SkipStorage:    true,
+		SkipJVMs:       true,
 	})
 
 	if snap.ID == "" {


### PR DESCRIPTION
## Summary

- Adds `internal/jvm` package implementing Layer 1 of docs/inspection/jvm.md: jps-based process discovery + jcmd-based read-only inspection (system properties, command line, thread count)
- `CollectAll()` runs one goroutine per discovered PID; all subprocess calls go through an injectable `CmdRunner` for full testability
- `InspectPID()` for targeted single-process drill-down from the CLI
- `snapshot.Snapshot` gains `JVMs []jvm.Info` field; `Build()` gets `SkipJVMs` flag used in tests
- `spectra jvm` — list view shows PID/version/threads/main-class; `spectra jvm <pid>` shows full detail with system properties table; `--json` flag

## Test plan

- [ ] `go test ./internal/jvm/...` — 8 tests covering parseJPS, parseSysProps, parseCommandLine, countThreads, CollectAll with fake runner
- [ ] `go test ./internal/snapshot/...` — snapshot test updated to use SkipJVMs
- [ ] `go build ./...` — clean build