### PR TITLE
feat(process): add StartTime from ps lstart column

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -17,16 +17,17 @@ import (
 
 // Info is one running process at snapshot time.
 type Info struct {
-	PID             int     `json:"pid"`
-	PPID            int     `json:"ppid"`
-	UID             int     `json:"uid"`
-	User            string  `json:"user,omitempty"`
-	Command         string  `json:"command"`          // short (comm) — just the exe name
-	FullCommandLine string  `json:"full_command_line"` // full argv[0...] string
-	RSSKiB          int64   `json:"rss_kib"`
-	VSizeKiB        int64   `json:"vsize_kib"`
-	ThreadCount     int     `json:"thread_count"`      // number of threads (nlwp)
-	CPUPct          float64 `json:"cpu_pct"`           // CPU % at sample time (pcpu)
+	PID             int       `json:"pid"`
+	PPID            int       `json:"ppid"`
+	UID             int       `json:"uid"`
+	User            string    `json:"user,omitempty"`
+	Command         string    `json:"command"`           // short (comm) — just the exe name
+	FullCommandLine string    `json:"full_command_line"` // full argv[0...] string
+	RSSKiB          int64     `json:"rss_kib"`
+	VSizeKiB        int64     `json:"vsize_kib"`
+	ThreadCount     int       `json:"thread_count"`      // number of threads (nlwp)
+	CPUPct          float64   `json:"cpu_pct"`           // CPU % at sample time (pcpu)
+	StartTime       time.Time `json:"start_time,omitempty"` // process start time (lstart)
 
 	// AppPath is set when the process's executable path starts with a known
 	// .app bundle path. Populated only when CollectAll is called with a set
@@ -51,10 +52,11 @@ func CollectAll(_ context.Context, opts CollectOptions) []Info {
 	if run == nil {
 		run = defaultRunner
 	}
-	// Column order: pid ppid pcpu rss vsz uid user command...
+	// Column order: pid ppid pcpu rss vsz uid user lstart command...
+	// lstart produces a 5-token date "Dow Mon DD HH:MM:SS YYYY".
 	// macOS ps does not support nlwp; ThreadCount is populated by separate
 	// collectors when available.
-	out, err := run("ps", "-axwwo", "pid=,ppid=,pcpu=,rss=,vsz=,uid=,user=,command=")
+	out, err := run("ps", "-axwwo", "pid=,ppid=,pcpu=,rss=,vsz=,uid=,user=,lstart=,command=")
 	if err != nil {
 		return nil
 	}
@@ -89,12 +91,17 @@ func parsePS(raw string) []Info {
 	return out
 }
 
+// lstartLayout matches the macOS lstart format: "Mon Jan  2 15:04:05 2006"
+// (single-digit days are space-padded in the raw string but normalised after
+// Fields() splits on whitespace, so we use two-digit zero-padded day here).
+const lstartLayout = "Mon Jan 2 15:04:05 2006"
+
 func parseRow(line string) Info {
-	// Order: pid ppid pcpu rss vsz uid user command...
-	// The first 7 fields have no spaces. Everything from field 8 onward is
-	// the full argv string (may contain spaces).
+	// Order: pid ppid pcpu rss vsz uid user <lstart:5 tokens> command...
+	// lstart is "Dow Mon DD HH:MM:SS YYYY" — always 5 space-separated tokens.
+	// Minimum field count: 7 fixed + 5 lstart + 1 command = 13.
 	fields := strings.Fields(line)
-	if len(fields) < 8 {
+	if len(fields) < 13 {
 		return Info{}
 	}
 	pid, _ := strconv.Atoi(fields[0])
@@ -103,7 +110,13 @@ func parseRow(line string) Info {
 	rss, _ := strconv.ParseInt(fields[3], 10, 64)
 	vsz, _ := strconv.ParseInt(fields[4], 10, 64)
 	uid, _ := strconv.Atoi(fields[5])
-	full := strings.Join(fields[7:], " ")
+	// fields[6] = user; fields[7:12] = lstart (5 tokens); fields[12:] = command
+	lstartStr := strings.Join(fields[7:12], " ")
+	var startTime time.Time
+	if t, err := time.Parse(lstartLayout, lstartStr); err == nil {
+		startTime = t
+	}
+	full := strings.Join(fields[12:], " ")
 	return Info{
 		PID:             pid,
 		PPID:            ppid,
@@ -114,6 +127,7 @@ func parseRow(line string) Info {
 		User:            fields[6],
 		Command:         shortName(full),
 		FullCommandLine: full,
+		StartTime:       startTime,
 	}
 }
 

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -13,13 +13,12 @@ func fakePS(output string) func(string, ...string) ([]byte, error) {
 	}
 }
 
-// Synthetic ps output: pid ppid rss vsz uid user command...
-// Matches the format from `ps -axwwo pid=,ppid=,rss=,vsz=,uid=,user=,command=`
-// psFixture matches the ps format: pid ppid pcpu rss vsz uid user command
-const psFixture = `1      0   0.0   4096    8192 0 root /sbin/launchd
-412   1    1.2  184320  409600 501 alice /Applications/Slack.app/Contents/MacOS/Slack --some-flag
-415   412  0.5  92160   204800 501 alice /Applications/Slack.app/Contents/Frameworks/Slack Helper.app/Contents/MacOS/Slack Helper --type=renderer
-999   1    0.0  2048    4096 501 alice /bin/bash -l
+// psFixture matches the ps format: pid ppid pcpu rss vsz uid user lstart(5) command
+// lstart is "Dow Mon DD HH:MM:SS YYYY" — always 5 tokens after Fields().
+const psFixture = `1      0   0.0   4096    8192 0 root Sat May  2 22:37:01 2026 /sbin/launchd
+412   1    1.2  184320  409600 501 alice Sat May  2 22:40:00 2026 /Applications/Slack.app/Contents/MacOS/Slack --some-flag
+415   412  0.5  92160   204800 501 alice Sat May  2 22:40:05 2026 /Applications/Slack.app/Contents/Frameworks/Slack Helper.app/Contents/MacOS/Slack Helper --type=renderer
+999   1    0.0  2048    4096 501 alice Sat May  2 23:00:00 2026 /bin/bash -l
 `
 
 func TestParsePS(t *testing.T) {
@@ -69,10 +68,24 @@ func TestParsePSEmptyLines(t *testing.T) {
 }
 
 func TestParsePSShortRow(t *testing.T) {
-	// Fewer than 9 fields → skipped.
+	// Fewer than 13 fields (7 fixed + 5 lstart + 1 command) → skipped.
 	procs := parsePS("412 1 1 0.0 100")
 	if len(procs) != 0 {
 		t.Errorf("expected empty for short row, got %d", len(procs))
+	}
+}
+
+func TestParsePSStartTime(t *testing.T) {
+	procs := parsePS(psFixture)
+	slack := procs[1]
+	if slack.StartTime.IsZero() {
+		t.Error("StartTime should not be zero for Slack process")
+	}
+	if slack.StartTime.Month().String() != "May" {
+		t.Errorf("StartTime month = %v, want May", slack.StartTime.Month())
+	}
+	if slack.StartTime.Year() != 2026 {
+		t.Errorf("StartTime year = %d, want 2026", slack.StartTime.Year())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `StartTime time.Time` to `process.Info` via `lstart=` in the ps format
- `lstart` yields a 5-token "Dow Mon DD HH:MM:SS YYYY" string; `parseRow` now extracts it from `fields[7:12]`, command from `fields[12:]`
- Minimum field count updated from 8 → 13

## Test plan
- [ ] `TestParsePSStartTime` — verifies month and year parsed correctly
- [ ] `TestParsePSShortRow` — short rows still skipped
- [ ] `go test ./...` green