### PR TITLE
feat(toolchain): detect installed JVM version managers

### DIFF
--- a/internal/toolchain/collect.go
+++ b/internal/toolchain/collect.go
@@ -86,6 +86,10 @@ func Collect(ctx context.Context, opts CollectOptions) Toolchains {
 			return func(t *Toolchains) { t.Rust = chains }, err
 		}),
 		run(func() (func(*Toolchains), error) {
+			managers := discoverJVMManagers(opts.Home)
+			return func(t *Toolchains) { t.JVMManagers = managers }, nil
+		}),
+		run(func() (func(*Toolchains), error) {
 			snap := collectEnv()
 			return func(t *Toolchains) { t.Env = snap }, nil
 		}),

--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -243,3 +243,25 @@ func runtimeInstall(source, version, binPath, activePath string) RuntimeInstall 
 		Active:  isActive,
 	}
 }
+
+// discoverJVMManagers returns the names of JVM version managers present in the
+// user's home directory. Checks for sdkman, asdf, mise, and jenv by probing
+// their canonical install paths.
+func discoverJVMManagers(home string) []string {
+	probes := []struct {
+		name string
+		path string
+	}{
+		{"sdkman", filepath.Join(home, ".sdkman", "bin", "sdkman-init.sh")},
+		{"asdf", filepath.Join(home, ".asdf", "bin", "asdf")},
+		{"mise", filepath.Join(home, ".local", "share", "mise")},
+		{"jenv", filepath.Join(home, ".jenv", "bin", "jenv")},
+	}
+	var found []string
+	for _, p := range probes {
+		if _, err := os.Stat(p.path); err == nil {
+			found = append(found, p.name)
+		}
+	}
+	return found
+}

--- a/internal/toolchain/runtime_test.go
+++ b/internal/toolchain/runtime_test.go
@@ -177,3 +177,68 @@ func TestDiscoverRubyFromRbenv(t *testing.T) {
 		t.Errorf("got %d rbenv installs, want 1", count)
 	}
 }
+
+func TestDiscoverJVMManagersNone(t *testing.T) {
+	home := t.TempDir()
+	managers := discoverJVMManagers(home)
+	if len(managers) != 0 {
+		t.Errorf("expected no managers, got %v", managers)
+	}
+}
+
+func TestDiscoverJVMManagersSDKMan(t *testing.T) {
+	home := t.TempDir()
+	sdkmanBin := filepath.Join(home, ".sdkman", "bin")
+	if err := os.MkdirAll(sdkmanBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sdkmanBin, "sdkman-init.sh"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	managers := discoverJVMManagers(home)
+	if len(managers) != 1 || managers[0] != "sdkman" {
+		t.Errorf("expected [sdkman], got %v", managers)
+	}
+}
+
+func TestDiscoverJVMManagersMise(t *testing.T) {
+	home := t.TempDir()
+	misePath := filepath.Join(home, ".local", "share", "mise")
+	if err := os.MkdirAll(misePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	managers := discoverJVMManagers(home)
+	if len(managers) != 1 || managers[0] != "mise" {
+		t.Errorf("expected [mise], got %v", managers)
+	}
+}
+
+func TestDiscoverJVMManagersMultiple(t *testing.T) {
+	home := t.TempDir()
+	// Install both asdf and jenv.
+	asdfBin := filepath.Join(home, ".asdf", "bin")
+	if err := os.MkdirAll(asdfBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(asdfBin, "asdf"), []byte(""), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jenvBin := filepath.Join(home, ".jenv", "bin")
+	if err := os.MkdirAll(jenvBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jenvBin, "jenv"), []byte(""), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	managers := discoverJVMManagers(home)
+	if len(managers) != 2 {
+		t.Errorf("expected 2 managers, got %v", managers)
+	}
+	found := map[string]bool{}
+	for _, m := range managers {
+		found[m] = true
+	}
+	if !found["asdf"] || !found["jenv"] {
+		t.Errorf("expected asdf and jenv in %v", managers)
+	}
+}

--- a/internal/toolchain/types.go
+++ b/internal/toolchain/types.go
@@ -5,14 +5,15 @@ package toolchain
 
 // Toolchains is the aggregate result of all subsystem discoverers.
 type Toolchains struct {
-	Brew    BrewInventory    `json:"brew"`
-	JDKs    []JDKInstall     `json:"jdks,omitempty"`
-	Node    []RuntimeInstall `json:"node,omitempty"`
-	Python  []RuntimeInstall `json:"python,omitempty"`
-	Go      []RuntimeInstall `json:"go,omitempty"`
-	Ruby    []RuntimeInstall `json:"ruby,omitempty"`
-	Rust    []RustToolchain  `json:"rust,omitempty"`
-	Env     EnvSnapshot      `json:"env"`
+	Brew        BrewInventory    `json:"brew"`
+	JDKs        []JDKInstall     `json:"jdks,omitempty"`
+	Node        []RuntimeInstall `json:"node,omitempty"`
+	Python      []RuntimeInstall `json:"python,omitempty"`
+	Go          []RuntimeInstall `json:"go,omitempty"`
+	Ruby        []RuntimeInstall `json:"ruby,omitempty"`
+	Rust        []RustToolchain  `json:"rust,omitempty"`
+	JVMManagers []string         `json:"jvm_managers,omitempty"` // "sdkman", "asdf", "mise", "jenv"
+	Env         EnvSnapshot      `json:"env"`
 }
 
 // BrewInventory holds installed Homebrew formulae, casks, and taps.


### PR DESCRIPTION
## Summary
- Adds `JVMManagers []string` to `Toolchains` (JSON: `jvm_managers`)
- `discoverJVMManagers(home)` probes canonical install paths for sdkman, asdf, mise, and jenv
- Wired into `Collect` as a parallel task alongside other discoverers

## Test plan
- `TestDiscoverJVMManagersNone` — empty home yields no managers
- `TestDiscoverJVMManagersSDKMan` — creates sdkman-init.sh, expects `["sdkman"]`
- `TestDiscoverJVMManagersMise` — creates mise dir, expects `["mise"]`
- `TestDiscoverJVMManagersMultiple` — asdf + jenv both detected