### PR TITLE
Surface RunAtLoad and KeepAlive flags from login item plists

### DIFF
--- a/cmd/spectra/inspect.go
+++ b/cmd/spectra/inspect.go
@@ -235,13 +235,23 @@ func printMeta(r detect.Result) {
 	if len(r.LoginItems) > 0 {
 		labels := make([]string, len(r.LoginItems))
 		for i, li := range r.LoginItems {
-			suffix := ""
+			var flags []string
 			if li.Daemon {
-				suffix = " (daemon)"
+				flags = append(flags, "daemon")
 			} else if li.Scope == "system" {
-				suffix = " (system)"
+				flags = append(flags, "system")
 			}
-			labels[i] = li.Label + suffix
+			if li.RunAtLoad {
+				flags = append(flags, "run-at-load")
+			}
+			if li.KeepAlive {
+				flags = append(flags, "keep-alive")
+			}
+			if len(flags) > 0 {
+				labels[i] = li.Label + " (" + strings.Join(flags, ", ") + ")"
+			} else {
+				labels[i] = li.Label
+			}
 		}
 		fmt.Printf("    login items (%d): %s\n", len(labels), strings.Join(labels, ", "))
 	}

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -101,10 +101,12 @@ type Helpers struct {
 
 // LoginItem is one launchd plist installed for this bundle.
 type LoginItem struct {
-	Path  string // full path to the plist
-	Label string // launchd Label (typically the bundle ID + suffix)
-	Scope string // user | system
-	Daemon bool  // true for /Library/LaunchDaemons
+	Path       string // full path to the plist
+	Label      string // launchd Label (typically the bundle ID + suffix)
+	Scope      string // user | system
+	Daemon     bool   // true for /Library/LaunchDaemons
+	RunAtLoad  bool   // plist RunAtLoad key
+	KeepAlive  bool   // plist KeepAlive key (simple true/false form)
 }
 
 // ProcessInfo is one running process belonging to this bundle.
@@ -1207,7 +1209,15 @@ func scanLoginItems(appPath, bundleID string) []LoginItem {
 				}
 			}
 			if matched {
-				items = append(items, LoginItem{Path: full, Label: label, Scope: d.scope, Daemon: d.daemon})
+				runAtLoad, keepAlive := parsePlistLaunchFlags(full)
+				items = append(items, LoginItem{
+					Path:      full,
+					Label:     label,
+					Scope:     d.scope,
+					Daemon:    d.daemon,
+					RunAtLoad: runAtLoad,
+					KeepAlive: keepAlive,
+				})
 			}
 		}
 	}
@@ -1233,6 +1243,32 @@ func plistMentionsAppPath(plistPath, appPath string) bool {
 		return false
 	}
 	return bytes.Contains(out, []byte(appPath))
+}
+
+// parsePlistXMLBool returns true if the converted XML for plistPath contains
+// the given key immediately followed by a <true/> element.
+// It reads the plist once and checks both RunAtLoad and KeepAlive so the
+// caller gets both flags from a single plutil invocation.
+func parsePlistLaunchFlags(plistPath string) (runAtLoad, keepAlive bool) {
+	out, err := exec.Command("plutil", "-convert", "xml1", "-o", "-", plistPath).Output()
+	if err != nil {
+		return
+	}
+	runAtLoad = plistXMLBool(out, "RunAtLoad")
+	keepAlive = plistXMLBool(out, "KeepAlive")
+	return
+}
+
+// plistXMLBool returns true when the XML payload contains <key>name</key>
+// followed (possibly with whitespace) by <true/>.
+func plistXMLBool(xml []byte, name string) bool {
+	key := []byte("<key>" + name + "</key>")
+	idx := bytes.Index(xml, key)
+	if idx < 0 {
+		return false
+	}
+	rest := bytes.TrimSpace(xml[idx+len(key):])
+	return bytes.HasPrefix(rest, []byte("<true/>"))
 }
 
 func home() string {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -372,3 +372,82 @@ func TestParseGatekeeperOutput(t *testing.T) {
 		}
 	}
 }
+
+func TestPlistXMLBool(t *testing.T) {
+	cases := []struct {
+		xml  string
+		key  string
+		want bool
+	}{
+		{"<key>RunAtLoad</key>\n<true/>", "RunAtLoad", true},
+		{"<key>RunAtLoad</key>\n<false/>", "RunAtLoad", false},
+		{"<key>RunAtLoad</key><true/>", "RunAtLoad", true},
+		{"<key>KeepAlive</key>\n\t<true/>", "KeepAlive", true},
+		{"<key>KeepAlive</key>\n\t<false/>", "KeepAlive", false},
+		{"<key>Other</key><true/>", "RunAtLoad", false},
+		{"", "RunAtLoad", false},
+	}
+	for _, tc := range cases {
+		got := plistXMLBool([]byte(tc.xml), tc.key)
+		if got != tc.want {
+			t.Errorf("plistXMLBool(%q, %q) = %v, want %v", tc.xml, tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestParsePlistLaunchFlagsFromFile(t *testing.T) {
+	plistContent := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.example.agent</string>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/example</string>
+	</array>
+</dict>
+</plist>`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "com.example.agent.plist")
+	if err := os.WriteFile(path, []byte(plistContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runAtLoad, keepAlive := parsePlistLaunchFlags(path)
+	if !runAtLoad {
+		t.Error("RunAtLoad: got false, want true")
+	}
+	if keepAlive {
+		t.Error("KeepAlive: got true, want false")
+	}
+}
+
+func TestParsePlistLaunchFlagsBothTrue(t *testing.T) {
+	plistContent := `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.example.daemon</string>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+</dict>
+</plist>`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "com.example.daemon.plist")
+	if err := os.WriteFile(path, []byte(plistContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runAtLoad, keepAlive := parsePlistLaunchFlags(path)
+	if !runAtLoad {
+		t.Error("RunAtLoad: got false, want true")
+	}
+	if !keepAlive {
+		t.Error("KeepAlive: got false, want true")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `RunAtLoad bool` and `KeepAlive bool` to `detect.LoginItem`, parsed from the plist XML using `plutil -convert xml1`
- Extends `scanLoginItems` to call `parsePlistLaunchFlags` per matched plist, reusing the single plutil invocation for both flags
- `spectra inspect` output now shows `run-at-load` and `keep-alive` annotations alongside `daemon`/`system` scope tags
- Addresses the limitation noted in `docs/inspection/login-items.md`

## Test plan
- [ ] `go test ./internal/detect/...` — unit tests for `plistXMLBool` (7 cases), `parsePlistLaunchFlags` with a temp file (RunAtLoad=true/KeepAlive=false), and both-true case
- [ ] `go test ./...` — all packages green