### PR TITLE
Add snapshot retention: PruneSnapshots + spectra snapshot prune

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -22,6 +22,7 @@ func snapshotSubcommands() []subcommand {
 		{"list", "List stored snapshots", runSnapshotList},
 		{"show", "Show details of one snapshot by ID", runSnapshotShow},
 		{"diff", "Diff two stored snapshots", runSnapshotDiff},
+		{"prune", "Delete live snapshots beyond the retention limit (default: keep 100)", runSnapshotPrune},
 	}
 }
 
@@ -75,7 +76,8 @@ func runSnapshot(args []string) int {
 	return 0
 }
 
-// saveSnapshot opens the default DB and persists snap.
+// saveSnapshot opens the default DB, persists snap, and prunes old live
+// snapshots beyond the default retention limit (100 per machine).
 func saveSnapshot(snap snapshot.Snapshot) error {
 	dbPath, err := store.DefaultPath()
 	if err != nil {
@@ -86,7 +88,12 @@ func saveSnapshot(snap snapshot.Snapshot) error {
 		return err
 	}
 	defer db.Close()
-	return db.SaveSnapshot(context.Background(), store.FromSnapshot(snap))
+	ctx := context.Background()
+	if err := db.SaveSnapshot(ctx, store.FromSnapshot(snap)); err != nil {
+		return err
+	}
+	_, _ = db.PruneSnapshots(ctx, 100) // best-effort; ignore prune errors
+	return nil
 }
 
 // runSnapshotList prints stored snapshots in a summary table.
@@ -317,6 +324,40 @@ func loadSnapshotFromDB(ctx context.Context, db *store.DB, id string) (*snapshot
 		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 	return &s, nil
+}
+
+// runSnapshotPrune deletes live snapshots beyond the retention limit.
+func runSnapshotPrune(args []string) int {
+	fs := flag.NewFlagSet("spectra snapshot prune", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	keepN := fs.Int("keep", 100, "Number of live snapshots to retain per machine")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+
+	deleted, err := db.PruneSnapshots(context.Background(), *keepN)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if deleted == 0 {
+		fmt.Printf("nothing to prune (≤%d live snapshots)\n", *keepN)
+	} else {
+		fmt.Printf("pruned %d live snapshot(s) (keeping last %d per machine)\n", deleted, *keepN)
+	}
+	return 0
 }
 
 // printDiff renders a diff.Result as a human-readable table.

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -268,6 +268,21 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		return diff.Compare(*snapA, *snapB), nil
 	})
 
+	// snapshot.prune — delete live snapshots beyond retention limit.
+	// Optional: { "keep": 100 }
+	d.Register("snapshot.prune", func(params json.RawMessage) (any, error) {
+		var p struct{ Keep int `json:"keep"` }
+		_ = json.Unmarshal(params, &p)
+		if p.Keep <= 0 {
+			p.Keep = 100
+		}
+		deleted, err := db.PruneSnapshots(context.Background(), p.Keep)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"deleted": deleted, "keep": p.Keep}, nil
+	})
+
 	d.Register("rules.check", func(params json.RawMessage) (any, error) {
 		// Optional: { "snapshot_id": "snap-..." } to evaluate against stored snapshot.
 		var p struct{ SnapshotID string `json:"snapshot_id"` }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -458,6 +458,68 @@ type ProcessMetricRow struct {
 	SampleCount int
 }
 
+// PruneSnapshots deletes live snapshots beyond the retention limit for each
+// machine. Baselines (kind != "live") are never deleted. The default limit
+// is 100 live snapshots per machine UUID.
+func (s *DB) PruneSnapshots(ctx context.Context, keepN int) (int64, error) {
+	if keepN <= 0 {
+		keepN = 100
+	}
+	// Find all machine UUIDs that have live snapshots.
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT machine_uuid FROM snapshots WHERE kind='live'`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	var machines []string
+	for rows.Next() {
+		var m string
+		if err := rows.Scan(&m); err != nil {
+			return 0, err
+		}
+		machines = append(machines, m)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	rows.Close()
+
+	var total int64
+	for _, m := range machines {
+		// Delete snapshot_apps for the to-be-pruned snapshots first (FK constraint).
+		if _, err := s.db.ExecContext(ctx, `
+			DELETE FROM snapshot_apps
+			WHERE snapshot_id IN (
+			  SELECT id FROM snapshots
+			  WHERE kind='live' AND machine_uuid=?
+			    AND id NOT IN (
+			      SELECT id FROM snapshots
+			      WHERE kind='live' AND machine_uuid=?
+			      ORDER BY taken_at DESC
+			      LIMIT ?
+			    )
+			)`, m, m, keepN); err != nil {
+			return total, fmt.Errorf("store: prune apps %s: %w", m, err)
+		}
+		res, err := s.db.ExecContext(ctx, `
+			DELETE FROM snapshots
+			WHERE kind='live' AND machine_uuid=?
+			  AND id NOT IN (
+			    SELECT id FROM snapshots
+			    WHERE kind='live' AND machine_uuid=?
+			    ORDER BY taken_at DESC
+			    LIMIT ?
+			  )`, m, m, keepN)
+		if err != nil {
+			return total, fmt.Errorf("store: prune %s: %w", m, err)
+		}
+		n, _ := res.RowsAffected()
+		total += n
+	}
+	return total, nil
+}
+
 // ErrNotFound is returned when a requested record doesn't exist.
 var ErrNotFound = errors.New("store: not found")
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -159,6 +160,77 @@ func TestListSnapshotsByMachine(t *testing.T) {
 	rows, _ := db.ListSnapshots(ctx, "UUID-A")
 	if len(rows) != 1 || rows[0].ID != "snap-A" {
 		t.Errorf("filtered list: %+v", rows)
+	}
+}
+
+// --- Snapshot retention / pruning ---
+
+func TestPruneSnapshotsKeepsBaselines(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	// Insert 3 live + 1 baseline.
+	for i := 1; i <= 3; i++ {
+		in := sampleInput()
+		in.ID = fmt.Sprintf("snap-live-%02d", i)
+		in.Kind = "live"
+		_ = db.SaveSnapshot(ctx, in)
+	}
+	baseline := sampleInput()
+	baseline.ID = "snap-baseline-01"
+	baseline.Kind = "baseline"
+	_ = db.SaveSnapshot(ctx, baseline)
+
+	// Prune keeping 2 live.
+	deleted, err := db.PruneSnapshots(ctx, 2)
+	if err != nil {
+		t.Fatalf("PruneSnapshots: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+
+	// Baseline must still exist.
+	row, err := db.GetSnapshot(ctx, "snap-baseline-01")
+	if err != nil {
+		t.Fatalf("baseline gone after prune: %v", err)
+	}
+	if row.Kind != "baseline" {
+		t.Errorf("kind = %q, want baseline", row.Kind)
+	}
+}
+
+func TestPruneSnapshotsNoOp(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	// Only 1 live snapshot — pruning with keep=100 should delete nothing.
+	_ = db.SaveSnapshot(ctx, sampleInput())
+	deleted, err := db.PruneSnapshots(ctx, 100)
+	if err != nil {
+		t.Fatalf("PruneSnapshots: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("expected 0 deleted, got %d", deleted)
+	}
+}
+
+func TestPruneSnapshotsZeroKeepDefaultsTo100(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	// 5 snapshots, prune with keep=0 (should default to 100, so none deleted).
+	for i := 1; i <= 5; i++ {
+		in := sampleInput()
+		in.ID = fmt.Sprintf("snap-%02d", i)
+		_ = db.SaveSnapshot(ctx, in)
+	}
+	deleted, err := db.PruneSnapshots(ctx, 0)
+	if err != nil {
+		t.Fatalf("PruneSnapshots: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("keep=0 should default to 100 and delete nothing; got %d", deleted)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `DB.PruneSnapshots(ctx, keepN)` deletes live snapshots beyond the retention limit per machine UUID; baselines (kind != "live") are never touched. Cleans up `snapshot_apps` child rows first to satisfy the FK constraint.
- `saveSnapshot` (CLI) now calls `PruneSnapshots(ctx, 100)` after each capture — retention is automatically enforced on every `spectra snapshot` run.
- `spectra snapshot prune [--keep N]` subcommand for manual pruning.
- `snapshot.prune` RPC handler for daemon clients.

## Test plan
- [ ] `TestPruneSnapshotsKeepsBaselines` — prunes 1 of 3 live; baseline survives
- [ ] `TestPruneSnapshotsNoOp` — 1 snapshot, keep=100, nothing deleted
- [ ] `TestPruneSnapshotsZeroKeepDefaultsTo100` — keep=0 treated as 100
- [ ] `go test ./...` — all 24 packages pass