### PR TITLE
Inject active runtime command runner

### DIFF
--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -10,7 +10,7 @@ import (
 
 // discoverNode enumerates Node.js installations from all common managers.
 func discoverNode(opts CollectOptions) ([]RuntimeInstall, error) {
-	active := activeVersion("node")
+	active := activeVersion(opts.CmdRunner, "node")
 	var out []RuntimeInstall
 
 	// nvm
@@ -55,7 +55,7 @@ func discoverNode(opts CollectOptions) ([]RuntimeInstall, error) {
 
 // discoverPython enumerates Python installations.
 func discoverPython(opts CollectOptions) ([]RuntimeInstall, error) {
-	active := activeVersion("python3")
+	active := activeVersion(opts.CmdRunner, "python3")
 	var out []RuntimeInstall
 
 	// system
@@ -96,7 +96,7 @@ func discoverPython(opts CollectOptions) ([]RuntimeInstall, error) {
 
 // discoverGo enumerates Go installations.
 func discoverGo(opts CollectOptions) ([]RuntimeInstall, error) {
-	active := activeVersion("go")
+	active := activeVersion(opts.CmdRunner, "go")
 	var out []RuntimeInstall
 
 	// system /usr/local/go
@@ -133,7 +133,7 @@ func discoverGo(opts CollectOptions) ([]RuntimeInstall, error) {
 
 // discoverRuby enumerates Ruby installations.
 func discoverRuby(opts CollectOptions) ([]RuntimeInstall, error) {
-	active := activeVersion("ruby")
+	active := activeVersion(opts.CmdRunner, "ruby")
 	var out []RuntimeInstall
 
 	// rbenv
@@ -224,9 +224,13 @@ func listDirs(dir string) []string {
 	return out
 }
 
-// activeVersion runs `which <bin>` and returns the resolved path.
-func activeVersion(bin string) string {
-	out, err := execRunner("which", bin)
+// activeVersion runs `which <bin>` through the injected runner and returns the
+// resolved path.
+func activeVersion(run CmdRunner, bin string) string {
+	if run == nil {
+		run = execRunner
+	}
+	out, err := run("which", bin)
 	if err != nil {
 		return ""
 	}

--- a/internal/toolchain/runtime_test.go
+++ b/internal/toolchain/runtime_test.go
@@ -61,6 +61,34 @@ func TestDiscoverNodeFromMultipleManagers(t *testing.T) {
 	}
 }
 
+func TestDiscoverNodeMarksActiveFromInjectedRunner(t *testing.T) {
+	home := t.TempDir()
+	version := "v22.1.0"
+	makeVersionDir(t, filepath.Join(home, ".nvm", "versions", "node"), version)
+	activeNode := filepath.Join(home, ".nvm", "versions", "node", version, "bin", "node")
+
+	opts := CollectOptions{
+		Home:        home,
+		BrewCellars: []string{},
+		CmdRunner: func(name string, args ...string) ([]byte, error) {
+			if name == "which" && len(args) == 1 && args[0] == "node" {
+				return []byte(activeNode + "\n"), nil
+			}
+			return nil, errors.New("unexpected command")
+		},
+	}
+	installs, err := discoverNode(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installs) != 1 {
+		t.Fatalf("got %d installs, want 1: %+v", len(installs), installs)
+	}
+	if !installs[0].Active {
+		t.Fatalf("Active = false, want true for %s", activeNode)
+	}
+}
+
 func TestDiscoverRustToolchains(t *testing.T) {
 	home := t.TempDir()
 	rtBase := filepath.Join(home, ".rustup", "toolchains")


### PR DESCRIPTION
## Summary
- route active runtime resolution through the existing toolchain CmdRunner injection point
- keep nil-runner fallback behavior for direct helper calls
- add a fake `which node` test that verifies active Node detection is deterministic

## Validation
- go test ./internal/toolchain -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make complexity
- golangci-lint run
- make security