### PR TITLE
Add permission-mismatch and sparse-file-inflation rules

### DIFF
--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -39,7 +39,8 @@ type Result struct {
 	BuildNumber      string   // CFBundleVersion
 	ElectronVersion  string   // version of bundled Electron Framework, if any
 	Architectures    []string // arm64, x86_64
-	BundleSizeBytes  int64    // total disk usage of the .app
+	BundleSizeBytes  int64    // total disk usage of the .app (sparse-aware: Blocks*512)
+	ApparentSizeBytes int64   // logical size of the .app (fi.Size() sum; may be >> BundleSizeBytes for sparse images)
 	TeamID           string   // code-sign team identifier
 	SparkleFeedURL   string   // SUFeedURL from Info.plist, if present
 	MASReceipt       bool     // Mac App Store receipt is embedded
@@ -227,7 +228,7 @@ func populateMetadata(appPath, exe string, r *Result) {
 	if exe != "" {
 		r.Architectures = readArchitectures(exe)
 	}
-	r.BundleSizeBytes = bundleSize(appPath)
+	r.BundleSizeBytes, r.ApparentSizeBytes = bundleSizes(appPath)
 	r.TeamID, r.HardenedRuntime = readSigning(appPath)
 	r.Sandboxed, r.Entitlements = readEntitlements(appPath)
 	r.MASReceipt = exists(filepath.Join(appPath, "Contents", "_MASReceipt"))
@@ -321,13 +322,12 @@ func readArchitectures(exe string) []string {
 	return arches
 }
 
-// bundleSize sums the actual on-disk size (not apparent size) of every
-// regular file under appPath. We use Stat_t.Blocks * 512 so sparse files
-// — most notably Docker's VM disk image at ~/Library/Containers/com.docker
-// .docker — report the real space used rather than their virtual ceiling.
-// Errors are ignored; partial sums are fine.
-func bundleSize(appPath string) int64 {
-	var total int64
+// bundleSizes walks appPath once and returns (actual, apparent) byte counts
+// for all regular files. actual uses Stat_t.Blocks*512 so sparse files report
+// real allocation; apparent uses fi.Size() (the logical ceiling). For
+// non-sparse files they are equal; a Docker VM disk image may show
+// apparent 60 GiB vs actual 4 GiB. Errors are ignored; partial sums are fine.
+func bundleSizes(appPath string) (actual, apparent int64) {
 	_ = filepath.WalkDir(appPath, func(_ string, d os.DirEntry, err error) error {
 		if err != nil || d == nil || d.IsDir() {
 			return nil
@@ -336,10 +336,18 @@ func bundleSize(appPath string) int64 {
 		if err != nil || !fi.Mode().IsRegular() {
 			return nil
 		}
-		total += diskBytes(fi)
+		actual += diskBytes(fi)
+		apparent += fi.Size()
 		return nil
 	})
-	return total
+	return actual, apparent
+}
+
+// bundleSize returns the actual (sparse-aware) disk usage for appPath.
+// Deprecated: prefer bundleSizes when you also need apparent size.
+func bundleSize(appPath string) int64 {
+	a, _ := bundleSizes(appPath)
+	return a
 }
 
 // readSigning parses `codesign -dv` stderr for the team identifier and

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -23,6 +23,8 @@ func V1Catalog() []Rule {
 		ruleAppNoHardenedRuntime(),
 		ruleAppUnsigned(),
 		ruleLoginItemDangling(),
+		rulePermissionMismatch(),
+		ruleSparseFileInflation(),
 	}
 }
 
@@ -277,6 +279,97 @@ func ruleLoginItemDangling() Rule {
 						}
 					}
 				}
+			}
+			return findings
+		},
+	}
+}
+
+// rulePermissionMismatch fires when an app has a TCC-granted permission
+// that has no corresponding NS*UsageDescription in its Info.plist. Apps
+// that silently receive TCC access without declaring why are a security
+// concern and cannot pass App Review.
+func rulePermissionMismatch() Rule {
+	// Maps the human-readable TCC service name (kTCCService prefix stripped)
+	// to the NS*UsageDescription key the app is expected to declare.
+	// Services without a required NS key (e.g. SystemPolicyAllFiles, Accessibility)
+	// are omitted — they don't require a usage description in Info.plist.
+	tccToNSKey := map[string]string{
+		"Camera":                 "NSCameraUsageDescription",
+		"Microphone":             "NSMicrophoneUsageDescription",
+		"Contacts":               "NSContactsUsageDescription",
+		"PhotoLibrary":           "NSPhotoLibraryUsageDescription",
+		"PhotoLibraryAdd":        "NSPhotoLibraryAddUsageDescription",
+		"Calendar":               "NSCalendarsUsageDescription",
+		"Reminders":              "NSRemindersUsageDescription",
+		"Bluetooth":              "NSBluetoothAlwaysUsageDescription",
+		"SpeechRecognition":      "NSSpeechRecognitionUsageDescription",
+		"FaceID":                 "NSFaceIDUsageDescription",
+		"Motion":                 "NSMotionUsageDescription",
+		"HealthShare":            "NSHealthShareUsageDescription",
+		"HealthUpdate":           "NSHealthUpdateUsageDescription",
+		"HomeKit":                "NSHomeKitUsageDescription",
+		"NearbyInteraction":      "NSNearbyInteractionUsageDescription",
+		"UserTracking":           "NSUserTrackingUsageDescription",
+		"FocusStatus":            "NSFocusStatusUsageDescription",
+		"LocalNetwork":           "NSLocalNetworkUsageDescription",
+	}
+
+	return Rule{
+		ID:       "permission-mismatch",
+		Severity: SeverityMedium,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, app := range s.Apps {
+				for _, svc := range app.GrantedPermissions {
+					nsKey, known := tccToNSKey[svc]
+					if !known {
+						continue
+					}
+					if _, declared := app.PrivacyDescriptions[nsKey]; !declared {
+						findings = append(findings, Finding{
+							RuleID:   "permission-mismatch",
+							Severity: SeverityMedium,
+							Subject:  appDisplayName(app.Path),
+							Message:  fmt.Sprintf("%s has %s granted (TCC) but no %s in Info.plist.", appDisplayName(app.Path), svc, nsKey),
+							Fix:      fmt.Sprintf("Add %s to %s/Contents/Info.plist, or revoke the TCC grant if this permission is unintended.", nsKey, app.Path),
+						})
+					}
+				}
+			}
+			return findings
+		},
+	}
+}
+
+// ruleSparseFileInflation fires when an app bundle's apparent (logical) size
+// exceeds its actual on-disk allocation by more than 10×. This is the
+// signature of sparse disk images such as Docker Desktop's VM disk
+// (~/Library/Containers/com.docker.docker/…/Docker.raw), which may
+// appear as tens of GiB while occupying much less real space.
+func ruleSparseFileInflation() Rule {
+	const inflationFactor = 10
+
+	return Rule{
+		ID:       "sparse-file-inflation",
+		Severity: SeverityInfo,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, app := range s.Apps {
+				actual := app.BundleSizeBytes
+				apparent := app.ApparentSizeBytes
+				// Only fire when actual is non-trivial (>1 MiB) to avoid
+				// divide-by-zero and noise from empty bundles.
+				if actual < 1024*1024 || apparent <= actual*inflationFactor {
+					continue
+				}
+				findings = append(findings, Finding{
+					RuleID:   "sparse-file-inflation",
+					Severity: SeverityInfo,
+					Subject:  appDisplayName(app.Path),
+					Message:  fmt.Sprintf("%s apparent size %.1f GiB vs %.1f GiB actual (%.0f×) — likely a sparse disk image.", appDisplayName(app.Path), float64(apparent)/(1<<30), float64(actual)/(1<<30), float64(apparent)/float64(actual)),
+					Fix:      "If this is a Docker or VM disk image, run `docker system prune` or compact the image to reclaim logical space.",
+				})
 			}
 			return findings
 		},

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -326,6 +326,127 @@ func TestLoginItemDanglingAppExists(t *testing.T) {
 	}
 }
 
+// --- permission-mismatch ---
+
+func TestPermissionMismatchFires(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{
+			Path:               "/Applications/Sneaky.app",
+			TeamID:             "TEAM1",
+			GrantedPermissions: []string{"Camera", "Microphone"},
+			PrivacyDescriptions: map[string]string{
+				// NSCameraUsageDescription declared, NSMicrophoneUsageDescription missing
+				"NSCameraUsageDescription": "Used for video calls",
+			},
+		},
+	}
+	findings := rulePermissionMismatch().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (Microphone missing NS key), got %d: %v", len(findings), findings)
+	}
+	if findings[0].RuleID != "permission-mismatch" {
+		t.Errorf("rule ID = %q", findings[0].RuleID)
+	}
+}
+
+func TestPermissionMismatchBothDeclared(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{
+			Path:               "/Applications/GoodApp.app",
+			TeamID:             "TEAM1",
+			GrantedPermissions: []string{"Camera", "Microphone"},
+			PrivacyDescriptions: map[string]string{
+				"NSCameraUsageDescription":     "Video calls",
+				"NSMicrophoneUsageDescription": "Audio calls",
+			},
+		},
+	}
+	if findings := rulePermissionMismatch().MatchFn(s); len(findings) != 0 {
+		t.Errorf("all NS keys declared — expected no findings, got %v", findings)
+	}
+}
+
+func TestPermissionMismatchUnknownServiceIgnored(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{
+			Path:               "/Applications/FDA.app",
+			TeamID:             "TEAM1",
+			GrantedPermissions: []string{"SystemPolicyAllFiles", "Accessibility"},
+			PrivacyDescriptions: map[string]string{},
+		},
+	}
+	// SystemPolicyAllFiles and Accessibility have no required NS key — rule must be silent.
+	if findings := rulePermissionMismatch().MatchFn(s); len(findings) != 0 {
+		t.Errorf("services with no NS requirement should be ignored, got %v", findings)
+	}
+}
+
+func TestPermissionMismatchNoGrantedPermissions(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/Plain.app", TeamID: "TEAM1"},
+	}
+	if findings := rulePermissionMismatch().MatchFn(s); len(findings) != 0 {
+		t.Errorf("app with no granted permissions should produce no findings, got %v", findings)
+	}
+}
+
+// --- sparse-file-inflation ---
+
+func TestSparseFileInflationFires(t *testing.T) {
+	s := baseSnap()
+	actual := int64(5 * 1024 * 1024 * 1024)   // 5 GiB real
+	apparent := int64(60 * 1024 * 1024 * 1024) // 60 GiB logical (12×)
+	s.Apps = []detect.Result{
+		{
+			Path:              "/Applications/Docker.app",
+			BundleSizeBytes:   actual,
+			ApparentSizeBytes: apparent,
+		},
+	}
+	findings := ruleSparseFileInflation().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 inflation finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].RuleID != "sparse-file-inflation" {
+		t.Errorf("rule ID = %q", findings[0].RuleID)
+	}
+}
+
+func TestSparseFileInflationBelowThreshold(t *testing.T) {
+	s := baseSnap()
+	actual := int64(10 * 1024 * 1024 * 1024) // 10 GiB
+	apparent := int64(15 * 1024 * 1024 * 1024) // 15 GiB (1.5×)
+	s.Apps = []detect.Result{
+		{
+			Path:              "/Applications/BigApp.app",
+			BundleSizeBytes:   actual,
+			ApparentSizeBytes: apparent,
+		},
+	}
+	if findings := ruleSparseFileInflation().MatchFn(s); len(findings) != 0 {
+		t.Errorf("1.5× inflation is below threshold — expected no findings, got %v", findings)
+	}
+}
+
+func TestSparseFileInflationSmallBundle(t *testing.T) {
+	s := baseSnap()
+	// Bundle < 1 MiB actual — rule should stay silent to avoid noise.
+	s.Apps = []detect.Result{
+		{
+			Path:              "/Applications/Tiny.app",
+			BundleSizeBytes:   100 * 1024,            // 100 KiB actual
+			ApparentSizeBytes: 100 * 1024 * 1024 * 1024, // 100 GiB apparent (absurd edge case)
+		},
+	}
+	if findings := ruleSparseFileInflation().MatchFn(s); len(findings) != 0 {
+		t.Errorf("small actual size should suppress firing, got %v", findings)
+	}
+}
+
 // --- Evaluate (engine) ---
 
 func TestEvaluateSortOrder(t *testing.T) {


### PR DESCRIPTION
## Summary
- `detect.Result` gains `ApparentSizeBytes` (logical fi.Size() sum) alongside the existing sparse-aware `BundleSizeBytes`, computed in a single bundle walk via the new `bundleSizes` helper
- `rulePermissionMismatch`: fires when a TCC-granted service (Camera, Microphone, Contacts, Photos, Calendar, etc.) has no corresponding `NS*UsageDescription` in the app's Info.plist — the doc example is "Slack has Camera granted but no NSCameraUsageDescription"
- `ruleSparseFileInflation`: fires when apparent size > 10× actual on-disk allocation, catching Docker VM disk images and similar sparse file patterns
- 7 new unit tests covering fire/no-fire cases for both rules

## Test plan
- [ ] `go test ./internal/rules/...` — all 7 new tests pass
- [ ] `go test ./...` — no regressions across 24 packages