### PR TITLE
Add Gatekeeper status detection (spctl --assess) + rejection rule

### DIFF
--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -83,6 +83,13 @@ type Result struct {
 	// per-user TCC.db is readable as long as the user runs the tool as
 	// themselves. Empty when neither database is accessible.
 	GrantedPermissions []string
+
+	// GatekeeperStatus is the result of `spctl --assess --type exec` on
+	// the bundle: "accepted", "rejected", or "" when spctl is unavailable
+	// or the assessment could not be completed. "accepted" means the app
+	// passes Gatekeeper's notarization / Developer ID check; "rejected"
+	// means it would be blocked by Gatekeeper on macOS 10.15+.
+	GatekeeperStatus string
 }
 
 // Helpers groups sub-bundles found inside the .app.
@@ -204,6 +211,7 @@ func DetectWith(appPath string, opts Options) (Result, error) {
 	r.LoginItems = scanLoginItems(appPath, r.BundleID)
 	r.RunningProcesses = scanRunningProcesses(appPath)
 	r.GrantedPermissions = scanGrantedPermissions(r.BundleID)
+	r.GatekeeperStatus = readGatekeeperStatus(appPath)
 	if opts.ScanNetwork {
 		r.NetworkEndpoints = scanNetworkEndpoints(appPath, exe)
 	}
@@ -374,6 +382,33 @@ func readSigning(appPath string) (teamID string, hardened bool) {
 // readEntitlements asks codesign for the bundle's entitlements plist
 // (XML form) and extracts the boolean ones set to true. The full set
 // is large and noisy; we keep a curated allowlist of notable ones.
+// readGatekeeperStatus runs `spctl --assess --type exec <appPath>` and
+// returns "accepted", "rejected", or "" when spctl is unavailable or the
+// assessment cannot be completed. spctl writes its verdict to stderr
+// regardless of exit code, so we parse stderr for the verdict string.
+func readGatekeeperStatus(appPath string) string {
+	cmd := exec.Command("spctl", "--assess", "--type", "exec", appPath)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	_ = cmd.Run()
+	return parseGatekeeperOutput(stderr.String())
+}
+
+// parseGatekeeperOutput extracts the Gatekeeper verdict from spctl stderr.
+// Expected formats:
+//
+//	"/Applications/Foo.app: accepted"
+//	"/Applications/Foo.app: rejected"
+func parseGatekeeperOutput(out string) string {
+	if strings.Contains(out, "accepted") {
+		return "accepted"
+	}
+	if strings.Contains(out, "rejected") {
+		return "rejected"
+	}
+	return ""
+}
+
 func readEntitlements(appPath string) (sandboxed bool, notable []string) {
 	out, err := exec.Command("codesign", "-d", "--entitlements", ":-", appPath).Output()
 	if err != nil || len(out) == 0 {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -353,3 +353,22 @@ func TestDetectRejectsNonBundle(t *testing.T) {
 		t.Errorf("expected error for non-.app path")
 	}
 }
+
+func TestParseGatekeeperOutput(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"/Applications/Foo.app: accepted\n", "accepted"},
+		{"/Applications/Foo.app: rejected\n", "rejected"},
+		{"", ""},
+		{"error: some other failure\n", ""},
+		{"/Applications/Foo.app: accepted source=Apple\n", "accepted"},
+	}
+	for _, tc := range cases {
+		got := parseGatekeeperOutput(tc.input)
+		if got != tc.want {
+			t.Errorf("parseGatekeeperOutput(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -25,6 +25,7 @@ func V1Catalog() []Rule {
 		ruleLoginItemDangling(),
 		rulePermissionMismatch(),
 		ruleSparseFileInflation(),
+		ruleGatekeeperRejected(),
 	}
 }
 
@@ -439,4 +440,30 @@ func atoi(s string) int {
 		n = n*10 + int(c-'0')
 	}
 	return n
+}
+
+// ruleGatekeeperRejected fires when spctl --assess explicitly rejects an app.
+// A "rejected" verdict means Gatekeeper would block the app from running on
+// an unmodified macOS 10.15+ system.
+func ruleGatekeeperRejected() Rule {
+	return Rule{
+		ID:       "app-gatekeeper-rejected",
+		Severity: SeverityHigh,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, app := range s.Apps {
+				if app.GatekeeperStatus != "rejected" {
+					continue
+				}
+				findings = append(findings, Finding{
+					RuleID:   "app-gatekeeper-rejected",
+					Severity: SeverityHigh,
+					Subject:  appDisplayName(app.Path),
+					Message:  fmt.Sprintf("%s is rejected by Gatekeeper — it would be blocked from running on an unmodified macOS system.", appDisplayName(app.Path)),
+					Fix:      "Re-sign and notarize the app with a valid Apple Developer ID certificate, or remove it if it is no longer needed.",
+				})
+			}
+			return findings
+		},
+	}
 }

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -466,3 +466,44 @@ func TestEvaluateSortOrder(t *testing.T) {
 		t.Errorf("first finding severity = %q, want high", findings[0].Severity)
 	}
 }
+
+// --- ruleGatekeeperRejected ---
+
+func TestGatekeeperRejectedFires(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/BadApp.app", GatekeeperStatus: "rejected", TeamID: "ABC123"},
+	}
+	findings := ruleGatekeeperRejected().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "app-gatekeeper-rejected" {
+		t.Errorf("rule ID = %q", findings[0].RuleID)
+	}
+	if findings[0].Severity != SeverityHigh {
+		t.Errorf("severity = %q, want high", findings[0].Severity)
+	}
+}
+
+func TestGatekeeperRejectedNoFireAccepted(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/GoodApp.app", GatekeeperStatus: "accepted"},
+	}
+	findings := ruleGatekeeperRejected().MatchFn(s)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for accepted app, got %d", len(findings))
+	}
+}
+
+func TestGatekeeperRejectedNoFireUnknown(t *testing.T) {
+	s := baseSnap()
+	s.Apps = []detect.Result{
+		{Path: "/Applications/UnknownApp.app", GatekeeperStatus: ""},
+	}
+	findings := ruleGatekeeperRejected().MatchFn(s)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for unknown status, got %d", len(findings))
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GatekeeperStatus string` field to `detect.Result` populated by `spctl --assess --type exec`
- Possible values: `"accepted"`, `"rejected"`, `""` (unavailable)
- Add `app-gatekeeper-rejected` rule (high severity) that fires when spctl explicitly rejects an app bundle
- Tests for `parseGatekeeperOutput` (3 cases) and the new rule (3 cases)

## Test plan
- [ ] `TestParseGatekeeperOutput` — parses accepted/rejected/empty/error output
- [ ] `TestGatekeeperRejectedFires` — rule fires for rejected app
- [ ] `TestGatekeeperRejectedNoFireAccepted` — rule silent for accepted
- [ ] `TestGatekeeperRejectedNoFireUnknown` — rule silent for unknown status