### PR TITLE
Add list alias

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -6,6 +6,7 @@
 //	spectra /Applications/*.app
 //	spectra --all                               # inspect every /Applications app
 //	spectra --json /Applications/Cursor.app
+//	spectra list                                # inspect every /Applications app
 //	spectra snapshot                            # capture host + apps snapshot
 //	spectra snapshot --json
 //	spectra version
@@ -33,6 +34,7 @@ type subcommand struct {
 func subcommandList() []subcommand {
 	return []subcommand{
 		{"inspect", "Inspect .app bundles (default; runs when no subcommand given)", runInspect},
+		{"list", "Inspect every .app under /Applications", runList},
 		{"snapshot", "Capture a structured snapshot of host + installed apps", runSnapshot},
 		{"jvm", "List or inspect running JVM processes", runJVM},
 		{"toolchain", "Show installed language runtimes and package managers", runToolchain},
@@ -85,6 +87,17 @@ func runVersion(_ []string) int {
 	return 0
 }
 
+func runList(args []string) int {
+	return runInspect(listInspectArgs(args))
+}
+
+func listInspectArgs(args []string) []string {
+	next := make([]string, 0, len(args)+1)
+	next = append(next, "--all")
+	next = append(next, args...)
+	return next
+}
+
 func runHelpCmd(_ []string) int {
 	runHelp(os.Stdout)
 	return 0
@@ -103,5 +116,6 @@ func runHelp(w *os.File) {
 	fmt.Fprintln(w, "Flag-only invocations route to `inspect`:")
 	fmt.Fprintln(w, "  spectra /Applications/Slack.app")
 	fmt.Fprintln(w, "  spectra --all -v")
+	fmt.Fprintln(w, "  spectra list -v")
 	fmt.Fprintln(w, "  spectra --json /Applications/Cursor.app")
 }

--- a/cmd/spectra/main_test.go
+++ b/cmd/spectra/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestSubcommandListIncludesList(t *testing.T) {
+	for _, sc := range subcommandList() {
+		if sc.name == "list" {
+			return
+		}
+	}
+	t.Fatal("subcommandList missing list alias")
+}
+
+func TestListInspectArgsPrependsAll(t *testing.T) {
+	got := listInspectArgs([]string{"-v", "--json"})
+	want := []string{"--all", "-v", "--json"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("arg %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -17,6 +17,7 @@ spectra [flags] <App.app>...     # routes to `inspect` (default)
 | Name | Description |
 |---|---|
 | `inspect` | Inspect `.app` bundles (default; runs when no subcommand given) |
+| `list` | Inspect every `.app` under `/Applications` |
 | `snapshot` | Capture a structured snapshot of host + installed apps |
 | `diff` | Diff two stored snapshots |
 | `rules` | Evaluate recommendation rules against a snapshot |
@@ -54,6 +55,7 @@ flags for one.
 spectra /Applications/Slack.app                # one app, terse
 spectra -v /Applications/Claude.app            # full per-app dump
 spectra --all                                  # scan /Applications + Utilities
+spectra list -v                                # same scan with an explicit subcommand
 spectra --network -v /Applications/Cursor.app  # add embedded URL hosts
 spectra --json /Applications/*.app | jq '.[] | select(.UI == "Tauri")'
 ```
@@ -178,7 +180,6 @@ and processing continues for other paths.
 
 ```
 spectra connect <host>              # client targeting a remote daemon
-spectra list                        # alias for "scan all bundles via local daemon"
 ```
 
 See [../design/architecture.md](../design/architecture.md) for the


### PR DESCRIPTION
## Summary

- add `spectra list` as an explicit alias for `inspect --all`
- document the alias in the CLI reference and remove it from remaining planned commands
- add command registration and argument construction tests

## Validation

- go build ./...
- go vet ./...
- go test ./... -count=1
- make docs-validate