### PR TITLE
Use documented Gradle version flag

### DIFF
--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -291,10 +291,10 @@ func discoverBuildTools(opts CollectOptions) []BuildTool {
 		add("maven", v, "system")
 	}
 
-	// Gradle — check brew cellar first, then gradle --version.
+	// Gradle — check brew cellar first, then gradle -version.
 	if v := brewVersion(opts.BrewCellars, "gradle"); v != "" {
 		add("gradle", v, "brew")
-	} else if v := versionFromCmd(opts.CmdRunner, "gradle", "--version"); v != "" {
+	} else if v := versionFromCmd(opts.CmdRunner, "gradle", "-version"); v != "" {
 		add("gradle", v, "system")
 	}
 

--- a/internal/toolchain/runtime_test.go
+++ b/internal/toolchain/runtime_test.go
@@ -337,13 +337,13 @@ func TestDiscoverBuildToolsMavenFromCmdUsesDocumentedFlag(t *testing.T) {
 	}
 }
 
-func TestDiscoverBuildToolsGradleFromCmd(t *testing.T) {
+func TestDiscoverBuildToolsGradleFromCmdUsesDocumentedFlag(t *testing.T) {
 	home := t.TempDir()
 	opts := CollectOptions{
 		Home:        home,
 		BrewCellars: []string{filepath.Join(home, "Cellar")},
 		CmdRunner: func(name string, args ...string) ([]byte, error) {
-			if name == "gradle" {
+			if name == "gradle" && len(args) == 1 && args[0] == "-version" {
 				return []byte("Gradle 8.5\n..."), nil
 			}
 			return nil, errors.New("not found")


### PR DESCRIPTION
## Summary
- align Gradle build-tool probing with the documented `gradle -version` command
- tighten the fake-backed unit test so it only returns Gradle output for the documented flag

## Validation
- go test ./internal/toolchain -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make complexity
- golangci-lint run
- make security