### PR TITLE
Add inspect.app, inspect.host, snapshot.diff RPC handlers to daemon

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/diff"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/rules"
@@ -200,6 +201,71 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, fmt.Errorf("process.history requires {\"pid\": <pid>}")
 		}
 		return db.GetProcessMetrics(context.Background(), p.PID, p.Limit)
+	})
+
+	d.Register("inspect.app", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Path    string         `json:"path"`
+			Options detect.Options `json:"options"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.Path == "" {
+			return nil, fmt.Errorf("inspect.app requires {\"path\": \"<app-path>\"}")
+		}
+		return detect.DetectWith(p.Path, p.Options)
+	})
+
+	d.Register("inspect.app.batch", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Paths   []string       `json:"paths"`
+			Options detect.Options `json:"options"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || len(p.Paths) == 0 {
+			return nil, fmt.Errorf("inspect.app.batch requires {\"paths\": [...]}")
+		}
+		results := make([]detect.Result, 0, len(p.Paths))
+		for _, path := range p.Paths {
+			r, err := detect.DetectWith(path, p.Options)
+			if err != nil {
+				continue // silently skip unreadable bundles
+			}
+			results = append(results, r)
+		}
+		return results, nil
+	})
+
+	d.Register("inspect.host", func(_ json.RawMessage) (any, error) {
+		return snapshot.CollectHost(version), nil
+	})
+
+	d.Register("snapshot.diff", func(params json.RawMessage) (any, error) {
+		var p struct {
+			IDA string `json:"id_a"`
+			IDB string `json:"id_b"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.IDA == "" || p.IDB == "" {
+			return nil, fmt.Errorf("snapshot.diff requires {\"id_a\": \"...\", \"id_b\": \"...\"}")
+		}
+		ctx := context.Background()
+		loadSnap := func(id string) (*snapshot.Snapshot, error) {
+			raw, err := db.GetSnapshotJSON(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			if raw == nil {
+				return nil, fmt.Errorf("snapshot %q has no JSON blob", id)
+			}
+			var s snapshot.Snapshot
+			return &s, json.Unmarshal(raw, &s)
+		}
+		snapA, err := loadSnap(p.IDA)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot %q: %w", p.IDA, err)
+		}
+		snapB, err := loadSnap(p.IDB)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot %q: %w", p.IDB, err)
+		}
+		return diff.Compare(*snapA, *snapB), nil
 	})
 
 	d.Register("rules.check", func(params json.RawMessage) (any, error) {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -13,15 +13,20 @@ import (
 	"github.com/kaeawc/spectra/internal/store"
 )
 
-func TestDaemonHealthEndpoint(t *testing.T) {
+// testDaemon wires up a dispatcher with registered handlers, starts it on a
+// temp Unix socket, and returns a connected RPC client.
+func testDaemon(t *testing.T) (*json.Encoder, *json.Decoder, context.CancelFunc) {
+	t.Helper()
 	dir := t.TempDir()
-	sockPath := filepath.Join(dir, "test.sock")
-	dbPath := filepath.Join(dir, "test.db")
+	// Use a short socket name: macOS limits Unix socket paths to 104 bytes.
+	sockPath := filepath.Join(dir, "s.sock")
+	dbPath := filepath.Join(dir, "t.db")
 
 	db, err := store.Open(dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { db.Close() })
 
 	d := rpc.NewDispatcher()
 	registerHandlers(d, "test-version", db, metrics.NewCollector())
@@ -30,26 +35,25 @@ func TestDaemonHealthEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		<-ctx.Done()
-		ln.Close()
-	}()
+	go func() { <-ctx.Done(); ln.Close() }()
 	go d.ServeListener(ln)
-
-	// Give the listener a moment to start.
 	time.Sleep(10 * time.Millisecond)
 
 	conn, err := rpc.DialUnix(sockPath)
 	if err != nil {
+		cancel()
 		t.Fatal(err)
 	}
-	defer conn.Close()
+	conn.(interface{ SetDeadline(time.Time) error }).SetDeadline(time.Now().Add(5 * time.Second))
+	t.Cleanup(func() { conn.Close() })
 
-	enc := json.NewEncoder(conn)
-	dec := json.NewDecoder(conn)
+	return json.NewEncoder(conn), json.NewDecoder(conn), cancel
+}
+
+func TestDaemonHealthEndpoint(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
 
 	type req struct {
 		JSONRPC string `json:"jsonrpc"`
@@ -59,9 +63,6 @@ func TestDaemonHealthEndpoint(t *testing.T) {
 	if err := enc.Encode(req{JSONRPC: "2.0", ID: 1, Method: "health"}); err != nil {
 		t.Fatal(err)
 	}
-
-	conn.(interface{ SetDeadline(time.Time) error }).SetDeadline(time.Now().Add(3 * time.Second))
-
 	var resp rpc.Response
 	if err := dec.Decode(&resp); err != nil {
 		t.Fatal(err)
@@ -82,40 +83,8 @@ func TestDaemonHealthEndpoint(t *testing.T) {
 }
 
 func TestDaemonSnapshotList(t *testing.T) {
-	dir := t.TempDir()
-	sockPath := filepath.Join(dir, "test.sock")
-	dbPath := filepath.Join(dir, "test.db")
-
-	db, err := store.Open(dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	d := rpc.NewDispatcher()
-	registerHandlers(d, "test", db, metrics.NewCollector())
-
-	ln, err := net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
+	enc, dec, cancel := testDaemon(t)
 	defer cancel()
-	go func() {
-		<-ctx.Done()
-		ln.Close()
-	}()
-	go d.ServeListener(ln)
-	time.Sleep(10 * time.Millisecond)
-
-	conn, err := rpc.DialUnix(sockPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer conn.Close()
-	conn.(interface{ SetDeadline(time.Time) error }).SetDeadline(time.Now().Add(3 * time.Second))
-
-	enc := json.NewEncoder(conn)
-	dec := json.NewDecoder(conn)
 
 	type req struct {
 		JSONRPC string `json:"jsonrpc"`
@@ -132,5 +101,98 @@ func TestDaemonSnapshotList(t *testing.T) {
 		t.Fatalf("unexpected error: %+v", resp.Error)
 	}
 	// Empty DB → result should be nil or empty slice.
-	// Either is fine; just check it doesn't error.
+}
+
+func TestDaemonInspectAppMissingPath(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+
+	type req struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      int             `json:"id"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params"`
+	}
+	// Missing path → should return an RPC error, not crash.
+	_ = enc.Encode(req{JSONRPC: "2.0", ID: 3, Method: "inspect.app", Params: json.RawMessage(`{}`)})
+
+	var resp rpc.Response
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error == nil {
+		t.Error("expected RPC error for missing path, got nil")
+	}
+}
+
+func TestDaemonInspectAppBatchEmpty(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+
+	type req struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      int             `json:"id"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params"`
+	}
+	// Empty paths → should return an RPC error.
+	_ = enc.Encode(req{JSONRPC: "2.0", ID: 4, Method: "inspect.app.batch", Params: json.RawMessage(`{"paths":[]}`)})
+
+	var resp rpc.Response
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error == nil {
+		t.Error("expected RPC error for empty paths, got nil")
+	}
+}
+
+func TestDaemonInspectHost(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+
+	type req struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      int    `json:"id"`
+		Method  string `json:"method"`
+	}
+	_ = enc.Encode(req{JSONRPC: "2.0", ID: 5, Method: "inspect.host"})
+
+	var resp rpc.Response
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	// HostInfo should have at least a hostname field.
+	if m["hostname"] == nil && m["Hostname"] == nil {
+		t.Error("inspect.host: expected hostname in result")
+	}
+}
+
+func TestDaemonSnapshotDiffMissingIDs(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+
+	type req struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      int             `json:"id"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params"`
+	}
+	// Missing id_b → should return an RPC error.
+	_ = enc.Encode(req{JSONRPC: "2.0", ID: 6, Method: "snapshot.diff", Params: json.RawMessage(`{"id_a":"x"}`)})
+
+	var resp rpc.Response
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error == nil {
+		t.Error("expected RPC error for missing id_b, got nil")
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `inspect.app` — runs `detect.DetectWith` on a single app path, returns `detect.Result`
- Adds `inspect.app.batch` — inspects multiple paths in sequence, silently skips errors
- Adds `inspect.host` — returns current `HostInfo` without running a full snapshot
- Adds `snapshot.diff` — loads two stored snapshots by ID and returns a `diff.Result`
- Refactors `serve_test.go` to use a shared `testDaemon` helper (eliminates boilerplate)
- Fixes a latent macOS socket path length bug (104-char limit) in tests by using short filenames

## Test plan
- [ ] `go test ./internal/serve/...` — all 7 tests pass including new endpoint tests
- [ ] `go test ./...` — no regressions
- [ ] `go build ./...` — clean compile