### PR TITLE
feat(sample): add spectra sample command and process.sample RPC handler

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -44,6 +44,7 @@ func subcommandList() []subcommand {
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},
+		{"sample", "Collect a user-space CPU sample of a running process", runSample},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},

--- a/cmd/spectra/sample.go
+++ b/cmd/spectra/sample.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/cache"
+)
+
+func runSample(args []string) int {
+	fs := flag.NewFlagSet("spectra sample", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	duration := fs.Int("duration", 1, "Sample duration in seconds")
+	interval := fs.Int("interval", 10, "Sampling interval in milliseconds")
+	noCache := fs.Bool("no-cache", false, "Do not store the sample in the blob cache")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra sample [--duration <s>] [--interval <ms>] <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil || pid <= 0 {
+		fmt.Fprintf(os.Stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	// Run: sample <pid> <duration> <interval> -e (stderr only for errors)
+	// stdout receives the formatted call tree.
+	cmd := exec.Command("sample",
+		strconv.Itoa(pid),
+		strconv.Itoa(*duration),
+		strconv.Itoa(*interval),
+	)
+	cmd.Stderr = os.Stderr
+	data, err := cmd.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sample failed for PID %d: %v\n", pid, err)
+		return 1
+	}
+
+	if !*noCache && cacheStores != nil && cacheStores.Samples != nil {
+		key := cache.Key([]byte(fmt.Sprintf("sample:%d:%d", pid, time.Now().UnixNano())))
+		if putErr := cacheStores.Samples.Put(key, data); putErr == nil {
+			fmt.Fprintf(os.Stderr, "cached as samples/%x\n", key[:4])
+		}
+	}
+
+	os.Stdout.Write(data)
+	return 0
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/kaeawc/spectra/internal/cache"
@@ -625,6 +627,30 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		return process.BuildTree(procs), nil
 	})
 
+	// process.sample — run `sample <pid> <duration>` and return the text output.
+	// Required: {"pid": <pid>}. Optional: {"duration": 1, "interval": 10}.
+	d.Register("process.sample", func(params json.RawMessage) (any, error) {
+		var p struct {
+			PID      int `json:"pid"`
+			Duration int `json:"duration"`
+			Interval int `json:"interval"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.PID == 0 {
+			return nil, fmt.Errorf("process.sample requires {\"pid\": <pid>}")
+		}
+		if p.Duration == 0 {
+			p.Duration = 1
+		}
+		if p.Interval == 0 {
+			p.Interval = 10
+		}
+		out, err := runSampleCmd(p.PID, p.Duration, p.Interval)
+		if err != nil {
+			return nil, fmt.Errorf("sample pid %d: %w", p.PID, err)
+		}
+		return map[string]any{"pid": p.PID, "output": string(out)}, nil
+	})
+
 	// storage.system — disk volumes + ~/Library usage summary.
 	d.Register("storage.system", func(_ json.RawMessage) (any, error) {
 		return storagestate.Collect(storagestate.CollectOptions{}), nil
@@ -666,4 +692,16 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		}
 		return map[string]any{"cleared": p.Kind}, nil
 	})
+}
+
+// runSampleCmd runs `sample <pid> <duration> <interval>` and returns stdout.
+func runSampleCmd(pid, durationSec, intervalMS int) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(),
+		time.Duration(durationSec+5)*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "sample",
+		strconv.Itoa(pid),
+		strconv.Itoa(durationSec),
+		strconv.Itoa(intervalMS),
+	).Output()
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -472,3 +472,12 @@ func TestDaemonJVMHeapDumpRequiresPID(t *testing.T) {
 		t.Error("expected error when pid=0")
 	}
 }
+
+func TestDaemonProcessSampleRequiresPID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 53, "process.sample", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when pid=0")
+	}
+}


### PR DESCRIPTION
## Summary
- Wraps macOS `sample <pid> <duration> <interval>` (user-space CPU call tree collection) into `spectra sample <pid>`
- Stores output in the `samples` cache kind when available
- Registers `process.sample` RPC handler on the daemon
- Flags: `--duration` (default 1s), `--interval` (default 10ms), `--no-cache`

## Test plan
- [ ] `TestDaemonProcessSampleRequiresPID` — error when pid=0
- [ ] `go test ./...` green