### PR TITLE
Add issues and applied_fixes persistence with RPC handlers

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -290,4 +290,75 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		}
 		return rules.Evaluate(snap, rules.V1Catalog()), nil
 	})
+
+	// issues.list — { "machine_uuid": "...", "status": "open" }
+	// status is optional; omit to return all statuses.
+	d.Register("issues.list", func(params json.RawMessage) (any, error) {
+		var p struct {
+			MachineUUID string `json:"machine_uuid"`
+			Status      string `json:"status"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.MachineUUID == "" {
+			return nil, fmt.Errorf("issues.list requires {\"machine_uuid\": \"...\"}")
+		}
+		return db.ListIssues(context.Background(), p.MachineUUID, store.IssueStatus(p.Status))
+	})
+
+	// issues.record — persist findings from a snapshot evaluation into the issues table.
+	// { "machine_uuid": "...", "snapshot_id": "...", "findings": [...] }
+	d.Register("issues.record", func(params json.RawMessage) (any, error) {
+		var p struct {
+			MachineUUID string              `json:"machine_uuid"`
+			SnapshotID  string              `json:"snapshot_id"`
+			Findings    []store.FindingInput `json:"findings"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.MachineUUID == "" || p.SnapshotID == "" {
+			return nil, fmt.Errorf("issues.record requires {\"machine_uuid\": \"...\", \"snapshot_id\": \"...\", \"findings\": [...]}")
+		}
+		ids, err := db.UpsertIssues(context.Background(), p.MachineUUID, p.SnapshotID, p.Findings)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"upserted": len(ids), "ids": ids}, nil
+	})
+
+	// issues.update — change an issue's status.
+	// { "id": "...", "status": "acknowledged" }
+	d.Register("issues.update", func(params json.RawMessage) (any, error) {
+		var p struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.ID == "" || p.Status == "" {
+			return nil, fmt.Errorf("issues.update requires {\"id\": \"...\", \"status\": \"...\"}")
+		}
+		if err := db.UpdateIssueStatus(context.Background(), p.ID, store.IssueStatus(p.Status)); err != nil {
+			return nil, err
+		}
+		return map[string]any{"id": p.ID, "status": p.Status}, nil
+	})
+
+	// issues.fix.record — log a fix attempt against an issue.
+	// { "issue_id": "...", "applied_by": "user", "command": "...", "output": "...", "exit_code": 0 }
+	d.Register("issues.fix.record", func(params json.RawMessage) (any, error) {
+		var p store.AppliedFixInput
+		if err := json.Unmarshal(params, &p); err != nil || p.IssueID == "" {
+			return nil, fmt.Errorf("issues.fix.record requires {\"issue_id\": \"...\"}")
+		}
+		id, err := db.RecordAppliedFix(context.Background(), p)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"id": id}, nil
+	})
+
+	// issues.fix.list — list fix attempts for one issue.
+	// { "issue_id": "..." }
+	d.Register("issues.fix.list", func(params json.RawMessage) (any, error) {
+		var p struct{ IssueID string `json:"issue_id"` }
+		if err := json.Unmarshal(params, &p); err != nil || p.IssueID == "" {
+			return nil, fmt.Errorf("issues.fix.list requires {\"issue_id\": \"...\"}")
+		}
+		return db.ListAppliedFixes(context.Background(), p.IssueID)
+	})
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -17,8 +18,14 @@ import (
 // temp Unix socket, and returns a connected RPC client.
 func testDaemon(t *testing.T) (*json.Encoder, *json.Decoder, context.CancelFunc) {
 	t.Helper()
-	dir := t.TempDir()
-	// Use a short socket name: macOS limits Unix socket paths to 104 bytes.
+	// Use os.MkdirTemp with a short prefix under /tmp: macOS limits Unix socket
+	// paths to 104 bytes and t.TempDir() embeds the full test name which can
+	// exceed that limit for long test names.
+	dir, err := os.MkdirTemp("", "sp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
 	sockPath := filepath.Join(dir, "s.sock")
 	dbPath := filepath.Join(dir, "t.db")
 
@@ -172,6 +179,77 @@ func TestDaemonInspectHost(t *testing.T) {
 	// HostInfo should have at least a hostname field.
 	if m["hostname"] == nil && m["Hostname"] == nil {
 		t.Error("inspect.host: expected hostname in result")
+	}
+}
+
+func rpcCall(t *testing.T, enc *json.Encoder, dec *json.Decoder, id int, method string, params string) rpc.Response {
+	t.Helper()
+	type req struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      int             `json:"id"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params"`
+	}
+	_ = enc.Encode(req{JSONRPC: "2.0", ID: id, Method: method, Params: json.RawMessage(params)})
+	var resp rpc.Response
+	if err := dec.Decode(&resp); err != nil {
+		t.Fatalf("rpcCall %s: decode: %v", method, err)
+	}
+	return resp
+}
+
+func TestDaemonIssuesListMissingMachine(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 10, "issues.list", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when machine_uuid missing")
+	}
+}
+
+func TestDaemonIssuesRecordEmpty(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+
+	// issues.record with empty findings should succeed (0 upserts).
+	resp := rpcCall(t, enc, dec, 11, "issues.record",
+		`{"machine_uuid":"TEST-1","snapshot_id":"snap-X","findings":[]}`)
+	if resp.Error != nil {
+		t.Fatalf("issues.record (empty): %v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T", resp.Result)
+	}
+	if m["upserted"].(float64) != 0 {
+		t.Errorf("upserted = %v, want 0", m["upserted"])
+	}
+}
+
+func TestDaemonIssuesUpdateMissingStatus(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 12, "issues.update", `{"id":"x"}`)
+	if resp.Error == nil {
+		t.Error("expected error when status missing")
+	}
+}
+
+func TestDaemonIssuesFixRecordMissingIssueID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 13, "issues.fix.record", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when issue_id missing")
+	}
+}
+
+func TestDaemonIssuesFixListMissingIssueID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 14, "issues.fix.list", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when issue_id missing")
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -143,6 +144,38 @@ CREATE TABLE IF NOT EXISTS process_metrics (
 );
 
 CREATE INDEX IF NOT EXISTS idx_process_metrics_pid ON process_metrics(pid, minute_at DESC);
+
+CREATE TABLE IF NOT EXISTS issues (
+    id                     TEXT PRIMARY KEY,
+    rule_id                TEXT NOT NULL,
+    machine_uuid           TEXT NOT NULL,
+    subject                TEXT NOT NULL DEFAULT '',
+    severity               TEXT NOT NULL,
+    message                TEXT NOT NULL,
+    fix                    TEXT NOT NULL DEFAULT '',
+    status                 TEXT NOT NULL DEFAULT 'open',
+    first_seen_snapshot_id TEXT,
+    last_seen_snapshot_id  TEXT,
+    created_at             DATETIME NOT NULL,
+    updated_at             DATETIME NOT NULL,
+    FOREIGN KEY (machine_uuid) REFERENCES hosts(machine_uuid)
+);
+
+CREATE INDEX IF NOT EXISTS idx_issues_machine ON issues(machine_uuid, status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_issues_rule ON issues(rule_id, status);
+
+CREATE TABLE IF NOT EXISTS applied_fixes (
+    id         TEXT PRIMARY KEY,
+    issue_id   TEXT NOT NULL,
+    applied_at DATETIME NOT NULL,
+    applied_by TEXT NOT NULL DEFAULT '',
+    command    TEXT NOT NULL DEFAULT '',
+    output     TEXT NOT NULL DEFAULT '',
+    exit_code  INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (issue_id) REFERENCES issues(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_applied_fixes_issue ON applied_fixes(issue_id, applied_at DESC);
 `
 
 // SnapshotRow is a lightweight summary row from the snapshots table.
@@ -461,4 +494,222 @@ type AppInput struct {
 	AppVersion    string
 	Architectures []string
 	ResultJSON    any // the full detect.Result, marshalled to JSON
+}
+
+// IssueStatus enumerates the lifecycle states for an issue.
+type IssueStatus string
+
+const (
+	IssueOpen         IssueStatus = "open"
+	IssueAcknowledged IssueStatus = "acknowledged"
+	IssueDismissed    IssueStatus = "dismissed"
+	IssueFixed        IssueStatus = "fixed"
+	IssueClosed       IssueStatus = "closed"
+)
+
+// IssueRow is one row from the issues table.
+type IssueRow struct {
+	ID                  string
+	RuleID              string
+	MachineUUID         string
+	Subject             string
+	Severity            string
+	Message             string
+	Fix                 string
+	Status              IssueStatus
+	FirstSeenSnapshotID string
+	LastSeenSnapshotID  string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+// AppliedFixRow is one row from the applied_fixes table.
+type AppliedFixRow struct {
+	ID        string
+	IssueID   string
+	AppliedAt time.Time
+	AppliedBy string
+	Command   string
+	Output    string
+	ExitCode  int
+}
+
+// UpsertIssues reconciles a slice of findings against the issues table.
+// For each finding, it looks up an existing open/acknowledged issue by
+// (rule_id, machine_uuid, subject). If found, last_seen_snapshot_id and
+// updated_at are refreshed. If not found, a new open issue is inserted.
+// Returns the IDs of all touched (inserted or updated) issues.
+func (s *DB) UpsertIssues(ctx context.Context, machineUUID, snapshotID string, findings []FindingInput) ([]string, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("store: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	var ids []string
+	for _, f := range findings {
+		var existingID string
+		err := tx.QueryRowContext(ctx, `
+			SELECT id FROM issues
+			WHERE rule_id=? AND machine_uuid=? AND subject=?
+			  AND status IN ('open','acknowledged')
+			LIMIT 1`,
+			f.RuleID, machineUUID, f.Subject,
+		).Scan(&existingID)
+
+		if err == nil {
+			// Existing active issue — refresh last_seen.
+			_, err = tx.ExecContext(ctx, `
+				UPDATE issues SET last_seen_snapshot_id=?, updated_at=? WHERE id=?`,
+				snapshotID, now, existingID)
+			if err != nil {
+				return nil, fmt.Errorf("store: update issue: %w", err)
+			}
+			ids = append(ids, existingID)
+			continue
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("store: lookup issue: %w", err)
+		}
+
+		// New issue.
+		id := newID()
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO issues
+			    (id, rule_id, machine_uuid, subject, severity, message, fix,
+			     status, first_seen_snapshot_id, last_seen_snapshot_id, created_at, updated_at)
+			VALUES (?,?,?,?,?,?,?,'open',?,?,?,?)`,
+			id, f.RuleID, machineUUID, f.Subject, f.Severity, f.Message, f.Fix,
+			snapshotID, snapshotID, now, now,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("store: insert issue: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, tx.Commit()
+}
+
+// FindingInput is the data from a rules engine finding used to upsert an issue.
+type FindingInput struct {
+	RuleID   string
+	Subject  string
+	Severity string
+	Message  string
+	Fix      string
+}
+
+// ListIssues returns issues for the given machine, optionally filtered by status.
+// Pass status="" to return all statuses. Results are ordered newest-updated first.
+func (s *DB) ListIssues(ctx context.Context, machineUUID string, status IssueStatus) ([]IssueRow, error) {
+	q := `SELECT id, rule_id, machine_uuid, subject, severity, message, fix, status,
+	             COALESCE(first_seen_snapshot_id,''), COALESCE(last_seen_snapshot_id,''),
+	             created_at, updated_at
+	      FROM issues WHERE machine_uuid=?`
+	args := []any{machineUUID}
+	if status != "" {
+		q += ` AND status=?`
+		args = append(args, string(status))
+	}
+	q += ` ORDER BY updated_at DESC LIMIT 500`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanIssueRows(rows)
+}
+
+// UpdateIssueStatus transitions an issue to a new status.
+func (s *DB) UpdateIssueStatus(ctx context.Context, id string, status IssueStatus) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE issues SET status=?, updated_at=? WHERE id=?`,
+		string(status), now, id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// RecordAppliedFix inserts a new applied_fixes row.
+func (s *DB) RecordAppliedFix(ctx context.Context, fix AppliedFixInput) (string, error) {
+	id := newID()
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO applied_fixes (id, issue_id, applied_at, applied_by, command, output, exit_code)
+		VALUES (?,?,?,?,?,?,?)`,
+		id, fix.IssueID, now, fix.AppliedBy, fix.Command, fix.Output, fix.ExitCode,
+	)
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// AppliedFixInput carries the data for recording a fix attempt.
+type AppliedFixInput struct {
+	IssueID   string
+	AppliedBy string
+	Command   string
+	Output    string
+	ExitCode  int
+}
+
+// ListAppliedFixes returns the fix history for one issue.
+func (s *DB) ListAppliedFixes(ctx context.Context, issueID string) ([]AppliedFixRow, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, issue_id, applied_at, applied_by, command, output, exit_code
+		FROM applied_fixes WHERE issue_id=? ORDER BY applied_at DESC`, issueID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AppliedFixRow
+	for rows.Next() {
+		var r AppliedFixRow
+		var appliedAt string
+		if err := rows.Scan(&r.ID, &r.IssueID, &appliedAt, &r.AppliedBy, &r.Command, &r.Output, &r.ExitCode); err != nil {
+			return nil, err
+		}
+		r.AppliedAt, _ = time.Parse(time.RFC3339, appliedAt)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func scanIssueRows(rows *sql.Rows) ([]IssueRow, error) {
+	var out []IssueRow
+	for rows.Next() {
+		var r IssueRow
+		var status, createdAt, updatedAt string
+		if err := rows.Scan(&r.ID, &r.RuleID, &r.MachineUUID, &r.Subject,
+			&r.Severity, &r.Message, &r.Fix, &status,
+			&r.FirstSeenSnapshotID, &r.LastSeenSnapshotID,
+			&createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		r.Status = IssueStatus(status)
+		r.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+		r.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// newID generates a unique ID for a new record. Uses random to avoid
+// importing the idgen package and creating a cycle.
+func newID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: use timestamp nano as hex.
+		return fmt.Sprintf("%016x", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("%016x", b)
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -162,6 +162,150 @@ func TestListSnapshotsByMachine(t *testing.T) {
 	}
 }
 
+// --- Issues ---
+
+func seedSnapshot(t *testing.T, db *DB) string {
+	t.Helper()
+	in := sampleInput()
+	if err := db.SaveSnapshot(context.Background(), in); err != nil {
+		t.Fatalf("seedSnapshot: %v", err)
+	}
+	return in.ID
+}
+
+func TestUpsertIssuesNewAndRefresh(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	snapID := seedSnapshot(t, db)
+
+	findings := []FindingInput{
+		{RuleID: "app-unsigned", Subject: "MyApp", Severity: "medium", Message: "not signed", Fix: "sign it"},
+		{RuleID: "jvm-eol-version", Subject: "PID 123 (old.App)", Severity: "medium", Message: "JDK 9", Fix: "upgrade"},
+	}
+
+	ids, err := db.UpsertIssues(ctx, "TEST-UUID-1234", snapID, findings)
+	if err != nil {
+		t.Fatalf("UpsertIssues: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 IDs, got %d", len(ids))
+	}
+
+	// Second call with same findings should refresh, not insert.
+	ids2, err := db.UpsertIssues(ctx, "TEST-UUID-1234", snapID, findings)
+	if err != nil {
+		t.Fatalf("UpsertIssues (refresh): %v", err)
+	}
+	if ids2[0] != ids[0] || ids2[1] != ids[1] {
+		t.Errorf("refresh changed IDs: %v vs %v", ids, ids2)
+	}
+
+	rows, err := db.ListIssues(ctx, "TEST-UUID-1234", "")
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(rows))
+	}
+	if rows[0].Status != IssueOpen {
+		t.Errorf("status = %q, want open", rows[0].Status)
+	}
+}
+
+func TestListIssuesFilterByStatus(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	snapID := seedSnapshot(t, db)
+
+	findings := []FindingInput{
+		{RuleID: "rule-A", Subject: "S1", Severity: "medium", Message: "m1"},
+		{RuleID: "rule-B", Subject: "S2", Severity: "high", Message: "m2"},
+	}
+	ids, _ := db.UpsertIssues(ctx, "TEST-UUID-1234", snapID, findings)
+
+	// Acknowledge the first issue.
+	if err := db.UpdateIssueStatus(ctx, ids[0], IssueAcknowledged); err != nil {
+		t.Fatalf("UpdateIssueStatus: %v", err)
+	}
+
+	openOnes, _ := db.ListIssues(ctx, "TEST-UUID-1234", IssueOpen)
+	if len(openOnes) != 1 {
+		t.Errorf("expected 1 open issue, got %d", len(openOnes))
+	}
+
+	ackOnes, _ := db.ListIssues(ctx, "TEST-UUID-1234", IssueAcknowledged)
+	if len(ackOnes) != 1 {
+		t.Errorf("expected 1 acknowledged issue, got %d", len(ackOnes))
+	}
+}
+
+func TestUpdateIssueStatusNotFound(t *testing.T) {
+	db := openTestDB(t)
+	err := db.UpdateIssueStatus(context.Background(), "no-such-id", IssueClosed)
+	if err != ErrNotFound {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestRecordAndListAppliedFixes(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	snapID := seedSnapshot(t, db)
+
+	ids, _ := db.UpsertIssues(ctx, "TEST-UUID-1234", snapID, []FindingInput{
+		{RuleID: "rule-X", Subject: "App", Severity: "info", Message: "bloat", Fix: "clean"},
+	})
+	issueID := ids[0]
+
+	fixID, err := db.RecordAppliedFix(ctx, AppliedFixInput{
+		IssueID:   issueID,
+		AppliedBy: "user",
+		Command:   "docker system prune",
+		Output:    "Deleted 10 GiB",
+		ExitCode:  0,
+	})
+	if err != nil {
+		t.Fatalf("RecordAppliedFix: %v", err)
+	}
+	if fixID == "" {
+		t.Error("expected non-empty fix ID")
+	}
+
+	fixes, err := db.ListAppliedFixes(ctx, issueID)
+	if err != nil {
+		t.Fatalf("ListAppliedFixes: %v", err)
+	}
+	if len(fixes) != 1 {
+		t.Fatalf("expected 1 fix, got %d", len(fixes))
+	}
+	if fixes[0].Command != "docker system prune" {
+		t.Errorf("command = %q", fixes[0].Command)
+	}
+}
+
+func TestUpsertIssuesDoesNotReopenDismissed(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	snapID := seedSnapshot(t, db)
+
+	findings := []FindingInput{
+		{RuleID: "rule-Y", Subject: "App", Severity: "low", Message: "minor"},
+	}
+	ids, _ := db.UpsertIssues(ctx, "TEST-UUID-1234", snapID, findings)
+
+	// Dismiss the issue.
+	_ = db.UpdateIssueStatus(ctx, ids[0], IssueDismissed)
+
+	// Same finding again — should create a NEW issue because dismissed != open|acknowledged.
+	ids2, err := db.UpsertIssues(ctx, "TEST-UUID-1234", snapID, findings)
+	if err != nil {
+		t.Fatalf("UpsertIssues after dismiss: %v", err)
+	}
+	if len(ids2) != 1 || ids2[0] == ids[0] {
+		t.Errorf("expected new issue ID after dismiss, got same: %v", ids2)
+	}
+}
+
 func TestAppName(t *testing.T) {
 	cases := map[string]string{
 		"/Applications/Slack.app":        "Slack",


### PR DESCRIPTION
## Summary
- New `issues` and `applied_fixes` SQLite tables cover the issue lifecycle from the recommendations engine design doc
- `UpsertIssues` is idempotent: same `(rule_id, machine_uuid, subject)` with `open`/`acknowledged` status refreshes `last_seen`; dismissed/fixed/closed issues spawn a fresh open issue so recurring problems aren't silently suppressed
- Five new RPC handlers: `issues.list`, `issues.record`, `issues.update`, `issues.fix.record`, `issues.fix.list`
- Also fixes `testDaemon` to use `os.MkdirTemp("","sp")` instead of `t.TempDir()` so long test names don't push the Unix socket path past macOS's 104-char limit

## Test plan
- [ ] `go test ./internal/store/...` — 5 new store tests pass
- [ ] `go test ./internal/serve/...` — 5 new RPC handler tests pass (including previously failing long-name tests fixed by socket path fix)
- [ ] `go test ./...` — no regressions across 24 packages