### PR TITLE
Add jvm.list, jdk.list, toolchain.scan RPC handlers + snapshot show name

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -231,6 +231,9 @@ func runSnapshotShow(args []string) int {
 
 	fmt.Printf("id:         %s\n", row.ID)
 	fmt.Printf("kind:       %s\n", row.Kind)
+	if row.Name != "" {
+		fmt.Printf("name:       %s\n", row.Name)
+	}
 	fmt.Printf("taken-at:   %s\n", row.TakenAt.Format("2006-01-02T15:04:05Z"))
 	fmt.Printf("spectra:    %s\n", row.SpectraVer)
 	fmt.Printf("apps:       %d\n\n", row.AppCount)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -16,11 +16,13 @@ import (
 
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/diff"
+	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/rules"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/store"
+	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
 // DefaultSockPath returns the canonical Unix socket path (~/.spectra/sock).
@@ -375,5 +377,31 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, fmt.Errorf("issues.fix.list requires {\"issue_id\": \"...\"}")
 		}
 		return db.ListAppliedFixes(context.Background(), p.IssueID)
+	})
+
+	// jvm.list — list all running JVM processes.
+	// Optional: { "pid": 1234 } to inspect a single PID.
+	d.Register("jvm.list", func(params json.RawMessage) (any, error) {
+		var p struct{ PID int `json:"pid"` }
+		_ = json.Unmarshal(params, &p)
+		if p.PID != 0 {
+			info := jvm.InspectPID(context.Background(), p.PID, jvm.CollectOptions{})
+			if info == nil {
+				return nil, fmt.Errorf("JVM PID %d not found", p.PID)
+			}
+			return info, nil
+		}
+		return jvm.CollectAll(context.Background(), jvm.CollectOptions{}), nil
+	})
+
+	// jdk.list — enumerate installed JDK toolchains.
+	d.Register("jdk.list", func(_ json.RawMessage) (any, error) {
+		tc := toolchain.Collect(context.Background(), toolchain.CollectOptions{})
+		return tc.JDKs, nil
+	})
+
+	// toolchain.scan — full toolchain inventory (brew, JDKs, Node, Python, Go, etc.).
+	d.Register("toolchain.scan", func(_ json.RawMessage) (any, error) {
+		return toolchain.Collect(context.Background(), toolchain.CollectOptions{}), nil
 	})
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -253,6 +253,31 @@ func TestDaemonIssuesFixListMissingIssueID(t *testing.T) {
 	}
 }
 
+func TestDaemonJDKListReturnsSlice(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 16, "jdk.list", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("jdk.list: %v", resp.Error)
+	}
+}
+
+func TestDaemonToolchainScanReturnsObject(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 17, "toolchain.scan", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("toolchain.scan: %v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	if m["brew"] == nil {
+		t.Error("toolchain.scan: expected brew field in result")
+	}
+}
+
 func TestDaemonSnapshotDiffMissingIDs(t *testing.T) {
 	enc, dec, cancel := testDaemon(t)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Add `jvm.list`, `jdk.list`, and `toolchain.scan` RPC handlers to the daemon
- Fix `spectra snapshot show` to display the optional `name` field
- Add integration tests for the new RPC handlers

## Test plan
- [ ] `TestDaemonJDKListReturnsSlice` — jdk.list returns without error
- [ ] `TestDaemonToolchainScanReturnsObject` — toolchain.scan returns object with brew field
- [ ] All existing serve and store tests pass