### PR TITLE
feat(store): add login_items and granted_perms tables

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -172,6 +172,8 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB) {
 			})
 			_ = db.SaveSnapshot(ctx, store.FromSnapshot(snap))
 			_ = db.SaveSnapshotProcesses(ctx, snap.ID, store.ProcessesFromSnapshot(snap))
+			_ = db.SaveLoginItems(ctx, snap.ID, store.LoginItemsFromSnapshot(snap))
+			_ = db.SaveGrantedPerms(ctx, snap.ID, store.GrantedPermsFromSnapshot(snap))
 			_, _ = db.PruneSnapshots(ctx, 100)
 		}
 	}
@@ -216,6 +218,8 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, err
 		}
 		_ = db.SaveSnapshotProcesses(context.Background(), snap.ID, store.ProcessesFromSnapshot(snap))
+		_ = db.SaveLoginItems(context.Background(), snap.ID, store.LoginItemsFromSnapshot(snap))
+		_ = db.SaveGrantedPerms(context.Background(), snap.ID, store.GrantedPermsFromSnapshot(snap))
 		return snap, nil
 	})
 
@@ -319,6 +323,22 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, fmt.Errorf("snapshot.processes requires {\"id\":\"<snapshot-id>\"}")
 		}
 		return db.GetSnapshotProcesses(context.Background(), p.ID)
+	})
+
+	d.Register("snapshot.login_items", func(params json.RawMessage) (any, error) {
+		var p struct{ ID string `json:"id"` }
+		if err := json.Unmarshal(params, &p); err != nil || p.ID == "" {
+			return nil, fmt.Errorf("snapshot.login_items requires {\"id\":\"<snapshot-id>\"}")
+		}
+		return db.GetLoginItems(context.Background(), p.ID)
+	})
+
+	d.Register("snapshot.granted_perms", func(params json.RawMessage) (any, error) {
+		var p struct{ ID string `json:"id"` }
+		if err := json.Unmarshal(params, &p); err != nil || p.ID == "" {
+			return nil, fmt.Errorf("snapshot.granted_perms requires {\"id\":\"<snapshot-id>\"}")
+		}
+		return db.GetGrantedPerms(context.Background(), p.ID)
 	})
 
 	// snapshot.prune — delete live snapshots beyond retention limit.

--- a/internal/store/convert.go
+++ b/internal/store/convert.go
@@ -60,6 +60,41 @@ func ProcessesFromSnapshot(s snapshot.Snapshot) []ProcessSnapshotRow {
 	return rows
 }
 
+// LoginItemsFromSnapshot converts a snapshot's per-app LoginItems into
+// LoginItemRows ready for SaveLoginItems.
+func LoginItemsFromSnapshot(s snapshot.Snapshot) []LoginItemRow {
+	var rows []LoginItemRow
+	for _, r := range s.Apps {
+		for _, li := range r.LoginItems {
+			rows = append(rows, LoginItemRow{
+				BundleID:  r.BundleID,
+				PlistPath: li.Path,
+				Label:     li.Label,
+				Scope:     li.Scope,
+				Daemon:    li.Daemon,
+				RunAtLoad: li.RunAtLoad,
+				KeepAlive: li.KeepAlive,
+			})
+		}
+	}
+	return rows
+}
+
+// GrantedPermsFromSnapshot converts a snapshot's per-app GrantedPermissions
+// into GrantedPermRows ready for SaveGrantedPerms.
+func GrantedPermsFromSnapshot(s snapshot.Snapshot) []GrantedPermRow {
+	var rows []GrantedPermRow
+	for _, r := range s.Apps {
+		for _, svc := range r.GrantedPermissions {
+			rows = append(rows, GrantedPermRow{
+				BundleID: r.BundleID,
+				Service:  svc,
+			})
+		}
+	}
+	return rows
+}
+
 func fromResult(r detect.Result) AppInput {
 	name := appName(r.Path)
 	return AppInput{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -148,6 +148,33 @@ CREATE TABLE IF NOT EXISTS snapshot_processes (
 CREATE INDEX IF NOT EXISTS idx_snapshot_processes_snap ON snapshot_processes(snapshot_id);
 CREATE INDEX IF NOT EXISTS idx_snapshot_processes_app  ON snapshot_processes(app_path) WHERE app_path != '';
 
+CREATE TABLE IF NOT EXISTS login_items (
+    snapshot_id  TEXT NOT NULL,
+    bundle_id    TEXT NOT NULL DEFAULT '',
+    plist_path   TEXT NOT NULL,
+    label        TEXT NOT NULL DEFAULT '',
+    scope        TEXT NOT NULL DEFAULT '',
+    daemon       INTEGER NOT NULL DEFAULT 0,
+    run_at_load  INTEGER NOT NULL DEFAULT 0,
+    keep_alive   INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (snapshot_id, plist_path),
+    FOREIGN KEY (snapshot_id) REFERENCES snapshots(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_login_items_snap   ON login_items(snapshot_id);
+CREATE INDEX IF NOT EXISTS idx_login_items_bundle ON login_items(bundle_id) WHERE bundle_id != '';
+
+CREATE TABLE IF NOT EXISTS granted_perms (
+    snapshot_id  TEXT NOT NULL,
+    bundle_id    TEXT NOT NULL,
+    service      TEXT NOT NULL,
+    PRIMARY KEY (snapshot_id, bundle_id, service),
+    FOREIGN KEY (snapshot_id) REFERENCES snapshots(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_granted_perms_snap   ON granted_perms(snapshot_id);
+CREATE INDEX IF NOT EXISTS idx_granted_perms_bundle ON granted_perms(bundle_id);
+
 CREATE TABLE IF NOT EXISTS process_metrics (
     pid          INTEGER NOT NULL,
     minute_at    DATETIME NOT NULL,
@@ -435,6 +462,129 @@ func (s *DB) GetSnapshotProcesses(ctx context.Context, snapID string) ([]Process
 	return out, rows.Err()
 }
 
+// LoginItemRow is one row from login_items.
+type LoginItemRow struct {
+	SnapshotID string
+	BundleID   string
+	PlistPath  string
+	Label      string
+	Scope      string
+	Daemon     bool
+	RunAtLoad  bool
+	KeepAlive  bool
+}
+
+// SaveLoginItems inserts login item rows for snapID. Uses INSERT OR IGNORE.
+func (s *DB) SaveLoginItems(ctx context.Context, snapID string, items []LoginItemRow) error {
+	if len(items) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	for _, it := range items {
+		_, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO login_items
+			  (snapshot_id, bundle_id, plist_path, label, scope, daemon, run_at_load, keep_alive)
+			VALUES (?,?,?,?,?,?,?,?)`,
+			snapID, it.BundleID, it.PlistPath, it.Label, it.Scope,
+			boolInt(it.Daemon), boolInt(it.RunAtLoad), boolInt(it.KeepAlive),
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetLoginItems returns all login item rows for snapID.
+func (s *DB) GetLoginItems(ctx context.Context, snapID string) ([]LoginItemRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT bundle_id, plist_path, label, scope, daemon, run_at_load, keep_alive
+		 FROM login_items WHERE snapshot_id=? ORDER BY plist_path`, snapID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []LoginItemRow
+	for rows.Next() {
+		var r LoginItemRow
+		var daemon, runAtLoad, keepAlive int
+		if err := rows.Scan(&r.BundleID, &r.PlistPath, &r.Label, &r.Scope,
+			&daemon, &runAtLoad, &keepAlive); err != nil {
+			return nil, err
+		}
+		r.SnapshotID = snapID
+		r.Daemon = daemon != 0
+		r.RunAtLoad = runAtLoad != 0
+		r.KeepAlive = keepAlive != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// GrantedPermRow is one row from granted_perms.
+type GrantedPermRow struct {
+	SnapshotID string
+	BundleID   string
+	Service    string
+}
+
+// SaveGrantedPerms inserts TCC permission rows for snapID. Uses INSERT OR IGNORE.
+func (s *DB) SaveGrantedPerms(ctx context.Context, snapID string, perms []GrantedPermRow) error {
+	if len(perms) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	for _, p := range perms {
+		_, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO granted_perms (snapshot_id, bundle_id, service)
+			VALUES (?,?,?)`,
+			snapID, p.BundleID, p.Service,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetGrantedPerms returns all TCC permission rows for snapID.
+func (s *DB) GetGrantedPerms(ctx context.Context, snapID string) ([]GrantedPermRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT bundle_id, service FROM granted_perms
+		 WHERE snapshot_id=? ORDER BY bundle_id, service`, snapID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []GrantedPermRow
+	for rows.Next() {
+		var r GrantedPermRow
+		if err := rows.Scan(&r.BundleID, &r.Service); err != nil {
+			return nil, err
+		}
+		r.SnapshotID = snapID
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func boolInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 // SaveProcessMetrics persists a batch of 1-minute aggregates from the ring
 // buffer. Uses INSERT OR IGNORE so duplicate (pid, minute_at) rows are skipped.
 func (s *DB) SaveProcessMetrics(ctx context.Context, aggs []ProcessMetricRow) error {
@@ -558,35 +708,15 @@ func (s *DB) PruneSnapshots(ctx context.Context, keepN int) (int64, error) {
 
 	var total int64
 	for _, m := range machines {
-		// Delete snapshot_processes for the to-be-pruned snapshots first (FK constraint).
-		if _, err := s.db.ExecContext(ctx, `
-			DELETE FROM snapshot_processes
-			WHERE snapshot_id IN (
-			  SELECT id FROM snapshots
-			  WHERE kind='live' AND machine_uuid=?
-			    AND id NOT IN (
-			      SELECT id FROM snapshots
-			      WHERE kind='live' AND machine_uuid=?
-			      ORDER BY taken_at DESC
-			      LIMIT ?
-			    )
-			)`, m, m, keepN); err != nil {
-			return total, fmt.Errorf("store: prune processes %s: %w", m, err)
-		}
-		// Delete snapshot_apps for the to-be-pruned snapshots first (FK constraint).
-		if _, err := s.db.ExecContext(ctx, `
-			DELETE FROM snapshot_apps
-			WHERE snapshot_id IN (
-			  SELECT id FROM snapshots
-			  WHERE kind='live' AND machine_uuid=?
-			    AND id NOT IN (
-			      SELECT id FROM snapshots
-			      WHERE kind='live' AND machine_uuid=?
-			      ORDER BY taken_at DESC
-			      LIMIT ?
-			    )
-			)`, m, m, keepN); err != nil {
-			return total, fmt.Errorf("store: prune apps %s: %w", m, err)
+		// Delete child rows for to-be-pruned snapshots first (FK constraints).
+		pruneSubquery := `SELECT id FROM snapshots WHERE kind='live' AND machine_uuid=?
+			AND id NOT IN (SELECT id FROM snapshots WHERE kind='live' AND machine_uuid=? ORDER BY taken_at DESC LIMIT ?)`
+		for _, table := range []string{"snapshot_processes", "login_items", "granted_perms", "snapshot_apps"} {
+			if _, err := s.db.ExecContext(ctx,
+				`DELETE FROM `+table+` WHERE snapshot_id IN (`+pruneSubquery+`)`,
+				m, m, keepN); err != nil {
+				return total, fmt.Errorf("store: prune %s %s: %w", table, m, err)
+			}
 		}
 		res, err := s.db.ExecContext(ctx, `
 			DELETE FROM snapshots

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/snapshot"
 )
@@ -514,5 +515,147 @@ func TestProcessesFromSnapshot(t *testing.T) {
 	}
 	if !found[1] || !found[412] {
 		t.Errorf("pids = %v, want {1, 412}", found)
+	}
+}
+
+func TestSaveAndGetLoginItems(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	snap := sampleInput(); snap.ID = "snap-li-1"
+	if err := db.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+
+	items := []LoginItemRow{
+		{BundleID: "com.example.app", PlistPath: "/Library/LaunchAgents/com.example.app.plist",
+			Label: "com.example.app", Scope: "user", RunAtLoad: true},
+		{BundleID: "com.example.app", PlistPath: "/Library/LaunchDaemons/com.example.daemon.plist",
+			Label: "com.example.daemon", Scope: "system", Daemon: true, KeepAlive: true},
+	}
+	if err := db.SaveLoginItems(ctx, snap.ID, items); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := db.GetLoginItems(ctx, snap.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	byPath := map[string]LoginItemRow{}
+	for _, r := range got {
+		byPath[r.PlistPath] = r
+	}
+	agent := byPath["/Library/LaunchAgents/com.example.app.plist"]
+	if !agent.RunAtLoad {
+		t.Error("RunAtLoad should be true for agent")
+	}
+	daemon := byPath["/Library/LaunchDaemons/com.example.daemon.plist"]
+	if !daemon.Daemon || !daemon.KeepAlive {
+		t.Error("Daemon and KeepAlive should be true for daemon row")
+	}
+}
+
+func TestSaveLoginItemsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	snap := sampleInput(); snap.ID = "snap-li-2"
+	if err := db.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+
+	items := []LoginItemRow{
+		{BundleID: "com.test", PlistPath: "/Library/LaunchAgents/com.test.plist", Label: "com.test"},
+	}
+	if err := db.SaveLoginItems(ctx, snap.ID, items); err != nil {
+		t.Fatal(err)
+	}
+	// second call should be a no-op
+	if err := db.SaveLoginItems(ctx, snap.ID, items); err != nil {
+		t.Fatalf("second SaveLoginItems: %v", err)
+	}
+	got, err := db.GetLoginItems(ctx, snap.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len = %d, want 1", len(got))
+	}
+}
+
+func TestSaveAndGetGrantedPerms(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	snap := sampleInput(); snap.ID = "snap-gp-1"
+	if err := db.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+
+	perms := []GrantedPermRow{
+		{BundleID: "com.slack.slack", Service: "kTCCServiceMicrophone"},
+		{BundleID: "com.slack.slack", Service: "kTCCServiceCamera"},
+		{BundleID: "com.zoom.xos", Service: "kTCCServiceMicrophone"},
+	}
+	if err := db.SaveGrantedPerms(ctx, snap.ID, perms); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := db.GetGrantedPerms(ctx, snap.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	slackSvcs := map[string]bool{}
+	for _, r := range got {
+		if r.BundleID == "com.slack.slack" {
+			slackSvcs[r.Service] = true
+		}
+	}
+	if !slackSvcs["kTCCServiceMicrophone"] || !slackSvcs["kTCCServiceCamera"] {
+		t.Errorf("missing expected services for slack: %v", slackSvcs)
+	}
+}
+
+func TestLoginItemsFromSnapshot(t *testing.T) {
+	snap := snapshot.Snapshot{
+		ID: "snap-conv",
+		Apps: []detect.Result{
+			{
+				BundleID: "com.example.app",
+				LoginItems: []detect.LoginItem{
+					{Path: "/Library/LaunchAgents/com.example.plist", Label: "com.example", Scope: "user", RunAtLoad: true},
+				},
+			},
+		},
+	}
+	rows := LoginItemsFromSnapshot(snap)
+	if len(rows) != 1 {
+		t.Fatalf("len = %d, want 1", len(rows))
+	}
+	if rows[0].BundleID != "com.example.app" {
+		t.Errorf("BundleID = %q", rows[0].BundleID)
+	}
+	if !rows[0].RunAtLoad {
+		t.Error("RunAtLoad should be true")
+	}
+}
+
+func TestGrantedPermsFromSnapshot(t *testing.T) {
+	snap := snapshot.Snapshot{
+		ID: "snap-gp-conv",
+		Apps: []detect.Result{
+			{BundleID: "com.slack.slack", GrantedPermissions: []string{"kTCCServiceMicrophone", "kTCCServiceCamera"}},
+			{BundleID: "com.zoom.xos", GrantedPermissions: []string{"kTCCServiceMicrophone"}},
+		},
+	}
+	rows := GrantedPermsFromSnapshot(snap)
+	if len(rows) != 3 {
+		t.Fatalf("len = %d, want 3", len(rows))
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `login_items` and `granted_perms` SQLite tables per the storage design doc
- Persists LaunchAgent/Daemon plists and TCC privacy permissions for each snapshot
- Wires save calls into the periodic collector and `snapshot.create` RPC path
- Adds `snapshot.login_items` and `snapshot.granted_perms` RPC query methods
- Unifies `PruneSnapshots` child-table cleanup into a single loop

## Test plan
- [ ] `TestSaveAndGetLoginItems` — round-trip with bool fields
- [ ] `TestSaveLoginItemsIdempotent` — second save is a no-op
- [ ] `TestSaveAndGetGrantedPerms` — multiple services per bundle
- [ ] `TestLoginItemsFromSnapshot` / `TestGrantedPermsFromSnapshot` — converters
- [ ] `go test ./...` passes