### PR TITLE
Add recommendations engine (spectra rules)

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -35,6 +35,7 @@ func subcommandList() []subcommand {
 		{"inspect", "Inspect .app bundles (default; runs when no subcommand given)", runInspect},
 		{"snapshot", "Capture a structured snapshot of host + installed apps", runSnapshot},
 		{"jvm", "List or inspect running JVM processes", runJVM},
+		{"rules", "Evaluate recommendations rules against a snapshot", runRules},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},

--- a/cmd/spectra/rules.go
+++ b/cmd/spectra/rules.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+func runRules(args []string) int {
+	fs := flag.NewFlagSet("spectra rules", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	snapID := fs.String("snapshot", "", "Evaluate against a stored snapshot by ID (default: take a live snapshot)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	var snap snapshot.Snapshot
+	if *snapID != "" {
+		s, err := loadStoredSnapshot(*snapID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "rules: %v\n", err)
+			return 1
+		}
+		snap = *s
+	} else {
+		snap = snapshot.Build(context.Background(), snapshot.Options{
+			SpectraVersion: version,
+			DetectOpts:     detect.Options{},
+		})
+	}
+
+	findings := rules.Evaluate(snap, rules.V1Catalog())
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(findings)
+		return 0
+	}
+
+	if len(findings) == 0 {
+		fmt.Println("no findings — all rules passed")
+		return 0
+	}
+
+	printFindings(findings)
+	return 0
+}
+
+func loadStoredSnapshot(id string) (*snapshot.Snapshot, error) {
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		return nil, err
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	raw, err := db.GetSnapshotJSON(context.Background(), id)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot %q: %w", id, err)
+	}
+	if raw == nil {
+		return nil, fmt.Errorf("snapshot %q has no JSON blob (taken before this version)", id)
+	}
+	var s snapshot.Snapshot
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("unmarshal snapshot %q: %w", id, err)
+	}
+	return &s, nil
+}
+
+func printFindings(findings []rules.Finding) {
+	fmt.Printf("%-8s  %-30s  %s\n", "SEVERITY", "RULE", "MESSAGE")
+	fmt.Println(strings.Repeat("-", 90))
+	for _, f := range findings {
+		msg := f.Message
+		if f.Subject != "" {
+			msg = fmt.Sprintf("[%s] %s", f.Subject, msg)
+		}
+		fmt.Printf("%-8s  %-30s  %s\n", f.Severity, truncate(f.RuleID, 30), msg)
+	}
+	fmt.Printf("\n%d finding(s)\n", len(findings))
+}

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -1,0 +1,246 @@
+package rules
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+// V1Catalog returns all built-in rules for the V1 release.
+// Rules are ordered by severity (high first) within each category.
+func V1Catalog() []Rule {
+	return []Rule{
+		ruleJVMEOLVersion(),
+		ruleJVMHeapVsSystemRAM(),
+		ruleJDKMajorVersionDrift(),
+		ruleJavaHomeMismatch(),
+		ruleStorageFootprint(),
+	}
+}
+
+// ruleJVMEOLVersion fires for each running JVM using a JDK major version
+// that is past Oracle's public support window.
+func ruleJVMEOLVersion() Rule {
+	// Oracle's public support EOL dates (as of 2026).
+	// Versions 8 (LTS), 11 (LTS), 17 (LTS), 21 (LTS) still supported.
+	// Versions 9, 10, 12-16, 18-20, 22+ (non-LTS) are EOL.
+	eolNonLTS := map[int]bool{9: true, 10: true, 12: true, 13: true, 14: true,
+		15: true, 16: true, 18: true, 19: true, 20: true, 22: true, 23: true, 24: true}
+
+	return Rule{
+		ID:       "jvm-eol-version",
+		Severity: SeverityMedium,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, j := range s.JVMs {
+				if j.JDKVersion == "" {
+					continue
+				}
+				major := parseMajor(j.JDKVersion)
+				if major == 0 {
+					continue
+				}
+				// Versions < 8 are clearly EOL; non-LTS post-8 are also EOL.
+				if major < 8 || eolNonLTS[major] {
+					findings = append(findings, Finding{
+						RuleID:   "jvm-eol-version",
+						Severity: SeverityMedium,
+						Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
+						Message:  fmt.Sprintf("JDK %s (major %d) is past public support.", j.JDKVersion, major),
+						Fix:      "Upgrade to JDK 21 LTS or JDK 17 LTS. Run `spectra jvm` to see all running JVMs.",
+					})
+				}
+			}
+			return findings
+		},
+	}
+}
+
+// ruleJVMHeapVsSystemRAM fires when a running JVM's -Xmx setting allocates
+// more than 60% of system RAM, which can cause OS-level swap pressure.
+func ruleJVMHeapVsSystemRAM() Rule {
+	return Rule{
+		ID:       "jvm-heap-vs-system",
+		Severity: SeverityHigh,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			ramMB := int64(s.Host.RAMBytes / (1024 * 1024))
+			if ramMB == 0 {
+				return nil
+			}
+			var findings []Finding
+			for _, j := range s.JVMs {
+				if j.VMArgs == "" {
+					continue
+				}
+				xmxMB := parseXmxMB(j.VMArgs)
+				if xmxMB <= 0 {
+					continue
+				}
+				pct := xmxMB * 100 / ramMB
+				if pct > 60 {
+					findings = append(findings, Finding{
+						RuleID:   "jvm-heap-vs-system",
+						Severity: SeverityHigh,
+						Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
+						Message:  fmt.Sprintf("-Xmx%dMB is %d%% of system RAM (%dMB). Swap thrashing likely under GC pressure.", xmxMB, pct, ramMB),
+						Fix:      "Reduce -Xmx, or if this is intentional ensure sufficient swap headroom.",
+					})
+				}
+			}
+			return findings
+		},
+	}
+}
+
+// ruleJDKMajorVersionDrift fires when more than one installed JDK shares
+// the same major version but different patch/vendor combinations, which
+// can cause confusing version resolution.
+func ruleJDKMajorVersionDrift() Rule {
+	return Rule{
+		ID:       "jdk-major-version-drift",
+		Severity: SeverityLow,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			// Group JDKs by major version.
+			byMajor := make(map[int][]toolchain.JDKInstall)
+			for _, j := range s.Toolchains.JDKs {
+				byMajor[j.VersionMajor] = append(byMajor[j.VersionMajor], j)
+			}
+			var findings []Finding
+			// Stable iteration order.
+			majors := make([]int, 0, len(byMajor))
+			for m := range byMajor {
+				majors = append(majors, m)
+			}
+			sort.Ints(majors)
+			for _, m := range majors {
+				group := byMajor[m]
+				if len(group) <= 1 {
+					continue
+				}
+				paths := make([]string, len(group))
+				for i, j := range group {
+					paths[i] = fmt.Sprintf("%s %s", j.Vendor, j.ReleaseString)
+				}
+				findings = append(findings, Finding{
+					RuleID:   "jdk-major-version-drift",
+					Severity: SeverityLow,
+					Subject:  fmt.Sprintf("JDK %d (%d installs)", m, len(group)),
+					Message:  fmt.Sprintf("%d JDK %d installs found: %s", len(group), m, strings.Join(paths, "; ")),
+					Fix:      "Remove duplicate JDK installations to avoid version-resolution surprises.",
+				})
+			}
+			return findings
+		},
+	}
+}
+
+// ruleJavaHomeMismatch fires when JAVA_HOME points to a path not found in
+// the list of discovered JDK installs.
+func ruleJavaHomeMismatch() Rule {
+	return Rule{
+		ID:       "java-home-mismatch",
+		Severity: SeverityMedium,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			javaHome := s.Toolchains.Env.JavaHome
+			if javaHome == "" {
+				return nil
+			}
+			for _, j := range s.Toolchains.JDKs {
+				if strings.HasPrefix(j.Path, javaHome) || strings.HasPrefix(javaHome, j.Path) {
+					return nil // found a match
+				}
+			}
+			return []Finding{{
+				RuleID:   "java-home-mismatch",
+				Severity: SeverityMedium,
+				Subject:  javaHome,
+				Message:  fmt.Sprintf("JAVA_HOME=%q does not match any discovered JDK installation.", javaHome),
+				Fix:      "Run `spectra jvm` to see discovered JDKs and update JAVA_HOME in your shell profile.",
+			}}
+		},
+	}
+}
+
+// ruleStorageFootprint fires when ~/Library exceeds 5 GB (potential bloat).
+func ruleStorageFootprint() Rule {
+	const threshold = 5 * 1024 * 1024 * 1024 // 5 GiB
+	return Rule{
+		ID:       "library-storage-footprint",
+		Severity: SeverityInfo,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			if s.Storage.UserLibraryBytes < threshold {
+				return nil
+			}
+			gb := float64(s.Storage.UserLibraryBytes) / (1024 * 1024 * 1024)
+			return []Finding{{
+				RuleID:   "library-storage-footprint",
+				Severity: SeverityInfo,
+				Message:  fmt.Sprintf("~/Library is %.1f GB — above the 5 GB alert threshold.", gb),
+				Fix:      "Run `spectra snapshot` and check LargestApps to identify top consumers.",
+			}}
+		},
+	}
+}
+
+// parseMajor extracts the major version number from a Java version string.
+// Handles both legacy ("1.8.0_362") and modern ("21.0.6") formats.
+func parseMajor(v string) int {
+	// Legacy format: "1.8.0_N" → major 8
+	if strings.HasPrefix(v, "1.") {
+		parts := strings.SplitN(v, ".", 3)
+		if len(parts) >= 2 {
+			return atoi(parts[1])
+		}
+	}
+	// Modern: "21.0.6" → 21
+	parts := strings.SplitN(v, ".", 2)
+	return atoi(parts[0])
+}
+
+// parseXmxMB extracts the -Xmx heap ceiling in MiB from a VM args string.
+// Returns 0 if not found.
+func parseXmxMB(vmArgs string) int64 {
+	for _, part := range strings.Fields(vmArgs) {
+		if !strings.HasPrefix(part, "-Xmx") {
+			continue
+		}
+		raw := part[4:] // strip -Xmx
+		if len(raw) == 0 {
+			continue
+		}
+		suffix := raw[len(raw)-1]
+		digits := raw
+		if suffix >= 'A' && suffix <= 'z' {
+			digits = raw[:len(raw)-1]
+		}
+		n := int64(atoi(digits))
+		if n == 0 {
+			continue
+		}
+		switch suffix {
+		case 'g', 'G':
+			return n * 1024
+		case 'm', 'M':
+			return n
+		case 'k', 'K':
+			return n / 1024
+		default:
+			return n / (1024 * 1024) // bare bytes → MiB
+		}
+	}
+	return 0
+}
+
+func atoi(s string) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return n
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/internal/rules/engine.go
+++ b/internal/rules/engine.go
@@ -1,0 +1,36 @@
+package rules
+
+import (
+	"sort"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+// severityOrder maps severities to sort keys (lower = higher priority).
+var severityOrder = map[Severity]int{
+	SeverityHigh:   0,
+	SeverityMedium: 1,
+	SeverityLow:    2,
+	SeverityInfo:   3,
+}
+
+// Evaluate runs all rules in catalog against snap and returns the findings
+// sorted by severity (high first) then rule ID for stable output.
+func Evaluate(snap snapshot.Snapshot, catalog []Rule) []Finding {
+	var all []Finding
+	for _, r := range catalog {
+		all = append(all, r.MatchFn(snap)...)
+	}
+	sort.SliceStable(all, func(i, j int) bool {
+		si := severityOrder[all[i].Severity]
+		sj := severityOrder[all[j].Severity]
+		if si != sj {
+			return si < sj
+		}
+		if all[i].RuleID != all[j].RuleID {
+			return all[i].RuleID < all[j].RuleID
+		}
+		return all[i].Subject < all[j].Subject
+	})
+	return all
+}

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1,0 +1,220 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/storagestate"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+func baseSnap() snapshot.Snapshot {
+	return snapshot.Snapshot{
+		ID:   "snap-test",
+		Kind: snapshot.KindLive,
+		Host: snapshot.HostInfo{
+			Hostname: "test-mac",
+			RAMBytes: 16 * 1024 * 1024 * 1024, // 16 GiB
+		},
+	}
+}
+
+// --- parseMajor ---
+
+func TestParseMajor(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"21.0.6", 21},
+		{"17.0.10", 17},
+		{"11.0.22", 11},
+		{"1.8.0_402", 8},
+		{"1.11.0", 11}, // unusual legacy prefix
+		{"9.0.4", 9},
+		{"bad", 0},
+	}
+	for _, c := range cases {
+		if got := parseMajor(c.in); got != c.want {
+			t.Errorf("parseMajor(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// --- parseXmxMB ---
+
+func TestParseXmxMB(t *testing.T) {
+	cases := []struct {
+		args string
+		want int64
+	}{
+		{"-Xmx4g -Xms256m", 4096},
+		{"-Xmx2048m", 2048},
+		{"-Xmx512m", 512},
+		{"-Xmx1G", 1024},
+		{"-Xms256m", 0}, // no -Xmx
+		{"", 0},
+	}
+	for _, c := range cases {
+		if got := parseXmxMB(c.args); got != c.want {
+			t.Errorf("parseXmxMB(%q) = %d, want %d", c.args, got, c.want)
+		}
+	}
+}
+
+// --- jvm-eol-version ---
+
+func TestJVMEOLVersionFires(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{
+		{PID: 100, MainClass: "com.example.App", JDKVersion: "11.0.22"}, // supported
+		{PID: 200, MainClass: "com.old.App", JDKVersion: "1.8.0_402"},   // 8 = supported
+		{PID: 300, MainClass: "com.ancient.App", JDKVersion: "9.0.4"},   // 9 = EOL non-LTS
+		{PID: 400, MainClass: "com.jdk7.App", JDKVersion: "7.0.80"},     // < 8 = EOL
+	}
+	findings := ruleJVMEOLVersion().MatchFn(s)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 EOL findings (JDK 9 and JDK 7), got %d: %v", len(findings), findings)
+	}
+}
+
+func TestJVMEOLVersionNoFire(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{
+		{PID: 1, JDKVersion: "21.0.6"},
+		{PID: 2, JDKVersion: "17.0.10"},
+		{PID: 3, JDKVersion: "11.0.22"},
+	}
+	if findings := ruleJVMEOLVersion().MatchFn(s); len(findings) != 0 {
+		t.Errorf("expected no findings for supported JDK versions, got %v", findings)
+	}
+}
+
+// --- jvm-heap-vs-system ---
+
+func TestJVMHeapVsSystemFires(t *testing.T) {
+	s := baseSnap() // 16 GiB RAM → 16384 MiB
+	s.JVMs = []jvm.Info{
+		{PID: 1, MainClass: "big.App", VMArgs: "-Xmx12g"}, // 12288 MiB = 75% → fires
+		{PID: 2, MainClass: "ok.App", VMArgs: "-Xmx4g"},   // 4096 MiB = 25% → no fire
+	}
+	findings := ruleJVMHeapVsSystemRAM().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 heap finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityHigh {
+		t.Errorf("severity = %q, want high", findings[0].Severity)
+	}
+}
+
+func TestJVMHeapVsSystemNoFire(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{PID: 1, VMArgs: "-Xmx2g"}} // 12.5% → ok
+	if findings := ruleJVMHeapVsSystemRAM().MatchFn(s); len(findings) != 0 {
+		t.Errorf("expected no findings for -Xmx2g on 16 GiB, got %v", findings)
+	}
+}
+
+// --- jdk-major-version-drift ---
+
+func TestJDKDriftFires(t *testing.T) {
+	s := baseSnap()
+	s.Toolchains.JDKs = []toolchain.JDKInstall{
+		{VersionMajor: 21, Vendor: "Eclipse Adoptium", Source: "brew"},
+		{VersionMajor: 21, Vendor: "Azul Zulu", Source: "sdkman"},
+		{VersionMajor: 17, Vendor: "Oracle", Source: "manual"},
+	}
+	findings := ruleJDKMajorVersionDrift().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 drift finding (JDK 21 x2), got %d: %v", len(findings), findings)
+	}
+	if findings[0].Subject != "JDK 21 (2 installs)" {
+		t.Errorf("subject = %q", findings[0].Subject)
+	}
+}
+
+func TestJDKDriftNoFire(t *testing.T) {
+	s := baseSnap()
+	s.Toolchains.JDKs = []toolchain.JDKInstall{
+		{VersionMajor: 21, Vendor: "Eclipse Adoptium"},
+		{VersionMajor: 17, Vendor: "Eclipse Adoptium"},
+	}
+	if findings := ruleJDKMajorVersionDrift().MatchFn(s); len(findings) != 0 {
+		t.Errorf("expected no drift for different major versions, got %v", findings)
+	}
+}
+
+// --- java-home-mismatch ---
+
+func TestJavaHomeMismatchFires(t *testing.T) {
+	s := baseSnap()
+	s.Toolchains.Env.JavaHome = "/nonexistent/path/jdk"
+	s.Toolchains.JDKs = []toolchain.JDKInstall{
+		{Path: "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home"},
+	}
+	findings := ruleJavaHomeMismatch().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 mismatch finding, got %d", len(findings))
+	}
+}
+
+func TestJavaHomeMismatchNoFire(t *testing.T) {
+	s := baseSnap()
+	s.Toolchains.Env.JavaHome = "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home"
+	s.Toolchains.JDKs = []toolchain.JDKInstall{
+		{Path: "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home"},
+	}
+	if findings := ruleJavaHomeMismatch().MatchFn(s); len(findings) != 0 {
+		t.Errorf("expected no mismatch when JAVA_HOME matches a JDK, got %v", findings)
+	}
+}
+
+func TestJavaHomeMissingEnv(t *testing.T) {
+	s := baseSnap() // JAVA_HOME empty
+	if findings := ruleJavaHomeMismatch().MatchFn(s); len(findings) != 0 {
+		t.Errorf("expected no finding when JAVA_HOME not set, got %v", findings)
+	}
+}
+
+// --- library storage footprint ---
+
+func TestStorageFootprintFires(t *testing.T) {
+	s := baseSnap()
+	s.Storage = storagestate.State{UserLibraryBytes: 6 * 1024 * 1024 * 1024} // 6 GiB
+	findings := ruleStorageFootprint().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 storage finding, got %d", len(findings))
+	}
+	if findings[0].Severity != SeverityInfo {
+		t.Errorf("severity = %q, want info", findings[0].Severity)
+	}
+}
+
+func TestStorageFootprintNoFire(t *testing.T) {
+	s := baseSnap()
+	s.Storage = storagestate.State{UserLibraryBytes: 2 * 1024 * 1024 * 1024} // 2 GiB
+	if findings := ruleStorageFootprint().MatchFn(s); len(findings) != 0 {
+		t.Errorf("expected no finding for 2 GiB ~/Library, got %v", findings)
+	}
+}
+
+// --- Evaluate (engine) ---
+
+func TestEvaluateSortOrder(t *testing.T) {
+	s := baseSnap()
+	// RAMBytes = 16 GiB
+	s.JVMs = []jvm.Info{
+		{PID: 1, MainClass: "big", VMArgs: "-Xmx12g"}, // high
+		{PID: 2, MainClass: "old", JDKVersion: "9.0.4"}, // medium
+	}
+	s.Storage = storagestate.State{UserLibraryBytes: 10 * 1024 * 1024 * 1024} // info
+	findings := Evaluate(s, V1Catalog())
+	if len(findings) < 3 {
+		t.Fatalf("expected at least 3 findings, got %d", len(findings))
+	}
+	// First finding must be high severity.
+	if findings[0].Severity != SeverityHigh {
+		t.Errorf("first finding severity = %q, want high", findings[0].Severity)
+	}
+}

--- a/internal/rules/types.go
+++ b/internal/rules/types.go
@@ -1,0 +1,39 @@
+// Package rules implements the Spectra recommendations engine.
+//
+// Rules are defined as Go functions today; the long-term architecture
+// (docs/design/recommendations-engine.md) targets CEL expressions loaded
+// from YAML so new rules don't require a binary release. The MatchFn
+// signature is the seam where CEL evaluators will plug in.
+package rules
+
+import "github.com/kaeawc/spectra/internal/snapshot"
+
+// Severity classifies how urgent a finding is.
+type Severity string
+
+const (
+	SeverityHigh   Severity = "high"
+	SeverityMedium Severity = "medium"
+	SeverityLow    Severity = "low"
+	SeverityInfo   Severity = "info"
+)
+
+// Finding is one instance of a rule firing against a snapshot. Multiple
+// findings can come from one rule (e.g. one per JDK).
+type Finding struct {
+	RuleID   string   `json:"rule_id"`
+	Severity Severity `json:"severity"`
+	Message  string   `json:"message"`
+	Fix      string   `json:"fix,omitempty"`
+	// Subject identifies what the finding is about (e.g. "JDK 11 at /path").
+	// Empty for host-level findings.
+	Subject string `json:"subject,omitempty"`
+}
+
+// Rule is one declarative check. MatchFn receives a snapshot and returns
+// zero or more findings. Zero findings means the rule did not fire.
+type Rule struct {
+	ID       string
+	Severity Severity
+	MatchFn  func(s snapshot.Snapshot) []Finding
+}


### PR DESCRIPTION
## Summary

- `internal/rules`: V1 recommendations engine with 5 rules from docs/design/recommendations-engine.md. Rules are Go `MatchFn` functions today; the `Rule` interface has a seam for CEL evaluation (no external dependency yet)
- `Evaluate()` runs all catalog rules and sorts findings high→medium→low→info
- `spectra rules` CLI: live snapshot by default, `--snapshot <id>` for stored, `--json` flag

**V1 Catalog:**
| Rule | Severity | What it catches |
|---|---|---|
| jvm-eol-version | medium | Running JVMs on EOL JDK (non-LTS or <8) |
| jvm-heap-vs-system | high | -Xmx > 60% of system RAM |
| jdk-major-version-drift | low | Multiple JDK installs at same major version |
| java-home-mismatch | medium | JAVA_HOME doesn't match any discovered JDK |
| library-storage-footprint | info | ~/Library > 5 GiB |

## Test plan

- [ ] `go test ./internal/rules/...` — 15 table-driven tests
- [ ] `go build ./...` — clean build