### PR TITLE
feat(serve): add helper.* proxy RPC handlers for privileged helper

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/diff"
+	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/netstate"
@@ -691,6 +692,52 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return map[string]any{"cleared": "all"}, nil
 		}
 		return map[string]any{"cleared": p.Kind}, nil
+	})
+
+	// helper.* — proxy to the privileged helper when available.
+	hc := helperclient.New()
+
+	d.Register("helper.health", func(_ json.RawMessage) (any, error) {
+		result, err := hc.Health()
+		if err != nil {
+			if helperclient.IsUnavailable(err) {
+				return map[string]any{"ok": false, "helper": false, "reason": "helper not running"}, nil
+			}
+			return nil, err
+		}
+		return result, nil
+	})
+
+	d.Register("helper.powermetrics.sample", func(params json.RawMessage) (any, error) {
+		var p struct {
+			DurationMS int `json:"duration_ms"`
+		}
+		_ = json.Unmarshal(params, &p)
+		result, err := hc.PowermetricsSample(p.DurationMS)
+		if err != nil {
+			if helperclient.IsUnavailable(err) {
+				return nil, fmt.Errorf("privileged helper not running; install with: sudo spectra install-helper")
+			}
+			return nil, err
+		}
+		return result, nil
+	})
+
+	d.Register("helper.tcc.system.query", func(params json.RawMessage) (any, error) {
+		var p struct {
+			BundleID string `json:"bundle_id"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.BundleID == "" {
+			return nil, fmt.Errorf("helper.tcc.system.query requires {\"bundle_id\":\"...\"}")
+		}
+		result, err := hc.TCCSystemQuery(p.BundleID)
+		if err != nil {
+			if helperclient.IsUnavailable(err) {
+				return nil, fmt.Errorf("privileged helper not running; install with: sudo spectra install-helper")
+			}
+			return nil, err
+		}
+		return result, nil
 	})
 }
 

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -481,3 +481,39 @@ func TestDaemonProcessSampleRequiresPID(t *testing.T) {
 		t.Error("expected error when pid=0")
 	}
 }
+
+func TestDaemonHelperHealthWhenUnavailable(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	// Helper is not running in tests; should return ok=false, not an error.
+	resp := rpcCall(t, enc, dec, 54, "helper.health", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("helper.health: unexpected RPC error: %v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("helper.health: result type %T, want map", resp.Result)
+	}
+	if m["helper"] != false {
+		t.Errorf("helper.health: helper field = %v, want false", m["helper"])
+	}
+}
+
+func TestDaemonHelperPowermetricsRequiresHelper(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	// Helper not running → should return an error (not a silent no-op).
+	resp := rpcCall(t, enc, dec, 55, "helper.powermetrics.sample", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when helper not running")
+	}
+}
+
+func TestDaemonHelperTCCRequiresBundleID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 56, "helper.tcc.system.query", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when bundle_id missing")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `helper.health`, `helper.powermetrics.sample`, and `helper.tcc.system.query` RPC handlers to the daemon
- Each handler proxies to `helperclient.New()` (the privileged helper socket)
- `helper.health` degrades gracefully when the helper is unavailable (returns `{"ok":false}`)
- `helper.powermetrics.sample` and `helper.tcc.system.query` return a descriptive error when the helper is not running

## Test plan
- `TestDaemonHelperHealthWhenUnavailable` — helper not running → `{helper: false}`, no RPC error
- `TestDaemonHelperPowermetricsRequiresHelper` — helper not running → RPC error
- `TestDaemonHelperTCCRequiresBundleID` — missing bundle_id → RPC error