### PR TITLE
feat(diff): add active_runtimes diff section

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -61,6 +61,7 @@ func Compare(a, b snapshot.Snapshot) Result {
 			diffApps(a, b),
 			diffJDKs(a, b),
 			diffBrewFormulae(a, b),
+			diffActiveRuntimes(a, b),
 			diffListeningPorts(a, b),
 			diffVPN(a, b),
 			diffPathDirs(a, b),
@@ -336,4 +337,48 @@ func diffSysctls(a, b snapshot.Snapshot) Section {
 		}
 	}
 	return Section{Name: "sysctls", Changes: changes}
+}
+
+// diffActiveRuntimes compares the active version for each language runtime
+// (node, python, go, ruby). A change fires when the active version differs
+// between the two snapshots.
+func diffActiveRuntimes(a, b snapshot.Snapshot) Section {
+	type langRuntimes struct {
+		name     string
+		aSlice   []toolchain.RuntimeInstall
+		bSlice   []toolchain.RuntimeInstall
+	}
+	langs := []langRuntimes{
+		{"node", a.Toolchains.Node, b.Toolchains.Node},
+		{"python", a.Toolchains.Python, b.Toolchains.Python},
+		{"go", a.Toolchains.Go, b.Toolchains.Go},
+		{"ruby", a.Toolchains.Ruby, b.Toolchains.Ruby},
+	}
+
+	activeVersion := func(runtimes []toolchain.RuntimeInstall) string {
+		for _, r := range runtimes {
+			if r.Active {
+				return r.Version
+			}
+		}
+		return ""
+	}
+
+	var changes []Change
+	for _, l := range langs {
+		va := activeVersion(l.aSlice)
+		vb := activeVersion(l.bSlice)
+		if va == vb {
+			continue
+		}
+		switch {
+		case va == "" && vb != "":
+			changes = append(changes, Change{Kind: Added, Key: l.name, After: vb})
+		case va != "" && vb == "":
+			changes = append(changes, Change{Kind: Removed, Key: l.name, Before: va})
+		default:
+			changes = append(changes, Change{Kind: Changed, Key: l.name, Before: va, After: vb})
+		}
+	}
+	return Section{Name: "active_runtimes", Changes: changes}
 }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -315,3 +315,73 @@ func TestDiffVPNNoChange(t *testing.T) {
 		t.Errorf("expected no vpn changes, got %+v", sec.Changes)
 	}
 }
+
+func TestDiffActiveRuntimesVersionChanged(t *testing.T) {
+	a := base()
+	b := base()
+	a.ID = "snap-a"
+	b.ID = "snap-b"
+	a.Toolchains.Node = []toolchain.RuntimeInstall{
+		{Version: "v18.20.4", Source: "nvm", Active: true},
+		{Version: "v22.1.0", Source: "nvm", Active: false},
+	}
+	b.Toolchains.Node = []toolchain.RuntimeInstall{
+		{Version: "v18.20.4", Source: "nvm", Active: false},
+		{Version: "v22.1.0", Source: "nvm", Active: true},
+	}
+	result := Compare(a, b)
+	var section *Section
+	for i := range result.Sections {
+		if result.Sections[i].Name == "active_runtimes" {
+			section = &result.Sections[i]
+			break
+		}
+	}
+	if section == nil {
+		t.Fatal("missing active_runtimes section")
+	}
+	if len(section.Changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %+v", len(section.Changes), section.Changes)
+	}
+	c := section.Changes[0]
+	if c.Key != "node" {
+		t.Errorf("key = %q, want node", c.Key)
+	}
+	if c.Before != "v18.20.4" || c.After != "v22.1.0" {
+		t.Errorf("before/after = %q/%q", c.Before, c.After)
+	}
+}
+
+func TestDiffActiveRuntimesNoChange(t *testing.T) {
+	a := base()
+	b := base()
+	a.Toolchains.Node = []toolchain.RuntimeInstall{{Version: "v18.20.4", Active: true}}
+	b.Toolchains.Node = []toolchain.RuntimeInstall{{Version: "v18.20.4", Active: true}}
+	result := Compare(a, b)
+	for _, s := range result.Sections {
+		if s.Name == "active_runtimes" && len(s.Changes) != 0 {
+			t.Errorf("expected 0 changes, got %d: %+v", len(s.Changes), s.Changes)
+		}
+	}
+}
+
+func TestDiffActiveRuntimesAdded(t *testing.T) {
+	a := base()
+	b := base()
+	// a has no Go, b has Go active
+	b.Toolchains.Go = []toolchain.RuntimeInstall{{Version: "1.22.3", Source: "goenv", Active: true}}
+	result := Compare(a, b)
+	for _, s := range result.Sections {
+		if s.Name == "active_runtimes" {
+			found := false
+			for _, c := range s.Changes {
+				if c.Key == "go" && c.Kind == Added {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected go Added change, got %+v", s.Changes)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds `diffActiveRuntimes()` to the diff pipeline, comparing the active version for each language runtime (node, python, go, ruby) between two snapshots. Matches the toolchain.md diff-semantics doc.