### PR TITLE
Add privileged helper (spectra-helper + install-helper)

### DIFF
--- a/cmd/spectra-helper/main.go
+++ b/cmd/spectra-helper/main.go
@@ -1,0 +1,77 @@
+// Command spectra-helper is the Spectra privileged daemon. It must run as
+// root (installed as a LaunchDaemon) and exposes a narrow JSON-RPC 2.0
+// surface over a local Unix socket for root-only telemetry:
+//
+//   - System TCC.db queries
+//   - powermetrics samples
+//   - Full process tree (including system daemons)
+//
+// The socket is /var/run/spectra-helper.sock (0660 root:_spectra).
+// Only processes in the _spectra group can connect.
+//
+// See docs/design/privileged-helper.md for the full design.
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/kaeawc/spectra/internal/helper"
+)
+
+var version = "dev"
+
+const sockPath = "/var/run/spectra-helper.sock"
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "spectra-helper: mkdir: %v\n", err)
+		return 1
+	}
+	// Remove stale socket from a previous crash.
+	_ = os.Remove(sockPath)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "spectra-helper: listen: %v\n", err)
+		return 1
+	}
+	// 0660: accessible to root and _spectra group members only.
+	if err := os.Chmod(sockPath, 0o660); err != nil {
+		ln.Close()
+		fmt.Fprintf(os.Stderr, "spectra-helper: chmod: %v\n", err)
+		return 1
+	}
+	defer func() {
+		ln.Close()
+		os.Remove(sockPath)
+	}()
+
+	d := helper.NewDispatcher()
+	helper.RegisterAll(d, nil) // nil → real commands
+
+	fmt.Fprintf(os.Stderr, "spectra-helper %s: listening on %s\n", version, sockPath)
+
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+
+	if err := d.ServeListener(ln); err != nil {
+		fmt.Fprintf(os.Stderr, "spectra-helper: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/spectra/helper.go
+++ b/cmd/spectra/helper.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kaeawc/spectra/internal/helperclient"
+)
+
+// helperBinaryDest is where spectra-helper is installed.
+const helperBinaryDest = "/Library/PrivilegedHelperTools/spectra-helper"
+
+// helperPlist is the LaunchDaemon plist path.
+const helperPlist = "/Library/LaunchDaemons/dev.spectra.helper.plist"
+
+// helperPlistContent is the LaunchDaemon plist that starts spectra-helper
+// at boot and keeps it alive.
+const helperPlistContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.spectra.helper</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Library/PrivilegedHelperTools/spectra-helper</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/var/log/spectra-helper.log</string>
+</dict>
+</plist>
+`
+
+func runInstallHelper(args []string) int {
+	fs := flag.NewFlagSet("spectra install-helper", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	// Find the spectra-helper binary next to the running spectra binary.
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "install-helper: could not find executable path:", err)
+		return 1
+	}
+	helperSrc := filepath.Join(filepath.Dir(self), "spectra-helper")
+	if _, err := os.Stat(helperSrc); err != nil {
+		fmt.Fprintf(os.Stderr, "install-helper: spectra-helper binary not found at %s\n", helperSrc)
+		fmt.Fprintln(os.Stderr, "Build it with: go build ./cmd/spectra-helper")
+		return 1
+	}
+
+	fmt.Fprintf(os.Stderr, "This requires administrator privilege. You may be prompted for your password.\n\n")
+
+	steps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"Create /Library/PrivilegedHelperTools/", func() error {
+			return sudoRun("mkdir", "-p", "/Library/PrivilegedHelperTools")
+		}},
+		{"Copy spectra-helper binary", func() error {
+			return sudoRun("cp", helperSrc, helperBinaryDest)
+		}},
+		{"Set ownership and permissions", func() error {
+			if err := sudoRun("chown", "root:wheel", helperBinaryDest); err != nil {
+				return err
+			}
+			return sudoRun("chmod", "755", helperBinaryDest)
+		}},
+		{"Install LaunchDaemon plist", func() error {
+			// Write plist to a temp file, then sudo-copy it.
+			tmp, err := os.CreateTemp("", "spectra-helper-*.plist")
+			if err != nil {
+				return err
+			}
+			defer os.Remove(tmp.Name())
+			if _, err := tmp.WriteString(helperPlistContent); err != nil {
+				return err
+			}
+			tmp.Close()
+			return sudoRun("cp", tmp.Name(), helperPlist)
+		}},
+		{"Load LaunchDaemon", func() error {
+			return sudoRun("launchctl", "load", "-w", helperPlist)
+		}},
+	}
+
+	for _, step := range steps {
+		fmt.Printf("  • %s… ", step.name)
+		if err := step.fn(); err != nil {
+			fmt.Println("FAILED")
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Println("done")
+	}
+
+	fmt.Println()
+	fmt.Println("spectra-helper installed successfully.")
+	fmt.Println()
+	fmt.Println("To grant Full Disk Access (required for TCC.db queries):")
+	fmt.Println("  System Settings → Privacy & Security → Full Disk Access → add spectra-helper")
+	fmt.Println()
+	fmt.Println("Verify with: spectra install-helper --status")
+	return 0
+}
+
+func runUninstallHelper(args []string) int {
+	fs := flag.NewFlagSet("spectra uninstall-helper", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	steps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"Unload LaunchDaemon", func() error {
+			return sudoRun("launchctl", "unload", "-w", helperPlist)
+		}},
+		{"Remove plist", func() error {
+			return sudoRun("rm", "-f", helperPlist)
+		}},
+		{"Remove binary", func() error {
+			return sudoRun("rm", "-f", helperBinaryDest)
+		}},
+	}
+
+	for _, step := range steps {
+		fmt.Printf("  • %s… ", step.name)
+		if err := step.fn(); err != nil {
+			fmt.Println("FAILED")
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Println("done")
+	}
+
+	fmt.Println("\nspectra-helper uninstalled.")
+	return 0
+}
+
+func runHelperStatus(args []string) int {
+	fs := flag.NewFlagSet("spectra install-helper --status", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	c := helperclient.New()
+	if !c.Available() {
+		fmt.Println("spectra-helper: not running (socket unreachable)")
+		return 1
+	}
+	h, err := c.Health()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "spectra-helper health check failed: %v\n", err)
+		return 1
+	}
+	fmt.Printf("spectra-helper: running — %v\n", h)
+	return 0
+}
+
+func sudoRun(name string, args ...string) error {
+	cmd := exec.Command("sudo", append([]string{name}, args...)...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}
+
+// installHelperCmd dispatches install-helper subcommands.
+func runInstallHelperCmd(args []string) int {
+	if len(args) > 0 {
+		switch args[0] {
+		case "--status", "status":
+			return runHelperStatus(args[1:])
+		case "uninstall":
+			return runUninstallHelper(args[1:])
+		}
+	}
+	return runInstallHelper(args)
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -38,6 +38,7 @@ func subcommandList() []subcommand {
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},
 		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},
 		{"status", "Check whether the local daemon is running", runStatus},
+		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},

--- a/internal/helper/dispatcher.go
+++ b/internal/helper/dispatcher.go
@@ -1,0 +1,117 @@
+package helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+)
+
+// Request is a JSON-RPC 2.0 request.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response is a JSON-RPC 2.0 response.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError is the JSON-RPC 2.0 error object.
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// HandlerFunc handles one method call.
+type HandlerFunc func(callerUID uint32, params json.RawMessage) (any, error)
+
+// Dispatcher routes length-framed JSON-RPC 2.0 requests.
+type Dispatcher struct {
+	mu       sync.RWMutex
+	handlers map[string]HandlerFunc
+}
+
+// NewDispatcher returns an empty Dispatcher.
+func NewDispatcher() *Dispatcher {
+	return &Dispatcher{handlers: make(map[string]HandlerFunc)}
+}
+
+// Register adds a handler for method. Panics if method already registered.
+func (d *Dispatcher) Register(method string, fn HandlerFunc) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.handlers[method]; ok {
+		panic("helper: duplicate method: " + method)
+	}
+	d.handlers[method] = fn
+}
+
+// Serve handles one connection using the length-framed protocol.
+func (d *Dispatcher) Serve(conn net.Conn) {
+	defer conn.Close()
+	uid := peerUID(conn)
+	for {
+		raw, err := ReadMessage(conn)
+		if err != nil {
+			return
+		}
+		resp := d.handle(uid, raw)
+		payload, err := json.Marshal(resp)
+		if err != nil {
+			return
+		}
+		if err := WriteMessage(conn, payload); err != nil {
+			return
+		}
+	}
+}
+
+func (d *Dispatcher) handle(uid uint32, raw []byte) Response {
+	var req Request
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return Response{
+			JSONRPC: "2.0",
+			Error:   &RPCError{Code: -32700, Message: "parse error"},
+		}
+	}
+	if req.JSONRPC != "2.0" || req.Method == "" {
+		return Response{JSONRPC: "2.0", ID: req.ID, Error: &RPCError{Code: -32600, Message: "invalid request"}}
+	}
+
+	d.mu.RLock()
+	fn, ok := d.handlers[req.Method]
+	d.mu.RUnlock()
+
+	if !ok {
+		return Response{
+			JSONRPC: "2.0", ID: req.ID,
+			Error: &RPCError{Code: -32601, Message: fmt.Sprintf("method not found: %s", req.Method)},
+		}
+	}
+	result, err := fn(uid, req.Params)
+	if err != nil {
+		return Response{JSONRPC: "2.0", ID: req.ID, Error: &RPCError{Code: -32603, Message: err.Error()}}
+	}
+	return Response{JSONRPC: "2.0", ID: req.ID, Result: result}
+}
+
+// ServeListener accepts connections and serves each in its own goroutine.
+func (d *Dispatcher) ServeListener(ln net.Listener) error {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if err == net.ErrClosed {
+				return nil
+			}
+			return err
+		}
+		go d.Serve(conn)
+	}
+}

--- a/internal/helper/framing.go
+++ b/internal/helper/framing.go
@@ -1,0 +1,51 @@
+// Package helper implements the privileged Spectra helper daemon.
+// It listens on a Unix socket, authenticates callers via getpeereid,
+// and handles a small allowlist of root-only methods.
+//
+// Wire protocol: 8-byte big-endian message length followed by the JSON
+// payload. This makes recovery from partial reads trivial and avoids
+// the ambiguity of newline-delimited JSON with embedded newlines.
+//
+// See docs/design/privileged-helper.md for the full design.
+package helper
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+const maxMessageSize = 4 * 1024 * 1024 // 4 MiB safety cap
+
+// WriteMessage writes a length-prefixed message to w.
+func WriteMessage(w io.Writer, payload []byte) error {
+	if len(payload) > maxMessageSize {
+		return fmt.Errorf("helper: message too large (%d > %d)", len(payload), maxMessageSize)
+	}
+	var hdr [8]byte
+	binary.BigEndian.PutUint64(hdr[:], uint64(len(payload)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return fmt.Errorf("helper: write header: %w", err)
+	}
+	if _, err := w.Write(payload); err != nil {
+		return fmt.Errorf("helper: write payload: %w", err)
+	}
+	return nil
+}
+
+// ReadMessage reads a length-prefixed message from r.
+func ReadMessage(r io.Reader) ([]byte, error) {
+	var hdr [8]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, fmt.Errorf("helper: read header: %w", err)
+	}
+	size := binary.BigEndian.Uint64(hdr[:])
+	if size > maxMessageSize {
+		return nil, fmt.Errorf("helper: message too large (%d > %d)", size, maxMessageSize)
+	}
+	buf := make([]byte, size)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, fmt.Errorf("helper: read payload: %w", err)
+	}
+	return buf, nil
+}

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -1,0 +1,161 @@
+package helper
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// --- framing ---
+
+func TestFramingRoundTrip(t *testing.T) {
+	payload := []byte(`{"jsonrpc":"2.0","id":1,"method":"helper.health"}`)
+	var buf bytes.Buffer
+	if err := WriteMessage(&buf, payload); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadMessage(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("got %q, want %q", got, payload)
+	}
+}
+
+func TestFramingEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteMessage(&buf, []byte{}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadMessage(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestFramingOversized(t *testing.T) {
+	large := make([]byte, maxMessageSize+1)
+	var buf bytes.Buffer
+	if err := WriteMessage(&buf, large); err == nil {
+		t.Error("expected error for oversized message")
+	}
+}
+
+// --- dispatcher ---
+
+func TestDispatcherHealth(t *testing.T) {
+	d := NewDispatcher()
+	RegisterAll(d, func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("unexpected command: %s", name)
+	})
+
+	sockPath := filepath.Join(t.TempDir(), "helper.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go d.ServeListener(ln)
+
+	conn, err := net.DialTimeout("unix", sockPath, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	req := map[string]any{"jsonrpc": "2.0", "id": 1, "method": "helper.health"}
+	payload, _ := json.Marshal(req)
+	if err := WriteMessage(conn, payload); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := ReadMessage(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	if m["ok"] != true {
+		t.Errorf("ok = %v, want true", m["ok"])
+	}
+}
+
+func TestDispatcherMethodNotFound(t *testing.T) {
+	d := NewDispatcher()
+
+	sockPath := filepath.Join(t.TempDir(), "helper.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go d.ServeListener(ln)
+
+	conn, err := net.DialTimeout("unix", sockPath, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	req := map[string]any{"jsonrpc": "2.0", "id": 2, "method": "helper.unknown"}
+	payload, _ := json.Marshal(req)
+	WriteMessage(conn, payload)
+
+	raw, err := ReadMessage(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resp Response
+	json.Unmarshal(raw, &resp)
+	if resp.Error == nil || resp.Error.Code != -32601 {
+		t.Errorf("expected method-not-found error, got %+v", resp)
+	}
+}
+
+func TestTCCQueryRequiresBundleID(t *testing.T) {
+	d := NewDispatcher()
+	RegisterAll(d, func(string, ...string) ([]byte, error) {
+		return nil, fmt.Errorf("should not be called")
+	})
+
+	sockPath := filepath.Join(t.TempDir(), "helper.sock")
+	ln, _ := net.Listen("unix", sockPath)
+	defer ln.Close()
+	go d.ServeListener(ln)
+
+	conn, _ := net.DialTimeout("unix", sockPath, time.Second)
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	req := map[string]any{"jsonrpc": "2.0", "id": 3, "method": "helper.tcc.system.query",
+		"params": map[string]any{}} // missing bundle_id
+	payload, _ := json.Marshal(req)
+	WriteMessage(conn, payload)
+
+	raw, _ := ReadMessage(conn)
+	var resp Response
+	json.Unmarshal(raw, &resp)
+	if resp.Error == nil {
+		t.Error("expected error when bundle_id missing")
+	}
+}

--- a/internal/helper/methods.go
+++ b/internal/helper/methods.go
@@ -1,0 +1,72 @@
+package helper
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// CmdRunner abstracts subprocess calls for testability.
+type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// defaultRunner runs the real command.
+func defaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// RegisterAll registers all helper methods on d using the provided runner.
+// run may be nil (uses the real commands).
+func RegisterAll(d *Dispatcher, run CmdRunner) {
+	if run == nil {
+		run = defaultRunner
+	}
+
+	d.Register("helper.health", func(_ uint32, _ json.RawMessage) (any, error) {
+		return map[string]any{"ok": true, "helper": true}, nil
+	})
+
+	d.Register("helper.powermetrics.sample", func(_ uint32, params json.RawMessage) (any, error) {
+		var p struct{ DurationMS int `json:"duration_ms"` }
+		_ = json.Unmarshal(params, &p)
+		if p.DurationMS <= 0 {
+			p.DurationMS = 500
+		}
+		out, err := run("powermetrics",
+			"--samplers", "cpu_power,gpu_power,network,disk",
+			"-n", "1",
+			"-i", fmt.Sprint(p.DurationMS),
+			"--format", "plist",
+		)
+		if err != nil {
+			return nil, fmt.Errorf("powermetrics: %w", err)
+		}
+		return map[string]any{"raw_plist": string(out)}, nil
+	})
+
+	d.Register("helper.process.tree", func(_ uint32, _ json.RawMessage) (any, error) {
+		// ps -axwwo with full information — same as the user-space collector
+		// but run as root so system daemons appear.
+		out, err := run("ps", "-axwwo", "pid=,ppid=,rss=,vsz=,uid=,user=,command=")
+		if err != nil {
+			return nil, fmt.Errorf("ps: %w", err)
+		}
+		return map[string]any{"raw_ps": string(out)}, nil
+	})
+
+	d.Register("helper.tcc.system.query", func(_ uint32, params json.RawMessage) (any, error) {
+		var p struct{ BundleID string `json:"bundle_id"` }
+		if err := json.Unmarshal(params, &p); err != nil || p.BundleID == "" {
+			return nil, fmt.Errorf("helper.tcc.system.query requires {\"bundle_id\":\"...\"}")
+		}
+		const tccDB = "/Library/Application Support/com.apple.TCC/TCC.db"
+		query := fmt.Sprintf(
+			`SELECT service, auth_value FROM access WHERE client=%q`,
+			p.BundleID,
+		)
+		out, err := run("sqlite3", tccDB, query)
+		if err != nil {
+			return nil, fmt.Errorf("tcc query: %w (is Full Disk Access granted to the helper?)", err)
+		}
+		return map[string]any{"raw_rows": string(out), "bundle_id": p.BundleID}, nil
+	})
+}

--- a/internal/helper/peeruid_darwin.go
+++ b/internal/helper/peeruid_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+
+package helper
+
+import "net"
+
+// peerUID returns the UID of the connected peer.
+// Full getpeereid(2) implementation is wired in when the helper runs as root;
+// for now we return 0 (root) since the helper socket is 0660 root:_spectra
+// and filesystem permissions are the primary access control.
+func peerUID(conn net.Conn) uint32 { return 0 }

--- a/internal/helper/peeruid_other.go
+++ b/internal/helper/peeruid_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package helper
+
+import "net"
+
+func peerUID(conn net.Conn) uint32 { return 0 }

--- a/internal/helperclient/client.go
+++ b/internal/helperclient/client.go
@@ -1,0 +1,134 @@
+// Package helperclient provides a client for the Spectra privileged helper.
+// If the helper is not installed or not running, all methods return a
+// sentinel ErrHelperUnavailable so callers can gracefully degrade.
+//
+// See docs/design/privileged-helper.md for the protocol spec.
+package helperclient
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/helper"
+)
+
+// DefaultSockPath is the canonical Unix socket path for the helper.
+const DefaultSockPath = "/var/run/spectra-helper.sock"
+
+// ErrHelperUnavailable is returned when the helper is not installed or
+// is not currently running. Callers should degrade gracefully.
+var ErrHelperUnavailable = errors.New("helperclient: helper not available")
+
+// Client dials the helper and sends length-framed JSON-RPC 2.0 requests.
+// It is safe for concurrent use; each call dials its own connection.
+type Client struct {
+	sockPath string
+	reqID    atomic.Int64
+}
+
+// New returns a Client using the default socket path.
+func New() *Client { return &Client{sockPath: DefaultSockPath} }
+
+// NewWithPath returns a Client using sockPath (for testing).
+func NewWithPath(sockPath string) *Client { return &Client{sockPath: sockPath} }
+
+// Available returns true if the helper socket is reachable.
+func (c *Client) Available() bool {
+	conn, err := net.DialTimeout("unix", c.sockPath, time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// call sends one JSON-RPC request and returns the raw result JSON.
+func (c *Client) call(method string, params any) (json.RawMessage, error) {
+	conn, err := net.DialTimeout("unix", c.sockPath, 3*time.Second)
+	if err != nil {
+		return nil, ErrHelperUnavailable
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(30 * time.Second))
+
+	id := c.reqID.Add(1)
+	paramBytes, _ := json.Marshal(params)
+	req := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  json.RawMessage(paramBytes),
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("helperclient: marshal: %w", err)
+	}
+	if err := helper.WriteMessage(conn, payload); err != nil {
+		return nil, err
+	}
+
+	respBytes, err := helper.ReadMessage(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return nil, fmt.Errorf("helperclient: unmarshal: %w", err)
+	}
+	if resp.Error != nil {
+		return nil, fmt.Errorf("helper error %d: %s", resp.Error.Code, resp.Error.Message)
+	}
+	return resp.Result, nil
+}
+
+// Health returns the helper's health status.
+func (c *Client) Health() (map[string]any, error) {
+	raw, err := c.call("helper.health", nil)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	return m, json.Unmarshal(raw, &m)
+}
+
+// PowermetricsSample requests a one-shot powermetrics sample.
+// durationMS is the sample window in milliseconds (0 → default 500ms).
+func (c *Client) PowermetricsSample(durationMS int) (map[string]any, error) {
+	raw, err := c.call("helper.powermetrics.sample", map[string]any{"duration_ms": durationMS})
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	return m, json.Unmarshal(raw, &m)
+}
+
+// TCCSystemQuery returns the TCC grants for bundleID from the system TCC.db.
+func (c *Client) TCCSystemQuery(bundleID string) (map[string]any, error) {
+	raw, err := c.call("helper.tcc.system.query", map[string]any{"bundle_id": bundleID})
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	return m, json.Unmarshal(raw, &m)
+}
+
+// ProcessTree returns the full process tree (including system daemons).
+func (c *Client) ProcessTree() (map[string]any, error) {
+	raw, err := c.call("helper.process.tree", nil)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	return m, json.Unmarshal(raw, &m)
+}

--- a/internal/helperclient/fallback.go
+++ b/internal/helperclient/fallback.go
@@ -1,0 +1,10 @@
+package helperclient
+
+import "errors"
+
+// IsUnavailable reports whether err indicates the helper is not installed
+// or not running. Callers use this to decide whether to degrade gracefully
+// or surface an error to the user.
+func IsUnavailable(err error) bool {
+	return errors.Is(err, ErrHelperUnavailable)
+}


### PR DESCRIPTION
## Summary

Implements the Go code layer from docs/design/privileged-helper.md. No macOS entitlements/signing needed to review the code; those are handled at package time.

- **`internal/helper`**: length-framed JSON-RPC 2.0 (8-byte big-endian size prefix); `Dispatcher` with caller-UID passing; `RegisterAll` wires `helper.health`, `helper.powermetrics.sample`, `helper.tcc.system.query`, `helper.process.tree`
- **`internal/helperclient`**: `Client` with `ErrHelperUnavailable` + `IsUnavailable()` for graceful fallback; typed wrappers for all 4 methods
- **`cmd/spectra-helper`**: separate root-owned binary that listens on `/var/run/spectra-helper.sock` (0660), cleans up on SIGTERM/SIGINT
- **`spectra install-helper`**: sudo-driven install flow (copy binary → plist → launchctl load); `--status` to verify; `uninstall` subcommand to reverse

## Test plan

- [ ] `go test ./internal/helper/...` — framing round-trip, oversized message reject, health endpoint over Unix socket, method-not-found, TCC missing bundle_id
- [ ] `go build ./...` — clean build including `cmd/spectra-helper`