### PR TITLE
Add process.tree RPC handler and BuildTree

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -156,3 +156,29 @@ func TotalRSS(procs []Info) int64 {
 	}
 	return total
 }
+
+// TreeNode represents one process in the parent-child hierarchy.
+type TreeNode struct {
+	Info     Info        `json:"info"`
+	Children []*TreeNode `json:"children,omitempty"`
+}
+
+// BuildTree constructs a parent-child tree from a flat process list.
+// Processes whose parent PID is unknown (not in the list) or self-referential
+// become roots.
+func BuildTree(procs []Info) []*TreeNode {
+	nodes := make(map[int]*TreeNode, len(procs))
+	for i := range procs {
+		nodes[procs[i].PID] = &TreeNode{Info: procs[i]}
+	}
+	var roots []*TreeNode
+	for _, p := range procs {
+		node := nodes[p.PID]
+		if parent, ok := nodes[p.PPID]; ok && p.PPID != p.PID {
+			parent.Children = append(parent.Children, node)
+		} else {
+			roots = append(roots, node)
+		}
+	}
+	return roots
+}

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -147,3 +147,82 @@ func TestTotalRSSEmpty(t *testing.T) {
 		t.Error("TotalRSS(nil) should be 0")
 	}
 }
+
+func TestBuildTreeEmpty(t *testing.T) {
+	roots := BuildTree(nil)
+	if len(roots) != 0 {
+		t.Errorf("BuildTree(nil) = %d roots, want 0", len(roots))
+	}
+}
+
+func TestBuildTreeSingleRoot(t *testing.T) {
+	procs := []Info{{PID: 1, PPID: 0, Command: "launchd"}}
+	roots := BuildTree(procs)
+	if len(roots) != 1 {
+		t.Fatalf("roots = %d, want 1", len(roots))
+	}
+	if roots[0].Info.PID != 1 {
+		t.Errorf("root PID = %d, want 1", roots[0].Info.PID)
+	}
+	if len(roots[0].Children) != 0 {
+		t.Errorf("unexpected children on root")
+	}
+}
+
+func TestBuildTreeParentChild(t *testing.T) {
+	procs := []Info{
+		{PID: 1, PPID: 0, Command: "launchd"},
+		{PID: 10, PPID: 1, Command: "bash"},
+		{PID: 20, PPID: 10, Command: "go"},
+	}
+	roots := BuildTree(procs)
+	if len(roots) != 1 {
+		t.Fatalf("roots = %d, want 1", len(roots))
+	}
+	if len(roots[0].Children) != 1 {
+		t.Fatalf("launchd children = %d, want 1", len(roots[0].Children))
+	}
+	bash := roots[0].Children[0]
+	if bash.Info.PID != 10 {
+		t.Errorf("child PID = %d, want 10", bash.Info.PID)
+	}
+	if len(bash.Children) != 1 || bash.Children[0].Info.PID != 20 {
+		t.Errorf("bash child = %v, want PID 20", bash.Children)
+	}
+}
+
+func TestBuildTreeSelfReferentialBecomesRoot(t *testing.T) {
+	procs := []Info{
+		{PID: 0, PPID: 0, Command: "kernel"},
+		{PID: 1, PPID: 0, Command: "launchd"},
+	}
+	roots := BuildTree(procs)
+	// PID 0 is self-referential; PID 1's parent (PID 0) is in the map
+	// but PID 0 is itself a root, so PID 1 should be a child of PID 0.
+	found := false
+	for _, r := range roots {
+		if r.Info.PID == 0 {
+			found = true
+			if len(r.Children) != 1 || r.Children[0].Info.PID != 1 {
+				t.Errorf("kernel children = %v, want [launchd]", r.Children)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected PID 0 (kernel) as a root")
+	}
+}
+
+func TestBuildTreeOrphanBecomesRoot(t *testing.T) {
+	// Parent PID not in the list → child becomes a root.
+	procs := []Info{
+		{PID: 100, PPID: 999, Command: "orphan"},
+	}
+	roots := BuildTree(procs)
+	if len(roots) != 1 {
+		t.Fatalf("roots = %d, want 1", len(roots))
+	}
+	if roots[0].Info.PID != 100 {
+		t.Errorf("root PID = %d, want 100", roots[0].Info.PID)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -425,6 +425,18 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		}), nil
 	})
 
+	// process.tree — process list arranged as a parent-child tree.
+	d.Register("process.tree", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Bundles []string `json:"bundles"`
+		}
+		_ = json.Unmarshal(params, &p)
+		procs := process.CollectAll(context.Background(), process.CollectOptions{
+			BundlePaths: p.Bundles,
+		})
+		return process.BuildTree(procs), nil
+	})
+
 	// storage.system — disk volumes + ~/Library usage summary.
 	d.Register("storage.system", func(_ json.RawMessage) (any, error) {
 		return storagestate.Collect(storagestate.CollectOptions{}), nil

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -342,3 +342,16 @@ func TestDaemonStorageByAppEmptyPaths(t *testing.T) {
 		t.Error("expected error for empty paths")
 	}
 }
+
+func TestDaemonProcessTreeReturnsSlice(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 22, "process.tree", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("process.tree: %v", resp.Error)
+	}
+	// Result should be a JSON array (slice of tree roots).
+	if _, ok := resp.Result.([]any); !ok {
+		t.Fatalf("result type %T, want []any", resp.Result)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `BuildTree([]Info) []*TreeNode` to `internal/process` — builds a parent-child hierarchy from a flat process list using PPID linkage
- Adds `process.tree` JSON-RPC handler to the daemon, returning the full tree of running processes
- Tests cover empty input, single root, parent-child chains, self-referential PIDs (kernel PID 0), and orphaned processes

## Test plan
- [ ] `go test ./internal/process/...` — 5 new BuildTree unit tests pass
- [ ] `go test ./internal/serve/...` — `TestDaemonProcessTreeReturnsSlice` passes