### PR TITLE
Report active JVM manager

### DIFF
--- a/cmd/spectra/toolchain.go
+++ b/cmd/spectra/toolchain.go
@@ -163,7 +163,11 @@ func printToolchains(tc toolchain.Toolchains) {
 	}
 
 	if len(tc.JVMManagers) > 0 {
-		fmt.Printf("\nJVM managers: %s\n", strings.Join(tc.JVMManagers, ", "))
+		active := ""
+		if tc.ActiveJVMManager != "" {
+			active = fmt.Sprintf(" (active: %s)", tc.ActiveJVMManager)
+		}
+		fmt.Printf("\nJVM managers: %s%s\n", strings.Join(tc.JVMManagers, ", "), active)
 	}
 
 	b := tc.Brew

--- a/internal/toolchain/collect.go
+++ b/internal/toolchain/collect.go
@@ -90,7 +90,11 @@ func Collect(ctx context.Context, opts CollectOptions) Toolchains {
 		}),
 		run(func() (func(*Toolchains), error) {
 			managers := discoverJVMManagers(opts.Home)
-			return func(t *Toolchains) { t.JVMManagers = managers }, nil
+			active := discoverActiveJVMManager(opts.Home, opts.CmdRunner)
+			return func(t *Toolchains) {
+				t.JVMManagers = managers
+				t.ActiveJVMManager = active
+			}, nil
 		}),
 		run(func() (func(*Toolchains), error) {
 			buildTools := discoverBuildTools(opts)

--- a/internal/toolchain/collect_test.go
+++ b/internal/toolchain/collect_test.go
@@ -24,10 +24,18 @@ JAVA_RUNTIME_VERSION="21.0.6+7-LTS"
 	// Plant a fake rustup toolchain.
 	os.MkdirAll(filepath.Join(home, ".rustup", "toolchains", "stable-aarch64-apple-darwin"), 0o755)
 
+	// Plant a fake jenv install and make it the active java shim.
+	os.MkdirAll(filepath.Join(home, ".jenv", "bin"), 0o755)
+	os.WriteFile(filepath.Join(home, ".jenv", "bin", "jenv"), []byte(""), 0o755)
+	activeJava := filepath.Join(home, ".jenv", "shims", "java")
+
 	// Stub brew to return empty.
 	stub := func(name string, args ...string) ([]byte, error) {
 		if name == "brew" && len(args) > 0 && args[0] == "info" {
 			return []byte(`{"formulae":[]}`), nil
+		}
+		if name == "which" && len(args) == 1 && args[0] == "java" {
+			return []byte(activeJava + "\n"), nil
 		}
 		return []byte{}, nil
 	}
@@ -48,5 +56,8 @@ JAVA_RUNTIME_VERSION="21.0.6+7-LTS"
 	}
 	if len(tc.Rust) != 1 {
 		t.Errorf("Rust: got %d, want 1", len(tc.Rust))
+	}
+	if tc.ActiveJVMManager != "jenv" {
+		t.Errorf("ActiveJVMManager: got %q, want jenv", tc.ActiveJVMManager)
 	}
 }

--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -272,6 +272,28 @@ func discoverJVMManagers(home string) []string {
 	return found
 }
 
+func discoverActiveJVMManager(home string, run CmdRunner) string {
+	java := activeVersion(run, "java")
+	if java == "" {
+		return ""
+	}
+	probes := []struct {
+		name   string
+		prefix string
+	}{
+		{"jenv", filepath.Join(home, ".jenv", "shims") + string(os.PathSeparator)},
+		{"asdf", filepath.Join(home, ".asdf", "shims") + string(os.PathSeparator)},
+		{"mise", filepath.Join(home, ".local", "share", "mise", "shims") + string(os.PathSeparator)},
+		{"sdkman", filepath.Join(home, ".sdkman", "candidates", "java") + string(os.PathSeparator)},
+	}
+	for _, p := range probes {
+		if strings.HasPrefix(java, p.prefix) {
+			return p.name
+		}
+	}
+	return ""
+}
+
 // discoverBuildTools finds installed Maven, Gradle, Bazel, Make, and CMake.
 // Uses brew cellar presence (fast, no forking) as primary detection;
 // falls back to version commands for tools not managed by brew.

--- a/internal/toolchain/runtime_test.go
+++ b/internal/toolchain/runtime_test.go
@@ -272,6 +272,33 @@ func TestDiscoverJVMManagersMultiple(t *testing.T) {
 	}
 }
 
+func TestDiscoverActiveJVMManagerFromJenvShim(t *testing.T) {
+	home := t.TempDir()
+	activeJava := filepath.Join(home, ".jenv", "shims", "java")
+	manager := discoverActiveJVMManager(home, func(name string, args ...string) ([]byte, error) {
+		if name == "which" && len(args) == 1 && args[0] == "java" {
+			return []byte(activeJava + "\n"), nil
+		}
+		return nil, errors.New("not found")
+	})
+	if manager != "jenv" {
+		t.Fatalf("manager = %q, want jenv", manager)
+	}
+}
+
+func TestDiscoverActiveJVMManagerIgnoresSystemJava(t *testing.T) {
+	home := t.TempDir()
+	manager := discoverActiveJVMManager(home, func(name string, args ...string) ([]byte, error) {
+		if name == "which" && len(args) == 1 && args[0] == "java" {
+			return []byte("/usr/bin/java\n"), nil
+		}
+		return nil, errors.New("not found")
+	})
+	if manager != "" {
+		t.Fatalf("manager = %q, want empty", manager)
+	}
+}
+
 func TestDiscoverBuildToolsNone(t *testing.T) {
 	home := t.TempDir()
 	opts := CollectOptions{

--- a/internal/toolchain/types.go
+++ b/internal/toolchain/types.go
@@ -13,8 +13,10 @@ type Toolchains struct {
 	Ruby        []RuntimeInstall `json:"ruby,omitempty"`
 	Rust        []RustToolchain  `json:"rust,omitempty"`
 	JVMManagers []string         `json:"jvm_managers,omitempty"` // "sdkman", "asdf", "mise", "jenv"
-	BuildTools  []BuildTool      `json:"build_tools,omitempty"`
-	Env         EnvSnapshot      `json:"env"`
+	// ActiveJVMManager is the manager whose java shim wins PATH resolution.
+	ActiveJVMManager string      `json:"active_jvm_manager,omitempty"`
+	BuildTools       []BuildTool `json:"build_tools,omitempty"`
+	Env              EnvSnapshot `json:"env"`
 }
 
 // BuildTool is one JVM-ecosystem build tool installation (Maven, Gradle, Bazel, Make, CMake).


### PR DESCRIPTION
## Summary
- add `active_jvm_manager` to toolchain inventory when a JVM manager shim wins `which java`
- detect active jenv/asdf/mise/sdkman shims through the injected command runner
- surface the active manager in human `spectra toolchain` output
- add fake-backed unit coverage for active manager detection and aggregate collection

## Validation
- go test ./internal/toolchain -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make complexity
- golangci-lint run
- make security