### PR TITLE
feat(serve): add toolchain.brew and toolchain.runtimes RPC methods

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -589,6 +589,24 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		return toolchain.Collect(context.Background(), toolchain.CollectOptions{}), nil
 	})
 
+	// toolchain.brew — Homebrew formulae, casks, and taps.
+	d.Register("toolchain.brew", func(_ json.RawMessage) (any, error) {
+		tc := toolchain.Collect(context.Background(), toolchain.CollectOptions{})
+		return tc.Brew, nil
+	})
+
+	// toolchain.runtimes — language runtime installs (Node, Python, Go, Ruby, Rust).
+	d.Register("toolchain.runtimes", func(_ json.RawMessage) (any, error) {
+		tc := toolchain.Collect(context.Background(), toolchain.CollectOptions{})
+		return map[string]any{
+			"node":   tc.Node,
+			"python": tc.Python,
+			"go":     tc.Go,
+			"ruby":   tc.Ruby,
+			"rust":   tc.Rust,
+		}, nil
+	})
+
 	// network.state — current network configuration snapshot.
 	d.Register("network.state", func(_ json.RawMessage) (any, error) {
 		return netstate.Collect(netstate.DefaultRunner), nil

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -526,3 +526,40 @@ func TestDaemonSnapshotProcessesRequiresID(t *testing.T) {
 		t.Error("expected error when id missing")
 	}
 }
+
+func TestDaemonToolchainBrewReturnsObject(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 58, "toolchain.brew", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("toolchain.brew: %v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	// Should have formulae, casks, taps keys (even if empty slices / nil).
+	for _, key := range []string{"formulae", "casks", "taps"} {
+		if _, exists := m[key]; !exists {
+			t.Errorf("toolchain.brew: missing key %q", key)
+		}
+	}
+}
+
+func TestDaemonToolchainRuntimesReturnsObject(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 59, "toolchain.runtimes", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("toolchain.runtimes: %v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	for _, key := range []string{"node", "python", "go", "ruby", "rust"} {
+		if _, exists := m[key]; !exists {
+			t.Errorf("toolchain.runtimes: missing key %q", key)
+		}
+	}
+}


### PR DESCRIPTION
Adds two narrower RPC methods matching the daemon RPC surface doc: `toolchain.brew` and `toolchain.runtimes`. The existing `toolchain.scan` remains for the full inventory.