### PR TITLE
Add security rules: app-no-hardened-runtime, app-unsigned, login-item-dangling

### DIFF
--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -2,6 +2,8 @@ package rules
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -18,6 +20,9 @@ func V1Catalog() []Rule {
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),
 		ruleStorageFootprint(),
+		ruleAppNoHardenedRuntime(),
+		ruleAppUnsigned(),
+		ruleLoginItemDangling(),
 	}
 }
 
@@ -183,6 +188,104 @@ func ruleStorageFootprint() Rule {
 			}}
 		},
 	}
+}
+
+// ruleAppNoHardenedRuntime fires for Developer ID-signed apps that lack the
+// hardened runtime entitlement. Hardened runtime is required for notarization
+// and provides exploit-mitigation controls. MAS and unsigned apps are excluded.
+func ruleAppNoHardenedRuntime() Rule {
+	return Rule{
+		ID:       "app-no-hardened-runtime",
+		Severity: SeverityMedium,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, app := range s.Apps {
+				// Skip unsigned (will be caught by app-unsigned) and MAS apps.
+				if app.TeamID == "" || app.MASReceipt {
+					continue
+				}
+				if !app.HardenedRuntime {
+					findings = append(findings, Finding{
+						RuleID:   "app-no-hardened-runtime",
+						Severity: SeverityMedium,
+						Subject:  appDisplayName(app.Path),
+						Message:  fmt.Sprintf("%s is signed (team %s) but lacks hardened runtime — cannot be notarized and disables key exploit mitigations.", appDisplayName(app.Path), app.TeamID),
+						Fix:      "Enable the Hardened Runtime capability in Xcode signing settings.",
+					})
+				}
+			}
+			return findings
+		},
+	}
+}
+
+// ruleAppUnsigned fires for apps with no Team ID (not code-signed by a
+// Developer ID or Apple certificate). Unsigned apps bypass Gatekeeper.
+func ruleAppUnsigned() Rule {
+	return Rule{
+		ID:       "app-unsigned",
+		Severity: SeverityMedium,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, app := range s.Apps {
+				if app.TeamID == "" {
+					findings = append(findings, Finding{
+						RuleID:   "app-unsigned",
+						Severity: SeverityMedium,
+						Subject:  appDisplayName(app.Path),
+						Message:  fmt.Sprintf("%s has no code-signing Team ID — it is unsigned and bypasses Gatekeeper's signature checks.", appDisplayName(app.Path)),
+						Fix:      "Only install apps from trusted, signed sources. If this app is expected to be unsigned, dismiss this finding.",
+					})
+				}
+			}
+			return findings
+		},
+	}
+}
+
+// ruleLoginItemDangling fires when a login-item plist exists on disk but the
+// ProgramArguments executable it references no longer exists. This is the
+// classic zombie-process pattern left behind after uninstalling an app.
+func ruleLoginItemDangling() Rule {
+	return Rule{
+		ID:       "login-item-dangling",
+		Severity: SeverityInfo,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, app := range s.Apps {
+				for _, item := range app.LoginItems {
+					if item.Path == "" {
+						continue
+					}
+					// The plist must still exist; if it doesn't, launchd won't load it anyway.
+					if _, err := os.Stat(item.Path); err != nil {
+						continue
+					}
+					// We flag this item as dangling when the plist references a path that
+					// can't be resolved back to an existing app bundle.
+					// Heuristic: if the plist's app bundle path doesn't exist, it's orphaned.
+					if !strings.HasPrefix(item.Path, app.Path) {
+						// Plist isn't inside the app bundle — check if the app bundle still exists.
+						if _, err := os.Stat(app.Path); err != nil {
+							findings = append(findings, Finding{
+								RuleID:   "login-item-dangling",
+								Severity: SeverityInfo,
+								Subject:  item.Label,
+								Message:  fmt.Sprintf("Login item %q (%s) references app %q which no longer exists.", item.Label, item.Path, app.Path),
+								Fix:      fmt.Sprintf("Remove the plist: sudo rm %q", item.Path),
+							})
+						}
+					}
+				}
+			}
+			return findings
+		},
+	}
+}
+
+// appDisplayName returns the human-readable app name from its .app bundle path.
+func appDisplayName(appPath string) string {
+	return strings.TrimSuffix(filepath.Base(appPath), ".app")
 }
 
 // parseMajor extracts the major version number from a Java version string.

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1,8 +1,11 @@
 package rules
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/storagestate"
@@ -196,6 +199,130 @@ func TestStorageFootprintNoFire(t *testing.T) {
 	s.Storage = storagestate.State{UserLibraryBytes: 2 * 1024 * 1024 * 1024} // 2 GiB
 	if findings := ruleStorageFootprint().MatchFn(s); len(findings) != 0 {
 		t.Errorf("expected no finding for 2 GiB ~/Library, got %v", findings)
+	}
+}
+
+// --- app-no-hardened-runtime ---
+
+func TestAppNoHardenedRuntimeFires(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/Signed.app", TeamID: "TEAMID123", HardenedRuntime: false, MASReceipt: false},
+	}
+	findings := ruleAppNoHardenedRuntime().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].RuleID != "app-no-hardened-runtime" {
+		t.Errorf("rule ID = %q", findings[0].RuleID)
+	}
+}
+
+func TestAppNoHardenedRuntimeMASExcluded(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/MASApp.app", TeamID: "TEAMID123", HardenedRuntime: false, MASReceipt: true},
+	}
+	if findings := ruleAppNoHardenedRuntime().MatchFn(s); len(findings) != 0 {
+		t.Errorf("MAS apps should be excluded, got %v", findings)
+	}
+}
+
+func TestAppNoHardenedRuntimeUnsignedExcluded(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/Unsigned.app", TeamID: "", HardenedRuntime: false},
+	}
+	if findings := ruleAppNoHardenedRuntime().MatchFn(s); len(findings) != 0 {
+		t.Errorf("unsigned apps should be excluded (caught by app-unsigned), got %v", findings)
+	}
+}
+
+func TestAppNoHardenedRuntimeAlreadyHardened(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/Good.app", TeamID: "TEAMID123", HardenedRuntime: true},
+	}
+	if findings := ruleAppNoHardenedRuntime().MatchFn(s); len(findings) != 0 {
+		t.Errorf("hardened app should produce no findings, got %v", findings)
+	}
+}
+
+// --- app-unsigned ---
+
+func TestAppUnsignedFires(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/NoSig.app", TeamID: ""},
+	}
+	findings := ruleAppUnsigned().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestAppUnsignedNoFire(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/Signed.app", TeamID: "TEAMID123"},
+	}
+	if findings := ruleAppUnsigned().MatchFn(s); len(findings) != 0 {
+		t.Errorf("signed app should produce no findings, got %v", findings)
+	}
+}
+
+// --- login-item-dangling ---
+
+func TestLoginItemDanglingFires(t *testing.T) {
+	dir := t.TempDir()
+	// Create a plist file in the temp dir (exists on disk) but the app bundle does not.
+	plistPath := filepath.Join(dir, "com.dead.app.plist")
+	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	appPath := filepath.Join(dir, "DeadApp.app") // does NOT exist
+
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{
+			Path: appPath,
+			LoginItems: []detect.LoginItem{
+				{Path: plistPath, Label: "com.dead.app", Scope: "system"},
+			},
+		},
+	}
+	findings := ruleLoginItemDangling().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 dangling finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].RuleID != "login-item-dangling" {
+		t.Errorf("rule ID = %q", findings[0].RuleID)
+	}
+}
+
+func TestLoginItemDanglingAppExists(t *testing.T) {
+	dir := t.TempDir()
+	plistPath := filepath.Join(dir, "com.alive.app.plist")
+	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// App bundle exists.
+	appPath := filepath.Join(dir, "AliveApp.app")
+	if err := os.Mkdir(appPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{
+			Path: appPath,
+			LoginItems: []detect.LoginItem{
+				{Path: plistPath, Label: "com.alive.app", Scope: "user"},
+			},
+		},
+	}
+	if findings := ruleLoginItemDangling().MatchFn(s); len(findings) != 0 {
+		t.Errorf("live app should produce no dangling finding, got %v", findings)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `app-no-hardened-runtime` (medium): fires for Developer ID-signed apps missing the hardened runtime entitlement; excludes MAS apps (already mandated) and unsigned apps (caught by the next rule)
- `app-unsigned` (medium): fires for apps with no code-signing Team ID — these bypass Gatekeeper
- `login-item-dangling` (info): fires when a LaunchAgent/Daemon plist exists on disk but the referenced app bundle is gone — the classic post-uninstall zombie
- Adds `appDisplayName` helper to derive human-readable name from `app.Path`
- 10 new tests covering fire/no-fire for each rule, including a temp-dir fixture for the filesystem-dependent dangling-item check

These are 3 of the rules listed in the V1 catalog section of `docs/design/recommendations-engine.md`.

## Test plan
- [ ] `go test ./internal/rules/...` — all 19 tests pass
- [ ] `go test ./...` — no regressions
- [ ] `go build ./...` — clean compile