### PR TITLE
Fix security policy docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ docs-install:
 	pip install --user mkdocs mkdocs-material
 	./scripts/lychee/install_lychee.sh
 
-docs-validate: docs-nav docs-lychee
+docs-validate: docs-nav docs-lychee docs-build
 
 # --- Cleanup -----------------------------------------------------------------
 

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -225,8 +225,8 @@ Things Spectra commits to before v1 release:
 ## Reporting issues
 
 Security issues should be reported privately to the maintainers. See
-[../../SECURITY.md](../../SECURITY.md) for the current reporting
-policy.
+the [security policy](https://github.com/kaeawc/spectra/security/policy)
+for the current reporting process.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- replace the MkDocs-relative `SECURITY.md` link with the GitHub security policy URL
- make `make docs-validate` run `mkdocs build --strict`, matching CI

## Validation
- make docs-validate
- go build ./... && go vet ./...
- go test ./... -count=1
- make complexity
- golangci-lint run
- make security