### PR TITLE
Add JFR dump RPC method

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -33,7 +33,10 @@ import (
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
-var collectToolchains = toolchain.Collect
+var (
+	collectToolchains = toolchain.Collect
+	runJFRDump        = jvm.JFRDump
+)
 
 // DefaultSockPath returns the canonical Unix socket path (~/.spectra/sock).
 func DefaultSockPath() (string, error) {
@@ -580,6 +583,29 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, fmt.Errorf("jfr start pid %d: %w", p.PID, err)
 		}
 		return map[string]any{"pid": p.PID, "name": name, "started": true}, nil
+	})
+
+	// jvm.jfr.dump — dump a running JFR recording. Required: {"pid": <pid>, "dest": "/path/to/out.jfr"}.
+	d.Register("jvm.jfr.dump", func(params json.RawMessage) (any, error) {
+		var p struct {
+			PID  int    `json:"pid"`
+			Name string `json:"name"`
+			Dest string `json:"dest"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.PID == 0 {
+			return nil, fmt.Errorf("jvm.jfr.dump requires {\"pid\": <pid>, \"dest\": \"...\"}")
+		}
+		if p.Dest == "" {
+			return nil, fmt.Errorf("jvm.jfr.dump requires {\"dest\": \"...\"}")
+		}
+		name := p.Name
+		if name == "" {
+			name = "spectra"
+		}
+		if err := runJFRDump(p.PID, name, p.Dest, nil); err != nil {
+			return nil, fmt.Errorf("jfr dump pid %d: %w", p.PID, err)
+		}
+		return map[string]any{"pid": p.PID, "name": name, "dest": p.Dest, "dumped": true}, nil
 	})
 
 	// jvm.jfr.stop — stop a JFR recording. Optional: {"dest": "/path/to/out.jfr"}.

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/cache"
+	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/store"
@@ -411,6 +412,54 @@ func TestDaemonJVMJFRStartMissingPID(t *testing.T) {
 	resp := rpcCall(t, enc, dec, 33, "jvm.jfr.start", `{}`)
 	if resp.Error == nil {
 		t.Error("expected error when pid missing")
+	}
+}
+
+func TestDaemonJVMJFRDumpMissingPID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 35, "jvm.jfr.dump", `{"dest":"/tmp/out.jfr"}`)
+	if resp.Error == nil {
+		t.Error("expected error when pid missing")
+	}
+}
+
+func TestDaemonJVMJFRDumpMissingDest(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 36, "jvm.jfr.dump", `{"pid":42}`)
+	if resp.Error == nil {
+		t.Error("expected error when dest missing")
+	}
+}
+
+func TestDaemonJVMJFRDumpUsesDefaultName(t *testing.T) {
+	var gotPID int
+	var gotName, gotDest string
+	orig := runJFRDump
+	runJFRDump = func(pid int, name, dest string, _ jvm.CmdRunner) error {
+		gotPID = pid
+		gotName = name
+		gotDest = dest
+		return nil
+	}
+	t.Cleanup(func() { runJFRDump = orig })
+
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 37, "jvm.jfr.dump", `{"pid":42,"dest":"/tmp/out.jfr"}`)
+	if resp.Error != nil {
+		t.Fatalf("jvm.jfr.dump: %v", resp.Error)
+	}
+	if gotPID != 42 || gotName != "spectra" || gotDest != "/tmp/out.jfr" {
+		t.Fatalf("dump args = (%d, %q, %q), want (42, spectra, /tmp/out.jfr)", gotPID, gotName, gotDest)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	if m["dumped"] != true {
+		t.Errorf("dumped = %v, want true", m["dumped"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add the missing `jvm.jfr.dump` JSON-RPC method to match the documented JVM RPC surface and existing CLI behavior.
- Require `pid` and `dest`, default the recording name to `spectra`, and return a structured dump result.
- Add daemon RPC tests for missing parameters and the default-name happy path using a fake JFR dump runner.

## Validation
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make complexity`
- `golangci-lint run`
- `make security`
