### PR TITLE
feat(rules): add brew-deprecated-formula and brew-stale-pinned rules

### DIFF
--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -23,6 +23,8 @@ func V1Catalog() []Rule {
 		ruleAppNoHardenedRuntime(),
 		ruleAppUnsigned(),
 		ruleLoginItemDangling(),
+		ruleBrewDeprecatedFormula(),
+		ruleBrewStalePinned(),
 		rulePermissionMismatch(),
 		ruleSparseFileInflation(),
 		ruleGatekeeperRejected(),
@@ -461,6 +463,56 @@ func ruleGatekeeperRejected() Rule {
 					Subject:  appDisplayName(app.Path),
 					Message:  fmt.Sprintf("%s is rejected by Gatekeeper — it would be blocked from running on an unmodified macOS system.", appDisplayName(app.Path)),
 					Fix:      "Re-sign and notarize the app with a valid Apple Developer ID certificate, or remove it if it is no longer needed.",
+				})
+			}
+			return findings
+		},
+	}
+}
+
+// ruleBrewDeprecatedFormula fires for each Homebrew formula that is marked
+// deprecated by its tap maintainer.
+func ruleBrewDeprecatedFormula() Rule {
+	return Rule{
+		ID:       "brew-deprecated-formula",
+		Severity: SeverityLow,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, f := range s.Toolchains.Brew.Formulae {
+				if !f.Deprecated {
+					continue
+				}
+				findings = append(findings, Finding{
+					RuleID:   "brew-deprecated-formula",
+					Severity: SeverityLow,
+					Subject:  f.Name,
+					Message:  fmt.Sprintf("Homebrew formula %q is deprecated — the tap maintainer has marked it for removal.", f.Name),
+					Fix:      fmt.Sprintf("Run `brew info %s` to see the recommended replacement, then uninstall this formula.", f.Name),
+				})
+			}
+			return findings
+		},
+	}
+}
+
+// ruleBrewStalePinned fires for each Homebrew formula that is pinned,
+// which prevents security and bug-fix updates from being applied.
+func ruleBrewStalePinned() Rule {
+	return Rule{
+		ID:       "brew-stale-pinned",
+		Severity: SeverityLow,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, f := range s.Toolchains.Brew.Formulae {
+				if !f.Pinned {
+					continue
+				}
+				findings = append(findings, Finding{
+					RuleID:   "brew-stale-pinned",
+					Severity: SeverityLow,
+					Subject:  f.Name,
+					Message:  fmt.Sprintf("Homebrew formula %q is pinned at version %s — security and bug-fix updates will not be applied.", f.Name, f.Version),
+					Fix:      fmt.Sprintf("Run `brew unpin %s` to allow updates, or verify the pin is still intentional.", f.Name),
 				})
 			}
 			return findings

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -507,3 +507,86 @@ func TestGatekeeperRejectedNoFireUnknown(t *testing.T) {
 		t.Errorf("expected 0 findings for unknown status, got %d", len(findings))
 	}
 }
+
+func TestBrewDeprecatedFormulaFires(t *testing.T) {
+	s := baseSnap()
+	s.Toolchains.Brew.Formulae = []toolchain.BrewFormula{
+		{Name: "wget", Version: "1.21.4", Deprecated: false},
+		{Name: "ossp-uuid", Version: "1.6.2", Deprecated: true},
+	}
+	findings := ruleBrewDeprecatedFormula().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "brew-deprecated-formula" {
+		t.Errorf("rule ID = %q", findings[0].RuleID)
+	}
+	if findings[0].Subject != "ossp-uuid" {
+		t.Errorf("subject = %q, want ossp-uuid", findings[0].Subject)
+	}
+}
+
+func TestBrewDeprecatedFormulaNoFire(t *testing.T) {
+	s := baseSnap()
+	s.Toolchains.Brew.Formulae = []toolchain.BrewFormula{
+		{Name: "git", Version: "2.44.0", Deprecated: false},
+	}
+	findings := ruleBrewDeprecatedFormula().MatchFn(s)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+func TestBrewStalePinnedFires(t *testing.T) {
+	s := baseSnap()
+	s.Toolchains.Brew.Formulae = []toolchain.BrewFormula{
+		{Name: "node@18", Version: "18.20.4", Pinned: true},
+		{Name: "python@3.12", Version: "3.12.3", Pinned: false},
+	}
+	findings := ruleBrewStalePinned().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "brew-stale-pinned" {
+		t.Errorf("rule ID = %q", findings[0].RuleID)
+	}
+	if findings[0].Subject != "node@18" {
+		t.Errorf("subject = %q, want node@18", findings[0].Subject)
+	}
+}
+
+func TestBrewStalePinnedNoFire(t *testing.T) {
+	s := baseSnap()
+	s.Toolchains.Brew.Formulae = []toolchain.BrewFormula{
+		{Name: "wget", Version: "1.21.4", Pinned: false},
+	}
+	findings := ruleBrewStalePinned().MatchFn(s)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+func TestBrewStalePinnedMultiple(t *testing.T) {
+	s := baseSnap()
+	s.Toolchains.Brew.Formulae = []toolchain.BrewFormula{
+		{Name: "node@18", Version: "18.20.4", Pinned: true},
+		{Name: "maven", Version: "3.9.6", Pinned: true},
+	}
+	findings := ruleBrewStalePinned().MatchFn(s)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+}
+
+func TestV1CatalogContainsBrewRules(t *testing.T) {
+	catalog := V1Catalog()
+	ruleIDs := make(map[string]bool)
+	for _, r := range catalog {
+		ruleIDs[r.ID] = true
+	}
+	for _, want := range []string{"brew-deprecated-formula", "brew-stale-pinned"} {
+		if !ruleIDs[want] {
+			t.Errorf("V1Catalog missing rule %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds two low-severity rules surfacing Homebrew formula state that was already collected but not evaluated
- `brew-deprecated-formula`: fires when a formula is marked deprecated by its tap maintainer
- `brew-stale-pinned`: fires for each pinned formula (prevents security/bugfix updates)

## Test plan
- [ ] `TestBrewDeprecatedFormulaFires` / `TestBrewDeprecatedFormulaNoFire`
- [ ] `TestBrewStalePinnedFires` / `TestBrewStalePinnedNoFire` / `TestBrewStalePinnedMultiple`
- [ ] `TestV1CatalogContainsBrewRules` — catalog membership check
- [ ] `go test ./...` passes