### PR TITLE
Report Gradle user home

### DIFF
--- a/cmd/spectra/toolchain.go
+++ b/cmd/spectra/toolchain.go
@@ -158,11 +158,7 @@ func printToolchains(tc toolchain.Toolchains) {
 	if len(tc.BuildTools) > 0 {
 		fmt.Printf("\nBuild tools (%d):\n", len(tc.BuildTools))
 		for _, bt := range tc.BuildTools {
-			config := ""
-			if bt.ConfigPath != "" {
-				config = "  " + bt.ConfigPath
-			}
-			fmt.Printf("  %-8s  %-12s  %s%s\n", bt.Name, bt.Version, bt.Source, config)
+			fmt.Printf("  %-8s  %-12s  %s%s\n", bt.Name, bt.Version, bt.Source, buildToolDetails(bt))
 		}
 	}
 
@@ -187,6 +183,20 @@ func printToolchains(tc toolchain.Toolchains) {
 	if tc.Env.GoPath != "" {
 		fmt.Printf("GOPATH:    %s\n", tc.Env.GoPath)
 	}
+}
+
+func buildToolDetails(bt toolchain.BuildTool) string {
+	var details []string
+	if bt.ConfigPath != "" {
+		details = append(details, bt.ConfigPath)
+	}
+	if bt.UserHome != "" {
+		details = append(details, "user_home="+bt.UserHome)
+	}
+	if len(details) == 0 {
+		return ""
+	}
+	return "  " + strings.Join(details, "  ")
 }
 
 func printRuntimes(name string, runtimes []toolchain.RuntimeInstall) {

--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -139,7 +139,7 @@ Toolchains {
   ruby    []{ version, source ∈ {brew, asdf, rbenv}, active }
   rust    []{ toolchain, channel ∈ {stable, beta, nightly}, default }
   jvm_managers ∈ {sdkman, asdf, mise, jenv}
-  build_tools []{ name, version, source, config_path? }
+  build_tools []{ name, version, source, config_path?, user_home? }
 }
 ```
 

--- a/internal/toolchain/collect.go
+++ b/internal/toolchain/collect.go
@@ -25,10 +25,16 @@ type CollectOptions struct {
 	// CmdRunner runs external commands. Defaults to execRunner.
 	// Inject a fake in tests to avoid shelling out to brew.
 	CmdRunner CmdRunner
+	// EnvLookup reads named environment variables. Defaults to os.LookupEnv.
+	// Inject a fake in tests to avoid mutating process environment.
+	EnvLookup EnvLookup
 }
 
 // CmdRunner abstracts exec.Command for testability.
 type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// EnvLookup abstracts os.LookupEnv for testability.
+type EnvLookup func(key string) (string, bool)
 
 // Collect runs all subsystem discoverers in parallel and returns the
 // aggregate Toolchains. Any discoverer error is silently absorbed —
@@ -139,6 +145,9 @@ func withDefaults(o CollectOptions) CollectOptions {
 	}
 	if o.CmdRunner == nil {
 		o.CmdRunner = execRunner
+	}
+	if o.EnvLookup == nil {
+		o.EnvLookup = os.LookupEnv
 	}
 	return o
 }

--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -307,6 +307,7 @@ func discoverBuildTools(opts CollectOptions) []BuildTool {
 				Version:    version,
 				Source:     source,
 				ConfigPath: buildToolConfigPath(opts.Home, name),
+				UserHome:   buildToolUserHome(opts, name),
 			})
 		}
 	}
@@ -363,6 +364,16 @@ func buildToolConfigPath(home, name string) string {
 		if _, err := os.Stat(path); err == nil {
 			return path
 		}
+	}
+	return ""
+}
+
+func buildToolUserHome(opts CollectOptions, name string) string {
+	if name != "gradle" || opts.EnvLookup == nil {
+		return ""
+	}
+	if v, ok := opts.EnvLookup("GRADLE_USER_HOME"); ok {
+		return v
 	}
 	return ""
 }

--- a/internal/toolchain/runtime_test.go
+++ b/internal/toolchain/runtime_test.go
@@ -413,6 +413,34 @@ func TestDiscoverBuildToolsGradleFromCmdUsesDocumentedFlag(t *testing.T) {
 	}
 }
 
+func TestDiscoverBuildToolsGradleReportsUserHome(t *testing.T) {
+	home := t.TempDir()
+	gradleUserHome := filepath.Join(home, ".gradle-custom")
+	opts := CollectOptions{
+		Home:        home,
+		BrewCellars: []string{filepath.Join(home, "Cellar")},
+		CmdRunner: func(name string, args ...string) ([]byte, error) {
+			if name == "gradle" && len(args) == 1 && args[0] == "-version" {
+				return []byte("Gradle 8.5\n"), nil
+			}
+			return nil, errors.New("not found")
+		},
+		EnvLookup: func(key string) (string, bool) {
+			if key == "GRADLE_USER_HOME" {
+				return gradleUserHome, true
+			}
+			return "", false
+		},
+	}
+	tools := discoverBuildTools(opts)
+	if len(tools) != 1 || tools[0].Name != "gradle" {
+		t.Fatalf("expected [gradle], got %v", tools)
+	}
+	if tools[0].UserHome != gradleUserHome {
+		t.Fatalf("user home = %q, want %q", tools[0].UserHome, gradleUserHome)
+	}
+}
+
 func TestDiscoverBuildToolsBazelReportsConfigPath(t *testing.T) {
 	home := t.TempDir()
 	bazelrcPath := filepath.Join(home, ".bazelrc")

--- a/internal/toolchain/types.go
+++ b/internal/toolchain/types.go
@@ -25,6 +25,7 @@ type BuildTool struct {
 	Version    string `json:"version"`               // raw version string
 	Source     string `json:"source"`                // "brew", "system", "wrapper"
 	ConfigPath string `json:"config_path,omitempty"` // user-level config path when known
+	UserHome   string `json:"user_home,omitempty"`   // tool-specific user home when known
 }
 
 // BrewInventory holds installed Homebrew formulae, casks, and taps.


### PR DESCRIPTION
## Summary
- add optional `user_home` to build tool JSON rows
- report `GRADLE_USER_HOME` for Gradle via injected environment lookup
- include build-tool details in human output through a small formatter helper
- document the schema sketch

## Validation
- go test ./internal/toolchain ./cmd/spectra -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make complexity
- golangci-lint run
- make security
- make docs-validate