### PR TITLE
Add jstat GC stats collector (spectra jvm gc-stats)

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -28,6 +28,8 @@ func runJVM(args []string) int {
 			return runJVMHeapDump(args[1:])
 		case "jfr":
 			return runJVMJFR(args[1:])
+		case "gc-stats":
+			return runJVMGCStats(args[1:])
 		}
 	}
 
@@ -174,6 +176,46 @@ func runJVMHeapDump(args []string) int {
 		return 1
 	}
 	fmt.Println(destPath)
+	return 0
+}
+
+func runJVMGCStats(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm gc-stats", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm gc-stats [--json] <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	stats, err := jvm.CollectGCStats(pid, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gc-stats failed for PID %d: %v\n", pid, err)
+		return 1
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(stats)
+		return 0
+	}
+
+	fmt.Printf("GC stats for PID %d\n", pid)
+	fmt.Printf("  Young GC:  %d events, %.3fs total\n", stats.YGC, stats.YGCT)
+	fmt.Printf("  Full GC:   %d events, %.3fs total\n", stats.FGC, stats.FGCT)
+	fmt.Printf("  Total GC:  %.3fs\n", stats.GCT)
+	fmt.Printf("  Eden:      %.0f KiB used / %.0f KiB capacity\n", stats.EU, stats.EC)
+	fmt.Printf("  Old:       %.0f KiB used / %.0f KiB capacity\n", stats.OU, stats.OC)
+	fmt.Printf("  Metaspace: %.0f KiB used / %.0f KiB capacity\n", stats.MU, stats.MC)
 	return 0
 }
 

--- a/internal/jvm/jstat.go
+++ b/internal/jvm/jstat.go
@@ -1,0 +1,110 @@
+package jvm
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// GCStats holds the GC counter snapshot returned by `jstat -gc <pid>`.
+// Column names follow jstat's header row with underscores instead of spaces.
+// Zero values indicate the column was absent (e.g. CMS vs G1 have different sets).
+type GCStats struct {
+	// Survivor spaces
+	S0C float64 `json:"s0c"` // Survivor 0 capacity (KiB)
+	S1C float64 `json:"s1c"` // Survivor 1 capacity (KiB)
+	S0U float64 `json:"s0u"` // Survivor 0 utilization (KiB)
+	S1U float64 `json:"s1u"` // Survivor 1 utilization (KiB)
+
+	// Eden / Old
+	EC  float64 `json:"ec"`  // Eden capacity (KiB)
+	EU  float64 `json:"eu"`  // Eden utilization (KiB)
+	OC  float64 `json:"oc"`  // Old generation capacity (KiB)
+	OU  float64 `json:"ou"`  // Old generation utilization (KiB)
+
+	// Metaspace
+	MC  float64 `json:"mc"`  // Metaspace capacity (KiB)
+	MU  float64 `json:"mu"`  // Metaspace utilization (KiB)
+	CCSC float64 `json:"ccsc"` // Compressed class space capacity (KiB)
+	CCSU float64 `json:"ccsu"` // Compressed class space utilization (KiB)
+
+	// GC event counts
+	YGC  int64   `json:"ygc"`  // Young GC event count
+	YGCT float64 `json:"ygct"` // Young GC time (seconds)
+	FGC  int64   `json:"fgc"`  // Full GC event count
+	FGCT float64 `json:"fgct"` // Full GC time (seconds)
+	GCT  float64 `json:"gct"`  // Total GC time (seconds)
+}
+
+// CollectGCStats runs `jstat -gc <pid>` once and returns the current GC counters.
+// Pass nil for run to use the default system runner.
+func CollectGCStats(pid int, run CmdRunner) (*GCStats, error) {
+	if run == nil {
+		run = DefaultRunner
+	}
+	out, err := run("jstat", "-gc", fmt.Sprint(pid))
+	if err != nil {
+		return nil, fmt.Errorf("jstat: %w", err)
+	}
+	return parseGCStats(string(out))
+}
+
+// parseGCStats parses `jstat -gc` output.
+//
+// jstat -gc emits two lines: a header row and a data row.
+//
+// Example:
+//
+//	 S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT     GCT
+//	 0.0    0.0    0.0    0.0   40960.0  20480.0  204800.0    4096.0  61440.0 59900.3 8064.0 7678.7     5    0.078   0      0.000    0.078
+func parseGCStats(out string) (*GCStats, error) {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 2 {
+		return nil, fmt.Errorf("jstat: unexpected output (got %d lines)", len(lines))
+	}
+
+	headers := strings.Fields(lines[0])
+	values := strings.Fields(lines[len(lines)-1]) // last non-empty line is the data row
+	if len(headers) != len(values) {
+		return nil, fmt.Errorf("jstat: header/value count mismatch (%d vs %d)", len(headers), len(values))
+	}
+
+	colF := func(name string) float64 {
+		for i, h := range headers {
+			if strings.EqualFold(h, name) {
+				f, _ := strconv.ParseFloat(values[i], 64)
+				return f
+			}
+		}
+		return 0
+	}
+	colI := func(name string) int64 {
+		for i, h := range headers {
+			if strings.EqualFold(h, name) {
+				n, _ := strconv.ParseInt(values[i], 10, 64)
+				return n
+			}
+		}
+		return 0
+	}
+
+	return &GCStats{
+		S0C:  colF("S0C"),
+		S1C:  colF("S1C"),
+		S0U:  colF("S0U"),
+		S1U:  colF("S1U"),
+		EC:   colF("EC"),
+		EU:   colF("EU"),
+		OC:   colF("OC"),
+		OU:   colF("OU"),
+		MC:   colF("MC"),
+		MU:   colF("MU"),
+		CCSC: colF("CCSC"),
+		CCSU: colF("CCSU"),
+		YGC:  colI("YGC"),
+		YGCT: colF("YGCT"),
+		FGC:  colI("FGC"),
+		FGCT: colF("FGCT"),
+		GCT:  colF("GCT"),
+	}, nil
+}

--- a/internal/jvm/jstat_test.go
+++ b/internal/jvm/jstat_test.go
@@ -1,0 +1,98 @@
+package jvm
+
+import (
+	"testing"
+)
+
+func TestParseGCStats(t *testing.T) {
+	// Sample output from `jstat -gc <pid>` on a G1 JVM.
+	out := ` S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT     GCT
+ 0.0    0.0    0.0    0.0   40960.0  20480.0  204800.0    4096.0  61440.0 59900.3 8064.0 7678.7     5    0.078   0      0.000    0.078`
+
+	stats, err := parseGCStats(out)
+	if err != nil {
+		t.Fatalf("parseGCStats: %v", err)
+	}
+
+	if stats.EC != 40960.0 {
+		t.Errorf("EC = %v, want 40960.0", stats.EC)
+	}
+	if stats.EU != 20480.0 {
+		t.Errorf("EU = %v, want 20480.0", stats.EU)
+	}
+	if stats.OC != 204800.0 {
+		t.Errorf("OC = %v, want 204800.0", stats.OC)
+	}
+	if stats.OU != 4096.0 {
+		t.Errorf("OU = %v, want 4096.0", stats.OU)
+	}
+	if stats.MC != 61440.0 {
+		t.Errorf("MC = %v, want 61440.0", stats.MC)
+	}
+	if stats.MU != 59900.3 {
+		t.Errorf("MU = %v, want 59900.3", stats.MU)
+	}
+	if stats.YGC != 5 {
+		t.Errorf("YGC = %d, want 5", stats.YGC)
+	}
+	if stats.YGCT != 0.078 {
+		t.Errorf("YGCT = %v, want 0.078", stats.YGCT)
+	}
+	if stats.FGC != 0 {
+		t.Errorf("FGC = %d, want 0", stats.FGC)
+	}
+	if stats.GCT != 0.078 {
+		t.Errorf("GCT = %v, want 0.078", stats.GCT)
+	}
+}
+
+func TestParseGCStatsSurvivorSpaces(t *testing.T) {
+	// ParallelGC survivor spaces are non-zero.
+	out := ` S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT     GCT
+512.0  512.0  256.0    0.0   4096.0   2048.0   8192.0     1024.0  32768.0 30000.0 4096.0 3800.0    12    0.150   2      0.025    0.175`
+
+	stats, err := parseGCStats(out)
+	if err != nil {
+		t.Fatalf("parseGCStats: %v", err)
+	}
+	if stats.S0C != 512.0 {
+		t.Errorf("S0C = %v, want 512.0", stats.S0C)
+	}
+	if stats.S0U != 256.0 {
+		t.Errorf("S0U = %v, want 256.0", stats.S0U)
+	}
+	if stats.YGC != 12 {
+		t.Errorf("YGC = %d, want 12", stats.YGC)
+	}
+	if stats.FGC != 2 {
+		t.Errorf("FGC = %d, want 2", stats.FGC)
+	}
+}
+
+func TestParseGCStatsTooFewLines(t *testing.T) {
+	if _, err := parseGCStats(""); err == nil {
+		t.Error("expected error for empty input")
+	}
+	if _, err := parseGCStats("S0C S1C"); err == nil {
+		t.Error("expected error for single-line input")
+	}
+}
+
+func TestCollectGCStatsFakeRunner(t *testing.T) {
+	var capturedArgs []string
+	run := func(name string, args ...string) ([]byte, error) {
+		capturedArgs = append([]string{name}, args...)
+		return []byte(` S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT     GCT
+ 0.0    0.0    0.0    0.0   1024.0    512.0   4096.0     256.0  8192.0  7000.0 1024.0  900.0     3    0.030   0      0.000    0.030`), nil
+	}
+	stats, err := CollectGCStats(42, run)
+	if err != nil {
+		t.Fatalf("CollectGCStats: %v", err)
+	}
+	if capturedArgs[0] != "jstat" || capturedArgs[1] != "-gc" || capturedArgs[2] != "42" {
+		t.Errorf("unexpected command: %v", capturedArgs)
+	}
+	if stats.YGC != 3 {
+		t.Errorf("YGC = %d, want 3", stats.YGC)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/jvm/jstat.go` with `GCStats` type and `CollectGCStats(pid, run)` using `jstat -gc <pid>`
- Parses jstat's two-line (header + data) output into a structured `GCStats` with survivor spaces, Eden/Old/Metaspace capacity+utilization, and Young/Full GC event counts and times
- Adds `spectra jvm gc-stats [--json] <pid>` subcommand
- Human-readable output shows Young/Full GC event counts + total times, Eden/Old/Metaspace utilization

## Test plan
- [ ] `go test ./internal/jvm/...` — TestParseGCStats, TestParseGCStatsSurvivorSpaces, TestParseGCStatsTooFewLines, TestCollectGCStatsFakeRunner all pass
- [ ] `go test ./...` — no regressions
- [ ] `go build ./...` — clean compile