### PR TITLE
feat: add spectra power command and power.state RPC

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -37,6 +37,7 @@ func subcommandList() []subcommand {
 		{"jvm", "List or inspect running JVM processes", runJVM},
 		{"toolchain", "Show installed language runtimes and package managers", runToolchain},
 		{"network", "Show current network state (routes, DNS, VPN, proxy, listening ports)", runNetwork},
+		{"power", "Show current battery and thermal state", runPower},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
 		{"diff", "Diff two stored snapshots (alias for snapshot diff)", runSnapshotDiff},
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},

--- a/cmd/spectra/power.go
+++ b/cmd/spectra/power.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/sysinfo"
+)
+
+func runPower(args []string) int {
+	fs := flag.NewFlagSet("spectra power", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	state := sysinfo.CollectPower(sysinfo.DefaultRunner)
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(state)
+		return 0
+	}
+
+	printPowerState(state)
+	return 0
+}
+
+func printPowerState(s sysinfo.PowerState) {
+	fmt.Println("=== Power state ===")
+
+	if s.OnBattery {
+		fmt.Printf("source:    battery (%d%%)\n", s.BatteryPct)
+	} else {
+		fmt.Printf("source:    AC power\n")
+		if s.BatteryPct > 0 {
+			fmt.Printf("battery:   %d%% (charging)\n", s.BatteryPct)
+		}
+	}
+
+	if s.ThermalPressure != "" {
+		fmt.Printf("thermal:   %s\n", s.ThermalPressure)
+	}
+
+	if len(s.Assertions) > 0 {
+		fmt.Println()
+		fmt.Printf("assertions (%d):\n", len(s.Assertions))
+		for _, a := range s.Assertions {
+			name := ""
+			if a.Name != "" {
+				name = fmt.Sprintf(" %q", a.Name)
+			}
+			fmt.Printf("  pid %-7d  %-30s%s\n", a.PID, a.Type, name)
+		}
+	}
+
+	if len(s.EnergyTopUsers) > 0 {
+		fmt.Println()
+		fmt.Printf("energy top users:\n")
+		fmt.Printf("  %-7s  %-8s  %s\n", "PID", "IMPACT", "COMMAND")
+		fmt.Println("  " + strings.Repeat("-", 40))
+		for _, u := range s.EnergyTopUsers {
+			fmt.Printf("  %-7d  %-8.1f  %s\n", u.PID, u.EnergyImpact, u.Command)
+		}
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/store"
 	"github.com/kaeawc/spectra/internal/storagestate"
+	"github.com/kaeawc/spectra/internal/sysinfo"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
@@ -698,6 +699,11 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, fmt.Errorf("sample pid %d: %w", p.PID, err)
 		}
 		return map[string]any{"pid": p.PID, "output": string(out)}, nil
+	})
+
+	// power.state — battery level, thermal pressure, assertions, and top energy users.
+	d.Register("power.state", func(_ json.RawMessage) (any, error) {
+		return sysinfo.CollectPower(sysinfo.DefaultRunner), nil
 	})
 
 	// storage.system — disk volumes + ~/Library usage summary.

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -563,3 +563,19 @@ func TestDaemonToolchainRuntimesReturnsObject(t *testing.T) {
 		}
 	}
 }
+
+func TestDaemonPowerStateReturnsObject(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 60, "power.state", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("power.state: %v", resp.Error)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	if _, exists := m["on_battery"]; !exists {
+		t.Error("power.state: expected on_battery field in result")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `spectra power` CLI command showing battery state, thermal pressure, power assertions, and energy top users (analogous to `spectra network`)
- Adds `power.state` JSON-RPC 2.0 method to the daemon backed by `sysinfo.CollectPower`
- Uses `--json` flag for machine-readable output

## Test plan
- [ ] `TestDaemonPowerStateReturnsObject` — verifies `power.state` RPC returns an object with `on_battery` field
- [ ] Full build passes