### PR TITLE
feat(process): add OutboundConnections to deep enrichment

### DIFF
--- a/internal/process/deep.go
+++ b/internal/process/deep.go
@@ -26,10 +26,11 @@ func enrichDeep(procs []Info, run func(string, ...string) ([]byte, error)) {
 	parseLSOFDeep(procs, string(out))
 }
 
-// fdCounts and listenPorts accumulate results keyed by PID during parsing.
+// deepResult accumulates per-PID results during lsof parsing.
 type deepResult struct {
 	fdCount      int
 	listenPorts  []int
+	outboundConns []string
 }
 
 // parseLSOFDeep merges lsof output into the procs slice in-place.
@@ -75,17 +76,27 @@ func parseLSOFDeep(procs []Info, out string) {
 		}
 
 		// Listening port detection: NODE=TCP, NAME contains "(LISTEN)".
+		// Outbound connection: NODE=TCP, NAME contains "->", no "(LISTEN)".
 		if len(fields) >= 9 {
 			node := strings.ToUpper(fields[7])
 			if node == "TCP" {
 				name := strings.Join(fields[8:], " ")
 				if strings.Contains(name, "(LISTEN)") {
 					// Extract port from "host:port (LISTEN)".
-					name = strings.TrimSuffix(name, " (LISTEN)")
-					if colon := strings.LastIndex(name, ":"); colon >= 0 {
-						if port, err := strconv.Atoi(name[colon+1:]); err == nil && port > 0 {
+					addr := strings.TrimSuffix(name, " (LISTEN)")
+					if colon := strings.LastIndex(addr, ":"); colon >= 0 {
+						if port, err := strconv.Atoi(addr[colon+1:]); err == nil && port > 0 {
 							r.listenPorts = append(r.listenPorts, port)
 						}
+					}
+				} else if idx2 := strings.Index(name, "->"); idx2 >= 0 {
+					// "local->remote (STATE)" — record the remote address.
+					remote := name[idx2+2:]
+					if sp := strings.Index(remote, " "); sp >= 0 {
+						remote = remote[:sp]
+					}
+					if remote != "" {
+						r.outboundConns = append(r.outboundConns, remote)
 					}
 				}
 			}
@@ -99,6 +110,10 @@ func parseLSOFDeep(procs []Info, out string) {
 		if len(r.listenPorts) > 0 {
 			sort.Ints(r.listenPorts)
 			procs[i].ListeningPorts = r.listenPorts
+		}
+		if len(r.outboundConns) > 0 {
+			sort.Strings(r.outboundConns)
+			procs[i].OutboundConnections = r.outboundConns
 		}
 	}
 }

--- a/internal/process/deep_test.go
+++ b/internal/process/deep_test.go
@@ -52,6 +52,21 @@ func TestParseLSOFDeepListeningPorts(t *testing.T) {
 	}
 }
 
+func TestParseLSOFDeepOutboundConnections(t *testing.T) {
+	procs := []Info{
+		{PID: 412, Command: "Slack"},
+		{PID: 999, Command: "bash"},
+	}
+	parseLSOFDeep(procs, lsofDeepFixture)
+
+	if len(procs[0].OutboundConnections) != 1 || procs[0].OutboundConnections[0] != "127.0.0.1:443" {
+		t.Errorf("Slack OutboundConnections = %v, want [127.0.0.1:443]", procs[0].OutboundConnections)
+	}
+	if len(procs[1].OutboundConnections) != 0 {
+		t.Errorf("bash OutboundConnections = %v, want []", procs[1].OutboundConnections)
+	}
+}
+
 func TestParseLSOFDeepUnknownPIDSkipped(t *testing.T) {
 	// PID 999 not in procs — should not panic or produce errors.
 	procs := []Info{{PID: 412, Command: "Slack"}}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -30,8 +30,9 @@ type Info struct {
 	StartTime       time.Time `json:"start_time,omitempty"` // process start time (lstart)
 
 	// Deep fields — populated only when CollectOptions.Deep is true.
-	OpenFDs        int   `json:"open_fds,omitempty"`        // open file descriptor count
-	ListeningPorts []int `json:"listening_ports,omitempty"` // TCP ports this process listens on
+	OpenFDs             int      `json:"open_fds,omitempty"`             // open file descriptor count
+	ListeningPorts      []int    `json:"listening_ports,omitempty"`      // TCP ports this process listens on
+	OutboundConnections []string `json:"outbound_connections,omitempty"` // active TCP remote addresses (host:port)
 
 	// AppPath is set when the process's executable path starts with a known
 	// .app bundle path. Populated only when CollectAll is called with a set


### PR DESCRIPTION
## Summary
- Adds `OutboundConnections []string` to `process.Info` (JSON: `outbound_connections`); populated only when `--deep`
- Reuses the existing batched `lsof -p` call in `enrichDeep`; parses TCP rows with `->` to extract the remote `host:port`
- LISTEN rows are still handled separately (no change to ListeningPorts logic)

## Test plan
- `TestParseLSOFDeepOutboundConnections` — Slack gets `[127.0.0.1:443]`, bash gets none
- All existing deep enrichment tests remain green