### PR TITLE
Report Maven settings path

### DIFF
--- a/cmd/spectra/toolchain.go
+++ b/cmd/spectra/toolchain.go
@@ -158,7 +158,11 @@ func printToolchains(tc toolchain.Toolchains) {
 	if len(tc.BuildTools) > 0 {
 		fmt.Printf("\nBuild tools (%d):\n", len(tc.BuildTools))
 		for _, bt := range tc.BuildTools {
-			fmt.Printf("  %-8s  %-12s  %s\n", bt.Name, bt.Version, bt.Source)
+			config := ""
+			if bt.ConfigPath != "" {
+				config = "  " + bt.ConfigPath
+			}
+			fmt.Printf("  %-8s  %-12s  %s%s\n", bt.Name, bt.Version, bt.Source, config)
 		}
 	}
 

--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -139,6 +139,7 @@ Toolchains {
   ruby    []{ version, source ∈ {brew, asdf, rbenv}, active }
   rust    []{ toolchain, channel ∈ {stable, beta, nightly}, default }
   jvm_managers ∈ {sdkman, asdf, mise, jenv}
+  build_tools []{ name, version, source, config_path? }
 }
 ```
 

--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -302,7 +302,12 @@ func discoverBuildTools(opts CollectOptions) []BuildTool {
 
 	add := func(name, version, source string) {
 		if version != "" {
-			tools = append(tools, BuildTool{Name: name, Version: version, Source: source})
+			tools = append(tools, BuildTool{
+				Name:       name,
+				Version:    version,
+				Source:     source,
+				ConfigPath: buildToolConfigPath(opts.Home, name),
+			})
 		}
 	}
 
@@ -344,6 +349,17 @@ func discoverBuildTools(opts CollectOptions) []BuildTool {
 	}
 
 	return tools
+}
+
+func buildToolConfigPath(home, name string) string {
+	switch name {
+	case "maven":
+		path := filepath.Join(home, ".m2", "settings.xml")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
 }
 
 // brewVersion returns the installed version of a formula by scanning

--- a/internal/toolchain/runtime_test.go
+++ b/internal/toolchain/runtime_test.go
@@ -340,6 +340,34 @@ func TestDiscoverBuildToolsMavenFromBrew(t *testing.T) {
 	}
 }
 
+func TestDiscoverBuildToolsMavenReportsConfigPath(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".m2", "settings.xml")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte("<settings></settings>\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := CollectOptions{
+		Home:        home,
+		BrewCellars: []string{filepath.Join(home, "Cellar")},
+		CmdRunner: func(name string, args ...string) ([]byte, error) {
+			if name == "mvn" && len(args) == 1 && args[0] == "-version" {
+				return []byte("Apache Maven 3.9.6\n"), nil
+			}
+			return nil, errors.New("not found")
+		},
+	}
+	tools := discoverBuildTools(opts)
+	if len(tools) != 1 || tools[0].Name != "maven" {
+		t.Fatalf("expected [maven], got %v", tools)
+	}
+	if tools[0].ConfigPath != settingsPath {
+		t.Fatalf("config path = %q, want %q", tools[0].ConfigPath, settingsPath)
+	}
+}
+
 func TestDiscoverBuildToolsMavenFromCmdUsesDocumentedFlag(t *testing.T) {
 	home := t.TempDir()
 	opts := CollectOptions{

--- a/internal/toolchain/types.go
+++ b/internal/toolchain/types.go
@@ -21,9 +21,10 @@ type Toolchains struct {
 
 // BuildTool is one JVM-ecosystem build tool installation (Maven, Gradle, Bazel, Make, CMake).
 type BuildTool struct {
-	Name    string `json:"name"`    // "maven", "gradle", "bazel", "make", "cmake"
-	Version string `json:"version"` // raw version string
-	Source  string `json:"source"`  // "brew", "system", "wrapper"
+	Name       string `json:"name"`                  // "maven", "gradle", "bazel", "make", "cmake"
+	Version    string `json:"version"`               // raw version string
+	Source     string `json:"source"`                // "brew", "system", "wrapper"
+	ConfigPath string `json:"config_path,omitempty"` // user-level config path when known
 }
 
 // BrewInventory holds installed Homebrew formulae, casks, and taps.


### PR DESCRIPTION
## Summary
- add optional `config_path` to build tool JSON rows
- report `~/.m2/settings.xml` for Maven when present
- include the path in human toolchain output and document the schema sketch

## Validation
- go test ./internal/toolchain -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make complexity
- golangci-lint run
- make security
- make docs-validate