### PR TITLE
feat(sysinfo): add EnergyTopUsers to PowerState

### DIFF
--- a/internal/sysinfo/power.go
+++ b/internal/sysinfo/power.go
@@ -9,10 +9,18 @@ import (
 // PowerState captures battery and thermal facts.
 // See docs/design/system-inventory.md#powerstate.
 type PowerState struct {
-	OnBattery       bool    `json:"on_battery"`
-	BatteryPct      int     `json:"battery_pct"`
-	ThermalPressure string  `json:"thermal_pressure,omitempty"` // "nominal", "fair", "serious", "critical"
+	OnBattery       bool           `json:"on_battery"`
+	BatteryPct      int            `json:"battery_pct"`
+	ThermalPressure string         `json:"thermal_pressure,omitempty"` // "nominal", "fair", "serious", "critical"
 	Assertions      []PowerAssertion `json:"assertions,omitempty"`
+	EnergyTopUsers  []EnergyUser   `json:"energy_top_users,omitempty"`
+}
+
+// EnergyUser is one entry from `top -l 1 -o power`.
+type EnergyUser struct {
+	PID           int     `json:"pid"`
+	EnergyImpact  float64 `json:"energy_impact"`
+	Command       string  `json:"command"`
 }
 
 // PowerAssertion is one pmset sleep/display assertion.
@@ -36,8 +44,35 @@ func CollectPower(run CmdRunner) PowerState {
 	if out, err := run("pmset", "-g", "assertions"); err == nil {
 		ps.Assertions = parseAssertions(string(out))
 	}
+	if out, err := run("top", "-l", "1", "-n", "10", "-o", "power", "-stats", "pid,power,command"); err == nil {
+		ps.EnergyTopUsers = parseEnergyTop(string(out))
+	}
 
 	return ps
+}
+
+// parseEnergyTop parses `top -l 1 -n 10 -o power -stats pid,power,command` output.
+func parseEnergyTop(out string) []EnergyUser {
+	var result []EnergyUser
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[0] == "PID" {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		impact, err := strconv.ParseFloat(fields[1], 64)
+		if err != nil {
+			continue
+		}
+		result = append(result, EnergyUser{PID: pid, EnergyImpact: impact, Command: fields[2]})
+	}
+	return result
 }
 
 // parseBatt extracts OnBattery + BatteryPct from `pmset -g batt` output.

--- a/internal/sysinfo/power_test.go
+++ b/internal/sysinfo/power_test.go
@@ -31,8 +31,20 @@ Listed by owning process:
  pid 412(Slack): [0x000165b8000002f1] 00:00:04 PreventUserIdleSleep named: "playing audio"
 `
 
-func stubPmset(batt, therm, assertions string) CmdRunner {
+const topEnergyOutput = `PID    POWER  COMMAND
+99647  12.5   Slack
+412    3.2    com.apple.WebKit
+1      0.0    launchd
+`
+
+func stubPower(batt, therm, assertions, topEnergy string) CmdRunner {
 	return func(name string, args ...string) ([]byte, error) {
+		if name == "top" {
+			if topEnergy == "" {
+				return nil, errors.New("no top")
+			}
+			return []byte(topEnergy), nil
+		}
 		if name != "pmset" || len(args) < 2 {
 			return nil, errors.New("unexpected")
 		}
@@ -55,6 +67,10 @@ func stubPmset(batt, therm, assertions string) CmdRunner {
 		}
 		return nil, errors.New("unknown pmset arg")
 	}
+}
+
+func stubPmset(batt, therm, assertions string) CmdRunner {
+	return stubPower(batt, therm, assertions, "")
 }
 
 func TestCollectPowerOnBattery(t *testing.T) {
@@ -112,5 +128,34 @@ func TestCollectPowerAllFail(t *testing.T) {
 	// Should not panic; returns zero value.
 	if ps.OnBattery || ps.BatteryPct != 0 {
 		t.Errorf("expected zero value on all-fail: %+v", ps)
+	}
+}
+
+func TestParseEnergyTop(t *testing.T) {
+	users := parseEnergyTop(topEnergyOutput)
+	if len(users) != 3 {
+		t.Fatalf("len = %d, want 3", len(users))
+	}
+	if users[0].PID != 99647 {
+		t.Errorf("PID = %d, want 99647", users[0].PID)
+	}
+	if users[0].EnergyImpact != 12.5 {
+		t.Errorf("EnergyImpact = %v, want 12.5", users[0].EnergyImpact)
+	}
+	if users[0].Command != "Slack" {
+		t.Errorf("Command = %q, want Slack", users[0].Command)
+	}
+	if users[2].EnergyImpact != 0.0 {
+		t.Errorf("EnergyImpact = %v, want 0.0 for launchd", users[2].EnergyImpact)
+	}
+}
+
+func TestCollectPowerEnergyTopUsers(t *testing.T) {
+	ps := CollectPower(stubPower("", "", "", topEnergyOutput))
+	if len(ps.EnergyTopUsers) != 3 {
+		t.Fatalf("EnergyTopUsers = %d, want 3", len(ps.EnergyTopUsers))
+	}
+	if ps.EnergyTopUsers[1].PID != 412 {
+		t.Errorf("second PID = %d, want 412", ps.EnergyTopUsers[1].PID)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `EnergyUser{PID, EnergyImpact, Command}` struct and `EnergyTopUsers []EnergyUser` field to `PowerState`
- Calls `top -l 1 -n 10 -o power -stats pid,power,command` in `CollectPower`; failure is silently absorbed
- Parses PID/float/command columns, skipping the header row

## Test plan
- `TestParseEnergyTop` — verifies 3-entry parse with correct PID, EnergyImpact, and Command
- `TestCollectPowerEnergyTopUsers` — verifies integration through `CollectPower`
- All existing power tests remain green