### PR TITLE
Add storage.system and storage.byApp RPC handlers

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kaeawc/spectra/internal/rules"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/store"
+	"github.com/kaeawc/spectra/internal/storagestate"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
@@ -421,6 +422,25 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		_ = json.Unmarshal(params, &p)
 		return process.CollectAll(context.Background(), process.CollectOptions{
 			BundlePaths: p.Bundles,
+		}), nil
+	})
+
+	// storage.system — disk volumes + ~/Library usage summary.
+	d.Register("storage.system", func(_ json.RawMessage) (any, error) {
+		return storagestate.Collect(storagestate.CollectOptions{}), nil
+	})
+
+	// storage.byApp — per-app ~/Library usage.
+	// { "paths": ["/Applications/Foo.app", ...] }
+	d.Register("storage.byApp", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Paths []string `json:"paths"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || len(p.Paths) == 0 {
+			return nil, fmt.Errorf("storage.byApp requires {\"paths\": [...]}")
+		}
+		return storagestate.Collect(storagestate.CollectOptions{
+			AppPaths: p.Paths,
 		}), nil
 	})
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -329,3 +329,16 @@ func TestDaemonProcessListReturnsSlice(t *testing.T) {
 		t.Fatalf("result type %T, want []any", resp.Result)
 	}
 }
+
+// storage.system is deliberately not tested here: it walks ~/Library which
+// can take 10+ seconds, exceeding the 5-second test socket deadline. It is
+// tested via storagestate_test.go instead.
+
+func TestDaemonStorageByAppEmptyPaths(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 21, "storage.byApp", `{"paths":[]}`)
+	if resp.Error == nil {
+		t.Error("expected error for empty paths")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `storage.system` RPC: returns disk volumes + ~/Library usage via `storagestate.Collect()`
- Add `storage.byApp` RPC: returns storage state for given app bundle paths; requires non-empty `paths` array
- Note: storage.system is intentionally not integration-tested via testDaemon because ~/Library walks can exceed the 5s socket deadline

## Test plan
- [ ] `TestDaemonStorageByAppEmptyPaths` — validates error on empty paths
- [ ] All existing serve tests continue to pass