### PR TITLE
feat: add toolchain.build_tools and jdk.scan RPC methods

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -638,6 +638,18 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		}, nil
 	})
 
+	// toolchain.build_tools — installed JVM-ecosystem build tools (Maven, Gradle, Bazel, Make, CMake).
+	d.Register("toolchain.build_tools", func(_ json.RawMessage) (any, error) {
+		tc := toolchain.Collect(context.Background(), toolchain.CollectOptions{})
+		return tc.BuildTools, nil
+	})
+
+	// jdk.scan — re-enumerate installed JDK toolchains (alias for jdk.list that signals a fresh scan intent).
+	d.Register("jdk.scan", func(_ json.RawMessage) (any, error) {
+		tc := toolchain.Collect(context.Background(), toolchain.CollectOptions{})
+		return tc.JDKs, nil
+	})
+
 	// network.state — current network configuration snapshot.
 	d.Register("network.state", func(_ json.RawMessage) (any, error) {
 		return netstate.Collect(netstate.DefaultRunner), nil

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -597,3 +597,28 @@ func TestDaemonIssuesDismissMissingID(t *testing.T) {
 		t.Fatal("expected error for missing id, got nil")
 	}
 }
+
+func TestDaemonToolchainBuildToolsReturnsSlice(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 63, "toolchain.build_tools", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("toolchain.build_tools: %v", resp.Error)
+	}
+	// Result should be a JSON array (may be empty if no build tools installed).
+	if _, ok := resp.Result.([]any); !ok && resp.Result != nil {
+		t.Fatalf("result type %T, want []any or nil", resp.Result)
+	}
+}
+
+func TestDaemonJDKScanReturnsSlice(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 64, "jdk.scan", `{}`)
+	if resp.Error != nil {
+		t.Fatalf("jdk.scan: %v", resp.Error)
+	}
+	if _, ok := resp.Result.([]any); !ok && resp.Result != nil {
+		t.Fatalf("result type %T, want []any or nil", resp.Result)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `toolchain.build_tools` RPC — returns installed build tools (Maven, Gradle, Bazel, Make, CMake)
- Adds `jdk.scan` RPC — re-enumerates JDK installations (completes the `jdk.list`/`jdk.scan` pair from daemon.md)

## Test plan
- [ ] `TestDaemonToolchainBuildToolsReturnsSlice` — verifies slice result
- [ ] `TestDaemonJDKScanReturnsSlice` — verifies slice result