### PR TITLE
feat: add spectra storage command

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -38,6 +38,7 @@ func subcommandList() []subcommand {
 		{"toolchain", "Show installed language runtimes and package managers", runToolchain},
 		{"network", "Show current network state (routes, DNS, VPN, proxy, listening ports)", runNetwork},
 		{"power", "Show current battery and thermal state", runPower},
+		{"storage", "Show disk volumes and ~/Library footprint", runStorage},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
 		{"diff", "Diff two stored snapshots (alias for snapshot diff)", runSnapshotDiff},
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},

--- a/cmd/spectra/storage.go
+++ b/cmd/spectra/storage.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/storagestate"
+)
+
+func runStorage(args []string) int {
+	fs := flag.NewFlagSet("spectra storage", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	state := storagestate.Collect(storagestate.CollectOptions{})
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(state)
+		return 0
+	}
+
+	printStorageState(state)
+	return 0
+}
+
+func printStorageState(s storagestate.State) {
+	fmt.Println("=== Storage state ===")
+
+	if len(s.Volumes) > 0 {
+		fmt.Printf("volumes (%d):\n", len(s.Volumes))
+		fmt.Printf("  %-28s  %10s  %10s  %10s  %s\n", "MOUNT", "TOTAL", "USED", "AVAIL", "PCT")
+		fmt.Println("  " + strings.Repeat("-", 68))
+		for _, v := range s.Volumes {
+			pct := 0
+			if v.TotalBytes > 0 {
+				pct = int(float64(v.UsedBytes) / float64(v.TotalBytes) * 100)
+			}
+			fmt.Printf("  %-28s  %10s  %10s  %10s  %d%%\n",
+				truncate(v.MountPoint, 28),
+				humanSize(v.TotalBytes),
+				humanSize(v.UsedBytes),
+				humanSize(v.AvailBytes),
+				pct,
+			)
+		}
+	}
+
+	if s.UserLibraryBytes > 0 {
+		fmt.Printf("\n~/Library:       %s total\n", humanSize(s.UserLibraryBytes))
+		if s.AppCachesBytes > 0 {
+			fmt.Printf("  ~/Library/Caches: %s\n", humanSize(s.AppCachesBytes))
+		}
+	}
+
+	if len(s.LargestApps) > 0 {
+		fmt.Printf("\nlargest apps (%d):\n", len(s.LargestApps))
+		for _, a := range s.LargestApps {
+			fmt.Printf("  %10s  %s\n", humanSize(a.OnDiskBytes), a.Path)
+		}
+	}
+}
+


### PR DESCRIPTION
## Summary
- Adds `spectra storage` CLI command showing disk volumes (mount, total/used/avail, usage %) and ~/Library footprint
- Consistent with `spectra network` and `spectra power` (human table by default, `--json` for machine-readable)
- The `storage.system` and `storage.byApp` daemon RPCs were already implemented; this adds the missing CLI surface

## Test plan
- [ ] `go build ./...` passes
- [ ] Existing `storagestate` package tests pass