### PR TITLE
Add JFR commands (spectra jvm jfr start/dump/stop)

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -26,6 +26,8 @@ func runJVM(args []string) int {
 			return runJVMHeapHistogram(args[1:])
 		case "heap-dump":
 			return runJVMHeapDump(args[1:])
+		case "jfr":
+			return runJVMJFR(args[1:])
 		}
 	}
 
@@ -172,6 +174,84 @@ func runJVMHeapDump(args []string) int {
 		return 1
 	}
 	fmt.Println(destPath)
+	return 0
+}
+
+func runJVMJFR(args []string) int {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm jfr <start|dump|stop> <pid> [--out <path>] [--name <name>]")
+		return 2
+	}
+	sub := args[0]
+	rest := args[1:]
+
+	fs := flag.NewFlagSet("spectra jvm jfr "+sub, flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	outPath := fs.String("out", "", "Output .jfr path (for dump/stop)")
+	name := fs.String("name", "spectra", "Recording name")
+	if err := fs.Parse(rest); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintf(os.Stderr, "usage: spectra jvm jfr %s [flags] <pid>\n", sub)
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	switch sub {
+	case "start":
+		if err := jvm.JFRStart(pid, *name, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "JFR.start failed for PID %d: %v\n", pid, err)
+			return 1
+		}
+		fmt.Fprintf(os.Stdout, "JFR recording %q started on PID %d\n", *name, pid)
+
+	case "dump":
+		dest := *outPath
+		if dest == "" {
+			home, herr := os.UserHomeDir()
+			if herr != nil {
+				fmt.Fprintln(os.Stderr, herr)
+				return 1
+			}
+			ts := time.Now().UTC().Format("20060102T150405Z")
+			dest = filepath.Join(home, ".spectra", fmt.Sprintf("%d-%s.jfr", pid, ts))
+			if mkErr := os.MkdirAll(filepath.Dir(dest), 0o700); mkErr != nil {
+				fmt.Fprintln(os.Stderr, mkErr)
+				return 1
+			}
+		}
+		if err := jvm.JFRDump(pid, *name, dest, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "JFR.dump failed for PID %d: %v\n", pid, err)
+			return 1
+		}
+		if cacheStores != nil && cacheStores.JFR != nil {
+			if data, rerr := os.ReadFile(dest); rerr == nil {
+				key := cache.Key([]byte(fmt.Sprintf("jfr:%d:%d", pid, time.Now().UnixNano())))
+				_ = cacheStores.JFR.Put(key, data)
+			}
+		}
+		fmt.Println(dest)
+
+	case "stop":
+		dest := *outPath
+		if err := jvm.JFRStop(pid, *name, dest, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "JFR.stop failed for PID %d: %v\n", pid, err)
+			return 1
+		}
+		fmt.Fprintf(os.Stdout, "JFR recording %q stopped on PID %d\n", *name, pid)
+		if dest != "" {
+			fmt.Println(dest)
+		}
+
+	default:
+		fmt.Fprintf(os.Stderr, "unknown jfr subcommand %q; use start, dump, or stop\n", sub)
+		return 2
+	}
 	return 0
 }
 

--- a/internal/jvm/jcmd.go
+++ b/internal/jvm/jcmd.go
@@ -121,6 +121,42 @@ func HeapDump(pid int, destPath string, run CmdRunner) error {
 	return err
 }
 
+// JFRStart starts a Java Flight Recorder recording named recordingName on pid.
+// Pass nil for run to use the default system runner.
+func JFRStart(pid int, recordingName string, run CmdRunner) error {
+	if run == nil {
+		run = DefaultRunner
+	}
+	_, err := run("jcmd", fmt.Sprint(pid), "JFR.start", "name="+recordingName)
+	return err
+}
+
+// JFRDump dumps the named JFR recording for pid to destPath.
+// Pass nil for run to use the default system runner.
+func JFRDump(pid int, recordingName, destPath string, run CmdRunner) error {
+	if run == nil {
+		run = DefaultRunner
+	}
+	_, err := run("jcmd", fmt.Sprint(pid), "JFR.dump",
+		"name="+recordingName, "filename="+destPath)
+	return err
+}
+
+// JFRStop stops and optionally dumps the named JFR recording.
+// If destPath is non-empty the recording is dumped before stopping.
+// Pass nil for run to use the default system runner.
+func JFRStop(pid int, recordingName, destPath string, run CmdRunner) error {
+	if run == nil {
+		run = DefaultRunner
+	}
+	args := []string{fmt.Sprint(pid), "JFR.stop", "name=" + recordingName}
+	if destPath != "" {
+		args = append(args, "filename="+destPath)
+	}
+	_, err := run("jcmd", args...)
+	return err
+}
+
 // countThreads counts threads in `jcmd Thread.print` output.
 //
 // Thread entries begin with a line like:

--- a/internal/jvm/jvm_test.go
+++ b/internal/jvm/jvm_test.go
@@ -193,6 +193,79 @@ func TestThreadDumpNilDefaultRunner(t *testing.T) {
 	_, _ = ThreadDump(0, nil)
 }
 
+// --- JFR ---
+
+func TestJFRStartFakeRunner(t *testing.T) {
+	var capturedArgs []string
+	run := func(name string, args ...string) ([]byte, error) {
+		capturedArgs = args
+		return []byte("Started recording 1 with name spectra"), nil
+	}
+	if err := JFRStart(42, "spectra", run); err != nil {
+		t.Fatalf("JFRStart: %v", err)
+	}
+	if len(capturedArgs) < 3 || capturedArgs[1] != "JFR.start" || capturedArgs[2] != "name=spectra" {
+		t.Errorf("unexpected jcmd args: %v", capturedArgs)
+	}
+}
+
+func TestJFRDumpFakeRunner(t *testing.T) {
+	var capturedArgs []string
+	run := func(name string, args ...string) ([]byte, error) {
+		capturedArgs = args
+		return []byte("Dumped recording spectra to /tmp/test.jfr"), nil
+	}
+	if err := JFRDump(42, "spectra", "/tmp/test.jfr", run); err != nil {
+		t.Fatalf("JFRDump: %v", err)
+	}
+	if len(capturedArgs) < 4 || capturedArgs[1] != "JFR.dump" {
+		t.Errorf("unexpected jcmd args: %v", capturedArgs)
+	}
+	found := false
+	for _, a := range capturedArgs {
+		if a == "filename=/tmp/test.jfr" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("filename arg not found in: %v", capturedArgs)
+	}
+}
+
+func TestJFRStopFakeRunner(t *testing.T) {
+	var capturedArgs []string
+	run := func(name string, args ...string) ([]byte, error) {
+		capturedArgs = args
+		return []byte("Stopped recording spectra"), nil
+	}
+	if err := JFRStop(42, "spectra", "", run); err != nil {
+		t.Fatalf("JFRStop: %v", err)
+	}
+	if len(capturedArgs) < 3 || capturedArgs[1] != "JFR.stop" {
+		t.Errorf("unexpected jcmd args: %v", capturedArgs)
+	}
+}
+
+func TestJFRStopWithDumpFakeRunner(t *testing.T) {
+	var capturedArgs []string
+	run := func(name string, args ...string) ([]byte, error) {
+		capturedArgs = args
+		return []byte("Stopped recording spectra, dumped to /tmp/out.jfr"), nil
+	}
+	if err := JFRStop(42, "spectra", "/tmp/out.jfr", run); err != nil {
+		t.Fatalf("JFRStop with dump: %v", err)
+	}
+	found := false
+	for _, a := range capturedArgs {
+		if a == "filename=/tmp/out.jfr" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("filename arg not found in: %v", capturedArgs)
+	}
+}
+
 // --- CollectAll with fake runner ---
 
 func TestCollectAllNoJPS(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `JFRStart`, `JFRDump`, `JFRStop` to `internal/jvm/jcmd.go` via `jcmd JFR.*` (Layer 1, no Java agent required)
- Adds `spectra jvm jfr <start|dump|stop> <pid>` subcommand with `--name` (recording name, default "spectra") and `--out` (output .jfr path) flags
- `jfr dump` caches the recording file in the blob store (`KindJFR`) for later retrieval via `spectra cache stats`
- All three operations accept a `CmdRunner` for testability (nil → DefaultRunner)

## Test plan
- [ ] `go test ./internal/jvm/...` — TestJFRStartFakeRunner, TestJFRDumpFakeRunner, TestJFRStopFakeRunner, TestJFRStopWithDumpFakeRunner all pass
- [ ] `go test ./...` — no regressions
- [ ] `go build ./...` — clean compile