### PR TITLE
Add security reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+Spectra is pre-1.0. Security fixes target the `main` branch until the
+first tagged release establishes versioned support windows.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately by emailing
+Jason Pearson at <jason.d.pearson@gmail.com>. Do not open a public
+GitHub issue for security-sensitive reports.
+
+Include the affected command or component, the host macOS version,
+steps to reproduce, expected impact, and any logs or sample bundles
+needed to validate the issue.
+
+## Response
+
+Expect an acknowledgement within 7 days. Confirmed vulnerabilities are
+handled on a private branch until a fix is ready to publish. Release
+notes and advisories should avoid exposing exploit details before users
+have a reasonable upgrade path.
+
+## Scope
+
+Security reports are especially relevant for:
+
+- privileged helper installation and IPC boundaries
+- JSON-RPC request parsing and authorization
+- local snapshot storage permissions
+- handling of app bundles, process data, and user-controlled paths
+- remote access over Tailscale or future network transports
+
+Out-of-scope reports include social engineering, denial-of-service
+against development-only commands, and issues that require already
+compromised local administrator access unless they cross a Spectra
+privilege boundary.

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -224,8 +224,9 @@ Things Spectra commits to before v1 release:
 
 ## Reporting issues
 
-Security issues should be reported privately to the maintainers. A
-`SECURITY.md` will land alongside the v0.1 release with PGP details.
+Security issues should be reported privately to the maintainers. See
+[../../SECURITY.md](../../SECURITY.md) for the current reporting
+policy.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- add root `SECURITY.md` with private vulnerability reporting guidance
- update the threat model to link to the active policy instead of future-tense text

## Validation
- make docs-validate
- go build ./... && go vet ./...
- go test ./... -count=1
- make complexity
- golangci-lint run
- make security