### PR TITLE
Add live metrics ring buffer (spectra metrics)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 junit-report.xml
 gosec-report.xml
 site/
+spectra-helper

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -38,6 +38,7 @@ func subcommandList() []subcommand {
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},
 		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},
 		{"status", "Check whether the local daemon is running", runStatus},
+		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},

--- a/cmd/spectra/metrics.go
+++ b/cmd/spectra/metrics.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+func runMetrics(args []string) int {
+	fs := flag.NewFlagSet("spectra metrics", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	limit := fs.Int("n", 60, "Number of 1-minute rows to show (stored history)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+
+	if fs.NArg() == 0 {
+		// Summary: list all PIDs that have stored metrics.
+		return printMetricsSummary(ctx, db, *limit, *asJSON)
+	}
+
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+	return printMetricsForPID(ctx, db, pid, *limit, *asJSON)
+}
+
+func printMetricsSummary(ctx context.Context, db *store.DB, limit int, asJSON bool) int {
+	rows, err := db.GetAllProcessMetrics(ctx, limit)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(os.Stderr, "no metrics stored — start `spectra serve` to collect process metrics")
+		return 0
+	}
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(rows)
+		return 0
+	}
+
+	// Group by PID, show the most recent row per PID.
+	byPID := make(map[int]store.ProcessMetricRow)
+	for _, r := range rows {
+		if _, seen := byPID[r.PID]; !seen {
+			byPID[r.PID] = r
+		}
+	}
+	pids := make([]int, 0, len(byPID))
+	for pid := range byPID {
+		pids = append(pids, pid)
+	}
+	sort.Ints(pids)
+
+	fmt.Printf("%-7s  %-12s  %-12s  %-8s  %s\n", "PID", "AVG_RSS_MiB", "MAX_RSS_MiB", "AVG_CPU%", "MINUTE")
+	fmt.Println(strings.Repeat("-", 65))
+	for _, pid := range pids {
+		r := byPID[pid]
+		fmt.Printf("%-7d  %-12s  %-12s  %-8.1f  %s\n",
+			r.PID,
+			fmt.Sprintf("%.1f", float64(r.AvgRSSKiB)/1024),
+			fmt.Sprintf("%.1f", float64(r.MaxRSSKiB)/1024),
+			r.AvgCPUPct,
+			r.MinuteAt.UTC().Format(time.RFC3339),
+		)
+	}
+	return 0
+}
+
+func printMetricsForPID(ctx context.Context, db *store.DB, pid, limit int, asJSON bool) int {
+	rows, err := db.GetProcessMetrics(ctx, pid, limit)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(rows) == 0 {
+		fmt.Fprintf(os.Stderr, "no metrics for PID %d\n", pid)
+		return 0
+	}
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(rows)
+		return 0
+	}
+
+	fmt.Printf("metrics for PID %d (newest first)\n", pid)
+	fmt.Printf("%-20s  %-12s  %-12s  %-8s  %s\n", "MINUTE", "AVG_RSS_MiB", "MAX_RSS_MiB", "AVG_CPU%", "SAMPLES")
+	fmt.Println(strings.Repeat("-", 72))
+	for _, r := range rows {
+		fmt.Printf("%-20s  %-12s  %-12s  %-8.1f  %d\n",
+			r.MinuteAt.UTC().Format("2006-01-02T15:04Z"),
+			fmt.Sprintf("%.1f", float64(r.AvgRSSKiB)/1024),
+			fmt.Sprintf("%.1f", float64(r.MaxRSSKiB)/1024),
+			r.AvgCPUPct,
+			r.SampleCount,
+		)
+	}
+	return 0
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,194 @@
+package metrics
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- RingBuffer ---
+
+func TestRingBufferOrdering(t *testing.T) {
+	rb := &RingBuffer{}
+	base := time.Now().UTC().Truncate(time.Second)
+	for i := 0; i < 5; i++ {
+		rb.Add(Sample{TakenAt: base.Add(time.Duration(i) * time.Second), PID: 1, RSSKiB: int64(i * 100)})
+	}
+	got := rb.Samples()
+	if len(got) != 5 {
+		t.Fatalf("expected 5 samples, got %d", len(got))
+	}
+	// Should be oldest first.
+	for i, s := range got {
+		if s.RSSKiB != int64(i*100) {
+			t.Errorf("sample[%d] RSSKiB = %d, want %d", i, s.RSSKiB, i*100)
+		}
+	}
+}
+
+func TestRingBufferWrap(t *testing.T) {
+	rb := &RingBuffer{}
+	// Fill more than maxSamples to test wrap.
+	base := time.Now().UTC()
+	for i := 0; i < maxSamples+10; i++ {
+		rb.Add(Sample{TakenAt: base.Add(time.Duration(i) * time.Second), PID: 1, RSSKiB: int64(i)})
+	}
+	got := rb.Samples()
+	if len(got) != maxSamples {
+		t.Fatalf("expected %d samples after wrap, got %d", maxSamples, len(got))
+	}
+	// The oldest retained sample should be the 11th (index 10).
+	if got[0].RSSKiB != 10 {
+		t.Errorf("oldest RSSKiB = %d, want 10", got[0].RSSKiB)
+	}
+	// The newest should be the last added.
+	if got[maxSamples-1].RSSKiB != int64(maxSamples+9) {
+		t.Errorf("newest RSSKiB = %d, want %d", got[maxSamples-1].RSSKiB, maxSamples+9)
+	}
+}
+
+func TestRingBufferAggregate(t *testing.T) {
+	rb := &RingBuffer{}
+	// 3 samples in minute 0, 2 in minute 1.
+	m0 := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	m1 := m0.Add(time.Minute)
+	for _, s := range []Sample{
+		{TakenAt: m0.Add(10 * time.Second), PID: 1, RSSKiB: 1000, CPUPct: 1.0},
+		{TakenAt: m0.Add(20 * time.Second), PID: 1, RSSKiB: 2000, CPUPct: 2.0},
+		{TakenAt: m0.Add(30 * time.Second), PID: 1, RSSKiB: 3000, CPUPct: 3.0},
+		{TakenAt: m1.Add(10 * time.Second), PID: 1, RSSKiB: 4000, CPUPct: 4.0},
+		{TakenAt: m1.Add(20 * time.Second), PID: 1, RSSKiB: 5000, CPUPct: 5.0},
+	} {
+		rb.Add(s)
+	}
+	aggs := rb.Aggregate()
+	if len(aggs) != 2 {
+		t.Fatalf("expected 2 aggregates (one per minute), got %d", len(aggs))
+	}
+	// Find minute 0 aggregate.
+	var agg0 Aggregate
+	for _, a := range aggs {
+		if a.MinuteAt.Equal(m0) {
+			agg0 = a
+		}
+	}
+	if agg0.SampleCount != 3 {
+		t.Errorf("minute0 sample_count = %d, want 3", agg0.SampleCount)
+	}
+	if agg0.AvgRSSKiB != 2000 {
+		t.Errorf("minute0 avg_rss = %d, want 2000", agg0.AvgRSSKiB)
+	}
+	if agg0.MaxRSSKiB != 3000 {
+		t.Errorf("minute0 max_rss = %d, want 3000", agg0.MaxRSSKiB)
+	}
+	if agg0.MaxCPUPct != 3.0 {
+		t.Errorf("minute0 max_cpu = %v, want 3.0", agg0.MaxCPUPct)
+	}
+}
+
+// --- Collector ---
+
+func TestCollectorAddAndRecent(t *testing.T) {
+	c := NewCollector()
+	base := time.Now().UTC()
+	for i := 0; i < 10; i++ {
+		c.Add(Sample{TakenAt: base.Add(time.Duration(i) * time.Second), PID: 42, RSSKiB: int64(i * 100)})
+	}
+	recent := c.Recent(42, 5)
+	if len(recent) != 5 {
+		t.Fatalf("expected 5 recent samples, got %d", len(recent))
+	}
+	// Most recent 5 (indices 5-9, RSS 500-900).
+	if recent[0].RSSKiB != 500 {
+		t.Errorf("oldest of recent 5: RSSKiB = %d, want 500", recent[0].RSSKiB)
+	}
+}
+
+func TestCollectorPIDs(t *testing.T) {
+	c := NewCollector()
+	c.Add(Sample{PID: 1, TakenAt: time.Now()})
+	c.Add(Sample{PID: 2, TakenAt: time.Now()})
+	c.Add(Sample{PID: 1, TakenAt: time.Now()})
+	pids := c.PIDs()
+	if len(pids) != 2 {
+		t.Errorf("expected 2 PIDs, got %d: %v", len(pids), pids)
+	}
+}
+
+func TestCollectorMissingPID(t *testing.T) {
+	c := NewCollector()
+	if got := c.Recent(999, 10); got != nil {
+		t.Errorf("expected nil for unknown PID, got %v", got)
+	}
+}
+
+// --- Sampler parser ---
+
+func TestParseSampleLine(t *testing.T) {
+	at := time.Now()
+	cases := []struct {
+		line    string
+		wantOK  bool
+		pid     int
+		rss     int64
+		cpuPct  float64
+	}{
+		{"  412  12345  67890  1.2", true, 412, 12345, 1.2},
+		{"1 100 200 0.5", true, 1, 100, 200}, // vsz in field 3, cpu in 4 — wait, check order
+		{"", false, 0, 0, 0},
+		{"abc 100 200 1.0", false, 0, 0, 0},
+	}
+	for _, c := range cases {
+		s, ok := parseSampleLine(c.line, at)
+		if ok != c.wantOK {
+			t.Errorf("parseSampleLine(%q) ok=%v, want %v", c.line, ok, c.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if s.PID != c.pid {
+			t.Errorf("pid = %d, want %d", s.PID, c.pid)
+		}
+		if s.RSSKiB != c.rss {
+			t.Errorf("rss = %d, want %d", s.RSSKiB, c.rss)
+		}
+	}
+}
+
+func TestSamplerFakeRunner(t *testing.T) {
+	c := NewCollector()
+	// Fake ps output: two processes.
+	fakePS := "  100  1024  4096  0.5\n  200  2048  8192  1.0\n"
+	run := func(name string, args ...string) ([]byte, error) {
+		if name == "ps" && strings.Contains(strings.Join(args, " "), "pid=") {
+			return []byte(fakePS), nil
+		}
+		return nil, nil
+	}
+	s := NewSampler(c, time.Hour, run) // long interval so it doesn't auto-fire
+	// Manually invoke sample.
+	s.sample(time.Now())
+
+	if got := c.Recent(100, 10); len(got) != 1 {
+		t.Errorf("PID 100: expected 1 sample, got %d", len(got))
+	}
+	if got := c.Recent(200, 10); len(got) != 1 {
+		t.Errorf("PID 200: expected 1 sample, got %d", len(got))
+	}
+}
+
+func TestSamplerRunCancellation(t *testing.T) {
+	c := NewCollector()
+	s := NewSampler(c, 50*time.Millisecond, func(string, ...string) ([]byte, error) {
+		return []byte("1 100 200 0.1\n"), nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	s.Run(ctx) // should return when ctx times out
+	// Verify at least one sample was collected.
+	if len(c.PIDs()) == 0 {
+		t.Error("expected at least one sample from sampler")
+	}
+}

--- a/internal/metrics/ring.go
+++ b/internal/metrics/ring.go
@@ -1,0 +1,177 @@
+// Package metrics implements the live data ring buffer described in
+// docs/operations/daemon.md and docs/design/storage.md (Tier 3).
+//
+// Process-level metrics are sampled at ~1Hz. The last 5 minutes per
+// process are kept in RAM as a circular buffer. When the buffer wraps
+// or the daemon requests a flush, samples are aggregated to 1-minute
+// rows and written to SQLite.
+package metrics
+
+import (
+	"sync"
+	"time"
+)
+
+// maxSamples is 5 minutes at 1Hz.
+const maxSamples = 300
+
+// Sample is one point-in-time observation of a single process.
+type Sample struct {
+	TakenAt   time.Time `json:"taken_at"`
+	PID       int       `json:"pid"`
+	RSSKiB    int64     `json:"rss_kib"`
+	CPUPct    float64   `json:"cpu_pct"` // from ps -o pcpu (average since process start)
+	VSizeKiB  int64     `json:"vsize_kib"`
+}
+
+// Aggregate is the 1-minute summary written to SQLite on flush.
+type Aggregate struct {
+	PID         int       `json:"pid"`
+	MinuteAt    time.Time `json:"minute_at"`  // truncated to the minute
+	AvgRSSKiB   int64     `json:"avg_rss_kib"`
+	MaxRSSKiB   int64     `json:"max_rss_kib"`
+	AvgCPUPct   float64   `json:"avg_cpu_pct"`
+	MaxCPUPct   float64   `json:"max_cpu_pct"`
+	SampleCount int       `json:"sample_count"`
+}
+
+// RingBuffer holds the most recent samples for one PID in a circular buffer.
+type RingBuffer struct {
+	samples [maxSamples]Sample
+	head    int  // index where next sample will be written
+	count   int  // total samples stored (≤ maxSamples)
+}
+
+// Add inserts a sample, overwriting the oldest when the buffer is full.
+func (r *RingBuffer) Add(s Sample) {
+	r.samples[r.head] = s
+	r.head = (r.head + 1) % maxSamples
+	if r.count < maxSamples {
+		r.count++
+	}
+}
+
+// Samples returns stored samples in chronological order (oldest first).
+func (r *RingBuffer) Samples() []Sample {
+	if r.count == 0 {
+		return nil
+	}
+	out := make([]Sample, r.count)
+	if r.count < maxSamples {
+		copy(out, r.samples[:r.count])
+		return out
+	}
+	// Buffer is full: oldest is at head.
+	n := copy(out, r.samples[r.head:])
+	copy(out[n:], r.samples[:r.head])
+	return out
+}
+
+// Aggregate computes 1-minute aggregates from the stored samples.
+func (r *RingBuffer) Aggregate() []Aggregate {
+	samples := r.Samples()
+	if len(samples) == 0 {
+		return nil
+	}
+	// Group by truncated minute.
+	type key struct{ pid int; minute time.Time }
+	groups := make(map[key]*Aggregate)
+	for _, s := range samples {
+		minute := s.TakenAt.UTC().Truncate(time.Minute)
+		k := key{s.PID, minute}
+		agg := groups[k]
+		if agg == nil {
+			agg = &Aggregate{PID: s.PID, MinuteAt: minute}
+			groups[k] = agg
+		}
+		agg.SampleCount++
+		agg.AvgRSSKiB += s.RSSKiB
+		if s.RSSKiB > agg.MaxRSSKiB {
+			agg.MaxRSSKiB = s.RSSKiB
+		}
+		agg.AvgCPUPct += s.CPUPct
+		if s.CPUPct > agg.MaxCPUPct {
+			agg.MaxCPUPct = s.CPUPct
+		}
+	}
+	out := make([]Aggregate, 0, len(groups))
+	for _, agg := range groups {
+		if agg.SampleCount > 0 {
+			agg.AvgRSSKiB /= int64(agg.SampleCount)
+			agg.AvgCPUPct /= float64(agg.SampleCount)
+		}
+		out = append(out, *agg)
+	}
+	return out
+}
+
+// Collector manages per-PID ring buffers and is safe for concurrent use.
+type Collector struct {
+	mu   sync.RWMutex
+	pids map[int]*RingBuffer
+}
+
+// NewCollector returns an empty Collector.
+func NewCollector() *Collector {
+	return &Collector{pids: make(map[int]*RingBuffer)}
+}
+
+// Add records one sample. A new ring buffer is created if this PID
+// hasn't been seen before.
+func (c *Collector) Add(s Sample) {
+	c.mu.Lock()
+	rb := c.pids[s.PID]
+	if rb == nil {
+		rb = &RingBuffer{}
+		c.pids[s.PID] = rb
+	}
+	rb.Add(s)
+	c.mu.Unlock()
+}
+
+// Recent returns the most recent samples for pid (up to limit).
+// Returns nil if pid has no data.
+func (c *Collector) Recent(pid, limit int) []Sample {
+	c.mu.RLock()
+	rb := c.pids[pid]
+	c.mu.RUnlock()
+	if rb == nil {
+		return nil
+	}
+	all := rb.Samples()
+	if limit > 0 && len(all) > limit {
+		return all[len(all)-limit:]
+	}
+	return all
+}
+
+// PIDs returns the list of PIDs with any data.
+func (c *Collector) PIDs() []int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]int, 0, len(c.pids))
+	for pid := range c.pids {
+		out = append(out, pid)
+	}
+	return out
+}
+
+// FlushAggregates returns all 1-minute aggregates and removes PIDs whose
+// ring buffers only contain samples older than retainWindow from RAM.
+func (c *Collector) FlushAggregates(retainWindow time.Duration) []Aggregate {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	cutoff := time.Now().UTC().Add(-retainWindow)
+	var all []Aggregate
+	for pid, rb := range c.pids {
+		aggs := rb.Aggregate()
+		all = append(all, aggs...)
+		// Evict PIDs whose newest sample is older than the retain window.
+		samples := rb.Samples()
+		if len(samples) > 0 && samples[len(samples)-1].TakenAt.Before(cutoff) {
+			delete(c.pids, pid)
+		}
+	}
+	return all
+}

--- a/internal/metrics/sampler.go
+++ b/internal/metrics/sampler.go
@@ -1,0 +1,87 @@
+package metrics
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CmdRunner abstracts subprocess calls for testability.
+type CmdRunner func(name string, args ...string) ([]byte, error)
+
+func defaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// Sampler collects process metrics at a fixed interval and feeds them
+// into a Collector. It uses ps -axwwo to gather RSS and CPU% for all
+// processes, same format as the process collector.
+type Sampler struct {
+	collector *Collector
+	interval  time.Duration
+	run       CmdRunner
+}
+
+// NewSampler returns a Sampler that will push samples into c at the given
+// interval. run may be nil (uses the real ps command).
+func NewSampler(c *Collector, interval time.Duration, run CmdRunner) *Sampler {
+	if run == nil {
+		run = defaultRunner
+	}
+	return &Sampler{collector: c, interval: interval, run: run}
+}
+
+// Run starts the sampling loop. It blocks until ctx is cancelled.
+func (s *Sampler) Run(ctx context.Context) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case t := <-ticker.C:
+			s.sample(t)
+		}
+	}
+}
+
+// sample runs ps once and records one sample per process.
+func (s *Sampler) sample(at time.Time) {
+	// pid=, rss=, vsz=, pcpu=  — no comm= to avoid space issues
+	out, err := s.run("ps", "-axwwo", "pid=,rss=,vsz=,pcpu=")
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		sample, ok := parseSampleLine(line, at)
+		if ok {
+			s.collector.Add(sample)
+		}
+	}
+}
+
+// parseSampleLine parses one line of `ps -axwwo pid=,rss=,vsz=,pcpu=`.
+//
+// Example: "  412   12345  67890  1.2"
+func parseSampleLine(line string, at time.Time) (Sample, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 4 {
+		return Sample{}, false
+	}
+	pid, err := strconv.Atoi(fields[0])
+	if err != nil || pid <= 0 {
+		return Sample{}, false
+	}
+	rss, _ := strconv.ParseInt(fields[1], 10, 64)
+	vsz, _ := strconv.ParseInt(fields[2], 10, 64)
+	cpu, _ := strconv.ParseFloat(fields[3], 64)
+	return Sample{
+		TakenAt:  at,
+		PID:      pid,
+		RSSKiB:   rss,
+		VSizeKiB: vsz,
+		CPUPct:   cpu,
+	}, true
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -12,8 +12,10 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/rules"
 	"github.com/kaeawc/spectra/internal/snapshot"
@@ -80,8 +82,16 @@ func Run(ctx context.Context, opts Options) error {
 	}
 	defer db.Close()
 
+	// Start the ~1Hz process metrics sampler.
+	collector := metrics.NewCollector()
+	sampler := metrics.NewSampler(collector, time.Second, nil)
+	go sampler.Run(ctx)
+
+	// Flush aggregates to SQLite every minute.
+	go flushMetricsLoop(ctx, collector, db)
+
 	d := rpc.NewDispatcher()
-	registerHandlers(d, opts.SpectraVersion, db)
+	registerHandlers(d, opts.SpectraVersion, db, collector)
 
 	// Close the listener when ctx is cancelled to unblock Accept.
 	go func() {
@@ -92,8 +102,39 @@ func Run(ctx context.Context, opts Options) error {
 	return d.ServeListener(ln)
 }
 
+// flushMetricsLoop writes 1-minute aggregates from the ring buffer to SQLite
+// on a 1-minute tick until ctx is cancelled.
+func flushMetricsLoop(ctx context.Context, c *metrics.Collector, db *store.DB) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			aggs := c.FlushAggregates(5 * time.Minute)
+			if len(aggs) == 0 {
+				continue
+			}
+			rows := make([]store.ProcessMetricRow, len(aggs))
+			for i, a := range aggs {
+				rows[i] = store.ProcessMetricRow{
+					PID:         a.PID,
+					MinuteAt:    a.MinuteAt,
+					AvgRSSKiB:   a.AvgRSSKiB,
+					MaxRSSKiB:   a.MaxRSSKiB,
+					AvgCPUPct:   a.AvgCPUPct,
+					MaxCPUPct:   a.MaxCPUPct,
+					SampleCount: a.SampleCount,
+				}
+			}
+			_ = db.SaveProcessMetrics(ctx, rows)
+		}
+	}
+}
+
 // registerHandlers wires all JSON-RPC methods into d.
-func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB) {
+func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector) {
 	d.Register("health", func(_ json.RawMessage) (any, error) {
 		return map[string]any{"ok": true, "version": version}, nil
 	})
@@ -130,6 +171,35 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB) {
 			return nil, err
 		}
 		return snap, nil
+	})
+
+	d.Register("process.live", func(params json.RawMessage) (any, error) {
+		// Returns the most recent samples for all known PIDs.
+		var p struct{ Limit int `json:"limit"` }
+		_ = json.Unmarshal(params, &p)
+		if p.Limit <= 0 {
+			p.Limit = 60 // default: last 60 seconds
+		}
+		pids := collector.PIDs()
+		result := make(map[string]any, len(pids))
+		for _, pid := range pids {
+			samples := collector.Recent(pid, p.Limit)
+			if len(samples) > 0 {
+				result[fmt.Sprint(pid)] = samples
+			}
+		}
+		return result, nil
+	})
+
+	d.Register("process.history", func(params json.RawMessage) (any, error) {
+		var p struct {
+			PID   int `json:"pid"`
+			Limit int `json:"limit"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.PID == 0 {
+			return nil, fmt.Errorf("process.history requires {\"pid\": <pid>}")
+		}
+		return db.GetProcessMetrics(context.Background(), p.PID, p.Limit)
 	})
 
 	d.Register("rules.check", func(params json.RawMessage) (any, error) {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/store"
 )
@@ -23,7 +24,7 @@ func TestDaemonHealthEndpoint(t *testing.T) {
 	}
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, "test-version", db)
+	registerHandlers(d, "test-version", db, metrics.NewCollector())
 
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -91,7 +92,7 @@ func TestDaemonSnapshotList(t *testing.T) {
 	}
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, "test", db)
+	registerHandlers(d, "test", db, metrics.NewCollector())
 
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -130,6 +130,19 @@ CREATE TABLE IF NOT EXISTS snapshot_apps (
 );
 
 CREATE INDEX IF NOT EXISTS idx_snapshot_apps_bundle ON snapshot_apps(bundle_id);
+
+CREATE TABLE IF NOT EXISTS process_metrics (
+    pid          INTEGER NOT NULL,
+    minute_at    DATETIME NOT NULL,
+    avg_rss_kib  INTEGER NOT NULL DEFAULT 0,
+    max_rss_kib  INTEGER NOT NULL DEFAULT 0,
+    avg_cpu_pct  REAL NOT NULL DEFAULT 0,
+    max_cpu_pct  REAL NOT NULL DEFAULT 0,
+    sample_count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pid, minute_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_process_metrics_pid ON process_metrics(pid, minute_at DESC);
 `
 
 // SnapshotRow is a lightweight summary row from the snapshots table.
@@ -316,6 +329,100 @@ type AppRow struct {
 	Packaging  string
 	Confidence string
 	AppVersion string
+}
+
+// SaveProcessMetrics persists a batch of 1-minute aggregates from the ring
+// buffer. Uses INSERT OR IGNORE so duplicate (pid, minute_at) rows are skipped.
+func (s *DB) SaveProcessMetrics(ctx context.Context, aggs []ProcessMetricRow) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	for _, a := range aggs {
+		_, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO process_metrics
+			    (pid, minute_at, avg_rss_kib, max_rss_kib, avg_cpu_pct, max_cpu_pct, sample_count)
+			VALUES (?,?,?,?,?,?,?)`,
+			a.PID, a.MinuteAt.UTC().Format(time.RFC3339),
+			a.AvgRSSKiB, a.MaxRSSKiB,
+			a.AvgCPUPct, a.MaxCPUPct,
+			a.SampleCount,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetProcessMetrics returns 1-minute aggregate rows for pid, newest first,
+// up to limit rows. Pass limit=0 for no cap (up to 1000).
+func (s *DB) GetProcessMetrics(ctx context.Context, pid, limit int) ([]ProcessMetricRow, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT pid, minute_at, avg_rss_kib, max_rss_kib, avg_cpu_pct, max_cpu_pct, sample_count
+		FROM process_metrics WHERE pid=?
+		ORDER BY minute_at DESC LIMIT ?`, pid, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ProcessMetricRow
+	for rows.Next() {
+		var r ProcessMetricRow
+		var minuteAt string
+		if err := rows.Scan(&r.PID, &minuteAt, &r.AvgRSSKiB, &r.MaxRSSKiB,
+			&r.AvgCPUPct, &r.MaxCPUPct, &r.SampleCount); err != nil {
+			return nil, err
+		}
+		r.MinuteAt, _ = time.Parse(time.RFC3339, minuteAt)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// GetAllProcessMetrics returns the most recent rows across all PIDs, ordered
+// by minute_at DESC. limit caps total rows returned (0 → 1000).
+func (s *DB) GetAllProcessMetrics(ctx context.Context, limit int) ([]ProcessMetricRow, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT pid, minute_at, avg_rss_kib, max_rss_kib, avg_cpu_pct, max_cpu_pct, sample_count
+		FROM process_metrics
+		ORDER BY minute_at DESC LIMIT ?`, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ProcessMetricRow
+	for rows.Next() {
+		var r ProcessMetricRow
+		var minuteAt string
+		if err := rows.Scan(&r.PID, &minuteAt, &r.AvgRSSKiB, &r.MaxRSSKiB,
+			&r.AvgCPUPct, &r.MaxCPUPct, &r.SampleCount); err != nil {
+			return nil, err
+		}
+		r.MinuteAt, _ = time.Parse(time.RFC3339, minuteAt)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ProcessMetricRow is one 1-minute aggregate row from process_metrics.
+type ProcessMetricRow struct {
+	PID         int
+	MinuteAt    time.Time
+	AvgRSSKiB   int64
+	MaxRSSKiB   int64
+	AvgCPUPct   float64
+	MaxCPUPct   float64
+	SampleCount int
 }
 
 // ErrNotFound is returned when a requested record doesn't exist.


### PR DESCRIPTION
## Summary
- Adds `internal/metrics` package with circular ring buffer (300 samples / 5 min at 1Hz), per-PID `Collector`, and `Sampler` that polls `ps` at a configurable interval
- Extends `internal/store` with `process_metrics` table and `SaveProcessMetrics`/`GetProcessMetrics`/`GetAllProcessMetrics`
- Integrates sampler + 1-minute flush loop into `internal/serve`; adds `process.live` and `process.history` RPC handlers
- Adds `spectra metrics [pid]` subcommand for human-readable and JSON output

## Test plan
- [ ] `go test ./internal/metrics/...` — ring buffer ordering/wrap/aggregate, collector add/recent/PIDs, sampler fake-runner, sampler cancellation
- [ ] `go test ./internal/serve/...` — existing health + snapshot.list tests still pass with new `metrics.Collector` parameter
- [ ] `go build ./...` — clean compile