### PR TITLE
Add spectra network command + network.state RPC handler

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -36,6 +36,7 @@ func subcommandList() []subcommand {
 		{"snapshot", "Capture a structured snapshot of host + installed apps", runSnapshot},
 		{"jvm", "List or inspect running JVM processes", runJVM},
 		{"toolchain", "Show installed language runtimes and package managers", runToolchain},
+		{"network", "Show current network state (routes, DNS, VPN, proxy, listening ports)", runNetwork},
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},
 		{"issues", "List, check, or update persisted issues from the recommendations engine", runIssues},
 		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},

--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/netstate"
+)
+
+func runNetwork(args []string) int {
+	fs := flag.NewFlagSet("spectra network", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	state := netstate.Collect(netstate.DefaultRunner)
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(state)
+		return 0
+	}
+
+	printNetworkState(state)
+	return 0
+}
+
+func printNetworkState(s netstate.State) {
+	fmt.Println("=== Network state ===")
+
+	if s.DefaultRouteIface != "" {
+		fmt.Printf("default route: %s via %s\n", s.DefaultRouteIface, s.DefaultRouteGW)
+	}
+
+	if s.VPNActive {
+		fmt.Printf("vpn:           active (%s)\n", strings.Join(s.VPNInterfaces, ", "))
+	} else {
+		fmt.Printf("vpn:           inactive\n")
+	}
+
+	if len(s.DNSServers) > 0 {
+		fmt.Printf("dns:           %s\n", strings.Join(s.DNSServers, ", "))
+	}
+
+	if s.Proxy.HTTP != "" || s.Proxy.HTTPS != "" || s.Proxy.SOCKS != "" {
+		fmt.Println()
+		fmt.Println("proxy:")
+		if s.Proxy.HTTP != "" {
+			fmt.Printf("  http:  %s\n", s.Proxy.HTTP)
+		}
+		if s.Proxy.HTTPS != "" {
+			fmt.Printf("  https: %s\n", s.Proxy.HTTPS)
+		}
+		if s.Proxy.SOCKS != "" {
+			fmt.Printf("  socks: %s\n", s.Proxy.SOCKS)
+		}
+	}
+
+	if len(s.HostsOverrides) > 0 {
+		fmt.Println()
+		fmt.Printf("hosts overrides (%d):\n", len(s.HostsOverrides))
+		for _, h := range s.HostsOverrides {
+			fmt.Printf("  %-16s  %s\n", h.IP, strings.Join(h.Names, " "))
+		}
+	}
+
+	if len(s.ListeningPorts) > 0 {
+		// Sort by port for stable output.
+		ports := make([]netstate.ListeningPort, len(s.ListeningPorts))
+		copy(ports, s.ListeningPorts)
+		sort.Slice(ports, func(i, j int) bool { return ports[i].Port < ports[j].Port })
+
+		fmt.Println()
+		fmt.Printf("listening ports (%d):\n", len(ports))
+		for _, p := range ports {
+			pid := ""
+			if p.PID > 0 {
+				pid = fmt.Sprintf(" pid=%d", p.PID)
+			}
+			app := ""
+			if p.AppPath != "" {
+				app = fmt.Sprintf(" (%s)", p.AppPath)
+			}
+			fmt.Printf("  %s/%d%s%s\n", p.Proto, p.Port, pid, app)
+		}
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kaeawc/spectra/internal/diff"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/metrics"
+	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/rules"
 	"github.com/kaeawc/spectra/internal/snapshot"
@@ -403,5 +404,10 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 	// toolchain.scan — full toolchain inventory (brew, JDKs, Node, Python, Go, etc.).
 	d.Register("toolchain.scan", func(_ json.RawMessage) (any, error) {
 		return toolchain.Collect(context.Background(), toolchain.CollectOptions{}), nil
+	})
+
+	// network.state — current network configuration snapshot.
+	d.Register("network.state", func(_ json.RawMessage) (any, error) {
+		return netstate.Collect(netstate.DefaultRunner), nil
 	})
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -299,3 +299,20 @@ func TestDaemonSnapshotDiffMissingIDs(t *testing.T) {
 		t.Error("expected RPC error for missing id_b, got nil")
 	}
 }
+
+func TestDaemonNetworkStateReturnsObject(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 18, "network.state", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("network.state: %v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	// network.state should have vpn_active field.
+	if _, exists := m["vpn_active"]; !exists {
+		t.Error("network.state: expected vpn_active field in result")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `spectra network` CLI subcommand: shows default route, VPN state, DNS servers, proxy config, hosts overrides, and listening ports
- Add `network.state` RPC handler to the daemon
- Add `TestDaemonNetworkStateReturnsObject` integration test

## Test plan
- [ ] `spectra network` prints network state summary
- [ ] `spectra network --json` emits valid JSON with vpn_active field
- [ ] `TestDaemonNetworkStateReturnsObject` passes