### PR TITLE
Enhance diffApps to track security field changes

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -96,10 +96,15 @@ func diffHost(a, b snapshot.Snapshot) Section {
 }
 
 // diffApps matches by bundle ID (falling back to path when bundle ID is empty).
-// Reports added, removed, and version-changed apps.
+// Reports added, removed, version-changed, and security-changed apps.
 func diffApps(a, b snapshot.Snapshot) Section {
-	type appKey struct{ bundleID, path string }
-	type appInfo struct{ version, path string }
+	type appInfo struct {
+		version          string
+		path             string
+		hardenedRuntime  bool
+		gatekeeperStatus string
+		teamID           string
+	}
 
 	mapA := make(map[string]appInfo, len(a.Apps))
 	for _, r := range a.Apps {
@@ -107,7 +112,12 @@ func diffApps(a, b snapshot.Snapshot) Section {
 		if k == "" {
 			k = r.Path
 		}
-		mapA[k] = appInfo{version: r.AppVersion, path: r.Path}
+		mapA[k] = appInfo{
+			version: r.AppVersion, path: r.Path,
+			hardenedRuntime:  r.HardenedRuntime,
+			gatekeeperStatus: r.GatekeeperStatus,
+			teamID:           r.TeamID,
+		}
 	}
 	mapB := make(map[string]appInfo, len(b.Apps))
 	for _, r := range b.Apps {
@@ -115,15 +125,49 @@ func diffApps(a, b snapshot.Snapshot) Section {
 		if k == "" {
 			k = r.Path
 		}
-		mapB[k] = appInfo{version: r.AppVersion, path: r.Path}
+		mapB[k] = appInfo{
+			version: r.AppVersion, path: r.Path,
+			hardenedRuntime:  r.HardenedRuntime,
+			gatekeeperStatus: r.GatekeeperStatus,
+			teamID:           r.TeamID,
+		}
+	}
+
+	boolStr := func(v bool) string {
+		if v {
+			return "true"
+		}
+		return "false"
 	}
 
 	var changes []Change
 	for k, ia := range mapA {
-		if ib, ok := mapB[k]; !ok {
+		ib, ok := mapB[k]
+		if !ok {
 			changes = append(changes, Change{Kind: Removed, Key: k, Before: ia.version})
-		} else if ia.version != ib.version {
+			continue
+		}
+		if ia.version != ib.version {
 			changes = append(changes, Change{Kind: Changed, Key: k, Before: ia.version, After: ib.version})
+		}
+		if ia.hardenedRuntime != ib.hardenedRuntime {
+			changes = append(changes, Change{Kind: Changed, Key: k + ":hardened-runtime",
+				Before: boolStr(ia.hardenedRuntime), After: boolStr(ib.hardenedRuntime)})
+		}
+		if ia.gatekeeperStatus != ib.gatekeeperStatus && ia.gatekeeperStatus != "" && ib.gatekeeperStatus != "" {
+			changes = append(changes, Change{Kind: Changed, Key: k + ":gatekeeper",
+				Before: ia.gatekeeperStatus, After: ib.gatekeeperStatus})
+		}
+		if ia.teamID != ib.teamID {
+			before, after := ia.teamID, ib.teamID
+			if before == "" {
+				before = "(unsigned)"
+			}
+			if after == "" {
+				after = "(unsigned)"
+			}
+			changes = append(changes, Change{Kind: Changed, Key: k + ":team-id",
+				Before: before, After: after})
 		}
 	}
 	for k, ib := range mapB {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -96,6 +96,59 @@ func TestDiffAppsVersionChanged(t *testing.T) {
 	}
 }
 
+func TestDiffAppsHardenedRuntimeChanged(t *testing.T) {
+	a := base()
+	b := base()
+	a.Apps = []detect.Result{{BundleID: "com.example.app", TeamID: "TEAM1", HardenedRuntime: true}}
+	b.Apps = []detect.Result{{BundleID: "com.example.app", TeamID: "TEAM1", HardenedRuntime: false}}
+
+	r := Compare(a, b)
+	sec := findSection(r, "apps")
+	if !hasChange(sec.Changes, Changed, "com.example.app:hardened-runtime") {
+		t.Errorf("expected hardened-runtime change, got %+v", sec.Changes)
+	}
+}
+
+func TestDiffAppsGatekeeperChanged(t *testing.T) {
+	a := base()
+	b := base()
+	a.Apps = []detect.Result{{BundleID: "com.example.app", GatekeeperStatus: "accepted"}}
+	b.Apps = []detect.Result{{BundleID: "com.example.app", GatekeeperStatus: "rejected"}}
+
+	r := Compare(a, b)
+	sec := findSection(r, "apps")
+	if !hasChange(sec.Changes, Changed, "com.example.app:gatekeeper") {
+		t.Errorf("expected gatekeeper change, got %+v", sec.Changes)
+	}
+}
+
+func TestDiffAppsTeamIDChanged(t *testing.T) {
+	a := base()
+	b := base()
+	a.Apps = []detect.Result{{BundleID: "com.example.app", TeamID: ""}}
+	b.Apps = []detect.Result{{BundleID: "com.example.app", TeamID: "NEWTEAM"}}
+
+	r := Compare(a, b)
+	sec := findSection(r, "apps")
+	if !hasChange(sec.Changes, Changed, "com.example.app:team-id") {
+		t.Errorf("expected team-id change, got %+v", sec.Changes)
+	}
+}
+
+func TestDiffAppsGatekeeperUnknownNotReported(t *testing.T) {
+	// Empty string means spctl was unavailable — don't report as a change.
+	a := base()
+	b := base()
+	a.Apps = []detect.Result{{BundleID: "com.example.app", GatekeeperStatus: ""}}
+	b.Apps = []detect.Result{{BundleID: "com.example.app", GatekeeperStatus: "accepted"}}
+
+	r := Compare(a, b)
+	sec := findSection(r, "apps")
+	if hasChange(sec.Changes, Changed, "com.example.app:gatekeeper") {
+		t.Errorf("should not report gatekeeper change when one side is empty: %+v", sec.Changes)
+	}
+}
+
 func TestDiffJDKsAddedRemoved(t *testing.T) {
 	a := base()
 	b := base()


### PR DESCRIPTION
## Summary
- Extend `diff.diffApps` to report changes to:
  - `HardenedRuntime` (true→false is a security regression)
  - `GatekeeperStatus` (accepted→rejected is a critical change)
  - `TeamID` (unsigned→signed or team transfer)
- Gatekeeper changes suppressed when either side has empty status (spctl unavailable)
- 4 new tests covering each new change type plus the empty-status suppression case

## Test plan
- [ ] `TestDiffAppsHardenedRuntimeChanged`
- [ ] `TestDiffAppsGatekeeperChanged`
- [ ] `TestDiffAppsTeamIDChanged`
- [ ] `TestDiffAppsGatekeeperUnknownNotReported`