### PR TITLE
fix: resolve G202 gosec and cyclomatic complexity CI failures

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -232,14 +232,19 @@ func runSnapshotShow(args []string) int {
 		}
 	}
 
-	// Fallback: snapshot JSON not available — use the lightweight row + apps.
+	return runSnapshotShowFallback(ctx, db, row, id, *asJSON)
+}
+
+// runSnapshotShowFallback renders a snapshot using the lightweight row + apps
+// when the full snapshot JSON blob is not available.
+func runSnapshotShowFallback(ctx context.Context, db *store.DB, row store.SnapshotRow, id string, asJSON bool) int {
 	apps, err := db.GetSnapshotApps(ctx, id)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
 
-	if *asJSON {
+	if asJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		_ = enc.Encode(map[string]any{"snapshot": row, "apps": apps})

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -379,7 +379,7 @@ func (s *DB) GetSnapshotJSON(ctx context.Context, id string) ([]byte, error) {
 // DeleteSnapshot deletes a snapshot and all its child rows by ID.
 func (s *DB) DeleteSnapshot(ctx context.Context, id string) error {
 	for _, table := range []string{"snapshot_processes", "login_items", "granted_perms", "snapshot_apps"} {
-		if _, err := s.db.ExecContext(ctx, `DELETE FROM `+table+` WHERE snapshot_id=?`, id); err != nil {
+		if _, err := s.db.ExecContext(ctx, `DELETE FROM `+table+` WHERE snapshot_id=?`, id); err != nil { // #nosec G202 — table is a hardcoded literal, not user input
 			return fmt.Errorf("store: delete %s for %s: %w", table, id, err)
 		}
 	}
@@ -730,7 +730,7 @@ func (s *DB) PruneSnapshots(ctx context.Context, keepN int) (int64, error) {
 		pruneSubquery := `SELECT id FROM snapshots WHERE kind='live' AND machine_uuid=?
 			AND id NOT IN (SELECT id FROM snapshots WHERE kind='live' AND machine_uuid=? ORDER BY taken_at DESC LIMIT ?)`
 		for _, table := range []string{"snapshot_processes", "login_items", "granted_perms", "snapshot_apps"} {
-			if _, err := s.db.ExecContext(ctx,
+			if _, err := s.db.ExecContext(ctx, // #nosec G202 — table is a hardcoded literal, not user input
 				`DELETE FROM `+table+` WHERE snapshot_id IN (`+pruneSubquery+`)`,
 				m, m, keepN); err != nil {
 				return total, fmt.Errorf("store: prune %s %s: %w", table, m, err)


### PR DESCRIPTION
## Summary
- Adds `#nosec G202` to the two hardcoded-table DELETE loops in `store.go` — gosec flags string concatenation but the table names are internal compile-time literals, not user input
- Extracts `runSnapshotShowFallback` from `runSnapshotShow` to bring `runSnapshotShow` from complexity 16 to ≤15

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./internal/store/` passes