### PR TITLE
Add spectra serve daemon (Unix socket JSON-RPC)

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -36,6 +36,8 @@ func subcommandList() []subcommand {
 		{"snapshot", "Capture a structured snapshot of host + installed apps", runSnapshot},
 		{"jvm", "List or inspect running JVM processes", runJVM},
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},
+		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},
+		{"status", "Check whether the local daemon is running", runStatus},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},

--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/rpc"
+	"github.com/kaeawc/spectra/internal/serve"
+)
+
+func runServe(args []string) int {
+	fs := flag.NewFlagSet("spectra serve", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	sockPath := fs.String("sock", "", "Unix socket path (default: ~/.spectra/sock)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	sock := *sockPath
+	if sock == "" {
+		var err error
+		sock, err = serve.DefaultSockPath()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+	}
+	fmt.Fprintf(os.Stderr, "spectra serve: listening on %s\n", sock)
+
+	if err := serve.Run(ctx, serve.Options{
+		SockPath:       sock,
+		SpectraVersion: version,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+// runStatus sends a health request to the running daemon and prints the result.
+func runStatus(args []string) int {
+	fs := flag.NewFlagSet("spectra status", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	sockPath := fs.String("sock", "", "Unix socket path (default: ~/.spectra/sock)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	sock := *sockPath
+	if sock == "" {
+		var err error
+		sock, err = serve.DefaultSockPath()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+	}
+
+	conn, err := rpc.DialUnix(sock)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "daemon not running (could not connect to %s): %v\n", sock, err)
+		return 1
+	}
+	defer conn.Close()
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	type req struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      int    `json:"id"`
+		Method  string `json:"method"`
+	}
+	_ = enc.Encode(req{JSONRPC: "2.0", ID: 1, Method: "health"})
+
+	// Set a short read deadline so status doesn't hang if daemon is stuck.
+	type deadliner interface{ SetDeadline(time.Time) error }
+	if d, ok := conn.(deadliner); ok {
+		_ = d.SetDeadline(time.Now().Add(3 * time.Second))
+	}
+
+	var resp rpc.Response
+	if err := dec.Decode(&resp); err != nil {
+		fmt.Fprintf(os.Stderr, "error reading daemon response: %v\n", err)
+		return 1
+	}
+	if resp.Error != nil {
+		fmt.Fprintf(os.Stderr, "daemon error: %s\n", resp.Error.Message)
+		return 1
+	}
+
+	out, _ := json.MarshalIndent(resp.Result, "", "  ")
+	fmt.Println(string(out))
+	return 0
+}

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -1,0 +1,154 @@
+// Package rpc implements a JSON-RPC 2.0 dispatcher for Spectra's daemon.
+// Each connection from a client gets its own request/response loop.
+// Handlers are registered by method name; unrecognised methods return
+// the standard JSON-RPC "method not found" error.
+package rpc
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+// Request is a JSON-RPC 2.0 request object.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response is a JSON-RPC 2.0 response object.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError is the JSON-RPC 2.0 error object.
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Standard JSON-RPC error codes.
+const (
+	CodeParseError     = -32700
+	CodeInvalidRequest = -32600
+	CodeMethodNotFound = -32601
+	CodeInvalidParams  = -32602
+	CodeInternalError  = -32603
+)
+
+// HandlerFunc is the type of a registered method handler.
+// params is the raw JSON params value (may be nil). The handler returns
+// any JSON-serializable result or an error.
+type HandlerFunc func(params json.RawMessage) (any, error)
+
+// Dispatcher routes JSON-RPC 2.0 requests to registered handlers.
+type Dispatcher struct {
+	mu       sync.RWMutex
+	handlers map[string]HandlerFunc
+}
+
+// NewDispatcher returns an empty Dispatcher.
+func NewDispatcher() *Dispatcher {
+	return &Dispatcher{handlers: make(map[string]HandlerFunc)}
+}
+
+// Register registers a handler for the given method name.
+func (d *Dispatcher) Register(method string, fn HandlerFunc) {
+	d.mu.Lock()
+	d.handlers[method] = fn
+	d.mu.Unlock()
+}
+
+// Serve handles one connection. Each newline-delimited JSON request on
+// the connection produces a newline-delimited JSON response.
+// The function returns when the connection is closed.
+func (d *Dispatcher) Serve(conn net.Conn) {
+	defer conn.Close()
+	scanner := bufio.NewScanner(conn)
+	enc := json.NewEncoder(conn)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		resp := d.handle(line)
+		_ = enc.Encode(resp)
+	}
+}
+
+func (d *Dispatcher) handle(raw []byte) Response {
+	var req Request
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return Response{
+			JSONRPC: "2.0",
+			Error:   &RPCError{Code: CodeParseError, Message: "parse error: " + err.Error()},
+		}
+	}
+	if req.JSONRPC != "2.0" || req.Method == "" {
+		return Response{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &RPCError{Code: CodeInvalidRequest, Message: "invalid request"},
+		}
+	}
+
+	d.mu.RLock()
+	fn, ok := d.handlers[req.Method]
+	d.mu.RUnlock()
+
+	if !ok {
+		return Response{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &RPCError{Code: CodeMethodNotFound, Message: fmt.Sprintf("method not found: %s", req.Method)},
+		}
+	}
+
+	result, err := fn(req.Params)
+	if err != nil {
+		return Response{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &RPCError{Code: CodeInternalError, Message: err.Error()},
+		}
+	}
+	return Response{JSONRPC: "2.0", ID: req.ID, Result: result}
+}
+
+// ServeListener accepts connections from ln and serves each in its own
+// goroutine until ln is closed or ctx signals done.
+func (d *Dispatcher) ServeListener(ln net.Listener) error {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			// ErrClosed is normal on shutdown.
+			if isClosedErr(err) {
+				return nil
+			}
+			return err
+		}
+		go d.Serve(conn)
+	}
+}
+
+func isClosedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	// net.ErrClosed is available since Go 1.16.
+	if err == net.ErrClosed {
+		return true
+	}
+	return false
+}
+
+// DialUnix connects to a Spectra daemon listening on sockPath. The returned
+// ReadWriter can be used to send requests and read responses.
+func DialUnix(sockPath string) (io.ReadWriteCloser, error) {
+	return net.Dial("unix", sockPath)
+}

--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -1,0 +1,103 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandleMethodNotFound(t *testing.T) {
+	d := NewDispatcher()
+	resp := d.handle([]byte(`{"jsonrpc":"2.0","id":1,"method":"missing"}`))
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown method")
+	}
+	if resp.Error.Code != CodeMethodNotFound {
+		t.Errorf("code = %d, want %d", resp.Error.Code, CodeMethodNotFound)
+	}
+}
+
+func TestHandleParseError(t *testing.T) {
+	d := NewDispatcher()
+	resp := d.handle([]byte(`{bad json`))
+	if resp.Error == nil || resp.Error.Code != CodeParseError {
+		t.Errorf("expected parse error, got %+v", resp)
+	}
+}
+
+func TestHandleInvalidRequest(t *testing.T) {
+	d := NewDispatcher()
+	// Missing method field.
+	resp := d.handle([]byte(`{"jsonrpc":"2.0","id":1}`))
+	if resp.Error == nil || resp.Error.Code != CodeInvalidRequest {
+		t.Errorf("expected invalid request, got %+v", resp)
+	}
+}
+
+func TestHandleRegisteredMethod(t *testing.T) {
+	d := NewDispatcher()
+	d.Register("add", func(params json.RawMessage) (any, error) {
+		var p struct{ A, B int }
+		_ = json.Unmarshal(params, &p)
+		return p.A + p.B, nil
+	})
+	resp := d.handle([]byte(`{"jsonrpc":"2.0","id":42,"method":"add","params":{"A":3,"B":4}}`))
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	n, ok := resp.Result.(int)
+	if !ok || n != 7 {
+		t.Errorf("result = %v, want 7", resp.Result)
+	}
+	// ID must round-trip.
+	if string(resp.ID) != "42" {
+		t.Errorf("id = %s, want 42", resp.ID)
+	}
+}
+
+func TestServeOverUnixSocket(t *testing.T) {
+	d := NewDispatcher()
+	d.Register("ping", func(_ json.RawMessage) (any, error) {
+		return "pong", nil
+	})
+
+	sockPath := t.TempDir() + "/test.sock"
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go d.ServeListener(ln)
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+	req := `{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 512)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := strings.TrimSpace(string(buf[:n]))
+	var resp Response
+	if err := json.Unmarshal([]byte(line), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	if resp.Result != "pong" {
+		t.Errorf("result = %v, want pong", resp.Result)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1,0 +1,157 @@
+// Package serve wires up the Spectra daemon: it creates the Unix socket
+// listener, registers JSON-RPC 2.0 handlers for every public method, and
+// runs the accept loop until the context is cancelled.
+//
+// See docs/operations/daemon.md for the design.
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/rpc"
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+// DefaultSockPath returns the canonical Unix socket path (~/.spectra/sock).
+func DefaultSockPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".spectra", "sock"), nil
+}
+
+// Options configures the daemon.
+type Options struct {
+	SockPath       string
+	SpectraVersion string
+	DBPath         string // empty = store.DefaultPath()
+}
+
+// Run starts the daemon: listens on the Unix socket and serves requests until
+// ctx is cancelled. Run blocks until the listener is shut down.
+func Run(ctx context.Context, opts Options) error {
+	sockPath := opts.SockPath
+	if sockPath == "" {
+		var err error
+		sockPath, err = DefaultSockPath()
+		if err != nil {
+			return fmt.Errorf("serve: resolve sock path: %w", err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		return fmt.Errorf("serve: mkdir: %w", err)
+	}
+	// Remove stale socket file if daemon was not cleanly shut down.
+	_ = os.Remove(sockPath)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("serve: listen %s: %w", sockPath, err)
+	}
+	// Restrict access to the running user.
+	if err := os.Chmod(sockPath, 0o600); err != nil {
+		ln.Close()
+		return fmt.Errorf("serve: chmod %s: %w", sockPath, err)
+	}
+	defer func() {
+		ln.Close()
+		os.Remove(sockPath)
+	}()
+
+	dbPath := opts.DBPath
+	if dbPath == "" {
+		dbPath, err = store.DefaultPath()
+		if err != nil {
+			return fmt.Errorf("serve: resolve db path: %w", err)
+		}
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return fmt.Errorf("serve: open db: %w", err)
+	}
+	defer db.Close()
+
+	d := rpc.NewDispatcher()
+	registerHandlers(d, opts.SpectraVersion, db)
+
+	// Close the listener when ctx is cancelled to unblock Accept.
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+
+	return d.ServeListener(ln)
+}
+
+// registerHandlers wires all JSON-RPC methods into d.
+func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB) {
+	d.Register("health", func(_ json.RawMessage) (any, error) {
+		return map[string]any{"ok": true, "version": version}, nil
+	})
+
+	d.Register("snapshot.list", func(_ json.RawMessage) (any, error) {
+		return db.ListSnapshots(context.Background(), "")
+	})
+
+	d.Register("snapshot.get", func(params json.RawMessage) (any, error) {
+		var p struct{ ID string }
+		if err := json.Unmarshal(params, &p); err != nil || p.ID == "" {
+			return nil, fmt.Errorf("snapshot.get requires {\"ID\":\"<id>\"}")
+		}
+		raw, err := db.GetSnapshotJSON(context.Background(), p.ID)
+		if err != nil {
+			return nil, err
+		}
+		if raw == nil {
+			return nil, fmt.Errorf("snapshot %q has no JSON blob", p.ID)
+		}
+		var s snapshot.Snapshot
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, err
+		}
+		return s, nil
+	})
+
+	d.Register("snapshot.create", func(_ json.RawMessage) (any, error) {
+		snap := snapshot.Build(context.Background(), snapshot.Options{
+			SpectraVersion: version,
+			DetectOpts:     detect.Options{},
+		})
+		if err := db.SaveSnapshot(context.Background(), store.FromSnapshot(snap)); err != nil {
+			return nil, err
+		}
+		return snap, nil
+	})
+
+	d.Register("rules.check", func(params json.RawMessage) (any, error) {
+		// Optional: { "snapshot_id": "snap-..." } to evaluate against stored snapshot.
+		var p struct{ SnapshotID string `json:"snapshot_id"` }
+		_ = json.Unmarshal(params, &p)
+
+		var snap snapshot.Snapshot
+		if p.SnapshotID != "" {
+			raw, err := db.GetSnapshotJSON(context.Background(), p.SnapshotID)
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(raw, &snap); err != nil {
+				return nil, err
+			}
+		} else {
+			snap = snapshot.Build(context.Background(), snapshot.Options{
+				SpectraVersion: version,
+				DetectOpts:     detect.Options{},
+			})
+		}
+		return rules.Evaluate(snap, rules.V1Catalog()), nil
+	})
+}

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -1,0 +1,135 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/rpc"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+func TestDaemonHealthEndpoint(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := rpc.NewDispatcher()
+	registerHandlers(d, "test-version", db)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+	go d.ServeListener(ln)
+
+	// Give the listener a moment to start.
+	time.Sleep(10 * time.Millisecond)
+
+	conn, err := rpc.DialUnix(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	type req struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      int    `json:"id"`
+		Method  string `json:"method"`
+	}
+	if err := enc.Encode(req{JSONRPC: "2.0", ID: 1, Method: "health"}); err != nil {
+		t.Fatal(err)
+	}
+
+	conn.(interface{ SetDeadline(time.Time) error }).SetDeadline(time.Now().Add(3 * time.Second))
+
+	var resp rpc.Response
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %+v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	if m["ok"] != true {
+		t.Errorf("ok = %v, want true", m["ok"])
+	}
+	if m["version"] != "test-version" {
+		t.Errorf("version = %v, want test-version", m["version"])
+	}
+}
+
+func TestDaemonSnapshotList(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := rpc.NewDispatcher()
+	registerHandlers(d, "test", db)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+	go d.ServeListener(ln)
+	time.Sleep(10 * time.Millisecond)
+
+	conn, err := rpc.DialUnix(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.(interface{ SetDeadline(time.Time) error }).SetDeadline(time.Now().Add(3 * time.Second))
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	type req struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      int    `json:"id"`
+		Method  string `json:"method"`
+	}
+	_ = enc.Encode(req{JSONRPC: "2.0", ID: 2, Method: "snapshot.list"})
+
+	var resp rpc.Response
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	// Empty DB → result should be nil or empty slice.
+	// Either is fine; just check it doesn't error.
+}


### PR DESCRIPTION
## Summary

- `internal/rpc`: JSON-RPC 2.0 dispatcher — `Register(method, fn)`, newline-delimited request/response over any `net.Conn`, `ServeListener()` accept loop, `DialUnix()` client helper
- `internal/serve`: `Run(ctx, opts)` — creates `~/.spectra/sock` (0600 perms, stale cleanup), registers 5 RPC methods, shuts down cleanly on ctx cancellation
- RPC methods: `health`, `snapshot.list`, `snapshot.get`, `snapshot.create`, `rules.check`
- `spectra serve [--sock <path>]` — foreground daemon mode
- `spectra status [--sock <path>]` — health ping against running daemon

## Test plan

- [ ] `go test ./internal/rpc/...` — 4 unit tests (method-not-found, parse error, invalid request, end-to-end ping over Unix socket)
- [ ] `go test ./internal/serve/...` — 2 integration tests (health endpoint, snapshot.list on empty DB)
- [ ] `go build ./...` — clean build