### PR TITLE
feat(cmd): add top-level spectra diff subcommand

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -38,6 +38,7 @@ func subcommandList() []subcommand {
 		{"toolchain", "Show installed language runtimes and package managers", runToolchain},
 		{"network", "Show current network state (routes, DNS, VPN, proxy, listening ports)", runNetwork},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
+		{"diff", "Diff two stored snapshots (alias for snapshot diff)", runSnapshotDiff},
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},
 		{"issues", "List, check, or update persisted issues from the recommendations engine", runIssues},
 		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},


### PR DESCRIPTION
## Summary
- Adds `diff` to the top-level subcommand dispatch table as an alias for `snapshot diff`
- `spectra diff <id-a> <id-b>` now works without the `snapshot` prefix
- No new logic — delegates directly to `runSnapshotDiff`

## Test plan
- `go run ./cmd/spectra help` shows the diff subcommand
- Binary builds cleanly; all existing tests pass