### PR TITLE
Add baseline workflow CLI aliases

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -45,6 +45,7 @@ func subcommandList() []subcommand {
 		{"diff", "Diff two stored snapshots (alias for snapshot diff)", runSnapshotDiff},
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},
 		{"issues", "List, check, or update persisted issues from the recommendations engine", runIssues},
+		{"baseline", "Manage baseline snapshots (list, drop)", runSnapshotBaseline},
 		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},

--- a/cmd/spectra/main_test.go
+++ b/cmd/spectra/main_test.go
@@ -11,6 +11,15 @@ func TestSubcommandListIncludesList(t *testing.T) {
 	t.Fatal("subcommandList missing list alias")
 }
 
+func TestSubcommandListIncludesBaseline(t *testing.T) {
+	for _, sc := range subcommandList() {
+		if sc.name == "baseline" {
+			return
+		}
+	}
+	t.Fatal("subcommandList missing baseline alias")
+}
+
 func TestListInspectArgsPrependsAll(t *testing.T) {
 	got := listInspectArgs([]string{"-v", "--json"})
 	want := []string{"--all", "-v", "--json"}

--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -20,6 +20,7 @@ import (
 // to mirror the top-level pattern and avoid init cycles.
 func snapshotSubcommands() []subcommand {
 	return []subcommand{
+		{"create", "Capture a structured snapshot", runSnapshotCreate},
 		{"list", "List stored snapshots", runSnapshotList},
 		{"show", "Show details of one snapshot by ID", runSnapshotShow},
 		{"diff", "Diff two stored snapshots", runSnapshotDiff},
@@ -50,6 +51,11 @@ func runSnapshot(args []string) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	snapName, ok := snapshotNameFromArgs(*baseline, *name, fs.Args())
+	if !ok {
+		fmt.Fprintln(os.Stderr, "usage: spectra snapshot [--baseline [name]] [--name name]")
+		return 2
+	}
 
 	opts := snapshot.Options{
 		SpectraVersion: version,
@@ -62,7 +68,6 @@ func runSnapshot(args []string) int {
 	}
 
 	if !*noStore {
-		snapName := *name
 		if err := saveSnapshotNamed(snap, snapName); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not persist snapshot: %v\n", err)
 		}
@@ -79,6 +84,20 @@ func runSnapshot(args []string) int {
 	}
 	printSnapshot(snap)
 	return 0
+}
+
+func runSnapshotCreate(args []string) int {
+	return runSnapshot(args)
+}
+
+func snapshotNameFromArgs(baseline bool, explicitName string, args []string) (string, bool) {
+	if len(args) == 0 {
+		return explicitName, true
+	}
+	if !baseline || explicitName != "" || len(args) > 1 {
+		return "", false
+	}
+	return args[0], true
 }
 
 // saveSnapshot opens the default DB, persists snap, and prunes old live
@@ -393,8 +412,10 @@ func sortStrings(s []string) {
 	}
 }
 
-// runSnapshotDiff loads two snapshots by ID and prints a structured diff.
+// runSnapshotDiff loads two snapshots and prints a structured diff.
 // Either ID may be the sentinel "live" to capture a fresh snapshot on the fly.
+// It also supports `diff baseline [name|id] [live|id]`, where the baseline
+// reference is optional and resolves to the newest baseline when omitted.
 func runSnapshotDiff(args []string) int {
 	fs := flag.NewFlagSet("spectra snapshot diff", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -402,11 +423,14 @@ func runSnapshotDiff(args []string) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if fs.NArg() != 2 {
-		fmt.Fprintln(os.Stderr, "usage: spectra snapshot diff <id-a> <id-b|live>")
+	if fs.NArg() < 1 || fs.NArg() > 3 {
+		printDiffUsage()
 		return 2
 	}
-	idA, idB := fs.Arg(0), fs.Arg(1)
+	if fs.Arg(0) != "baseline" && fs.NArg() != 2 {
+		printDiffUsage()
+		return 2
+	}
 
 	dbPath, err := store.DefaultPath()
 	if err != nil {
@@ -421,14 +445,9 @@ func runSnapshotDiff(args []string) int {
 	defer db.Close()
 
 	ctx := context.Background()
-	snapA, err := resolveSnapshot(ctx, db, idA)
+	snapA, snapB, err := resolveDiffOperands(ctx, db, fs.Args())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "snapshot %q: %v\n", idA, err)
-		return 1
-	}
-	snapB, err := resolveSnapshot(ctx, db, idB)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "snapshot %q: %v\n", idB, err)
+		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
 
@@ -445,6 +464,57 @@ func runSnapshotDiff(args []string) int {
 	return 0
 }
 
+func printDiffUsage() {
+	fmt.Fprintln(os.Stderr, "usage: spectra snapshot diff <id-a> <id-b|live>")
+	fmt.Fprintln(os.Stderr, "   or: spectra diff baseline [name|id] [live|id]")
+}
+
+func resolveDiffOperands(ctx context.Context, db *store.DB, args []string) (*snapshot.Snapshot, *snapshot.Snapshot, error) {
+	if len(args) > 0 && args[0] == "baseline" {
+		return resolveBaselineDiffOperands(ctx, db, args[1:])
+	}
+	if len(args) != 2 {
+		printDiffUsage()
+		return nil, nil, fmt.Errorf("invalid diff operands")
+	}
+	idA, idB := args[0], args[1]
+	snapA, err := resolveSnapshot(ctx, db, idA)
+	if err != nil {
+		return nil, nil, fmt.Errorf("snapshot %q: %w", idA, err)
+	}
+	snapB, err := resolveSnapshot(ctx, db, idB)
+	if err != nil {
+		return nil, nil, fmt.Errorf("snapshot %q: %w", idB, err)
+	}
+	return snapA, snapB, nil
+}
+
+func resolveBaselineDiffOperands(ctx context.Context, db *store.DB, args []string) (*snapshot.Snapshot, *snapshot.Snapshot, error) {
+	ref := ""
+	other := "live"
+	switch len(args) {
+	case 0:
+	case 1:
+		ref = args[0]
+	case 2:
+		ref = args[0]
+		other = args[1]
+	default:
+		printDiffUsage()
+		return nil, nil, fmt.Errorf("invalid baseline diff operands")
+	}
+
+	snapA, err := resolveBaselineSnapshot(ctx, db, ref)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baseline %q: %w", baselineDisplayName(ref), err)
+	}
+	snapB, err := resolveSnapshot(ctx, db, other)
+	if err != nil {
+		return nil, nil, fmt.Errorf("snapshot %q: %w", other, err)
+	}
+	return snapA, snapB, nil
+}
+
 // resolveSnapshot loads a snapshot from the DB by ID, or captures a fresh
 // live snapshot when id is the sentinel "live".
 func resolveSnapshot(ctx context.Context, db *store.DB, id string) (*snapshot.Snapshot, error) {
@@ -453,6 +523,45 @@ func resolveSnapshot(ctx context.Context, db *store.DB, id string) (*snapshot.Sn
 		return &snap, nil
 	}
 	return loadSnapshotFromDB(ctx, db, id)
+}
+
+func resolveBaselineSnapshot(ctx context.Context, db *store.DB, ref string) (*snapshot.Snapshot, error) {
+	if ref != "" {
+		row, err := db.GetSnapshot(ctx, ref)
+		if err == nil {
+			if row.Kind != string(snapshot.KindBaseline) {
+				return nil, fmt.Errorf("snapshot is %q, not baseline", row.Kind)
+			}
+			return loadSnapshotFromDB(ctx, db, row.ID)
+		}
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return nil, err
+		}
+	}
+
+	rows, err := db.ListSnapshots(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if row.Kind != string(snapshot.KindBaseline) {
+			continue
+		}
+		if ref == "" || row.Name == ref {
+			return loadSnapshotFromDB(ctx, db, row.ID)
+		}
+	}
+	if ref == "" {
+		return nil, fmt.Errorf("no baselines stored")
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func baselineDisplayName(ref string) string {
+	if ref == "" {
+		return "latest"
+	}
+	return ref
 }
 
 // loadSnapshotFromDB retrieves the full snapshot JSON blob for id and unmarshals

--- a/cmd/spectra/snapshot_test.go
+++ b/cmd/spectra/snapshot_test.go
@@ -36,6 +36,96 @@ func TestResolveSnapshotNotFoundReturnsError(t *testing.T) {
 	}
 }
 
+func TestSnapshotNameFromArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		baseline     bool
+		explicitName string
+		args         []string
+		wantName     string
+		wantOK       bool
+	}{
+		{name: "no name", wantOK: true},
+		{name: "explicit name", explicitName: "release", wantName: "release", wantOK: true},
+		{name: "baseline positional", baseline: true, args: []string{"pre-incident"}, wantName: "pre-incident", wantOK: true},
+		{name: "live positional rejected", args: []string{"pre-incident"}, wantOK: false},
+		{name: "ambiguous name rejected", baseline: true, explicitName: "a", args: []string{"b"}, wantOK: false},
+		{name: "too many args rejected", baseline: true, args: []string{"a", "b"}, wantOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := snapshotNameFromArgs(tc.baseline, tc.explicitName, tc.args)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.wantName {
+				t.Fatalf("name = %q, want %q", got, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestResolveBaselineSnapshotByNameAndLatest(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	old := testSnapshot("snap-old", snapshot.KindBaseline, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	newer := testSnapshot("snap-new", snapshot.KindBaseline, time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
+	live := testSnapshot("snap-live", snapshot.KindLive, time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC))
+	saveTestSnapshot(t, db, old, "pre-incident")
+	saveTestSnapshot(t, db, newer, "release")
+	saveTestSnapshot(t, db, live, "")
+
+	got, err := resolveBaselineSnapshot(ctx, db, "pre-incident")
+	if err != nil {
+		t.Fatalf("resolve by name: %v", err)
+	}
+	if got.ID != old.ID {
+		t.Fatalf("resolve by name ID = %q, want %q", got.ID, old.ID)
+	}
+
+	got, err = resolveBaselineSnapshot(ctx, db, "")
+	if err != nil {
+		t.Fatalf("resolve latest: %v", err)
+	}
+	if got.ID != newer.ID {
+		t.Fatalf("latest ID = %q, want %q", got.ID, newer.ID)
+	}
+}
+
+func TestResolveBaselineSnapshotRejectsLiveID(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	live := testSnapshot("snap-live", snapshot.KindLive, time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC))
+	saveTestSnapshot(t, db, live, "")
+
+	if _, err := resolveBaselineSnapshot(ctx, db, live.ID); err == nil {
+		t.Fatal("expected live snapshot ID to be rejected as a baseline")
+	}
+}
+
+func testSnapshot(id string, kind snapshot.Kind, takenAt time.Time) snapshot.Snapshot {
+	return snapshot.Snapshot{
+		ID:      id,
+		TakenAt: takenAt,
+		Kind:    kind,
+		Host: snapshot.HostInfo{
+			Hostname:    "test.local",
+			MachineUUID: "TEST-MACHINE",
+			OSName:      "macOS",
+		},
+	}
+}
+
+func saveTestSnapshot(t *testing.T, db *store.DB, snap snapshot.Snapshot, name string) {
+	t.Helper()
+	input := store.FromSnapshot(snap)
+	input.Name = name
+	if err := db.SaveSnapshot(context.Background(), input); err != nil {
+		t.Fatalf("SaveSnapshot(%s): %v", snap.ID, err)
+	}
+}
+
 func TestSaveSnapshotNamedPersistsChildTables(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -20,6 +20,7 @@ spectra [flags] <App.app>...     # routes to `inspect` (default)
 | `list` | Inspect every `.app` under `/Applications` |
 | `snapshot` | Capture a structured snapshot of host + installed apps |
 | `diff` | Diff two stored snapshots |
+| `baseline` | Manage baseline snapshots (alias for `snapshot baseline`) |
 | `rules` | Evaluate recommendation rules against a snapshot |
 | `issues` | List, check, or update persisted recommendation issues |
 | `jvm` | List or inspect running JVM processes |
@@ -94,10 +95,16 @@ alongside the full JSON snapshot blob.
 
 ```bash
 spectra snapshot                   # full snapshot, persisted + printed
+spectra snapshot create            # explicit form; same as `snapshot`
 spectra snapshot --no-apps         # ~50ms, just the host facts
+spectra snapshot create --baseline pre-incident
 spectra snapshot --json | jq .host
 spectra snapshot --no-store        # ephemeral — do not write to DB
 ```
+
+`spectra snapshot create` is an explicit alias for `spectra snapshot`.
+When `--baseline` is set, a single positional argument is accepted as
+the baseline name; `--name pre-incident` remains equivalent.
 
 ## `spectra snapshot list`
 
@@ -160,6 +167,34 @@ by-ui:
   ComposeDesktop             3
   Electron                  17
   ...
+```
+
+## `spectra diff`
+
+Diffs two stored snapshots. `live` can be used as either side to
+capture an ephemeral current snapshot without storing it.
+
+### Examples
+
+```bash
+spectra diff snap-20260504T095749Z-4829 live
+spectra diff baseline                  # newest baseline against live
+spectra diff baseline pre-incident live
+```
+
+`spectra diff baseline <name|id> [live|id]` resolves the first operand
+to a baseline by ID first, then by baseline name. When the name/id is
+omitted, the newest baseline is used.
+
+## `spectra baseline`
+
+Convenience alias for `spectra snapshot baseline`.
+
+### Examples
+
+```bash
+spectra baseline list
+spectra baseline drop snap-20260504T095749Z-4829
 ```
 
 ## `spectra version`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -63,5 +63,5 @@ not-yet-built recommendations engine.
 | Why is this app heavy? | `spectra -v APP.app` (look at storage + processes) |
 | What can this app do to my machine? | `spectra -v APP.app` (entitlements + granted) |
 | What hosts does this app talk to? | `spectra -v --network APP.app` |
-| Is anything new on my machine since last week? | _planned: `spectra diff baseline`_ |
+| Is anything new on my machine since last week? | `spectra diff baseline pre-incident live` |
 | What's running on my work Mac right now? | _planned: `spectra connect work-mac`_ |

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -20,7 +20,6 @@ import (
 )
 
 // Kind distinguishes a live snapshot from an immutable baseline.
-// Today only Live is produced; baselines arrive with the daemon.
 type Kind string
 
 const (


### PR DESCRIPTION
## Summary
- add the documented `spectra snapshot create` alias and positional baseline naming
- add top-level `spectra baseline list/drop` alias
- support `spectra diff baseline [name|id] [live|id]` with newest-baseline fallback
- update CLI docs and quickstart for the now-implemented baseline workflow

## Validation
- go test ./cmd/spectra -run 'Test(SubcommandListIncludesBaseline|SnapshotNameFromArgs|ResolveBaselineSnapshot)' -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
- PATH="/Users/jason/go/bin:/Users/jason/.codex/tmp/arg0/codex-arg0oTpPPN:/Users/jason/.antigravity/antigravity/bin:/Users/jason/.local/bin:/Users/jason/Library/pnpm:/Users/jason/.local/bin:/opt/local/bin:/opt/local/sbin:/Users/jason/.pyenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/jason/.cargo/bin:/Users/jason/Library/Application Support/JetBrains/Toolbox/scripts:/Users/jason/Library/Android/sdk/platform-tools:/Users/jason/Library/Android/sdk/emulator:/Users/jason/Library/Android/sdk/build-tools/36.0.0:/opt/homebrew/opt/go/libexec/bin:/Users/jason/go/bin:/Users/jason/.maestro/bin:/Applications/Codex.app/Contents/Resources" make ci