### PR TITLE
feat(rules): add path-shadows-active-runtime rule

### DIFF
--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -25,6 +25,7 @@ func V1Catalog() []Rule {
 		ruleLoginItemDangling(),
 		ruleBrewDeprecatedFormula(),
 		ruleBrewStalePinned(),
+		rulePathShadowsActiveRuntime(),
 		rulePermissionMismatch(),
 		ruleSparseFileInflation(),
 		ruleGatekeeperRejected(),
@@ -464,6 +465,62 @@ func ruleGatekeeperRejected() Rule {
 					Message:  fmt.Sprintf("%s is rejected by Gatekeeper — it would be blocked from running on an unmodified macOS system.", appDisplayName(app.Path)),
 					Fix:      "Re-sign and notarize the app with a valid Apple Developer ID certificate, or remove it if it is no longer needed.",
 				})
+			}
+			return findings
+		},
+	}
+}
+
+// rulePathShadowsActiveRuntime fires when a language-manager install (nvm,
+// pyenv, rbenv, goenv, asdf, mise) is present but the active binary for that
+// language resolves to a system or brew install instead — indicating that
+// PATH is not configured to use the version manager.
+func rulePathShadowsActiveRuntime() Rule {
+	return Rule{
+		ID:       "path-shadows-active-runtime",
+		Severity: SeverityLow,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			tc := s.Toolchains
+			groups := []struct {
+				lang     string
+				runtimes []toolchain.RuntimeInstall
+			}{
+				{"node", tc.Node},
+				{"python", tc.Python},
+				{"go", tc.Go},
+				{"ruby", tc.Ruby},
+			}
+			managerSources := map[string]bool{
+				"nvm": true, "fnm": true, "volta": true,
+				"pyenv": true, "uv": true,
+				"goenv": true,
+				"rbenv": true,
+				"asdf": true, "mise": true,
+			}
+			var findings []Finding
+			for _, g := range groups {
+				if len(g.runtimes) == 0 {
+					continue
+				}
+				hasManager := false
+				activeSource := ""
+				for _, r := range g.runtimes {
+					if managerSources[r.Source] {
+						hasManager = true
+					}
+					if r.Active {
+						activeSource = r.Source
+					}
+				}
+				if hasManager && (activeSource == "system" || activeSource == "brew") {
+					findings = append(findings, Finding{
+						RuleID:   "path-shadows-active-runtime",
+						Severity: SeverityLow,
+						Subject:  g.lang,
+						Message:  fmt.Sprintf("A version manager is installed for %s but the active binary resolves to a %s install — PATH is not configured to use the version manager.", g.lang, activeSource),
+						Fix:      fmt.Sprintf("Add the version manager's shim directory to the front of $PATH in your shell profile, or use `%s` to manage the active version.", activeSource),
+					})
+				}
 			}
 			return findings
 		},

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -590,3 +590,71 @@ func TestV1CatalogContainsBrewRules(t *testing.T) {
 		}
 	}
 }
+
+func TestPathShadowsActiveRuntimeFires(t *testing.T) {
+	s := baseSnap()
+	// nvm is installed but system node is active
+	s.Toolchains.Node = []toolchain.RuntimeInstall{
+		{Version: "v18.20.4", Source: "nvm", Path: "/home/user/.nvm/versions/node/v18.20.4/bin/node", Active: false},
+		{Version: "system", Source: "system", Path: "/usr/bin/node", Active: true},
+	}
+	findings := rulePathShadowsActiveRuntime().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "path-shadows-active-runtime" {
+		t.Errorf("rule ID = %q", findings[0].RuleID)
+	}
+	if findings[0].Subject != "node" {
+		t.Errorf("subject = %q, want node", findings[0].Subject)
+	}
+}
+
+func TestPathShadowsActiveRuntimeNoFireManagerActive(t *testing.T) {
+	s := baseSnap()
+	// nvm is installed AND nvm-managed version is active — no finding
+	s.Toolchains.Node = []toolchain.RuntimeInstall{
+		{Version: "v18.20.4", Source: "nvm", Path: "/home/user/.nvm/versions/node/v18.20.4/bin/node", Active: true},
+		{Version: "system", Source: "system", Path: "/usr/bin/node", Active: false},
+	}
+	findings := rulePathShadowsActiveRuntime().MatchFn(s)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+func TestPathShadowsActiveRuntimeNoFireOnlySystem(t *testing.T) {
+	s := baseSnap()
+	// only system install, no manager — not a problem
+	s.Toolchains.Node = []toolchain.RuntimeInstall{
+		{Version: "system", Source: "system", Path: "/usr/bin/node", Active: true},
+	}
+	findings := rulePathShadowsActiveRuntime().MatchFn(s)
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+func TestPathShadowsActiveRuntimeMultipleLanguages(t *testing.T) {
+	s := baseSnap()
+	// pyenv installed but brew python active; goenv installed but brew go active
+	s.Toolchains.Python = []toolchain.RuntimeInstall{
+		{Version: "3.12.3", Source: "pyenv", Active: false},
+		{Version: "system", Source: "brew", Active: true},
+	}
+	s.Toolchains.Go = []toolchain.RuntimeInstall{
+		{Version: "1.22.3", Source: "goenv", Active: false},
+		{Version: "system", Source: "brew", Active: true},
+	}
+	findings := rulePathShadowsActiveRuntime().MatchFn(s)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(findings))
+	}
+	langs := map[string]bool{}
+	for _, f := range findings {
+		langs[f.Subject] = true
+	}
+	if !langs["python"] || !langs["go"] {
+		t.Errorf("expected python and go in findings: %v", langs)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds low-severity rule `path-shadows-active-runtime` that fires when a version manager (nvm, pyenv, rbenv, goenv, asdf, mise, fnm, volta, uv) is installed but the active binary resolves to system/brew instead
- Covers node, python, go, and ruby runtimes
- Detects the common PATH misconfiguration where the manager's shim directory is missing from the front of PATH

## Test plan
- [ ] `TestPathShadowsActiveRuntimeFires` — nvm present, system node active
- [ ] `TestPathShadowsActiveRuntimeNoFireManagerActive` — nvm present and active → no finding
- [ ] `TestPathShadowsActiveRuntimeNoFireOnlySystem` — only system install → no finding
- [ ] `TestPathShadowsActiveRuntimeMultipleLanguages` — fires for both python and go
- [ ] `go test ./...` passes