### PR TITLE
feat(detect+inspect): add StartTime to ProcessInfo; show app uptime

### DIFF
--- a/cmd/spectra/inspect.go
+++ b/cmd/spectra/inspect.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
 )
@@ -257,11 +258,20 @@ func printMeta(r detect.Result) {
 	}
 	if len(r.RunningProcesses) > 0 {
 		var totalRSS int
+		var oldest time.Time
 		for _, p := range r.RunningProcesses {
 			totalRSS += p.RSSKiB
+			if !p.StartTime.IsZero() && (oldest.IsZero() || p.StartTime.Before(oldest)) {
+				oldest = p.StartTime
+			}
 		}
-		fmt.Printf("    running: %d processes, %s RSS\n",
-			len(r.RunningProcesses), humanSize(int64(totalRSS)*1024))
+		uptimeStr := ""
+		if !oldest.IsZero() {
+			d := time.Since(oldest).Round(time.Second)
+			uptimeStr = fmt.Sprintf(", uptime %s", formatDuration(d))
+		}
+		fmt.Printf("    running: %d processes, %s RSS%s\n",
+			len(r.RunningProcesses), humanSize(int64(totalRSS)*1024), uptimeStr)
 	}
 	if r.Storage != nil {
 		parts := []string{}
@@ -294,6 +304,19 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n-1] + "…"
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd%dh", int(d.Hours())/24, int(d.Hours())%24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
 }
 
 func humanSize(n int64) string {

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 )
 
 // Result is the diagnosis for one .app bundle.
@@ -111,9 +112,10 @@ type LoginItem struct {
 
 // ProcessInfo is one running process belonging to this bundle.
 type ProcessInfo struct {
-	PID     int
-	RSSKiB  int    // resident set size, kibibytes
-	Command string // executable path (truncated to bundle-relative)
+	PID       int
+	RSSKiB    int       // resident set size, kibibytes
+	Command   string    // executable path (truncated to bundle-relative)
+	StartTime time.Time // process start time (from ps lstart)
 }
 
 // Dependencies enumerates the third-party libraries an app embeds.
@@ -1279,10 +1281,18 @@ func home() string {
 	return h
 }
 
+// lstartLayout is the Go parse layout for the 5-token lstart output from ps.
+// e.g. "Sat May  2 22:37:01 2026"
+const lstartLayout = "Mon Jan  2 15:04:05 2006"
+
 // scanRunningProcesses uses `ps` to find processes whose executable path
-// lives inside this bundle. Reports PID, RSS, and a bundle-relative path.
+// lives inside this bundle. Reports PID, RSS, start time, and a bundle-relative path.
+//
+// ps format: pid=,rss=,lstart=,comm=
+// lstart produces 5 whitespace-separated tokens ("Sat May  2 22:37:01 2026")
+// so the command starts at fields[7] (0-indexed: 0=pid, 1=rss, 2-6=lstart, 7+=comm).
 func scanRunningProcesses(appPath string) []ProcessInfo {
-	out, err := exec.Command("ps", "-axwwo", "pid=,rss=,comm=").Output()
+	out, err := exec.Command("ps", "-axwwo", "pid=,rss=,lstart=,comm=").Output()
 	if err != nil {
 		return nil
 	}
@@ -1292,23 +1302,28 @@ func scanRunningProcesses(appPath string) []ProcessInfo {
 		if line == "" {
 			continue
 		}
-		// Format: "PID RSS COMMAND..."
 		fields := strings.Fields(line)
-		if len(fields) < 3 {
+		// minimum: pid(1) + rss(1) + lstart(5) + comm(1) = 8 fields
+		if len(fields) < 8 {
 			continue
 		}
-		// Reconstruct the command (which may contain spaces) by joining fields[2:].
-		cmd := strings.Join(fields[2:], " ")
+		// fields[2:7] are the 5 lstart tokens; fields[7:] are the command.
+		cmd := strings.Join(fields[7:], " ")
 		if !strings.HasPrefix(cmd, appPath+"/") {
 			continue
 		}
 		var pid, rss int
 		fmt.Sscanf(fields[0], "%d", &pid)
 		fmt.Sscanf(fields[1], "%d", &rss)
+
+		lstartStr := strings.Join(fields[2:7], " ")
+		startTime, _ := time.Parse(lstartLayout, lstartStr)
+
 		procs = append(procs, ProcessInfo{
-			PID:     pid,
-			RSSKiB:  rss,
-			Command: strings.TrimPrefix(cmd, appPath+"/"),
+			PID:       pid,
+			RSSKiB:    rss,
+			Command:   strings.TrimPrefix(cmd, appPath+"/"),
+			StartTime: startTime,
 		})
 	}
 	return procs

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // makeBundle creates a synthetic .app skeleton at t.TempDir()/Name.app
@@ -449,5 +450,27 @@ func TestParsePlistLaunchFlagsBothTrue(t *testing.T) {
 	}
 	if !keepAlive {
 		t.Error("KeepAlive: got false, want true")
+	}
+}
+
+func TestLstartLayoutParse(t *testing.T) {
+	samples := []struct {
+		raw      string
+		wantYear int
+	}{
+		{"Sat May  2 22:37:01 2026", 2026},
+		{"Mon Jan  1 00:00:00 2025", 2025},
+	}
+	for _, s := range samples {
+		raw := strings.Join(strings.Fields(s.raw), " ")
+		layout := strings.Join(strings.Fields(lstartLayout), " ")
+		parsed, err := time.Parse(layout, raw)
+		if err != nil {
+			t.Errorf("Parse(%q): %v", s.raw, err)
+			continue
+		}
+		if parsed.Year() != s.wantYear {
+			t.Errorf("Year = %d, want %d", parsed.Year(), s.wantYear)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `StartTime time.Time` to `detect.ProcessInfo` populated from ps `lstart=` (5-token format)
- `scanRunningProcesses` now uses `pid=,rss=,lstart=,comm=` format and parses lstart into `StartTime`
- `spectra inspect` output now shows app uptime from the oldest matching process (e.g. `uptime 2d3h`)
- Adds `formatDuration` helper for human-readable duration display

## Test plan
- `TestLstartLayoutParse` — verifies the `lstartLayout` constant correctly parses 2-space day-padding and year
- All existing detect and cmd tests remain green