### PR TITLE
feat: support 'live' sentinel in snapshot diff

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -391,6 +391,7 @@ func sortStrings(s []string) {
 }
 
 // runSnapshotDiff loads two snapshots by ID and prints a structured diff.
+// Either ID may be the sentinel "live" to capture a fresh snapshot on the fly.
 func runSnapshotDiff(args []string) int {
 	fs := flag.NewFlagSet("spectra snapshot diff", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -399,7 +400,7 @@ func runSnapshotDiff(args []string) int {
 		return 2
 	}
 	if fs.NArg() != 2 {
-		fmt.Fprintln(os.Stderr, "usage: spectra snapshot diff <id-a> <id-b>")
+		fmt.Fprintln(os.Stderr, "usage: spectra snapshot diff <id-a> <id-b|live>")
 		return 2
 	}
 	idA, idB := fs.Arg(0), fs.Arg(1)
@@ -417,12 +418,12 @@ func runSnapshotDiff(args []string) int {
 	defer db.Close()
 
 	ctx := context.Background()
-	snapA, err := loadSnapshotFromDB(ctx, db, idA)
+	snapA, err := resolveSnapshot(ctx, db, idA)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "snapshot %q: %v\n", idA, err)
 		return 1
 	}
-	snapB, err := loadSnapshotFromDB(ctx, db, idB)
+	snapB, err := resolveSnapshot(ctx, db, idB)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "snapshot %q: %v\n", idB, err)
 		return 1
@@ -439,6 +440,16 @@ func runSnapshotDiff(args []string) int {
 
 	printDiff(result)
 	return 0
+}
+
+// resolveSnapshot loads a snapshot from the DB by ID, or captures a fresh
+// live snapshot when id is the sentinel "live".
+func resolveSnapshot(ctx context.Context, db *store.DB, id string) (*snapshot.Snapshot, error) {
+	if id == "live" {
+		snap := snapshot.Build(ctx, snapshot.Options{SpectraVersion: version})
+		return &snap, nil
+	}
+	return loadSnapshotFromDB(ctx, db, id)
 }
 
 // loadSnapshotFromDB retrieves the full snapshot JSON blob for id and unmarshals

--- a/cmd/spectra/snapshot_test.go
+++ b/cmd/spectra/snapshot_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+func tempDB(t *testing.T) *store.DB {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "sp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	db, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestResolveSnapshotNotFoundReturnsError(t *testing.T) {
+	db := tempDB(t)
+	_, err := resolveSnapshot(context.Background(), db, "nonexistent-id")
+	if err == nil {
+		t.Fatal("expected error for nonexistent snapshot ID, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `resolveSnapshot` helper that returns a fresh live snapshot when id is `"live"`, otherwise loads from DB
- Updates `spectra snapshot diff` to accept `<id-a> <id-b|live>` — compare any stored snapshot against today's system state
- Adds test for the not-found error path

## Test plan
- [ ] `go test ./cmd/spectra/... -run TestResolveSnapshotNotFoundReturnsError` passes
- [ ] `go build ./...` passes