### PR TITLE
Show GatekeeperStatus in spectra inspect output

### DIFF
--- a/cmd/spectra/inspect.go
+++ b/cmd/spectra/inspect.go
@@ -184,6 +184,9 @@ func printMeta(r detect.Result) {
 	if len(security) > 0 {
 		fmt.Printf("    security: %s\n", strings.Join(security, ", "))
 	}
+	if r.GatekeeperStatus != "" {
+		fmt.Printf("    gatekeeper: %s\n", r.GatekeeperStatus)
+	}
 	if len(r.Entitlements) > 0 {
 		fmt.Printf("    entitlements: %s\n", strings.Join(r.Entitlements, ", "))
 	}


### PR DESCRIPTION
## Summary
- Display `gatekeeper: accepted/rejected` in `spectra inspect` verbose output (the `printMeta` section shown with `-v` or for verbose apps)
- Shows when spctl has assessed the app, so users can confirm an app is notarized or spot a rejected bundle immediately

## Test plan
- [ ] `go build ./cmd/spectra/...` compiles cleanly
- [ ] `spectra -v /Applications/SomeApp.app` shows `gatekeeper: accepted` line when spctl passes