### PR TITLE
feat(serve+store): persist snapshot processes and add snapshot.processes RPC

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -171,6 +171,7 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB) {
 				SkipJVMs:       true,
 			})
 			_ = db.SaveSnapshot(ctx, store.FromSnapshot(snap))
+			_ = db.SaveSnapshotProcesses(ctx, snap.ID, store.ProcessesFromSnapshot(snap))
 			_, _ = db.PruneSnapshots(ctx, 100)
 		}
 	}
@@ -214,6 +215,7 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err := db.SaveSnapshot(context.Background(), store.FromSnapshot(snap)); err != nil {
 			return nil, err
 		}
+		_ = db.SaveSnapshotProcesses(context.Background(), snap.ID, store.ProcessesFromSnapshot(snap))
 		return snap, nil
 	})
 
@@ -309,6 +311,14 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, fmt.Errorf("snapshot %q: %w", p.IDB, err)
 		}
 		return diff.Compare(*snapA, *snapB), nil
+	})
+
+	d.Register("snapshot.processes", func(params json.RawMessage) (any, error) {
+		var p struct{ ID string `json:"id"` }
+		if err := json.Unmarshal(params, &p); err != nil || p.ID == "" {
+			return nil, fmt.Errorf("snapshot.processes requires {\"id\":\"<snapshot-id>\"}")
+		}
+		return db.GetSnapshotProcesses(context.Background(), p.ID)
 	})
 
 	// snapshot.prune — delete live snapshots beyond retention limit.

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -517,3 +517,12 @@ func TestDaemonHelperTCCRequiresBundleID(t *testing.T) {
 		t.Error("expected error when bundle_id missing")
 	}
 }
+
+func TestDaemonSnapshotProcessesRequiresID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 57, "snapshot.processes", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when id missing")
+	}
+}

--- a/internal/store/convert.go
+++ b/internal/store/convert.go
@@ -43,6 +43,23 @@ func FromSnapshot(s snapshot.Snapshot) SnapshotInput {
 	}
 }
 
+// ProcessesFromSnapshot converts a snapshot's Processes into ProcessSnapshotRows
+// ready for SaveSnapshotProcesses.
+func ProcessesFromSnapshot(s snapshot.Snapshot) []ProcessSnapshotRow {
+	rows := make([]ProcessSnapshotRow, len(s.Processes))
+	for i, p := range s.Processes {
+		rows[i] = ProcessSnapshotRow{
+			PID:     p.PID,
+			PPID:    p.PPID,
+			Command: p.Command,
+			RSSKiB:  p.RSSKiB,
+			CPUPct:  p.CPUPct,
+			AppPath: p.AppPath,
+		}
+	}
+	return rows
+}
+
 func fromResult(r detect.Result) AppInput {
 	name := appName(r.Path)
 	return AppInput{

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/snapshot"
 )
 
 func openTestDB(t *testing.T) *DB {
@@ -490,5 +493,26 @@ func TestSaveSnapshotProcessesIdempotent(t *testing.T) {
 	// Second call must not error (INSERT OR IGNORE).
 	if err := db.SaveSnapshotProcesses(ctx, "proc-snap-2", procs); err != nil {
 		t.Errorf("second call: %v", err)
+	}
+}
+
+func TestProcessesFromSnapshot(t *testing.T) {
+	snap := snapshot.Snapshot{
+		ID: "test-snap",
+		Processes: []process.Info{
+			{PID: 1, PPID: 0, Command: "launchd", RSSKiB: 4096, CPUPct: 0.0},
+			{PID: 412, PPID: 1, Command: "Slack", RSSKiB: 184320, CPUPct: 1.2, AppPath: "/Applications/Slack.app"},
+		},
+	}
+	rows := ProcessesFromSnapshot(snap)
+	if len(rows) != 2 {
+		t.Fatalf("len = %d, want 2", len(rows))
+	}
+	found := map[int]bool{}
+	for _, r := range rows {
+		found[r.PID] = true
+	}
+	if !found[1] || !found[412] {
+		t.Errorf("pids = %v, want {1, 412}", found)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `ProcessesFromSnapshot` converter in `store/convert.go` to map `process.Info` → `ProcessSnapshotRow`
- `SaveSnapshotProcesses` is now called after `SaveSnapshot` in both the scheduled loop and `snapshot.create` RPC
- Adds `snapshot.processes` RPC handler: `{"id":"<snap-id>"}` → `[]ProcessSnapshotRow`

## Test plan
- `TestProcessesFromSnapshot` — verifies both PIDs are converted correctly
- `TestDaemonSnapshotProcessesRequiresID` — missing id → RPC error
- All existing tests remain green