### PR TITLE
Use documented Maven version flag

### DIFF
--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -284,10 +284,10 @@ func discoverBuildTools(opts CollectOptions) []BuildTool {
 		}
 	}
 
-	// Maven — check brew cellar first, then mvn --version.
+	// Maven — check brew cellar first, then mvn -version.
 	if v := brewVersion(opts.BrewCellars, "maven"); v != "" {
 		add("maven", v, "brew")
-	} else if v := versionFromCmd(opts.CmdRunner, "mvn", "--version"); v != "" {
+	} else if v := versionFromCmd(opts.CmdRunner, "mvn", "-version"); v != "" {
 		add("maven", v, "system")
 	}
 

--- a/internal/toolchain/runtime_test.go
+++ b/internal/toolchain/runtime_test.go
@@ -313,6 +313,30 @@ func TestDiscoverBuildToolsMavenFromBrew(t *testing.T) {
 	}
 }
 
+func TestDiscoverBuildToolsMavenFromCmdUsesDocumentedFlag(t *testing.T) {
+	home := t.TempDir()
+	opts := CollectOptions{
+		Home:        home,
+		BrewCellars: []string{filepath.Join(home, "Cellar")},
+		CmdRunner: func(name string, args ...string) ([]byte, error) {
+			if name == "mvn" && len(args) == 1 && args[0] == "-version" {
+				return []byte("Apache Maven 3.9.6\n"), nil
+			}
+			return nil, errors.New("not found")
+		},
+	}
+	tools := discoverBuildTools(opts)
+	if len(tools) != 1 || tools[0].Name != "maven" {
+		t.Errorf("expected [maven], got %v", tools)
+	}
+	if tools[0].Version != "3.9.6" {
+		t.Errorf("version = %q, want 3.9.6", tools[0].Version)
+	}
+	if tools[0].Source != "system" {
+		t.Errorf("source = %q, want system", tools[0].Source)
+	}
+}
+
 func TestDiscoverBuildToolsGradleFromCmd(t *testing.T) {
 	home := t.TempDir()
 	opts := CollectOptions{


### PR DESCRIPTION
## Summary
- align Maven build-tool probing with the documented `mvn -version` command
- add a fake-based unit test that asserts the documented flag is used

## Validation
- go test ./internal/toolchain -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make complexity
- golangci-lint run
- make security