### PR TITLE
Add baseline snapshot support (--baseline, name field, --kind filter)

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -42,6 +42,8 @@ func runSnapshot(args []string) int {
 	withNetwork := fs.Bool("network", false, "Extract embedded URL hosts (slower; scans app.asar)")
 	skipApps := fs.Bool("no-apps", false, "Skip the apps inventory; capture host info only")
 	noStore := fs.Bool("no-store", false, "Do not persist the snapshot to the local database")
+	baseline := fs.Bool("baseline", false, "Save as a baseline (immutable; never auto-pruned)")
+	name := fs.String("name", "", "Human label for the snapshot (most useful with --baseline)")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -59,10 +61,17 @@ func runSnapshot(args []string) int {
 	if *skipApps {
 		snap.Apps = nil
 	}
+	if *baseline {
+		snap.Kind = snapshot.KindBaseline
+	}
 
 	if !*noStore {
-		if err := saveSnapshot(snap); err != nil {
+		snapName := *name
+		if err := saveSnapshotNamed(snap, snapName); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not persist snapshot: %v\n", err)
+		}
+		if *baseline && snapName != "" {
+			fmt.Fprintf(os.Stderr, "baseline %q saved as %s\n", snapName, snap.ID)
 		}
 	}
 
@@ -79,6 +88,12 @@ func runSnapshot(args []string) int {
 // saveSnapshot opens the default DB, persists snap, and prunes old live
 // snapshots beyond the default retention limit (100 per machine).
 func saveSnapshot(snap snapshot.Snapshot) error {
+	return saveSnapshotNamed(snap, "")
+}
+
+// saveSnapshotNamed persists snap with an optional human name label and prunes
+// old live snapshots. Baselines are never pruned.
+func saveSnapshotNamed(snap snapshot.Snapshot, name string) error {
 	dbPath, err := store.DefaultPath()
 	if err != nil {
 		return err
@@ -89,10 +104,14 @@ func saveSnapshot(snap snapshot.Snapshot) error {
 	}
 	defer db.Close()
 	ctx := context.Background()
-	if err := db.SaveSnapshot(ctx, store.FromSnapshot(snap)); err != nil {
+	input := store.FromSnapshot(snap)
+	input.Name = name
+	if err := db.SaveSnapshot(ctx, input); err != nil {
 		return err
 	}
-	_, _ = db.PruneSnapshots(ctx, 100) // best-effort; ignore prune errors
+	if snap.Kind == snapshot.KindLive {
+		_, _ = db.PruneSnapshots(ctx, 100) // best-effort; baselines skipped by PruneSnapshots
+	}
 	return nil
 }
 
@@ -101,6 +120,7 @@ func runSnapshotList(args []string) int {
 	fs := flag.NewFlagSet("spectra snapshot list", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON")
+	kindFilter := fs.String("kind", "", "Filter by kind: live or baseline")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -122,6 +142,18 @@ func runSnapshotList(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
+
+	// Apply kind filter client-side (avoids schema change to ListSnapshots sig).
+	if *kindFilter != "" {
+		filtered := rows[:0]
+		for _, r := range rows {
+			if r.Kind == *kindFilter {
+				filtered = append(filtered, r)
+			}
+		}
+		rows = filtered
+	}
+
 	if len(rows) == 0 {
 		fmt.Fprintln(os.Stderr, "no snapshots stored — run `spectra snapshot` first")
 		return 0
@@ -134,12 +166,13 @@ func runSnapshotList(args []string) int {
 		return 0
 	}
 
-	fmt.Printf("%-32s  %-8s  %-20s  %s\n", "ID", "KIND", "TAKEN AT", "APPS")
-	fmt.Println(strings.Repeat("-", 72))
+	fmt.Printf("%-32s  %-8s  %-20s  %-20s  %s\n", "ID", "KIND", "TAKEN AT", "NAME", "APPS")
+	fmt.Println(strings.Repeat("-", 90))
 	for _, r := range rows {
-		fmt.Printf("%-32s  %-8s  %-20s  %d\n",
+		fmt.Printf("%-32s  %-8s  %-20s  %-20s  %d\n",
 			r.ID, r.Kind,
 			r.TakenAt.Format("2006-01-02 15:04:05Z"),
+			truncate(r.Name, 20),
 			r.AppCount,
 		)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -106,6 +106,7 @@ CREATE TABLE IF NOT EXISTS snapshots (
     machine_uuid  TEXT NOT NULL,
     taken_at      DATETIME NOT NULL,
     kind          TEXT NOT NULL DEFAULT 'live',
+    name          TEXT,
     spectra_ver   TEXT,
     app_count     INTEGER NOT NULL DEFAULT 0,
     snapshot_json TEXT,
@@ -184,6 +185,7 @@ type SnapshotRow struct {
 	MachineUUID string
 	TakenAt     time.Time
 	Kind        string
+	Name        string // optional human label, used for baselines
 	SpectraVer  string
 	AppCount    int
 }
@@ -234,10 +236,11 @@ func upsertHost(tx *sql.Tx, s SnapshotInput) error {
 }
 
 func insertSnapshot(tx *sql.Tx, s SnapshotInput) error {
+	name := sql.NullString{String: s.Name, Valid: s.Name != ""}
 	_, err := tx.Exec(`
-		INSERT OR IGNORE INTO snapshots (id, machine_uuid, taken_at, kind, spectra_ver, app_count, snapshot_json)
-		VALUES (?,?,?,?,?,?,?)`,
-		s.ID, s.MachineUUID, s.TakenAt, s.Kind, s.SpectraVer, len(s.Apps), nullableJSON(s.SnapshotJSON),
+		INSERT OR IGNORE INTO snapshots (id, machine_uuid, taken_at, kind, name, spectra_ver, app_count, snapshot_json)
+		VALUES (?,?,?,?,?,?,?,?)`,
+		s.ID, s.MachineUUID, s.TakenAt, s.Kind, name, s.SpectraVer, len(s.Apps), nullableJSON(s.SnapshotJSON),
 	)
 	return err
 }
@@ -265,13 +268,13 @@ func insertApp(tx *sql.Tx, snapID string, a AppInput) error {
 }
 
 // ListSnapshots returns summary rows ordered newest-first.
-// Pass machine_uuid="" to list all hosts.
+// Pass machine_uuid="" to list all hosts. Pass kind="" to list all kinds.
 func (s *DB) ListSnapshots(ctx context.Context, machineUUID string) ([]SnapshotRow, error) {
-	q := `SELECT id, machine_uuid, taken_at, kind, COALESCE(spectra_ver,''), app_count
+	q := `SELECT id, machine_uuid, taken_at, kind, COALESCE(name,''), COALESCE(spectra_ver,''), app_count
 	      FROM snapshots ORDER BY taken_at DESC LIMIT 100`
 	args := []any{}
 	if machineUUID != "" {
-		q = `SELECT id, machine_uuid, taken_at, kind, COALESCE(spectra_ver,''), app_count
+		q = `SELECT id, machine_uuid, taken_at, kind, COALESCE(name,''), COALESCE(spectra_ver,''), app_count
 		     FROM snapshots WHERE machine_uuid=? ORDER BY taken_at DESC LIMIT 100`
 		args = append(args, machineUUID)
 	}
@@ -284,7 +287,7 @@ func (s *DB) ListSnapshots(ctx context.Context, machineUUID string) ([]SnapshotR
 	for rows.Next() {
 		var r SnapshotRow
 		var takenAt string
-		if err := rows.Scan(&r.ID, &r.MachineUUID, &takenAt, &r.Kind, &r.SpectraVer, &r.AppCount); err != nil {
+		if err := rows.Scan(&r.ID, &r.MachineUUID, &takenAt, &r.Kind, &r.Name, &r.SpectraVer, &r.AppCount); err != nil {
 			return nil, err
 		}
 		r.TakenAt, _ = time.Parse(time.RFC3339, takenAt)
@@ -298,9 +301,9 @@ func (s *DB) GetSnapshot(ctx context.Context, id string) (SnapshotRow, error) {
 	var r SnapshotRow
 	var takenAt string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, machine_uuid, taken_at, kind, COALESCE(spectra_ver,''), app_count
+		`SELECT id, machine_uuid, taken_at, kind, COALESCE(name,''), COALESCE(spectra_ver,''), app_count
 		 FROM snapshots WHERE id=?`, id,
-	).Scan(&r.ID, &r.MachineUUID, &takenAt, &r.Kind, &r.SpectraVer, &r.AppCount)
+	).Scan(&r.ID, &r.MachineUUID, &takenAt, &r.Kind, &r.Name, &r.SpectraVer, &r.AppCount)
 	if errors.Is(err, sql.ErrNoRows) {
 		return r, ErrNotFound
 	}
@@ -529,6 +532,7 @@ type SnapshotInput struct {
 	MachineUUID  string
 	TakenAt      time.Time
 	Kind         string
+	Name         string // optional label for baselines
 	SpectraVer   string
 	Hostname     string
 	OSName       string

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -163,6 +163,40 @@ func TestListSnapshotsByMachine(t *testing.T) {
 	}
 }
 
+// --- Baseline snapshots (name field) ---
+
+func TestBaselineNameRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	in := sampleInput()
+	in.Kind = "baseline"
+	in.Name = "pre-incident"
+	if err := db.SaveSnapshot(ctx, in); err != nil {
+		t.Fatalf("SaveSnapshot baseline: %v", err)
+	}
+
+	row, err := db.GetSnapshot(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if row.Name != "pre-incident" {
+		t.Errorf("name = %q, want pre-incident", row.Name)
+	}
+	if row.Kind != "baseline" {
+		t.Errorf("kind = %q, want baseline", row.Kind)
+	}
+
+	// ListSnapshots should also return the name.
+	rows, err := db.ListSnapshots(ctx, "")
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Name != "pre-incident" {
+		t.Errorf("list name = %q", rows[0].Name)
+	}
+}
+
 // --- Snapshot retention / pruning ---
 
 func TestPruneSnapshotsKeepsBaselines(t *testing.T) {


### PR DESCRIPTION
## Summary
- `snapshots` table gains a nullable `name` column — human label most useful for baselines
- `spectra snapshot --baseline [--name pre-incident]` saves with `kind=baseline`; the existing `PruneSnapshots` already skips baselines
- `spectra snapshot list --kind baseline` filters to baselines and shows the `Name` column in the table
- `SnapshotInput` and `SnapshotRow` carry `Name` through the full stack

Closes the "diff my Mac vs a named baseline" workflow from quickstart.md.

## Test plan
- [ ] `TestBaselineNameRoundTrip` — name survives round-trip through save + list + get
- [ ] `go test ./...` — all 24 packages pass