### PR TITLE
Document Gatekeeper status output

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -92,7 +92,7 @@ target JVM (each process's `java.home` system property tells us which).
 |---|---|---|---|---|
 | `codesign -dv <app>` | signing identity + flags | user | ~100ms | `TeamID`, `HardenedRuntime` |
 | `codesign -d --entitlements :- <app>` | entitlements XML | user | ~100ms | `Entitlements` |
-| `spctl --assess <app>` | Gatekeeper status | user | ~100ms | (planned) trust audit |
+| `spctl --assess --type exec <app>` | Gatekeeper status | user | ~100ms | `GatekeeperStatus` |
 
 ## Permissions
 

--- a/docs/inspection/security.md
+++ b/docs/inspection/security.md
@@ -1,8 +1,8 @@
 # Security inspection
 
-Spectra surfaces three layers of an app's security posture: code
-signing, hardened runtime / sandbox, and the entitlements vs granted
-permissions split.
+Spectra surfaces four layers of an app's security posture: code
+signing, Gatekeeper trust assessment, hardened runtime / sandbox, and
+the entitlements vs granted permissions split.
 
 ## Code signing
 
@@ -20,6 +20,16 @@ Detected from the `flags=0x10000(runtime)` substring in
 `codesign -dv` output. Required for Developer ID notarization. Apps
 without it can't pass Gatekeeper on macOS 10.15+ and are a meaningful
 security regression.
+
+## Gatekeeper assessment
+
+Collected with `spctl --assess --type exec <app>`. Spectra records the
+coarse verdict as `accepted` or `rejected` and leaves the field empty
+when `spctl` is unavailable or cannot assess the bundle.
+
+This is separate from code signing metadata. A bundle can expose a Team
+ID and entitlements but still be rejected by Gatekeeper because it is
+not notarized, is damaged, or fails policy checks on the current host.
 
 ## Sandbox
 
@@ -120,6 +130,7 @@ will flag in the future as a permission-vs-declaration mismatch.
 
 `internal/detect/detect.go`:
 - `readSigning(appPath)` — team ID + hardened runtime
+- `readGatekeeperStatus(appPath)` — Gatekeeper accepted / rejected
 - `readEntitlements(appPath)` — declared entitlements
 - `readPrivacyDescriptions(appPath)` — `NS*UsageDescription`
 - `scanGrantedPermissions(bundleID)` — TCC reads

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -41,6 +41,7 @@ Source of truth: `internal/detect/detect.go`.
 | `Entitlements` | []string | Curated boolean entitlements set true |
 | `PrivacyDescriptions` | map[string]string | `NS*UsageDescription` keys + values |
 | `GrantedPermissions` | []string | TCC.db `auth_value >= 2` services |
+| `GatekeeperStatus` | string | `spctl --assess --type exec`: `accepted`, `rejected`, or empty when unavailable |
 
 ## Live + structural fields
 


### PR DESCRIPTION
## Summary
- document the implemented Gatekeeper assessment field in the security inspection docs
- mark spctl as backing GatekeeperStatus in the live data source table
- add GatekeeperStatus to the result schema reference

## Validation
- make docs-validate
- go build ./... && go vet ./...
- go test ./... -count=1