### PR TITLE
Add spectra process CLI command + process.list RPC handler

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -37,6 +37,7 @@ func subcommandList() []subcommand {
 		{"jvm", "List or inspect running JVM processes", runJVM},
 		{"toolchain", "Show installed language runtimes and package managers", runToolchain},
 		{"network", "Show current network state (routes, DNS, VPN, proxy, listening ports)", runNetwork},
+		{"process", "List running processes sorted by memory (RSS)", runProcess},
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},
 		{"issues", "List, check, or update persisted issues from the recommendations engine", runIssues},
 		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},

--- a/cmd/spectra/process_cmd.go
+++ b/cmd/spectra/process_cmd.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+func runProcess(args []string) int {
+	fs := flag.NewFlagSet("spectra process", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	sortBy := fs.String("sort", "rss", "Sort by: rss, pid, or cmd")
+	topN := fs.Int("top", 0, "Show only top N processes (0 = all)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	procs := process.CollectAll(context.Background(), process.CollectOptions{})
+	if len(procs) == 0 {
+		fmt.Fprintln(os.Stderr, "no processes found")
+		return 0
+	}
+
+	switch *sortBy {
+	case "pid":
+		sort.Slice(procs, func(i, j int) bool { return procs[i].PID < procs[j].PID })
+	case "cmd":
+		sort.Slice(procs, func(i, j int) bool { return procs[i].Command < procs[j].Command })
+	default: // rss
+		sort.Slice(procs, func(i, j int) bool { return procs[i].RSSKiB > procs[j].RSSKiB })
+	}
+
+	if *topN > 0 && *topN < len(procs) {
+		procs = procs[:*topN]
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(procs)
+		return 0
+	}
+
+	fmt.Printf("%-7s  %-10s  %-10s  %s\n", "PID", "RSS", "VSIZE", "COMMAND")
+	fmt.Println(strings.Repeat("-", 70))
+	for _, p := range procs {
+		fmt.Printf("%-7d  %-10s  %-10s  %s\n",
+			p.PID, humanSizeKiB(p.RSSKiB), humanSizeKiB(p.VSizeKiB),
+			truncate(p.Command, 50))
+	}
+	return 0
+}
+
+func humanSizeKiB(kib int64) string {
+	if kib == 0 {
+		return "-"
+	}
+	const mib = 1024
+	const gib = 1024 * mib
+	switch {
+	case kib >= gib:
+		return fmt.Sprintf("%.1fG", float64(kib)/gib)
+	case kib >= mib:
+		return fmt.Sprintf("%.1fM", float64(kib)/mib)
+	default:
+		return fmt.Sprintf("%dK", kib)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/netstate"
+	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/rules"
 	"github.com/kaeawc/spectra/internal/snapshot"
@@ -409,5 +410,17 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 	// network.state — current network configuration snapshot.
 	d.Register("network.state", func(_ json.RawMessage) (any, error) {
 		return netstate.Collect(netstate.DefaultRunner), nil
+	})
+
+	// process.list — snapshot of all running processes via ps.
+	// Optional: { "bundles": ["/Applications/Foo.app"] } to enable app attribution.
+	d.Register("process.list", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Bundles []string `json:"bundles"`
+		}
+		_ = json.Unmarshal(params, &p)
+		return process.CollectAll(context.Background(), process.CollectOptions{
+			BundlePaths: p.Bundles,
+		}), nil
 	})
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -316,3 +316,16 @@ func TestDaemonNetworkStateReturnsObject(t *testing.T) {
 		t.Error("network.state: expected vpn_active field in result")
 	}
 }
+
+func TestDaemonProcessListReturnsSlice(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 19, "process.list", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("process.list: %v", resp.Error)
+	}
+	// Result should be a JSON array (slice).
+	if _, ok := resp.Result.([]any); !ok {
+		t.Fatalf("result type %T, want []any", resp.Result)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `spectra process` CLI subcommand: lists all running processes sorted by RSS, with `--top N`, `--sort pid|rss|cmd`, and `--json` flags
- Add `process.list` RPC handler: returns ps snapshot; supports optional `bundles` param for app-path attribution
- Add `TestDaemonProcessListReturnsSlice` integration test

## Test plan
- [ ] `spectra process --top 10` prints top 10 processes by RSS
- [ ] `spectra process --sort pid` sorts by PID
- [ ] `spectra process --json` emits valid JSON array
- [ ] `TestDaemonProcessListReturnsSlice` passes