### PR TITLE
Fix non-Darwin peer UID lint

### DIFF
--- a/internal/helper/peeruid_other.go
+++ b/internal/helper/peeruid_other.go
@@ -4,4 +4,4 @@ package helper
 
 import "net"
 
-func peerUID(conn net.Conn) uint32 { return 0 }
+func peerUID(_ net.Conn) uint32 { return 0 }


### PR DESCRIPTION
## Summary
- Fix the Linux/non-Darwin helper peer UID stub so revive does not flag its unused parameter in CI.

## Validation
- `golangci-lint run`
- `GOOS=linux golangci-lint run ./internal/helper`
- `go test ./internal/helper -count=1`
