### PR TITLE
feat(netstate): add EstablishedConnectionsCount to NetworkState

### DIFF
--- a/internal/netstate/netstate.go
+++ b/internal/netstate/netstate.go
@@ -20,7 +20,8 @@ type State struct {
 	DNSServers        []string        `json:"dns_servers,omitempty"`
 	Proxy             ProxyConfig     `json:"proxy"`
 	HostsOverrides    []HostsEntry    `json:"hosts_overrides,omitempty"`
-	ListeningPorts    []ListeningPort `json:"listening_ports,omitempty"`
+	ListeningPorts              []ListeningPort `json:"listening_ports,omitempty"`
+	EstablishedConnectionsCount int             `json:"established_connections_count,omitempty"`
 
 	// VPNActive is true when at least one tunnel interface (utun*) is UP with
 	// an assigned address. macOS uses utun interfaces for all VPN types:
@@ -78,6 +79,9 @@ func Collect(run CmdRunner) State {
 	if out, err := run("ifconfig"); err == nil {
 		s.VPNInterfaces = parseVPNInterfaces(string(out))
 		s.VPNActive = len(s.VPNInterfaces) > 0
+	}
+	if out, err := run("lsof", "-i", "-P", "-n"); err == nil {
+		s.EstablishedConnectionsCount = len(parseLSOFConnections(string(out)))
 	}
 	return s
 }

--- a/internal/netstate/netstate_test.go
+++ b/internal/netstate/netstate_test.go
@@ -177,6 +177,15 @@ func TestParseVPNInterfacesEmpty(t *testing.T) {
 	}
 }
 
+func hasArg(args []string, s string) bool {
+	for _, a := range args {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}
+
 func TestCollect(t *testing.T) {
 	stub := func(name string, args ...string) ([]byte, error) {
 		switch name {
@@ -188,7 +197,10 @@ func TestCollect(t *testing.T) {
 			}
 			return []byte("HTTPEnable : 0\n"), nil
 		case "lsof":
-			return []byte(lsofOutput), nil
+			if hasArg(args, "-sTCP:LISTEN") {
+				return []byte(lsofOutput), nil
+			}
+			return []byte(lsofFixture), nil
 		case "ifconfig":
 			return []byte(ifconfigWithVPN), nil
 		}
@@ -210,6 +222,9 @@ func TestCollect(t *testing.T) {
 	}
 	if len(s.VPNInterfaces) != 1 || s.VPNInterfaces[0] != "utun3" {
 		t.Errorf("VPNInterfaces = %v, want [utun3]", s.VPNInterfaces)
+	}
+	if s.EstablishedConnectionsCount != 3 {
+		t.Errorf("EstablishedConnectionsCount = %d, want 3", s.EstablishedConnectionsCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `EstablishedConnectionsCount int` to `netstate.State` (JSON: `established_connections_count`)
- Counts non-LISTEN TCP/UDP sockets via `lsof -i -P -n` in `Collect`; reuses `parseLSOFConnections`

## Test plan
- `TestCollect` updated to use `lsofFixture` (3 non-LISTEN entries) for the count call and `lsofOutput` for the listen call; asserts count == 3
- All existing netstate tests remain green