### PR TITLE
feat(toolchain): detect build tools (Maven, Gradle, Bazel, CMake)

### DIFF
--- a/internal/toolchain/collect.go
+++ b/internal/toolchain/collect.go
@@ -90,6 +90,10 @@ func Collect(ctx context.Context, opts CollectOptions) Toolchains {
 			return func(t *Toolchains) { t.JVMManagers = managers }, nil
 		}),
 		run(func() (func(*Toolchains), error) {
+			buildTools := discoverBuildTools(opts)
+			return func(t *Toolchains) { t.BuildTools = buildTools }, nil
+		}),
+		run(func() (func(*Toolchains), error) {
 			snap := collectEnv()
 			return func(t *Toolchains) { t.Env = snap }, nil
 		}),

--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -3,6 +3,8 @@ package toolchain
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -264,4 +266,89 @@ func discoverJVMManagers(home string) []string {
 		}
 	}
 	return found
+}
+
+// discoverBuildTools finds installed Maven, Gradle, Bazel, Make, and CMake.
+// Uses brew cellar presence (fast, no forking) as primary detection;
+// falls back to version commands for tools not managed by brew.
+func discoverBuildTools(opts CollectOptions) []BuildTool {
+	var tools []BuildTool
+
+	add := func(name, version, source string) {
+		if version != "" {
+			tools = append(tools, BuildTool{Name: name, Version: version, Source: source})
+		}
+	}
+
+	// Maven — check brew cellar first, then mvn --version.
+	if v := brewVersion(opts.BrewCellars, "maven"); v != "" {
+		add("maven", v, "brew")
+	} else if v := versionFromCmd(opts.CmdRunner, "mvn", "--version"); v != "" {
+		add("maven", v, "system")
+	}
+
+	// Gradle — check brew cellar first, then gradle --version.
+	if v := brewVersion(opts.BrewCellars, "gradle"); v != "" {
+		add("gradle", v, "brew")
+	} else if v := versionFromCmd(opts.CmdRunner, "gradle", "--version"); v != "" {
+		add("gradle", v, "system")
+	}
+
+	// Bazel — check brew cellar first, then bazel version.
+	if v := brewVersion(opts.BrewCellars, "bazel"); v != "" {
+		add("bazel", v, "brew")
+	} else if v := brewVersion(opts.BrewCellars, "bazelbuild/tap/bazel"); v != "" {
+		add("bazel", v, "brew")
+	} else if v := versionFromCmd(opts.CmdRunner, "bazel", "version"); v != "" {
+		add("bazel", v, "system")
+	}
+
+	// CMake — check brew cellar first.
+	if v := brewVersion(opts.BrewCellars, "cmake"); v != "" {
+		add("cmake", v, "brew")
+	} else if v := versionFromCmd(opts.CmdRunner, "cmake", "--version"); v != "" {
+		add("cmake", v, "system")
+	}
+
+	return tools
+}
+
+// brewVersion returns the installed version of a formula by scanning
+// the Cellar directory (no subprocess). Returns "" if not installed.
+func brewVersion(cellars []string, formula string) string {
+	base := filepath.Base(formula)
+	for _, cellar := range cellars {
+		dir := filepath.Join(cellar, base)
+		entries, err := os.ReadDir(dir)
+		if err != nil || len(entries) == 0 {
+			continue
+		}
+		// Sort and return the last (highest) version directory.
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			if e.IsDir() {
+				names = append(names, e.Name())
+			}
+		}
+		if len(names) > 0 {
+			sort.Strings(names)
+			return names[len(names)-1]
+		}
+	}
+	return ""
+}
+
+// versionFromCmd runs cmd args and extracts the first version-like token.
+func versionFromCmd(run CmdRunner, cmd string, args ...string) string {
+	out, err := run(cmd, args...)
+	if err != nil {
+		return ""
+	}
+	// Look for first token matching "X.Y.Z" or similar.
+	re := regexp.MustCompile(`\d+\.\d+[\.\d]*`)
+	m := re.Find(out)
+	if m == nil {
+		return ""
+	}
+	return string(m)
 }

--- a/internal/toolchain/runtime_test.go
+++ b/internal/toolchain/runtime_test.go
@@ -1,6 +1,7 @@
 package toolchain
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -240,5 +241,67 @@ func TestDiscoverJVMManagersMultiple(t *testing.T) {
 	}
 	if !found["asdf"] || !found["jenv"] {
 		t.Errorf("expected asdf and jenv in %v", managers)
+	}
+}
+
+func TestDiscoverBuildToolsNone(t *testing.T) {
+	home := t.TempDir()
+	opts := CollectOptions{
+		Home:        home,
+		BrewCellars: []string{filepath.Join(home, "Cellar")},
+		CmdRunner: func(name string, args ...string) ([]byte, error) {
+			return nil, errors.New("not found")
+		},
+	}
+	tools := discoverBuildTools(opts)
+	if len(tools) != 0 {
+		t.Errorf("expected no tools, got %v", tools)
+	}
+}
+
+func TestDiscoverBuildToolsMavenFromBrew(t *testing.T) {
+	home := t.TempDir()
+	cellar := filepath.Join(home, "Cellar")
+	mavenDir := filepath.Join(cellar, "maven", "3.9.6")
+	if err := os.MkdirAll(mavenDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	opts := CollectOptions{
+		Home:        home,
+		BrewCellars: []string{cellar},
+		CmdRunner: func(name string, args ...string) ([]byte, error) {
+			return nil, errors.New("not found")
+		},
+	}
+	tools := discoverBuildTools(opts)
+	if len(tools) != 1 || tools[0].Name != "maven" {
+		t.Errorf("expected [maven], got %v", tools)
+	}
+	if tools[0].Version != "3.9.6" {
+		t.Errorf("version = %q, want 3.9.6", tools[0].Version)
+	}
+	if tools[0].Source != "brew" {
+		t.Errorf("source = %q, want brew", tools[0].Source)
+	}
+}
+
+func TestDiscoverBuildToolsGradleFromCmd(t *testing.T) {
+	home := t.TempDir()
+	opts := CollectOptions{
+		Home:        home,
+		BrewCellars: []string{filepath.Join(home, "Cellar")},
+		CmdRunner: func(name string, args ...string) ([]byte, error) {
+			if name == "gradle" {
+				return []byte("Gradle 8.5\n..."), nil
+			}
+			return nil, errors.New("not found")
+		},
+	}
+	tools := discoverBuildTools(opts)
+	if len(tools) != 1 || tools[0].Name != "gradle" {
+		t.Errorf("expected [gradle], got %v", tools)
+	}
+	if tools[0].Version != "8.5" {
+		t.Errorf("version = %q, want 8.5", tools[0].Version)
 	}
 }

--- a/internal/toolchain/types.go
+++ b/internal/toolchain/types.go
@@ -13,7 +13,15 @@ type Toolchains struct {
 	Ruby        []RuntimeInstall `json:"ruby,omitempty"`
 	Rust        []RustToolchain  `json:"rust,omitempty"`
 	JVMManagers []string         `json:"jvm_managers,omitempty"` // "sdkman", "asdf", "mise", "jenv"
+	BuildTools  []BuildTool      `json:"build_tools,omitempty"`
 	Env         EnvSnapshot      `json:"env"`
+}
+
+// BuildTool is one JVM-ecosystem build tool installation (Maven, Gradle, Bazel, Make, CMake).
+type BuildTool struct {
+	Name    string `json:"name"`    // "maven", "gradle", "bazel", "make", "cmake"
+	Version string `json:"version"` // raw version string
+	Source  string `json:"source"`  // "brew", "system", "wrapper"
 }
 
 // BrewInventory holds installed Homebrew formulae, casks, and taps.


### PR DESCRIPTION
## Summary
- Adds `BuildTool{Name, Version, Source}` struct and `BuildTools []BuildTool` to `Toolchains`
- `discoverBuildTools` probes brew cellar directories first (no subprocess), then falls back to `--version` commands
- Detects: maven, gradle, bazel, cmake
- Wired into `Collect` as a parallel task

## Test plan
- `TestDiscoverBuildToolsNone` — no brew cellar, failing cmd runner → empty
- `TestDiscoverBuildToolsMavenFromBrew` — cellar dir with version subdir → maven 3.9.6 from brew
- `TestDiscoverBuildToolsGradleFromCmd` — no cellar, gradle --version output → gradle 8.5 from system