### PR TITLE
feat: add issues acknowledge/dismiss CLI subcommands and RPC methods

### DIFF
--- a/cmd/spectra/issues.go
+++ b/cmd/spectra/issues.go
@@ -17,6 +17,8 @@ func issuesSubcommands() []subcommand {
 	return []subcommand{
 		{"list", "List stored issues", runIssuesList},
 		{"update", "Update an issue status", runIssuesUpdate},
+		{"acknowledge", "Mark an issue acknowledged", runIssuesAcknowledge},
+		{"dismiss", "Mark an issue dismissed", runIssuesDismiss},
 		{"check", "Run rules, record findings as issues, and print a summary", runIssuesCheck},
 	}
 }
@@ -114,6 +116,41 @@ func runIssuesUpdate(args []string) int {
 		return 1
 	}
 	fmt.Printf("issue %s → %s\n", id, *status)
+	return 0
+}
+
+func runIssuesAcknowledge(args []string) int {
+	return runIssuesSetStatus(args, "acknowledge", store.IssueAcknowledged)
+}
+
+func runIssuesDismiss(args []string) int {
+	return runIssuesSetStatus(args, "dismiss", store.IssueDismissed)
+}
+
+func runIssuesSetStatus(args []string, verb string, status store.IssueStatus) int {
+	fs := flag.NewFlagSet("spectra issues "+verb, flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() == 0 {
+		fmt.Fprintf(os.Stderr, "usage: spectra issues %s <issue-id>\n", verb)
+		return 2
+	}
+
+	db, _, err := openIssuesDB()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+
+	id := fs.Arg(0)
+	if err := db.UpdateIssueStatus(context.Background(), id, status); err != nil {
+		fmt.Fprintf(os.Stderr, "%s %q: %v\n", verb, id, err)
+		return 1
+	}
+	fmt.Printf("issue %s → %s\n", id, status)
 	return 0
 }
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -428,6 +428,36 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		return map[string]any{"id": p.ID, "status": p.Status}, nil
 	})
 
+	// issues.acknowledge — shorthand for issues.update with status=acknowledged.
+	// { "id": "..." }
+	d.Register("issues.acknowledge", func(params json.RawMessage) (any, error) {
+		var p struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.ID == "" {
+			return nil, fmt.Errorf("issues.acknowledge requires {\"id\": \"...\"}")
+		}
+		if err := db.UpdateIssueStatus(context.Background(), p.ID, store.IssueAcknowledged); err != nil {
+			return nil, err
+		}
+		return map[string]any{"id": p.ID, "status": "acknowledged"}, nil
+	})
+
+	// issues.dismiss — shorthand for issues.update with status=dismissed.
+	// { "id": "..." }
+	d.Register("issues.dismiss", func(params json.RawMessage) (any, error) {
+		var p struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.ID == "" {
+			return nil, fmt.Errorf("issues.dismiss requires {\"id\": \"...\"}")
+		}
+		if err := db.UpdateIssueStatus(context.Background(), p.ID, store.IssueDismissed); err != nil {
+			return nil, err
+		}
+		return map[string]any{"id": p.ID, "status": "dismissed"}, nil
+	})
+
 	// issues.fix.record — log a fix attempt against an issue.
 	// { "issue_id": "...", "applied_by": "user", "command": "...", "output": "...", "exit_code": 0 }
 	d.Register("issues.fix.record", func(params json.RawMessage) (any, error) {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -579,3 +579,21 @@ func TestDaemonPowerStateReturnsObject(t *testing.T) {
 		t.Error("power.state: expected on_battery field in result")
 	}
 }
+
+func TestDaemonIssuesAcknowledgeMissingID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 61, "issues.acknowledge", `{}`)
+	if resp.Error == nil {
+		t.Fatal("expected error for missing id, got nil")
+	}
+}
+
+func TestDaemonIssuesDismissMissingID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 62, "issues.dismiss", `{}`)
+	if resp.Error == nil {
+		t.Fatal("expected error for missing id, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `spectra issues acknowledge <id>` and `spectra issues dismiss <id>` as shorthand CLI commands
- Adds `issues.acknowledge` and `issues.dismiss` JSON-RPC 2.0 daemon methods (from the daemon RPC surface sketch in daemon.md)
- Both new CLI commands and RPCs delegate to the existing `UpdateIssueStatus` storage method

## Test plan
- [ ] `TestDaemonIssuesAcknowledgeMissingID` — verifies error on missing id
- [ ] `TestDaemonIssuesDismissMissingID` — verifies error on missing id