### PR TITLE
Add detect result caching to snapshot.Build

### DIFF
--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/serve"
 )
@@ -36,9 +37,14 @@ func runServe(args []string) int {
 	}
 	fmt.Fprintf(os.Stderr, "spectra serve: listening on %s\n", sock)
 
+	var detectStore *cache.ShardedStore
+	if cacheStores != nil {
+		detectStore = cacheStores.Detect
+	}
 	if err := serve.Run(ctx, serve.Options{
 		SockPath:       sock,
 		SpectraVersion: version,
+		DetectStore:    detectStore,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -42,8 +42,9 @@ func DefaultSockPath() (string, error) {
 type Options struct {
 	SockPath       string
 	SpectraVersion string
-	DBPath         string        // empty = store.DefaultPath()
+	DBPath         string          // empty = store.DefaultPath()
 	CacheRegistry  *cache.Registry // nil = cache.Default
+	DetectStore    *cache.ShardedStore // nil = no detect caching
 }
 
 // Run starts the daemon: listens on the Unix socket and serves requests until
@@ -107,7 +108,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, opts.SpectraVersion, db, collector, cacheReg)
+	registerHandlers(d, opts.SpectraVersion, db, collector, cacheReg, opts.DetectStore)
 
 	// Close the listener when ctx is cancelled to unblock Accept.
 	go func() {
@@ -173,7 +174,7 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB) {
 }
 
 // registerHandlers wires all JSON-RPC methods into d.
-func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, cacheReg *cache.Registry) {
+func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, cacheReg *cache.Registry, detectStore *cache.ShardedStore) {
 	d.Register("health", func(_ json.RawMessage) (any, error) {
 		return map[string]any{"ok": true, "version": version}, nil
 	})
@@ -205,6 +206,7 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		snap := snapshot.Build(context.Background(), snapshot.Options{
 			SpectraVersion: version,
 			DetectOpts:     detect.Options{},
+			DetectStore:    detectStore,
 		})
 		if err := db.SaveSnapshot(context.Background(), store.FromSnapshot(snap)); err != nil {
 			return nil, err
@@ -339,6 +341,7 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			snap = snapshot.Build(context.Background(), snapshot.Options{
 				SpectraVersion: version,
 				DetectOpts:     detect.Options{},
+				DetectStore:    detectStore,
 			})
 		}
 		return rules.Evaluate(snap, rules.V1Catalog()), nil

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -37,7 +37,7 @@ func testDaemon(t *testing.T) (*json.Encoder, *json.Decoder, context.CancelFunc)
 	t.Cleanup(func() { db.Close() })
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default)
+	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default, nil)
 
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {

--- a/internal/snapshot/detect_cache.go
+++ b/internal/snapshot/detect_cache.go
@@ -1,0 +1,75 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/cache"
+	"github.com/kaeawc/spectra/internal/detect"
+)
+
+// detectWithCache runs detect.DetectWith, returning a cached result when
+// available. The cache key is SHA-256 of Info.plist bytes + first 64 KiB of
+// the main executable, so the entry is invalidated automatically when either
+// file changes.
+//
+// store may be nil, in which case the function falls through to a live Detect.
+func detectWithCache(appPath string, opts detect.Options, store *cache.ShardedStore) (detect.Result, error) {
+	if store == nil {
+		return detect.DetectWith(appPath, opts)
+	}
+
+	key := detectCacheKey(appPath)
+	if key != nil {
+		if blob, ok, _ := store.Get(key); ok {
+			var r detect.Result
+			if err := json.Unmarshal(blob, &r); err == nil {
+				return r, nil
+			}
+		}
+	}
+
+	r, err := detect.DetectWith(appPath, opts)
+	if err == nil && key != nil {
+		if blob, jerr := json.Marshal(r); jerr == nil {
+			_ = store.Put(key, blob)
+		}
+	}
+	return r, err
+}
+
+// detectCacheKey returns the cache key for appPath, or nil if the key cannot
+// be derived (e.g. Info.plist missing or unreadable).
+func detectCacheKey(appPath string) []byte {
+	plist := filepath.Join(appPath, "Contents", "Info.plist")
+	plistBytes, err := os.ReadFile(plist)
+	if err != nil {
+		return nil
+	}
+
+	var exeBytes []byte
+	if name := plistExecutableName(plist); name != "" {
+		exePath := filepath.Join(appPath, "Contents", "MacOS", name)
+		if f, err := os.Open(exePath); err == nil {
+			buf := make([]byte, 64*1024)
+			n, _ := f.Read(buf)
+			f.Close()
+			exeBytes = buf[:n]
+		}
+	}
+
+	return cache.Key(plistBytes, exeBytes)
+}
+
+// plistExecutableName reads the CFBundleExecutable value from a plist file.
+// Returns "" on any error.
+func plistExecutableName(plistPath string) string {
+	out, err := exec.Command("plutil", "-extract", "CFBundleExecutable", "raw", "-o", "-", plistPath).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/snapshot/detect_cache_test.go
+++ b/internal/snapshot/detect_cache_test.go
@@ -1,0 +1,138 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/cache"
+	"github.com/kaeawc/spectra/internal/detect"
+)
+
+// makeTestBundle creates a minimal .app directory in dir and returns its path.
+func makeTestBundle(t *testing.T, dir, name, bundleID, execName string) string {
+	t.Helper()
+	app := filepath.Join(dir, name+".app")
+	macosDir := filepath.Join(app, "Contents", "MacOS")
+	if err := os.MkdirAll(macosDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plistContent := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>` + bundleID + `</string>
+<key>CFBundleExecutable</key><string>` + execName + `</string>
+<key>CFBundleShortVersionString</key><string>1.0.0</string>
+</dict></plist>`
+	plistPath := filepath.Join(app, "Contents", "Info.plist")
+	if err := os.WriteFile(plistPath, []byte(plistContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Write a fake executable (just some bytes).
+	exePath := filepath.Join(macosDir, execName)
+	if err := os.WriteFile(exePath, []byte("fakebinary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return app
+}
+
+func TestDetectCacheKeyNonNilForValidBundle(t *testing.T) {
+	dir := t.TempDir()
+	app := makeTestBundle(t, dir, "TestApp", "com.test.app", "TestApp")
+	key := detectCacheKey(app)
+	if key == nil {
+		t.Error("detectCacheKey returned nil for valid bundle")
+	}
+	if len(key) == 0 {
+		t.Error("detectCacheKey returned empty key")
+	}
+}
+
+func TestDetectCacheKeyNilForMissingBundle(t *testing.T) {
+	key := detectCacheKey("/nonexistent/path/Foo.app")
+	if key != nil {
+		t.Errorf("detectCacheKey = %v, want nil for missing bundle", key)
+	}
+}
+
+func TestDetectCacheKeyChangesWhenPlistChanges(t *testing.T) {
+	dir := t.TempDir()
+	app := makeTestBundle(t, dir, "TestApp", "com.test.app", "TestApp")
+	k1 := detectCacheKey(app)
+
+	// Update the plist.
+	plistPath := filepath.Join(app, "Contents", "Info.plist")
+	original, _ := os.ReadFile(plistPath)
+	updated := append(original, []byte("<!-- updated -->")...)
+	_ = os.WriteFile(plistPath, updated, 0o644)
+
+	k2 := detectCacheKey(app)
+	if string(k1) == string(k2) {
+		t.Error("cache key did not change after plist update")
+	}
+}
+
+func TestDetectWithCacheNilStoreCallsLiveDetect(t *testing.T) {
+	dir := t.TempDir()
+	app := makeTestBundle(t, dir, "TestApp", "com.test.app", "TestApp")
+	// nil store → falls through to live detect
+	r, err := detectWithCache(app, detect.Options{}, nil)
+	if err != nil {
+		t.Fatalf("detectWithCache(nil store): %v", err)
+	}
+	if r.Path == "" {
+		t.Error("result.Path should not be empty")
+	}
+}
+
+func TestDetectWithCacheStoresAndRetrieves(t *testing.T) {
+	dir := t.TempDir()
+	app := makeTestBundle(t, dir, "CacheApp", "com.cache.app", "CacheApp")
+
+	storeDir := filepath.Join(dir, "cache", "v1")
+	st := cache.NewShardedStore(storeDir, "detect")
+
+	// Pre-populate the cache with a sentinel result under the app's key.
+	key := detectCacheKey(app)
+	if key == nil {
+		t.Fatal("detectCacheKey returned nil for valid bundle")
+	}
+	sentinel := detect.Result{Path: app, BundleID: "sentinel-bundle-id"}
+	blob, _ := json.Marshal(sentinel)
+	if err := st.Put(key, blob); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// detectWithCache should return the sentinel without running live detect.
+	r, err := detectWithCache(app, detect.Options{}, st)
+	if err != nil {
+		t.Fatalf("detectWithCache: %v", err)
+	}
+	if r.BundleID != "sentinel-bundle-id" {
+		t.Errorf("BundleID = %q, want sentinel-bundle-id (cache not hit)", r.BundleID)
+	}
+}
+
+func TestDetectWithCacheMissRunsLiveDetect(t *testing.T) {
+	dir := t.TempDir()
+	app := makeTestBundle(t, dir, "LiveApp", "com.live.app", "LiveApp")
+
+	storeDir := filepath.Join(dir, "cache", "v1")
+	st := cache.NewShardedStore(storeDir, "detect")
+
+	// Empty cache → live detect runs and result is stored.
+	r, err := detectWithCache(app, detect.Options{}, st)
+	if err != nil {
+		t.Fatalf("detectWithCache: %v", err)
+	}
+	if r.Path == "" {
+		t.Error("live detect result has empty Path")
+	}
+
+	// Second call → served from cache.
+	key := detectCacheKey(app)
+	if _, ok, _ := st.Get(key); !ok {
+		t.Error("result was not stored in cache after live detect")
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/netstate"
@@ -95,6 +96,11 @@ type Options struct {
 	// host-only snapshots where app data is not needed (e.g. daemon
 	// periodic captures).
 	SkipApps bool
+
+	// DetectStore is the sharded cache for detect.Result JSON. When non-nil,
+	// collectApps serves cached results keyed by Info.plist + main-exe hash and
+	// stores new results on miss.
+	DetectStore *cache.ShardedStore
 }
 
 // Build assembles a Snapshot by running every collector in parallel and
@@ -215,7 +221,7 @@ func collectApps(_ context.Context, opts Options) []detect.Result {
 		go func() {
 			defer wg.Done()
 			for i := range in {
-				r, err := detect.DetectWith(paths[i], opts.DetectOpts)
+				r, err := detectWithCache(paths[i], opts.DetectOpts, opts.DetectStore)
 				out <- job{i: i, res: r, err: err}
 			}
 		}()


### PR DESCRIPTION
## Summary
- Adds `detectWithCache` in `internal/snapshot/detect_cache.go`: checks a `*cache.ShardedStore` before running `detect.DetectWith`, stores new results on cache miss
- Cache key = SHA-256 of `Info.plist` bytes + first 64 KiB of main executable — invalidates automatically when either file changes
- Adds `DetectStore *cache.ShardedStore` to `snapshot.Options`; wired into `snapshot.create` and `rules.evaluate` handlers in the daemon
- `spectra serve` threads `cacheStores.Detect` into `serve.Options.DetectStore` so the daemon benefits automatically
- Implements the detect cache described in `docs/operations/caching.md`

## Test plan
- [ ] `TestDetectCacheKeyNonNilForValidBundle` — key is non-nil for a valid bundle
- [ ] `TestDetectCacheKeyNilForMissingBundle` — nil for missing path
- [ ] `TestDetectCacheKeyChangesWhenPlistChanges` — key changes on plist update
- [ ] `TestDetectWithCacheNilStoreCallsLiveDetect` — nil store → live detect
- [ ] `TestDetectWithCacheStoresAndRetrieves` — sentinel result returned from cache
- [ ] `TestDetectWithCacheMissRunsLiveDetect` — miss runs detect and stores result
- [ ] `go test ./...` — all green