### PR TITLE
feat(network): add network.connections collector, RPC handler, and CLI

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -12,6 +12,10 @@ import (
 )
 
 func runNetwork(args []string) int {
+	if len(args) > 0 && args[0] == "connections" {
+		return runNetworkConnections(args[1:])
+	}
+
 	fs := flag.NewFlagSet("spectra network", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
@@ -29,6 +33,58 @@ func runNetwork(args []string) int {
 	}
 
 	printNetworkState(state)
+	return 0
+}
+
+func runNetworkConnections(args []string) int {
+	fs := flag.NewFlagSet("spectra network connections", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	filterProto := fs.String("proto", "", "Filter by protocol: tcp or udp")
+	filterState := fs.String("state", "", "Filter by connection state (e.g. established)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	conns := netstate.CollectConnections(netstate.DefaultRunner)
+
+	var filtered []netstate.Connection
+	for _, c := range conns {
+		if *filterProto != "" && c.Proto != strings.ToLower(*filterProto) {
+			continue
+		}
+		if *filterState != "" && c.State != strings.ToLower(*filterState) {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(filtered)
+		return 0
+	}
+
+	if len(filtered) == 0 {
+		fmt.Println("no connections")
+		return 0
+	}
+
+	fmt.Printf("%-7s  %-5s  %-11s  %-25s  %-25s  %s\n",
+		"PID", "PROTO", "STATE", "LOCAL", "REMOTE", "COMMAND")
+	fmt.Println(strings.Repeat("-", 90))
+	for _, c := range filtered {
+		state := c.State
+		if state == "" {
+			state = "-"
+		}
+		fmt.Printf("%-7d  %-5s  %-11s  %-25s  %-25s  %s\n",
+			c.PID, c.Proto, state,
+			truncate(c.LocalAddr, 25),
+			truncate(c.RemoteAddr, 25),
+			truncate(c.Command, 30))
+	}
 	return 0
 }
 

--- a/internal/netstate/connections.go
+++ b/internal/netstate/connections.go
@@ -1,0 +1,94 @@
+package netstate
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Connection is one active TCP or UDP socket from `lsof -i -P -n`.
+type Connection struct {
+	PID        int    `json:"pid,omitempty"`
+	Command    string `json:"command,omitempty"`
+	Proto      string `json:"proto"` // "tcp", "udp"
+	LocalAddr  string `json:"local_addr"`
+	RemoteAddr string `json:"remote_addr,omitempty"` // empty for unconnected UDP
+	State      string `json:"state,omitempty"`       // "established", "close_wait", etc.
+}
+
+// CollectConnections returns all active (non-LISTEN) TCP and UDP sockets.
+// LISTEN entries are omitted — those appear in State.ListeningPorts.
+func CollectConnections(run CmdRunner) []Connection {
+	out, err := run("lsof", "-i", "-P", "-n")
+	if err != nil {
+		return nil
+	}
+	return parseLSOFConnections(string(out))
+}
+
+// parseLSOFConnections extracts active connections from `lsof -i -P -n` output.
+//
+// lsof column order: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME [STATE]
+//   NODE is "TCP" or "UDP"; NAME is "local->remote"; STATE is "(ESTABLISHED)" etc.
+//
+// Example lines:
+//
+//	Slack  412  alice  29u  IPv4  0xabc  0t0  TCP  192.168.1.1:55123->52.1.2.3:443 (ESTABLISHED)
+//	chrome 789  alice  41u  IPv4  0xdef  0t0  UDP  192.168.1.1:54812->8.8.8.8:53
+func parseLSOFConnections(out string) []Connection {
+	var conns []Connection
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 9 {
+			continue
+		}
+		// Find the NODE field (TCP/UDP) by scanning; it immediately precedes NAME.
+		// Typically at fields[7], but scan to be robust across lsof versions.
+		nodeIdx := -1
+		for i, f := range fields {
+			upper := strings.ToUpper(f)
+			if upper == "TCP" || upper == "UDP" {
+				nodeIdx = i
+				break
+			}
+		}
+		if nodeIdx < 0 || nodeIdx+1 >= len(fields) {
+			continue
+		}
+		proto := strings.ToLower(fields[nodeIdx])
+		name := fields[nodeIdx+1] // local or local->remote
+
+		// State is the next field if present (e.g. "(ESTABLISHED)").
+		state := ""
+		if nodeIdx+2 < len(fields) {
+			raw := fields[nodeIdx+2]
+			if strings.HasPrefix(raw, "(") && strings.HasSuffix(raw, ")") {
+				state = strings.ToLower(raw[1 : len(raw)-1])
+			}
+		}
+
+		// Skip LISTEN entries — those already appear in State.ListeningPorts.
+		if state == "listen" {
+			continue
+		}
+
+		// Split "local->remote" on "->".
+		var local, remote string
+		if idx := strings.Index(name, "->"); idx >= 0 {
+			local = name[:idx]
+			remote = name[idx+2:]
+		} else {
+			local = name
+		}
+
+		pid, _ := strconv.Atoi(fields[1])
+		conns = append(conns, Connection{
+			PID:        pid,
+			Command:    fields[0],
+			Proto:      proto,
+			LocalAddr:  local,
+			RemoteAddr: remote,
+			State:      state,
+		})
+	}
+	return conns
+}

--- a/internal/netstate/connections_test.go
+++ b/internal/netstate/connections_test.go
@@ -1,0 +1,92 @@
+package netstate
+
+import (
+	"errors"
+	"testing"
+)
+
+// lsof -i -P -n output fixture (header + representative rows).
+const lsofFixture = `COMMAND    PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+Slack      412   alice  29u  IPv4 0xabc          0t0  TCP  192.168.1.100:55123->52.1.2.3:443 (ESTABLISHED)
+Slack      412   alice  31u  IPv4 0xabc          0t0  TCP  *:3000 (LISTEN)
+firefox    789   alice  41u  IPv4 0xdef          0t0  UDP  192.168.1.100:54812->8.8.8.8:53
+netbiosd   999   root   6u   IPv4 0x111          0t0  UDP  *:138
+`
+
+func TestParseLSOFConnectionsCount(t *testing.T) {
+	conns := parseLSOFConnections(lsofFixture)
+	// Expect 3: the LISTEN entry is excluded.
+	if len(conns) != 3 {
+		t.Errorf("got %d connections, want 3; conns: %+v", len(conns), conns)
+	}
+}
+
+func TestParseLSOFConnectionsTCP(t *testing.T) {
+	conns := parseLSOFConnections(lsofFixture)
+	slack := conns[0]
+	if slack.Command != "Slack" {
+		t.Errorf("Command = %q, want Slack", slack.Command)
+	}
+	if slack.PID != 412 {
+		t.Errorf("PID = %d, want 412", slack.PID)
+	}
+	if slack.Proto != "tcp" {
+		t.Errorf("Proto = %q, want tcp", slack.Proto)
+	}
+	if slack.LocalAddr != "192.168.1.100:55123" {
+		t.Errorf("LocalAddr = %q, want 192.168.1.100:55123", slack.LocalAddr)
+	}
+	if slack.RemoteAddr != "52.1.2.3:443" {
+		t.Errorf("RemoteAddr = %q, want 52.1.2.3:443", slack.RemoteAddr)
+	}
+	if slack.State != "established" {
+		t.Errorf("State = %q, want established", slack.State)
+	}
+}
+
+func TestParseLSOFConnectionsUDP(t *testing.T) {
+	conns := parseLSOFConnections(lsofFixture)
+	ff := conns[1]
+	if ff.Proto != "udp" {
+		t.Errorf("Proto = %q, want udp", ff.Proto)
+	}
+	if ff.RemoteAddr != "8.8.8.8:53" {
+		t.Errorf("RemoteAddr = %q, want 8.8.8.8:53", ff.RemoteAddr)
+	}
+	if ff.State != "" {
+		t.Errorf("State = %q, want empty for UDP", ff.State)
+	}
+}
+
+func TestParseLSOFConnectionsListenExcluded(t *testing.T) {
+	for _, c := range parseLSOFConnections(lsofFixture) {
+		if c.State == "listen" {
+			t.Errorf("LISTEN entry leaked into connections: %+v", c)
+		}
+	}
+}
+
+func TestParseLSOFConnectionsEmpty(t *testing.T) {
+	if conns := parseLSOFConnections(""); len(conns) != 0 {
+		t.Errorf("expected empty for blank input, got %d", len(conns))
+	}
+}
+
+func TestCollectConnectionsError(t *testing.T) {
+	run := func(string, ...string) ([]byte, error) {
+		return nil, errors.New("lsof failed")
+	}
+	if conns := CollectConnections(run); len(conns) != 0 {
+		t.Errorf("expected nil on lsof error, got %d conns", len(conns))
+	}
+}
+
+func TestCollectConnectionsSuccess(t *testing.T) {
+	run := func(string, ...string) ([]byte, error) {
+		return []byte(lsofFixture), nil
+	}
+	conns := CollectConnections(run)
+	if len(conns) != 3 {
+		t.Errorf("CollectConnections: got %d, want 3", len(conns))
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -528,6 +528,11 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		return netstate.Collect(netstate.DefaultRunner), nil
 	})
 
+	// network.connections — active TCP/UDP sockets (non-LISTEN).
+	d.Register("network.connections", func(_ json.RawMessage) (any, error) {
+		return netstate.CollectConnections(netstate.DefaultRunner), nil
+	})
+
 	// process.list — snapshot of all running processes via ps.
 	// Optional: { "bundles": ["/Applications/Foo.app"] } to enable app attribution.
 	d.Register("process.list", func(params json.RawMessage) (any, error) {


### PR DESCRIPTION
## Summary
- Adds `CollectConnections()` to `internal/netstate` via `lsof -i -P -n`
- Parses active TCP/UDP sockets into a `Connection` slice; LISTEN entries excluded (already in `State.ListeningPorts`)
- Registers `network.connections` RPC handler on the daemon
- Adds `spectra network connections` CLI sub-subcommand with `--proto` and `--state` filters

## Test plan
- [ ] `TestParseLSOFConnectionsCount` — 3 connections parsed from fixture (LISTEN excluded)
- [ ] `TestParseLSOFConnectionsTCP` — correct fields for TCP ESTABLISHED entry
- [ ] `TestParseLSOFConnectionsUDP` — correct fields for UDP entry (empty state)
- [ ] `TestParseLSOFConnectionsListenExcluded` — no LISTEN entries leak through
- [ ] `go test ./...` green