### PR TITLE
feat: snapshot baseline list/drop subcommands

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -23,6 +23,7 @@ func snapshotSubcommands() []subcommand {
 		{"show", "Show details of one snapshot by ID", runSnapshotShow},
 		{"diff", "Diff two stored snapshots", runSnapshotDiff},
 		{"prune", "Delete live snapshots beyond the retention limit (default: keep 100)", runSnapshotPrune},
+		{"baseline", "Manage baseline snapshots (list, drop)", runSnapshotBaseline},
 	}
 }
 
@@ -409,6 +410,127 @@ func runSnapshotPrune(args []string) int {
 	} else {
 		fmt.Printf("pruned %d live snapshot(s) (keeping last %d per machine)\n", deleted, *keepN)
 	}
+	return 0
+}
+
+// runSnapshotBaseline dispatches to baseline sub-subcommands (list, drop).
+func runSnapshotBaseline(args []string) int {
+	if len(args) > 0 {
+		switch args[0] {
+		case "list":
+			return runBaselineList(args[1:])
+		case "drop":
+			return runBaselineDrop(args[1:])
+		}
+	}
+	fmt.Fprintln(os.Stderr, "usage: spectra snapshot baseline <list|drop>")
+	return 2
+}
+
+// runBaselineList lists baseline snapshots stored in the DB.
+func runBaselineList(args []string) int {
+	fs := flag.NewFlagSet("spectra snapshot baseline list", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	rows, err := db.ListSnapshots(ctx, "")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	var baselines []store.SnapshotRow
+	for _, r := range rows {
+		if r.Kind == "baseline" {
+			baselines = append(baselines, r)
+		}
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(baselines)
+		return 0
+	}
+
+	if len(baselines) == 0 {
+		fmt.Println("no baselines stored")
+		return 0
+	}
+	fmt.Printf("%-40s  %-20s  %-4s  %s\n", "ID", "TAKEN AT", "APPS", "NAME")
+	fmt.Println(strings.Repeat("-", 90))
+	for _, r := range baselines {
+		name := r.Name
+		if name == "" {
+			name = "(unnamed)"
+		}
+		fmt.Printf("%-40s  %-20s  %-4d  %s\n",
+			r.ID, r.TakenAt.Format("2006-01-02T15:04:05Z"), r.AppCount, name)
+	}
+	return 0
+}
+
+// runBaselineDrop deletes a baseline snapshot by ID.
+func runBaselineDrop(args []string) int {
+	fs := flag.NewFlagSet("spectra snapshot baseline drop", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "usage: spectra snapshot baseline drop <id>")
+		return 2
+	}
+	id := fs.Arg(0)
+
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	row, err := db.GetSnapshot(ctx, id)
+	if errors.Is(err, store.ErrNotFound) {
+		fmt.Fprintf(os.Stderr, "baseline %q not found\n", id)
+		return 1
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if row.Kind != "baseline" {
+		fmt.Fprintf(os.Stderr, "%q is a %q snapshot, not a baseline — use 'snapshot prune' for live snapshots\n", id, row.Kind)
+		return 1
+	}
+
+	if err := db.DeleteSnapshot(ctx, id); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("dropped baseline %s\n", id)
 	return 0
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -376,6 +376,24 @@ func (s *DB) GetSnapshotJSON(ctx context.Context, id string) ([]byte, error) {
 	return []byte(raw.String), nil
 }
 
+// DeleteSnapshot deletes a snapshot and all its child rows by ID.
+func (s *DB) DeleteSnapshot(ctx context.Context, id string) error {
+	for _, table := range []string{"snapshot_processes", "login_items", "granted_perms", "snapshot_apps"} {
+		if _, err := s.db.ExecContext(ctx, `DELETE FROM `+table+` WHERE snapshot_id=?`, id); err != nil {
+			return fmt.Errorf("store: delete %s for %s: %w", table, id, err)
+		}
+	}
+	res, err := s.db.ExecContext(ctx, `DELETE FROM snapshots WHERE id=?`, id)
+	if err != nil {
+		return fmt.Errorf("store: delete snapshot %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // GetSnapshotApps returns the per-app rows for a snapshot.
 func (s *DB) GetSnapshotApps(ctx context.Context, snapID string) ([]AppRow, error) {
 	rows, err := s.db.QueryContext(ctx,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -657,5 +658,36 @@ func TestGrantedPermsFromSnapshot(t *testing.T) {
 	rows := GrantedPermsFromSnapshot(snap)
 	if len(rows) != 3 {
 		t.Fatalf("len = %d, want 3", len(rows))
+	}
+}
+
+func TestDeleteSnapshotRemovesRow(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	in := sampleInput()
+	in.ID = "snap-del-01"
+	in.Kind = "baseline"
+	if err := db.SaveSnapshot(ctx, in); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	if err := db.DeleteSnapshot(ctx, in.ID); err != nil {
+		t.Fatalf("DeleteSnapshot: %v", err)
+	}
+
+	_, err := db.GetSnapshot(ctx, in.ID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestDeleteSnapshotNotFound(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	err := db.DeleteSnapshot(ctx, "does-not-exist")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `spectra snapshot baseline list` — prints baseline snapshots in a human table (or `--json`)
- Adds `spectra snapshot baseline drop <id>` — deletes a baseline by ID with a kind-guard that refuses to delete live snapshots
- Adds `store.DB.DeleteSnapshot` — removes child rows across all child tables then deletes the parent snapshot row

## Test plan
- [ ] `TestDeleteSnapshotRemovesRow` — verifies row + children are gone after delete
- [ ] `TestDeleteSnapshotNotFound` — verifies `ErrNotFound` for unknown ID
- [ ] Full store suite passes