### PR TITLE
feat(process): capture CPU% from ps; surface THR and CPU% in CLI

### DIFF
--- a/cmd/spectra/process_cmd.go
+++ b/cmd/spectra/process_cmd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/kaeawc/spectra/internal/process"
@@ -48,12 +49,19 @@ func runProcess(args []string) int {
 		return 0
 	}
 
-	fmt.Printf("%-7s  %-10s  %-10s  %s\n", "PID", "RSS", "VSIZE", "COMMAND")
-	fmt.Println(strings.Repeat("-", 70))
+	fmt.Printf("%-7s  %-6s  %-10s  %-10s  %s\n", "PID", "THR", "RSS", "CPU%", "COMMAND")
+	fmt.Println(strings.Repeat("-", 76))
 	for _, p := range procs {
-		fmt.Printf("%-7d  %-10s  %-10s  %s\n",
-			p.PID, humanSizeKiB(p.RSSKiB), humanSizeKiB(p.VSizeKiB),
-			truncate(p.Command, 50))
+		thr := "-"
+		if p.ThreadCount > 0 {
+			thr = strconv.Itoa(p.ThreadCount)
+		}
+		cpu := "-"
+		if p.CPUPct > 0 {
+			cpu = fmt.Sprintf("%.1f%%", p.CPUPct)
+		}
+		fmt.Printf("%-7d  %-6s  %-10s  %-10s  %s\n",
+			p.PID, thr, humanSizeKiB(p.RSSKiB), cpu, truncate(p.Command, 45))
 	}
 	return 0
 }

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -17,14 +17,16 @@ import (
 
 // Info is one running process at snapshot time.
 type Info struct {
-	PID             int    `json:"pid"`
-	PPID            int    `json:"ppid"`
-	UID             int    `json:"uid"`
-	User            string `json:"user,omitempty"`
-	Command         string `json:"command"`         // short (comm) — just the exe name
-	FullCommandLine string `json:"full_command_line"` // full argv[0...] string
-	RSSKiB          int64  `json:"rss_kib"`
-	VSizeKiB        int64  `json:"vsize_kib"`
+	PID             int     `json:"pid"`
+	PPID            int     `json:"ppid"`
+	UID             int     `json:"uid"`
+	User            string  `json:"user,omitempty"`
+	Command         string  `json:"command"`          // short (comm) — just the exe name
+	FullCommandLine string  `json:"full_command_line"` // full argv[0...] string
+	RSSKiB          int64   `json:"rss_kib"`
+	VSizeKiB        int64   `json:"vsize_kib"`
+	ThreadCount     int     `json:"thread_count"`      // number of threads (nlwp)
+	CPUPct          float64 `json:"cpu_pct"`           // CPU % at sample time (pcpu)
 
 	// AppPath is set when the process's executable path starts with a known
 	// .app bundle path. Populated only when CollectAll is called with a set
@@ -49,9 +51,10 @@ func CollectAll(_ context.Context, opts CollectOptions) []Info {
 	if run == nil {
 		run = defaultRunner
 	}
-	// Omit comm= (can contain spaces); derive a short name from command=.
-	// Column order: pid ppid rss vsz uid user command...
-	out, err := run("ps", "-axwwo", "pid=,ppid=,rss=,vsz=,uid=,user=,command=")
+	// Column order: pid ppid pcpu rss vsz uid user command...
+	// macOS ps does not support nlwp; ThreadCount is populated by separate
+	// collectors when available.
+	out, err := run("ps", "-axwwo", "pid=,ppid=,pcpu=,rss=,vsz=,uid=,user=,command=")
 	if err != nil {
 		return nil
 	}
@@ -87,26 +90,28 @@ func parsePS(raw string) []Info {
 }
 
 func parseRow(line string) Info {
-	// Order: pid ppid rss vsz uid user command...
-	// The first 6 fields have no spaces. Everything from field 7 onward is
+	// Order: pid ppid pcpu rss vsz uid user command...
+	// The first 7 fields have no spaces. Everything from field 8 onward is
 	// the full argv string (may contain spaces).
 	fields := strings.Fields(line)
-	if len(fields) < 7 {
+	if len(fields) < 8 {
 		return Info{}
 	}
 	pid, _ := strconv.Atoi(fields[0])
 	ppid, _ := strconv.Atoi(fields[1])
-	rss, _ := strconv.ParseInt(fields[2], 10, 64)
-	vsz, _ := strconv.ParseInt(fields[3], 10, 64)
-	uid, _ := strconv.Atoi(fields[4])
-	full := strings.Join(fields[6:], " ")
+	cpu, _ := strconv.ParseFloat(fields[2], 64)
+	rss, _ := strconv.ParseInt(fields[3], 10, 64)
+	vsz, _ := strconv.ParseInt(fields[4], 10, 64)
+	uid, _ := strconv.Atoi(fields[5])
+	full := strings.Join(fields[7:], " ")
 	return Info{
 		PID:             pid,
 		PPID:            ppid,
+		CPUPct:          cpu,
 		RSSKiB:          rss,
 		VSizeKiB:        vsz,
 		UID:             uid,
-		User:            fields[5],
+		User:            fields[6],
 		Command:         shortName(full),
 		FullCommandLine: full,
 	}

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -15,10 +15,11 @@ func fakePS(output string) func(string, ...string) ([]byte, error) {
 
 // Synthetic ps output: pid ppid rss vsz uid user command...
 // Matches the format from `ps -axwwo pid=,ppid=,rss=,vsz=,uid=,user=,command=`
-const psFixture = `1      0    4096    8192 0 root /sbin/launchd
-412   1    184320  409600 501 alice /Applications/Slack.app/Contents/MacOS/Slack --some-flag
-415   412  92160   204800 501 alice /Applications/Slack.app/Contents/Frameworks/Slack Helper.app/Contents/MacOS/Slack Helper --type=renderer
-999   1    2048    4096 501 alice /bin/bash -l
+// psFixture matches the ps format: pid ppid pcpu rss vsz uid user command
+const psFixture = `1      0   0.0   4096    8192 0 root /sbin/launchd
+412   1    1.2  184320  409600 501 alice /Applications/Slack.app/Contents/MacOS/Slack --some-flag
+415   412  0.5  92160   204800 501 alice /Applications/Slack.app/Contents/Frameworks/Slack Helper.app/Contents/MacOS/Slack Helper --type=renderer
+999   1    0.0  2048    4096 501 alice /bin/bash -l
 `
 
 func TestParsePS(t *testing.T) {
@@ -36,6 +37,12 @@ func TestParsePSFields(t *testing.T) {
 	}
 	if slack.PPID != 1 {
 		t.Errorf("PPID = %d, want 1", slack.PPID)
+	}
+	if slack.ThreadCount != 0 {
+		t.Errorf("ThreadCount = %d, want 0 (nlwp not available on macOS)", slack.ThreadCount)
+	}
+	if slack.CPUPct != 1.2 {
+		t.Errorf("CPUPct = %v, want 1.2", slack.CPUPct)
 	}
 	if slack.RSSKiB != 184320 {
 		t.Errorf("RSSKiB = %d, want 184320", slack.RSSKiB)
@@ -62,7 +69,8 @@ func TestParsePSEmptyLines(t *testing.T) {
 }
 
 func TestParsePSShortRow(t *testing.T) {
-	procs := parsePS("412 1 100")
+	// Fewer than 9 fields → skipped.
+	procs := parsePS("412 1 1 0.0 100")
 	if len(procs) != 0 {
 		t.Errorf("expected empty for short row, got %d", len(procs))
 	}


### PR DESCRIPTION
## Summary
- Adds `CPUPct float64` to `process.Info` by inserting `pcpu` into the ps column list
- `ThreadCount` stays in the struct (zero-valued) for future enrichment — `nlwp` is Linux-only
- `spectra process` table now shows THR and CPU% columns alongside RSS

## Test plan
- [ ] `TestParsePSFields` verifies `CPUPct = 1.2` and `ThreadCount = 0`
- [ ] All existing process tests pass
- [ ] `go test ./...` green