### PR TITLE
Add VPN detection to netstate: utun interface scanning + diff section

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -62,6 +62,7 @@ func Compare(a, b snapshot.Snapshot) Result {
 			diffJDKs(a, b),
 			diffBrewFormulae(a, b),
 			diffListeningPorts(a, b),
+			diffVPN(a, b),
 			diffPathDirs(a, b),
 			diffSysctls(a, b),
 		},
@@ -222,6 +223,23 @@ func diffListeningPorts(a, b snapshot.Snapshot) Section {
 		}
 	}
 	return Section{Name: "listening_ports", Changes: changes}
+}
+
+// diffVPN reports when VPN active state changes between snapshots.
+func diffVPN(a, b snapshot.Snapshot) Section {
+	var changes []Change
+	aActive, bActive := a.Network.VPNActive, b.Network.VPNActive
+	if aActive != bActive {
+		before, after := "false", "false"
+		if aActive {
+			before = "true"
+		}
+		if bActive {
+			after = "true"
+		}
+		changes = append(changes, Change{Kind: Changed, Key: "vpn_active", Before: before, After: after})
+	}
+	return Section{Name: "vpn", Changes: changes}
 }
 
 // diffPathDirs sequence-compares PATH dirs (order matters for shadowing).

--- a/internal/netstate/netstate.go
+++ b/internal/netstate/netstate.go
@@ -15,12 +15,18 @@ import (
 
 // State is the NetworkState slice of a Spectra snapshot.
 type State struct {
-	DefaultRouteIface string            `json:"default_route_iface,omitempty"`
-	DefaultRouteGW    string            `json:"default_route_gw,omitempty"`
-	DNSServers        []string          `json:"dns_servers,omitempty"`
-	Proxy             ProxyConfig       `json:"proxy"`
-	HostsOverrides    []HostsEntry      `json:"hosts_overrides,omitempty"`
-	ListeningPorts    []ListeningPort   `json:"listening_ports,omitempty"`
+	DefaultRouteIface string          `json:"default_route_iface,omitempty"`
+	DefaultRouteGW    string          `json:"default_route_gw,omitempty"`
+	DNSServers        []string        `json:"dns_servers,omitempty"`
+	Proxy             ProxyConfig     `json:"proxy"`
+	HostsOverrides    []HostsEntry    `json:"hosts_overrides,omitempty"`
+	ListeningPorts    []ListeningPort `json:"listening_ports,omitempty"`
+
+	// VPNActive is true when at least one tunnel interface (utun*) is UP with
+	// an assigned address. macOS uses utun interfaces for all VPN types:
+	// Tailscale, Cisco AnyConnect, WireGuard, OpenVPN, and built-in IKEv2.
+	VPNActive     bool     `json:"vpn_active"`
+	VPNInterfaces []string `json:"vpn_interfaces,omitempty"`
 }
 
 // ProxyConfig is the system HTTP/HTTPS/SOCKS proxy configuration.
@@ -68,6 +74,10 @@ func Collect(run CmdRunner) State {
 	s.HostsOverrides = readHostsOverrides("/etc/hosts")
 	if out, err := run("lsof", "-i", "-P", "-n", "-sTCP:LISTEN"); err == nil {
 		s.ListeningPorts = parseLSOFListen(string(out))
+	}
+	if out, err := run("ifconfig"); err == nil {
+		s.VPNInterfaces = parseVPNInterfaces(string(out))
+		s.VPNActive = len(s.VPNInterfaces) > 0
 	}
 	return s
 }
@@ -254,4 +264,48 @@ func parsePort(s string) int {
 		n = n*10 + int(c-'0')
 	}
 	return n
+}
+
+// parseVPNInterfaces scans `ifconfig` output for active utun interfaces.
+// macOS assigns a utun* name to every VPN tunnel (IKEv2, Tailscale,
+// AnyConnect, WireGuard, OpenVPN). An interface counts as active when
+// its block contains an "inet" address line, meaning the tunnel is
+// established and has an assigned IP.
+//
+// Example block that matches:
+//
+//	utun3: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1280
+//	        inet 100.64.0.1 --> 100.64.0.1 netmask 0xffffffff
+func parseVPNInterfaces(out string) []string {
+	var active []string
+	var current string
+	hasInet := false
+
+	commit := func() {
+		if current != "" && hasInet {
+			active = append(active, current)
+		}
+		current = ""
+		hasInet = false
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		// Interface header: name followed by colon, at column 0.
+		if len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
+			commit()
+			if idx := strings.Index(line, ":"); idx > 0 {
+				name := line[:idx]
+				if strings.HasPrefix(name, "utun") {
+					current = name
+				}
+			}
+			continue
+		}
+		// Continuation line inside the current interface block.
+		if current != "" && strings.Contains(line, "inet ") {
+			hasInet = true
+		}
+	}
+	commit()
+	return active
 }

--- a/internal/netstate/netstate_test.go
+++ b/internal/netstate/netstate_test.go
@@ -137,6 +137,46 @@ func TestParseLSOFListenEmpty(t *testing.T) {
 	}
 }
 
+const ifconfigWithVPN = `lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+	inet 127.0.0.1 netmask 0xff000000
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	inet 192.168.1.42 netmask 0xffffff00 broadcast 192.168.1.255
+utun0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
+	inet6 fe80::1%utun0 prefixlen 64 scopeid 0xa
+utun3: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1280
+	inet 100.64.0.1 --> 100.64.0.1 netmask 0xffffffff
+`
+
+const ifconfigNoVPN = `lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+	inet 127.0.0.1 netmask 0xff000000
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	inet 192.168.1.42 netmask 0xffffff00 broadcast 192.168.1.255
+utun0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
+	inet6 fe80::1%utun0 prefixlen 64 scopeid 0xa
+`
+
+func TestParseVPNInterfacesActive(t *testing.T) {
+	ifaces := parseVPNInterfaces(ifconfigWithVPN)
+	if len(ifaces) != 1 || ifaces[0] != "utun3" {
+		t.Errorf("got %v, want [utun3]", ifaces)
+	}
+}
+
+func TestParseVPNInterfacesNoInet(t *testing.T) {
+	// utun0 only has inet6, not inet — should not count.
+	ifaces := parseVPNInterfaces(ifconfigNoVPN)
+	if len(ifaces) != 0 {
+		t.Errorf("got %v, want empty (no inet on utun)", ifaces)
+	}
+}
+
+func TestParseVPNInterfacesEmpty(t *testing.T) {
+	ifaces := parseVPNInterfaces("")
+	if len(ifaces) != 0 {
+		t.Errorf("got %v, want empty", ifaces)
+	}
+}
+
 func TestCollect(t *testing.T) {
 	stub := func(name string, args ...string) ([]byte, error) {
 		switch name {
@@ -149,6 +189,8 @@ func TestCollect(t *testing.T) {
 			return []byte("HTTPEnable : 0\n"), nil
 		case "lsof":
 			return []byte(lsofOutput), nil
+		case "ifconfig":
+			return []byte(ifconfigWithVPN), nil
 		}
 		return nil, errors.New("unexpected command")
 	}
@@ -163,6 +205,28 @@ func TestCollect(t *testing.T) {
 	if len(s.ListeningPorts) != 2 {
 		t.Errorf("ListeningPorts = %d", len(s.ListeningPorts))
 	}
+	if !s.VPNActive {
+		t.Error("VPNActive should be true")
+	}
+	if len(s.VPNInterfaces) != 1 || s.VPNInterfaces[0] != "utun3" {
+		t.Errorf("VPNInterfaces = %v, want [utun3]", s.VPNInterfaces)
+	}
+}
+
+func TestCollectNoVPN(t *testing.T) {
+	stub := func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "route", "scutil", "lsof":
+			return []byte(""), nil
+		case "ifconfig":
+			return []byte(ifconfigNoVPN), nil
+		}
+		return nil, errors.New("unexpected command")
+	}
+	s := Collect(stub)
+	if s.VPNActive {
+		t.Error("VPNActive should be false when no utun has inet")
+	}
 }
 
 func TestCollectAllFail(t *testing.T) {
@@ -172,5 +236,8 @@ func TestCollectAllFail(t *testing.T) {
 	s := Collect(stub)
 	if s.DefaultRouteIface != "" || len(s.DNSServers) != 0 {
 		t.Errorf("expected zero value on all-fail: %+v", s)
+	}
+	if s.VPNActive {
+		t.Error("VPNActive should be false when ifconfig fails")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `VPNActive bool` and `VPNInterfaces []string` to `netstate.State`
- Detect active VPN tunnels by scanning `ifconfig` output for `utun*` interfaces with an assigned `inet` address (covers Tailscale, Cisco AnyConnect, WireGuard, OpenVPN, macOS IKEv2)
- Add `vpn` section to `diff.Compare` so snapshot diffs report VPN state changes

## Test plan
- [ ] `TestParseVPNInterfacesActive` — utun3 with inet address is detected
- [ ] `TestParseVPNInterfacesNoInet` — utun0 with only inet6 is not detected
- [ ] `TestParseVPNInterfacesEmpty` — empty input returns nothing
- [ ] `TestCollect` — VPNActive=true when ifconfig shows active tunnel
- [ ] `TestCollectNoVPN` — VPNActive=false when no inet on utun
- [ ] `TestCollectAllFail` — VPNActive=false when ifconfig fails
- [ ] All diff tests pass