### PR TITLE
Update caching docs to current behavior

### DIFF
--- a/docs/operations/caching.md
+++ b/docs/operations/caching.md
@@ -1,7 +1,8 @@
 # Caching
 
-> **Status: planned.** Documents the cache layout the daemon will use.
-> Today's CLI does no caching — every invocation re-runs every collector.
+Spectra uses a versioned, hash-sharded blob cache for expensive or
+large artifacts. The CLI initializes all cache stores at startup and
+exposes shared `stats` / `clear` commands through a registry.
 
 The cache layout follows the patterns proven out in
 [krit](https://github.com/kaeawc/krit). See
@@ -12,17 +13,17 @@ The cache layout follows the patterns proven out in
 ```
 ~/.cache/spectra/v1/
 ├── detect/
-│   └── {hash[:2]}/{hash[2:]}.json.zst
+│   └── {hash[:2]}/{hash[2:]}
 ├── hprof/
-│   └── {hash[:2]}/{hash[2:]}.hprof
+│   └── {hash[:2]}/{hash[2:]}
 ├── jfr/
-│   └── {hash[:2]}/{hash[2:]}.jfr
+│   └── {hash[:2]}/{hash[2:]}
 ├── threads/
-│   └── {hash[:2]}/{hash[2:]}.txt
+│   └── {hash[:2]}/{hash[2:]}
 ├── samples/
-│   └── {hash[:2]}/{hash[2:]}.txt
+│   └── {hash[:2]}/{hash[2:]}
 └── netcap/
-    └── {hash[:2]}/{hash[2:]}.pcap
+    └── {hash[:2]}/{hash[2:]}
 ```
 
 - `v1/` is a version segment. Bumping it invalidates every cache kind
@@ -30,14 +31,14 @@ The cache layout follows the patterns proven out in
   needed.
 - `{hash[:2]}/{hash[2:]}` is two-level sharding on a content hash.
   Keeps no directory above 256 entries.
-- File extensions reflect kind-specific encoding (zstd-compressed JSON
-  for detect results; raw .hprof / .jfr for JVM artifacts).
+- Cache paths are extensionless today. The kind directory names carry
+  the semantic type; payload encoding is owned by each caller.
 
 ## Cache kinds
 
 | Kind | Key | Notes |
 |---|---|---|
-| `detect` | hash of `Info.plist` + main exe | Detect() result for one app at one version |
+| `detect` | hash of `Info.plist` + first 64 KiB of main exe | Detect() result for one app at one version; used by daemon/snapshot paths |
 | `hprof` | content hash of dump file | `jcmd GC.heap_dump` output |
 | `jfr` | content hash of recording | Java Flight Recorder file |
 | `threads` | hash of `(pid, timestamp)` | Thread dump text |
@@ -66,26 +67,34 @@ queueSize) flushes blobs in the background; if the queue is full, the
 caller falls back to a synchronous write rather than dropping data.
 Counters track queued / completed / failed / bytes.
 
+The async writer is implemented in `internal/cache/async_writer.go`.
+Callers can still write synchronously when they need the artifact to be
+present before returning.
+
 ## Why content hashing matters for detect
 
-`Detect()` is deterministic given the same `Info.plist` + main
-executable bytes. Hashing those two as the cache key gives implicit
-invalidation: when an app updates, its bytes change, its hash changes,
-its old cache entry is unreachable. No timestamps, no version
-comparisons, no migration logic.
+`Detect()` is deterministic enough for snapshot reuse given the same
+`Info.plist` + main executable prefix. Hashing those inputs gives
+implicit invalidation: when an app updates, its metadata or executable
+bytes change, its hash changes, its old cache entry is unreachable. No
+timestamps, no version comparisons, no migration logic.
 
 This is the same pattern krit uses for its parse cache — the comment
 in `krit/internal/scanner/parse_cache.go` is worth reading for the
 rationale.
 
-## Implementation reference (planned)
+## Implementation reference
 
 `internal/cache/` — modeled after krit's `internal/cacheutil/`:
 - `registry.go` — `Register(name, ClearFunc, StatsFunc)`
 - `sharded.go` — two-level hash store
-- `versioned_dir.go` — `v<N>/` segment management
+- `kinds.go` — well-known cache kind constants and store registration
 - `async_writer.go` — bounded-queue background flushes
-- `zstd_json.go` — wrapped zstd-compressed JSON envelope
+
+Related call sites:
+- `cmd/spectra/cache.go` — `spectra cache stats` and `cache clear`
+- `internal/snapshot/detect_cache.go` — Detect() result reuse
+- `cmd/spectra/jvm.go` / `cmd/spectra/sample.go` — artifact caching
 
 ## Empirical thresholds
 


### PR DESCRIPTION
## Summary
- Update caching docs from planned status to current CLI/cache behavior
- Document extensionless sharded cache paths and implemented async writer
- Link current cache command and artifact call sites

## Validation
- go build ./... && go vet ./...
- make docs-validate