### PR TITLE
feat(cmd): show established connections count in spectra network output

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -95,6 +95,10 @@ func printNetworkState(s netstate.State) {
 		fmt.Printf("default route: %s via %s\n", s.DefaultRouteIface, s.DefaultRouteGW)
 	}
 
+	if s.EstablishedConnectionsCount > 0 {
+		fmt.Printf("connections:   %d established\n", s.EstablishedConnectionsCount)
+	}
+
 	if s.VPNActive {
 		fmt.Printf("vpn:           active (%s)\n", strings.Join(s.VPNInterfaces, ", "))
 	} else {


### PR DESCRIPTION
Adds established TCP/UDP connection count to the human-readable `spectra network` output. The count was already collected but not shown.