### PR TITLE
Persist snapshot child data

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -54,15 +54,9 @@ func runSnapshot(args []string) int {
 	opts := snapshot.Options{
 		SpectraVersion: version,
 		DetectOpts:     detect.Options{ScanNetwork: *withNetwork},
-	}
-	if *skipApps {
-		// Sentinel: a path that won't exist so detect drops it.
-		opts.AppPaths = []string{"/dev/null/__skip_apps_marker__"}
+		SkipApps:       *skipApps,
 	}
 	snap := snapshot.Build(context.Background(), opts)
-	if *skipApps {
-		snap.Apps = nil
-	}
 	if *baseline {
 		snap.Kind = snapshot.KindBaseline
 	}
@@ -109,6 +103,15 @@ func saveSnapshotNamed(snap snapshot.Snapshot, name string) error {
 	input := store.FromSnapshot(snap)
 	input.Name = name
 	if err := db.SaveSnapshot(ctx, input); err != nil {
+		return err
+	}
+	if err := db.SaveSnapshotProcesses(ctx, snap.ID, store.ProcessesFromSnapshot(snap)); err != nil {
+		return err
+	}
+	if err := db.SaveLoginItems(ctx, snap.ID, store.LoginItemsFromSnapshot(snap)); err != nil {
+		return err
+	}
+	if err := db.SaveGrantedPerms(ctx, snap.ID, store.GrantedPermsFromSnapshot(snap)); err != nil {
 		return err
 	}
 	if snap.Kind == snapshot.KindLive {

--- a/cmd/spectra/snapshot_test.go
+++ b/cmd/spectra/snapshot_test.go
@@ -5,7 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/store"
 )
 
@@ -29,5 +33,85 @@ func TestResolveSnapshotNotFoundReturnsError(t *testing.T) {
 	_, err := resolveSnapshot(context.Background(), db, "nonexistent-id")
 	if err == nil {
 		t.Fatal("expected error for nonexistent snapshot ID, got nil")
+	}
+}
+
+func TestSaveSnapshotNamedPersistsChildTables(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	snap := snapshot.Snapshot{
+		ID:      "snap-20260505T120000Z-0001",
+		TakenAt: time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC),
+		Kind:    snapshot.KindLive,
+		Host: snapshot.HostInfo{
+			Hostname:    "test.local",
+			MachineUUID: "TEST-MACHINE",
+			OSName:      "macOS",
+		},
+		Apps: []detect.Result{
+			{
+				Path:     "/Applications/Foo.app",
+				BundleID: "com.example.foo",
+				LoginItems: []detect.LoginItem{
+					{
+						Path:      "/Library/LaunchAgents/com.example.foo.plist",
+						Label:     "com.example.foo",
+						Scope:     "system",
+						RunAtLoad: true,
+					},
+				},
+				GrantedPermissions: []string{"Microphone"},
+			},
+		},
+		Processes: []process.Info{
+			{
+				PID:     412,
+				PPID:    1,
+				Command: "Foo",
+				RSSKiB:  184320,
+				CPUPct:  1.2,
+				AppPath: "/Applications/Foo.app",
+			},
+		},
+	}
+
+	if err := saveSnapshotNamed(snap, "with-children"); err != nil {
+		t.Fatalf("saveSnapshotNamed: %v", err)
+	}
+
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	procs, err := db.GetSnapshotProcesses(ctx, snap.ID)
+	if err != nil {
+		t.Fatalf("GetSnapshotProcesses: %v", err)
+	}
+	if len(procs) != 1 || procs[0].AppPath != "/Applications/Foo.app" {
+		t.Fatalf("process rows = %+v", procs)
+	}
+
+	items, err := db.GetLoginItems(ctx, snap.ID)
+	if err != nil {
+		t.Fatalf("GetLoginItems: %v", err)
+	}
+	if len(items) != 1 || !items[0].RunAtLoad {
+		t.Fatalf("login item rows = %+v", items)
+	}
+
+	perms, err := db.GetGrantedPerms(ctx, snap.ID)
+	if err != nil {
+		t.Fatalf("GetGrantedPerms: %v", err)
+	}
+	if len(perms) != 1 || perms[0].Service != "Microphone" {
+		t.Fatalf("permission rows = %+v", perms)
 	}
 }

--- a/docs/detection/native-modules.md
+++ b/docs/detection/native-modules.md
@@ -1,10 +1,11 @@
 # Electron native module sub-detection
 
-Confirmed Electron apps get an additional pass that walks
-`Contents/Resources/app.asar.unpacked/**/*.node` and classifies each
-native add-on by source language. This reveals the architectural split
-between vanilla Electron apps (only off-the-shelf C++ deps) and hybrid
-apps with custom Rust/Swift code.
+Confirmed Electron apps get an additional pass that walks native add-ons
+under `Contents/Resources/app.asar.unpacked/**/*.node` and unpacked
+`Contents/Resources/app/**/*.node` payloads. Each module is classified by
+source language. This reveals the architectural split between vanilla
+Electron apps (only off-the-shelf C++ deps) and hybrid apps with custom
+Rust/Swift code.
 
 ## Classification rules
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -18,6 +18,21 @@ spectra [flags] <App.app>...     # routes to `inspect` (default)
 |---|---|
 | `inspect` | Inspect `.app` bundles (default; runs when no subcommand given) |
 | `snapshot` | Capture a structured snapshot of host + installed apps |
+| `diff` | Diff two stored snapshots |
+| `rules` | Evaluate recommendation rules against a snapshot |
+| `issues` | List, check, or update persisted recommendation issues |
+| `jvm` | List or inspect running JVM processes |
+| `toolchain` | Show installed language runtimes and package managers |
+| `network` | Show current routes, DNS, VPN, proxy, and listening ports |
+| `power` | Show current battery and thermal state |
+| `storage` | Show disk volumes and `~/Library` footprint |
+| `process` | List running processes sorted by memory |
+| `serve` | Run the local Unix-socket JSON-RPC daemon |
+| `status` | Check whether the local daemon is running |
+| `metrics` | Show stored process metrics from daemon sampling |
+| `sample` | Collect a user-space CPU sample of a process |
+| `cache` | Manage the local blob cache |
+| `install-helper` | Install the privileged helper daemon |
 | `version` | Print Spectra version and exit |
 | `help` | Show top-level help |
 
@@ -58,16 +73,20 @@ per non-empty field.
 
 Captures a [system-inventory snapshot](../design/system-inventory.md)
 of the local machine and persists it to `~/.spectra/spectra.db`
-(SQLite, WAL mode). Today only `host` info and the `apps` slice are
-populated; processes / JVMs / JDKs / toolchains / network / storage
-state will land alongside the daemon.
+(SQLite, WAL mode). Snapshots include host facts, installed app
+inspection, processes, JVMs, toolchains, network state, storage state,
+power state, and selected sysctls. The relational store keeps summary
+rows for apps, processes, login items, and granted privacy permissions
+alongside the full JSON snapshot blob.
 
 | Flag | Default | Description |
 |---|---|---|
 | `--json` | false | Emit JSON instead of the human summary |
 | `--network` | false | Forwarded to per-app `Detect()` |
-| `--no-apps` | false | Skip the apps inventory (host-only, very fast) |
+| `--no-apps` | false | Skip installed-app inspection |
 | `--no-store` | false | Do not persist the snapshot to the local database |
+| `--baseline` | false | Save as an immutable baseline snapshot |
+| `--name` | empty | Human label for the snapshot, usually with `--baseline` |
 
 ### Examples
 
@@ -155,16 +174,11 @@ Prints the build version (typically a git describe from `make build`).
 Per-app errors are written to stderr; the offending entry is dropped
 and processing continues for other paths.
 
-## Planned subcommands (daemon era)
+## Remaining planned subcommands
 
 ```
-spectra serve                       # run the collector daemon
 spectra connect <host>              # client targeting a remote daemon
 spectra list                        # alias for "scan all bundles via local daemon"
-spectra diff <baseline-id> [host]   # snapshot diff
-spectra jvm [pid]                   # JVM inspection
-spectra cache stats / clear         # blob cache management
-spectra install-helper              # privileged helper install (sudo)
 ```
 
 See [../design/architecture.md](../design/architecture.md) for the

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -35,19 +35,19 @@ type Result struct {
 
 	// Metadata pulled from Info.plist and frameworks. Best-effort; any
 	// field may be empty if the bundle doesn't expose it.
-	BundleID         string   // CFBundleIdentifier (com.example.app)
-	AppVersion       string   // CFBundleShortVersionString
-	BuildNumber      string   // CFBundleVersion
-	ElectronVersion  string   // version of bundled Electron Framework, if any
-	Architectures    []string // arm64, x86_64
-	BundleSizeBytes  int64    // total disk usage of the .app (sparse-aware: Blocks*512)
-	ApparentSizeBytes int64   // logical size of the .app (fi.Size() sum; may be >> BundleSizeBytes for sparse images)
-	TeamID           string   // code-sign team identifier
-	SparkleFeedURL   string   // SUFeedURL from Info.plist, if present
-	MASReceipt       bool     // Mac App Store receipt is embedded
-	HardenedRuntime  bool     // codesign reports flags=0x10000(runtime)
-	Sandboxed        bool     // entitlements include com.apple.security.app-sandbox
-	Entitlements     []string // notable boolean entitlements (subset)
+	BundleID          string   // CFBundleIdentifier (com.example.app)
+	AppVersion        string   // CFBundleShortVersionString
+	BuildNumber       string   // CFBundleVersion
+	ElectronVersion   string   // version of bundled Electron Framework, if any
+	Architectures     []string // arm64, x86_64
+	BundleSizeBytes   int64    // total disk usage of the .app (sparse-aware: Blocks*512)
+	ApparentSizeBytes int64    // logical size of the .app (fi.Size() sum; may be >> BundleSizeBytes for sparse images)
+	TeamID            string   // code-sign team identifier
+	SparkleFeedURL    string   // SUFeedURL from Info.plist, if present
+	MASReceipt        bool     // Mac App Store receipt is embedded
+	HardenedRuntime   bool     // codesign reports flags=0x10000(runtime)
+	Sandboxed         bool     // entitlements include com.apple.security.app-sandbox
+	Entitlements      []string // notable boolean entitlements (subset)
 
 	Storage *StorageFootprint // user-data on disk in ~/Library
 
@@ -102,12 +102,12 @@ type Helpers struct {
 
 // LoginItem is one launchd plist installed for this bundle.
 type LoginItem struct {
-	Path       string // full path to the plist
-	Label      string // launchd Label (typically the bundle ID + suffix)
-	Scope      string // user | system
-	Daemon     bool   // true for /Library/LaunchDaemons
-	RunAtLoad  bool   // plist RunAtLoad key
-	KeepAlive  bool   // plist KeepAlive key (simple true/false form)
+	Path      string // full path to the plist
+	Label     string // launchd Label (typically the bundle ID + suffix)
+	Scope     string // user | system
+	Daemon    bool   // true for /Library/LaunchDaemons
+	RunAtLoad bool   // plist RunAtLoad key
+	KeepAlive bool   // plist KeepAlive key (simple true/false form)
 }
 
 // ProcessInfo is one running process belonging to this bundle.
@@ -422,19 +422,19 @@ func readEntitlements(appPath string) (sandboxed bool, notable []string) {
 	// Pairs look like <key>NAME</key><true/> in the single-line XML output.
 	xml := string(out)
 	notableKeys := map[string]bool{
-		"com.apple.security.app-sandbox":                   true,
-		"com.apple.security.network.client":                true,
-		"com.apple.security.network.server":                true,
-		"com.apple.security.device.camera":                 true,
-		"com.apple.security.device.audio-input":            true,
-		"com.apple.security.device.bluetooth":              true,
-		"com.apple.security.device.usb":                    true,
-		"com.apple.security.personal-information.location": true,
-		"com.apple.security.cs.allow-jit":                  true,
-		"com.apple.security.cs.disable-library-validation": true,
-		"com.apple.security.cs.allow-unsigned-executable-memory":      true,
-		"com.apple.security.automation.apple-events":                  true,
-		"com.apple.security.virtualization":                           true,
+		"com.apple.security.app-sandbox":                         true,
+		"com.apple.security.network.client":                      true,
+		"com.apple.security.network.server":                      true,
+		"com.apple.security.device.camera":                       true,
+		"com.apple.security.device.audio-input":                  true,
+		"com.apple.security.device.bluetooth":                    true,
+		"com.apple.security.device.usb":                          true,
+		"com.apple.security.personal-information.location":       true,
+		"com.apple.security.cs.allow-jit":                        true,
+		"com.apple.security.cs.disable-library-validation":       true,
+		"com.apple.security.cs.allow-unsigned-executable-memory": true,
+		"com.apple.security.automation.apple-events":             true,
+		"com.apple.security.virtualization":                      true,
 	}
 
 	for key := range notableKeys {
@@ -860,30 +860,52 @@ func findJVMRoot(contents string) string {
 	return found
 }
 
-// scanNativeModules walks app.asar.unpacked for *.node add-ons and
-// classifies each by language using its link map and binary fingerprint.
+// scanNativeModules walks Electron's unpacked payload roots for *.node
+// add-ons and classifies each by language using its link map and binary
+// fingerprint.
 func scanNativeModules(appPath string) []NativeModule {
-	root := filepath.Join(appPath, "Contents", "Resources", "app.asar.unpacked")
-	if !isDir(root) {
-		return nil
-	}
 	var mods []NativeModule
-	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d == nil || d.IsDir() {
+	seen := map[string]struct{}{}
+	for _, root := range nativeModuleRoots(appPath) {
+		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d == nil || d.IsDir() {
+				return nil
+			}
+			// Skip dSYM debug bundles and source maps.
+			if strings.Contains(path, ".dSYM/") {
+				return nil
+			}
+			if !strings.HasSuffix(d.Name(), ".node") {
+				return nil
+			}
+			rel, _ := filepath.Rel(appPath, path)
+			if _, ok := seen[rel]; ok {
+				return nil
+			}
+			seen[rel] = struct{}{}
+			mods = append(mods, classifyNativeModule(path, rel))
 			return nil
-		}
-		// Skip dSYM debug bundles and source maps.
-		if strings.Contains(path, ".dSYM/") {
-			return nil
-		}
-		if !strings.HasSuffix(d.Name(), ".node") {
-			return nil
-		}
-		rel, _ := filepath.Rel(appPath, path)
-		mods = append(mods, classifyNativeModule(path, rel))
-		return nil
+		})
+	}
+	sort.Slice(mods, func(i, j int) bool {
+		return mods[i].Path < mods[j].Path
 	})
 	return mods
+}
+
+func nativeModuleRoots(appPath string) []string {
+	resources := filepath.Join(appPath, "Contents", "Resources")
+	candidates := []string{
+		filepath.Join(resources, "app.asar.unpacked"),
+		filepath.Join(resources, "app"),
+	}
+	var roots []string
+	for _, root := range candidates {
+		if isDir(root) {
+			roots = append(roots, root)
+		}
+	}
+	return roots
 }
 
 // classifyNativeModule infers a language from a single .node file. The
@@ -1455,13 +1477,13 @@ func scanNetworkEndpoints(appPath, exe string) []string {
 
 	// Filter out hostnames that are too generic to be useful (schema URIs).
 	junk := map[string]bool{
-		"www.w3.org":                true,
-		"www.apple.com":             true,
-		"developer.apple.com":       true,
-		"schemas.microsoft.com":     true,
+		"www.w3.org":                 true,
+		"www.apple.com":              true,
+		"developer.apple.com":        true,
+		"schemas.microsoft.com":      true,
 		"schemas.openxmlformats.org": true,
-		"json-schema.org":           true,
-		"www.google.com":            false, // keep — meaningful when present
+		"json-schema.org":            true,
+		"www.google.com":             false, // keep — meaningful when present
 	}
 	out := make([]string, 0, len(hosts))
 	for h := range hosts {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -267,6 +267,87 @@ func TestDependenciesNPMPackages(t *testing.T) {
 	}
 }
 
+func TestElectronNativeModulesScannedFromAsarUnpackedAndAppDir(t *testing.T) {
+	app := makeBundle(t, "FakeNativeModules")
+	if err := os.MkdirAll(filepath.Join(app, "Contents/Frameworks/Electron Framework.framework"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	touch(t, filepath.Join(app, "Contents/Resources/app.asar"))
+
+	appDirModule := filepath.Join(app, "Contents/Resources/app/node_modules/plain/build/Release/plain.node")
+	if err := os.MkdirAll(filepath.Dir(appDirModule), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(appDirModule, []byte("native addon"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rustModule := filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/custom/build/Release/custom.node")
+	if err := os.MkdirAll(filepath.Dir(rustModule), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Repeat("rustc/library/core/src/panicking.rs core::panicking\n", 60)
+	if err := os.WriteFile(rustModule, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Debug-symbol bundles should not produce separate native modules.
+	dsymModule := filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/custom/build/Release/custom.node.dSYM/Contents/Resources/DWARF/custom.node")
+	if err := os.MkdirAll(filepath.Dir(dsymModule), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dsymModule, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Detect(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.NativeModules) != 2 {
+		t.Fatalf("NativeModules len = %d, want 2: %#v", len(r.NativeModules), r.NativeModules)
+	}
+	if r.NativeModules[0].Path != "Contents/Resources/app.asar.unpacked/node_modules/custom/build/Release/custom.node" {
+		t.Errorf("first module path = %q", r.NativeModules[0].Path)
+	}
+	if r.NativeModules[0].Language != "Rust" {
+		t.Errorf("custom module language = %q, want Rust; hints=%v", r.NativeModules[0].Language, r.NativeModules[0].Hints)
+	}
+	if r.NativeModules[1].Path != "Contents/Resources/app/node_modules/plain/build/Release/plain.node" {
+		t.Errorf("second module path = %q", r.NativeModules[1].Path)
+	}
+	if r.NativeModules[1].Language != "C++" {
+		t.Errorf("plain module language = %q, want C++", r.NativeModules[1].Language)
+	}
+}
+
+func TestNativeModuleRootsOnlyExistingElectronPayloads(t *testing.T) {
+	app := makeBundle(t, "FakeNativeRoots")
+	if roots := nativeModuleRoots(app); len(roots) != 0 {
+		t.Fatalf("roots without payloads = %v, want none", roots)
+	}
+
+	for _, root := range []string{
+		filepath.Join(app, "Contents/Resources/app.asar.unpacked"),
+		filepath.Join(app, "Contents/Resources/app"),
+	} {
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	roots := nativeModuleRoots(app)
+	if len(roots) != 2 {
+		t.Fatalf("roots len = %d, want 2: %v", len(roots), roots)
+	}
+	if !strings.HasSuffix(roots[0], "Contents/Resources/app.asar.unpacked") {
+		t.Errorf("roots[0] = %q", roots[0])
+	}
+	if !strings.HasSuffix(roots[1], "Contents/Resources/app") {
+		t.Errorf("roots[1] = %q", roots[1])
+	}
+}
+
 func TestNetworkEndpointsExtraction(t *testing.T) {
 	app := makeBundle(t, "FakeNet")
 	bin := filepath.Join(app, "Contents/MacOS/main")

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -37,10 +37,10 @@ type Snapshot struct {
 	Apps       []detect.Result      `json:"apps"`
 	Processes  []process.Info       `json:"processes,omitempty"`
 	Toolchains toolchain.Toolchains `json:"toolchains"`
-	Power      sysinfo.PowerState    `json:"power"`
-	Sysctls    map[string]string     `json:"sysctls,omitempty"`
-	Network    netstate.State        `json:"network"`
-	Storage    storagestate.State    `json:"storage"`
+	Power      sysinfo.PowerState   `json:"power"`
+	Sysctls    map[string]string    `json:"sysctls,omitempty"`
+	Network    netstate.State       `json:"network"`
+	Storage    storagestate.State   `json:"storage"`
 
 	JVMs []jvm.Info `json:"jvms,omitempty"`
 }
@@ -112,6 +112,7 @@ func Build(ctx context.Context, opts Options) Snapshot {
 		TakenAt: time.Now().UTC(),
 		Kind:    KindLive,
 	}
+	appPaths := snapshotAppPaths(opts)
 
 	siRun := opts.SysinfoCmdRunner
 	if siRun == nil {
@@ -145,7 +146,9 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	if !opts.SkipApps {
 		go func() {
 			defer wg.Done()
-			s.Apps = collectApps(ctx, opts)
+			appOpts := opts
+			appOpts.AppPaths = appPaths
+			s.Apps = collectApps(ctx, appOpts)
 		}()
 	}
 	go func() {
@@ -174,7 +177,11 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	if !opts.SkipProcesses {
 		go func() {
 			defer wg.Done()
-			s.Processes = process.CollectAll(ctx, opts.ProcessOpts)
+			processOpts := opts.ProcessOpts
+			if len(processOpts.BundlePaths) == 0 {
+				processOpts.BundlePaths = appPaths
+			}
+			s.Processes = process.CollectAll(ctx, processOpts)
 		}()
 	}
 	if !opts.SkipJVMs {
@@ -186,6 +193,20 @@ func Build(ctx context.Context, opts Options) Snapshot {
 
 	wg.Wait()
 	return s
+}
+
+func snapshotAppPaths(opts Options) []string {
+	if len(opts.AppPaths) > 0 {
+		paths := append([]string(nil), opts.AppPaths...)
+		sort.Strings(paths)
+		return paths
+	}
+	if opts.SkipApps {
+		return nil
+	}
+	paths := append(scanApps("/Applications"), scanApps("/Applications/Utilities")...)
+	sort.Strings(paths)
+	return paths
 }
 
 // collectApps runs Detect across opts.AppPaths in parallel. When

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
 )
 
 func TestBuildHostOnly(t *testing.T) {
@@ -99,5 +101,40 @@ func TestBuildSkipAppsProducesNoApps(t *testing.T) {
 	}
 	if len(snap.Apps) != 0 {
 		t.Errorf("Apps = %d, want 0 when SkipApps=true", len(snap.Apps))
+	}
+}
+
+func TestBuildAttributesProcessesToConfiguredAppPaths(t *testing.T) {
+	psOut := "412 1 0.5 184320 204800 501 alice Sat May 2 22:40:05 2026 /Applications/Foo.app/Contents/MacOS/Foo --type=renderer\n" +
+		"1 0 0.0 4096 8192 0 root Sat May 2 22:00:00 2026 /sbin/launchd\n"
+	snap := Build(context.Background(), Options{
+		AppPaths:    []string{"/Applications/Foo.app"},
+		SkipApps:    true,
+		SkipStorage: true,
+		SkipJVMs:    true,
+		ProcessOpts: process.CollectOptions{
+			CmdRunner: func(name string, args ...string) ([]byte, error) {
+				if name == "ps" {
+					return []byte(psOut), nil
+				}
+				return nil, nil
+			},
+		},
+	})
+
+	if len(snap.Processes) != 2 {
+		t.Fatalf("Processes len = %d, want 2", len(snap.Processes))
+	}
+	var matched bool
+	for _, p := range snap.Processes {
+		if p.PID == 412 {
+			matched = true
+			if p.AppPath != "/Applications/Foo.app" {
+				t.Errorf("AppPath = %q, want /Applications/Foo.app", p.AppPath)
+			}
+		}
+	}
+	if !matched {
+		t.Fatal("PID 412 not found")
 	}
 }


### PR DESCRIPTION
## Summary

- scan Electron native modules from both app.asar.unpacked and unpacked Resources/app payloads
- persist snapshot child rows for processes, login items, and granted privacy permissions from the CLI save path
- share app bundle paths with process collection so snapshot process rows can include app attribution
- update CLI and native-module docs to match current behavior

## Validation

- go build ./...
- go vet ./...
- go test ./... -count=1
- make docs-validate

## Notes

A first full test run hit a transient timeout in an existing internal/serve daemon RPC test. The specific test passed alone, and the full suite passed on rerun without code changes.