### PR TITLE
Add JVM on-demand commands (thread-dump, heap-histogram, heap-dump)

### DIFF
--- a/cmd/spectra/cache.go
+++ b/cmd/spectra/cache.go
@@ -14,6 +14,10 @@ import (
 // Stores register themselves; the CLI queries this registry for stats/clear.
 var cacheRegistry = cache.Default
 
+// cacheStores holds the concrete ShardedStore instances once initCacheStores
+// has run. Used by subcommands that need direct cache access (e.g. jvm thread-dump).
+var cacheStores *cache.Stores
+
 // initCacheStores initialises all ShardedStores into the default registry.
 // Called from main before dispatching so every subcommand sees a populated
 // registry. Failures are non-fatal: if the cache root can't be created, the
@@ -23,7 +27,7 @@ func initCacheStores() {
 	if err != nil {
 		return
 	}
-	cache.NewStores(root, cacheRegistry)
+	cacheStores = cache.NewStores(root, cacheRegistry)
 }
 
 func runCache(args []string) int {

--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -6,14 +6,29 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/jvm"
 )
 
 func runJVM(args []string) int {
+	// Dispatch subcommands before flag parsing so "--help" on a subcommand works.
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		switch args[0] {
+		case "thread-dump":
+			return runJVMThreadDump(args[1:])
+		case "heap-histogram":
+			return runJVMHeapHistogram(args[1:])
+		case "heap-dump":
+			return runJVMHeapDump(args[1:])
+		}
+	}
+
 	fs := flag.NewFlagSet("spectra jvm", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
@@ -25,14 +40,12 @@ func runJVM(args []string) int {
 	var infos []jvm.Info
 
 	if fs.NArg() == 0 {
-		// List all running JVMs.
 		infos = jvm.CollectAll(ctx, jvm.CollectOptions{})
 		if len(infos) == 0 {
 			fmt.Fprintln(os.Stderr, "no running JVMs found (is jps in your PATH?)")
 			return 0
 		}
 	} else {
-		// Inspect a specific PID.
 		pidStr := fs.Arg(0)
 		pid, err := strconv.Atoi(pidStr)
 		if err != nil {
@@ -62,8 +75,107 @@ func runJVM(args []string) int {
 	return 0
 }
 
+func runJVMThreadDump(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm thread-dump", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm thread-dump <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	data, err := jvm.ThreadDump(pid, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "thread-dump failed for PID %d: %v\n", pid, err)
+		return 1
+	}
+
+	key := cache.Key([]byte(fmt.Sprintf("threads:%d:%d", pid, time.Now().UnixNano())))
+	if cacheStores != nil && cacheStores.Threads != nil {
+		if putErr := cacheStores.Threads.Put(key, data); putErr == nil {
+			fmt.Fprintf(os.Stderr, "cached as threads/%x\n", key[:4])
+		}
+	}
+
+	os.Stdout.Write(data)
+	return 0
+}
+
+func runJVMHeapHistogram(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm heap-histogram", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm heap-histogram <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	data, err := jvm.HeapHistogram(pid, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "heap-histogram failed for PID %d: %v\n", pid, err)
+		return 1
+	}
+
+	os.Stdout.Write(data)
+	return 0
+}
+
+func runJVMHeapDump(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm heap-dump", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	out := fs.String("out", "", "Output .hprof path (default: ~/.spectra/<pid>-<ts>.hprof)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm heap-dump [--out <path>] <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	destPath := *out
+	if destPath == "" {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			fmt.Fprintln(os.Stderr, herr)
+			return 1
+		}
+		ts := time.Now().UTC().Format("20060102T150405Z")
+		destPath = filepath.Join(home, ".spectra", fmt.Sprintf("%d-%s.hprof", pid, ts))
+		if mkErr := os.MkdirAll(filepath.Dir(destPath), 0o700); mkErr != nil {
+			fmt.Fprintln(os.Stderr, mkErr)
+			return 1
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "writing heap dump to %s ...\n", destPath)
+	if err := jvm.HeapDump(pid, destPath, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "heap-dump failed for PID %d: %v\n", pid, err)
+		return 1
+	}
+	fmt.Println(destPath)
+	return 0
+}
+
 func printJVMList(infos []jvm.Info) {
-	// Sort by PID for stable output.
 	sort.Slice(infos, func(i, j int) bool { return infos[i].PID < infos[j].PID })
 
 	fmt.Printf("%-7s  %-12s  %-8s  %s\n", "PID", "VERSION", "THREADS", "MAIN CLASS")

--- a/internal/jvm/jcmd.go
+++ b/internal/jvm/jcmd.go
@@ -92,6 +92,35 @@ func collectThreadCount(pid int, run CmdRunner) int {
 	return countThreads(string(out))
 }
 
+// ThreadDump runs `jcmd <pid> Thread.print` and returns the raw output.
+// Pass nil for run to use the default system runner.
+func ThreadDump(pid int, run CmdRunner) ([]byte, error) {
+	if run == nil {
+		run = DefaultRunner
+	}
+	return run("jcmd", fmt.Sprint(pid), "Thread.print")
+}
+
+// HeapHistogram runs `jcmd <pid> GC.class_histogram` and returns the raw
+// output. The result can be large for apps with many loaded classes.
+// Pass nil for run to use the default system runner.
+func HeapHistogram(pid int, run CmdRunner) ([]byte, error) {
+	if run == nil {
+		run = DefaultRunner
+	}
+	return run("jcmd", fmt.Sprint(pid), "GC.class_histogram")
+}
+
+// HeapDump runs `jcmd <pid> GC.heap_dump <destPath>` to write a .hprof file.
+// Pass nil for run to use the default system runner.
+func HeapDump(pid int, destPath string, run CmdRunner) error {
+	if run == nil {
+		run = DefaultRunner
+	}
+	_, err := run("jcmd", fmt.Sprint(pid), "GC.heap_dump", destPath)
+	return err
+}
+
 // countThreads counts threads in `jcmd Thread.print` output.
 //
 // Thread entries begin with a line like:

--- a/internal/jvm/jvm_test.go
+++ b/internal/jvm/jvm_test.go
@@ -129,6 +129,70 @@ JNI global refs: 42, weak refs: 1
 	}
 }
 
+// --- ThreadDump / HeapHistogram / HeapDump ---
+
+func TestThreadDumpFakeRunner(t *testing.T) {
+	want := "\"main\" #1 prio=5\n\"GC\" #2\n"
+	run := func(name string, args ...string) ([]byte, error) {
+		if name == "jcmd" && len(args) == 2 && args[1] == "Thread.print" {
+			return []byte(want), nil
+		}
+		return nil, fmt.Errorf("unexpected: %s %v", name, args)
+	}
+	got, err := ThreadDump(42, run)
+	if err != nil {
+		t.Fatalf("ThreadDump: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestHeapHistogramFakeRunner(t *testing.T) {
+	want := " num     #instances         #bytes  class name\n   1:          1234       9876543  [B\n"
+	run := func(name string, args ...string) ([]byte, error) {
+		if name == "jcmd" && len(args) == 2 && args[1] == "GC.class_histogram" {
+			return []byte(want), nil
+		}
+		return nil, fmt.Errorf("unexpected: %s %v", name, args)
+	}
+	got, err := HeapHistogram(42, run)
+	if err != nil {
+		t.Fatalf("HeapHistogram: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestHeapDumpFakeRunner(t *testing.T) {
+	var capturedArgs []string
+	run := func(name string, args ...string) ([]byte, error) {
+		if name == "jcmd" {
+			capturedArgs = args
+			return []byte("Heap dump file created"), nil
+		}
+		return nil, fmt.Errorf("unexpected: %s %v", name, args)
+	}
+	if err := HeapDump(42, "/tmp/test.hprof", run); err != nil {
+		t.Fatalf("HeapDump: %v", err)
+	}
+	if len(capturedArgs) != 3 || capturedArgs[1] != "GC.heap_dump" || capturedArgs[2] != "/tmp/test.hprof" {
+		t.Errorf("unexpected jcmd args: %v", capturedArgs)
+	}
+}
+
+func TestThreadDumpNilDefaultRunner(t *testing.T) {
+	// nil runner should not panic (uses DefaultRunner which may fail if no jcmd).
+	// We just verify it doesn't panic — error is expected on machines without a JDK.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("ThreadDump panicked: %v", r)
+		}
+	}()
+	_, _ = ThreadDump(0, nil)
+}
+
 // --- CollectAll with fake runner ---
 
 func TestCollectAllNoJPS(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `ThreadDump`, `HeapHistogram`, `HeapDump` to `internal/jvm/jcmd.go` — Layer 1 JVM inspection via `jcmd` (no Java agent required)
- Extends `spectra jvm` with three subcommands: `thread-dump <pid>`, `heap-histogram <pid>`, `heap-dump [--out <path>] <pid>`
- Thread dumps are stored in the blob cache (`~/.cache/spectra/v1/threads/`) keyed by `(pid, timestamp)` for later retrieval
- Exposes `cacheStores` package var in `cmd/spectra/cache.go` so any subcommand can write to specific cache kinds

## Test plan
- [ ] `go test ./internal/jvm/...` — new TestThreadDumpFakeRunner, TestHeapHistogramFakeRunner, TestHeapDumpFakeRunner, TestThreadDumpNilDefaultRunner all pass
- [ ] `go test ./...` — no regressions
- [ ] `go build ./...` — clean compile