### PR TITLE
feat(cmd): enrich snapshot show with host info and by-ui breakdown

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -216,6 +216,22 @@ func runSnapshotShow(args []string) int {
 		return 1
 	}
 
+	// Try to use the full snapshot JSON for a rich display.
+	if snapJSON, err := db.GetSnapshotJSON(ctx, id); err == nil && len(snapJSON) > 0 {
+		var snap snapshot.Snapshot
+		if err := json.Unmarshal(snapJSON, &snap); err == nil {
+			if *asJSON {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(snap)
+				return 0
+			}
+			printSnapshot(snap)
+			return 0
+		}
+	}
+
+	// Fallback: snapshot JSON not available — use the lightweight row + apps.
 	apps, err := db.GetSnapshotApps(ctx, id)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
## Summary
- `spectra snapshot show <id>` now uses the stored `snapshot_json` blob to call `printSnapshot()`, showing host info (os, cpu, ram, uptime), apps count, and by-ui breakdown
- Matches the CLI reference doc output
- Falls back to the lightweight row+apps table for older rows saved without a JSON blob

## Test plan
- [ ] Build passes
- [ ] `go test ./...` passes
- [ ] `spectra snapshot show <id>` now outputs host section and by-ui breakdown