### PR TITLE
Add cache.stats and cache.clear RPC handlers to daemon

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/diff"
 	"github.com/kaeawc/spectra/internal/jvm"
@@ -41,7 +42,8 @@ func DefaultSockPath() (string, error) {
 type Options struct {
 	SockPath       string
 	SpectraVersion string
-	DBPath         string // empty = store.DefaultPath()
+	DBPath         string        // empty = store.DefaultPath()
+	CacheRegistry  *cache.Registry // nil = cache.Default
 }
 
 // Run starts the daemon: listens on the Unix socket and serves requests until
@@ -99,8 +101,13 @@ func Run(ctx context.Context, opts Options) error {
 	// Capture a live snapshot every minute; prune to the last 100 live snapshots.
 	go snapshotLoop(ctx, opts.SpectraVersion, db)
 
+	cacheReg := opts.CacheRegistry
+	if cacheReg == nil {
+		cacheReg = cache.Default
+	}
+
 	d := rpc.NewDispatcher()
-	registerHandlers(d, opts.SpectraVersion, db, collector)
+	registerHandlers(d, opts.SpectraVersion, db, collector, cacheReg)
 
 	// Close the listener when ctx is cancelled to unblock Accept.
 	go func() {
@@ -166,7 +173,7 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB) {
 }
 
 // registerHandlers wires all JSON-RPC methods into d.
-func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector) {
+func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, cacheReg *cache.Registry) {
 	d.Register("health", func(_ json.RawMessage) (any, error) {
 		return map[string]any{"ok": true, "version": version}, nil
 	})
@@ -559,5 +566,28 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		return storagestate.Collect(storagestate.CollectOptions{
 			AppPaths: p.Paths,
 		}), nil
+	})
+
+	// cache.stats — per-kind entry count, bytes on disk, and last-write time.
+	d.Register("cache.stats", func(_ json.RawMessage) (any, error) {
+		stats, err := cacheReg.Stats()
+		if err != nil {
+			return nil, fmt.Errorf("cache stats: %w", err)
+		}
+		return stats, nil
+	})
+
+	// cache.clear — evict cached data.
+	// Optional: { "kind": "detect" } to clear a single kind; omit for all.
+	d.Register("cache.clear", func(params json.RawMessage) (any, error) {
+		var p struct{ Kind string `json:"kind"` }
+		_ = json.Unmarshal(params, &p)
+		if err := cacheReg.Clear(p.Kind); err != nil {
+			return nil, fmt.Errorf("cache clear: %w", err)
+		}
+		if p.Kind == "" {
+			return map[string]any{"cleared": "all"}, nil
+		}
+		return map[string]any{"cleared": p.Kind}, nil
 	})
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/store"
@@ -36,7 +37,7 @@ func testDaemon(t *testing.T) (*json.Encoder, *json.Decoder, context.CancelFunc)
 	t.Cleanup(func() { db.Close() })
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, "test-version", db, metrics.NewCollector())
+	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default)
 
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -398,5 +399,45 @@ func TestDaemonJVMJFRStopMissingPID(t *testing.T) {
 	resp := rpcCall(t, enc, dec, 34, "jvm.jfr.stop", `{}`)
 	if resp.Error == nil {
 		t.Error("expected error when pid missing")
+	}
+}
+
+func TestDaemonCacheStatsReturnsSlice(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 40, "cache.stats", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("cache.stats: %v", resp.Error)
+	}
+	// Result should be a slice (may be empty if no cache kinds registered in tests).
+	if _, ok := resp.Result.([]any); !ok {
+		t.Fatalf("result type %T, want []any", resp.Result)
+	}
+}
+
+func TestDaemonCacheClearAll(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 41, "cache.clear", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("cache.clear (all): %v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	if m["cleared"] != "all" {
+		t.Errorf("cleared = %v, want all", m["cleared"])
+	}
+}
+
+func TestDaemonCacheClearUnknownKindReturnsError(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	// "detect" kind is not registered in the test registry (no initCacheStores),
+	// so clearing it should return an RPC error.
+	resp := rpcCall(t, enc, dec, 42, "cache.clear", `{"kind":"detect"}`)
+	if resp.Error == nil {
+		t.Error("expected error for unregistered cache kind")
 	}
 }


### PR DESCRIPTION
## Summary
- Threads `*cache.Registry` through `serve.Options` and `registerHandlers`
- Adds `cache.stats` RPC method: returns per-kind entry count, bytes on disk, last write
- Adds `cache.clear` RPC method: clears all kinds or a named kind via `{"kind": "detect"}`
- Implements the cache management methods listed in `docs/operations/daemon.md`

## Test plan
- [ ] `TestDaemonCacheStatsReturnsSlice` — result is a JSON array
- [ ] `TestDaemonCacheClearAll` — returns `{"cleared":"all"}`
- [ ] `TestDaemonCacheClearUnknownKindReturnsError` — returns error for unregistered kind
- [ ] `go test ./...` — all green