### PR TITLE
Add initial remote connect transport

### DIFF
--- a/cmd/spectra/connect.go
+++ b/cmd/spectra/connect.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/rpc"
+	"github.com/kaeawc/spectra/internal/serve"
+)
+
+const defaultRemotePort = "7878"
+
+type connectTarget struct {
+	Network string
+	Address string
+}
+
+func runConnect(args []string) int {
+	fs := flag.NewFlagSet("spectra connect", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	timeout := fs.Duration("timeout", 3*time.Second, "Dial/read timeout")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() < 1 {
+		printConnectUsage(os.Stderr)
+		return 2
+	}
+
+	target, err := parseConnectTarget(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	method, params, err := parseConnectCall(fs.Args()[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		printConnectUsage(os.Stderr)
+		return 2
+	}
+
+	conn, err := dialConnectTarget(target, *timeout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "connect %s: %v\n", fs.Arg(0), err)
+		return 1
+	}
+	defer conn.Close()
+
+	if d, ok := conn.(interface{ SetDeadline(time.Time) error }); ok {
+		_ = d.SetDeadline(time.Now().Add(*timeout))
+	}
+
+	result, err := callRPC(conn, method, params)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(result); err != nil {
+		fmt.Fprintf(os.Stderr, "encode response: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func printConnectUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: spectra connect [--timeout 3s] <target> [status|health]")
+	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> call <method> [json-params]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "targets: local, unix:/path/to/sock, /path/to/sock, host:port, host")
+}
+
+func parseConnectTarget(raw string) (connectTarget, error) {
+	switch {
+	case raw == "local":
+		sock, err := serve.DefaultSockPath()
+		if err != nil {
+			return connectTarget{}, fmt.Errorf("resolve local socket: %w", err)
+		}
+		return connectTarget{Network: "unix", Address: sock}, nil
+	case strings.HasPrefix(raw, "unix:"):
+		path := strings.TrimPrefix(raw, "unix:")
+		if path == "" {
+			return connectTarget{}, fmt.Errorf("empty unix socket target")
+		}
+		return connectTarget{Network: "unix", Address: path}, nil
+	case strings.HasPrefix(raw, "/"):
+		return connectTarget{Network: "unix", Address: raw}, nil
+	}
+	if _, _, err := net.SplitHostPort(raw); err == nil {
+		return connectTarget{Network: "tcp", Address: raw}, nil
+	}
+	return connectTarget{Network: "tcp", Address: net.JoinHostPort(raw, defaultRemotePort)}, nil
+}
+
+func parseConnectCall(args []string) (string, json.RawMessage, error) {
+	if len(args) == 0 || args[0] == "status" || args[0] == "health" {
+		return "health", nil, nil
+	}
+	if args[0] != "call" || len(args) < 2 || len(args) > 3 {
+		return "", nil, fmt.Errorf("invalid connect command")
+	}
+	if len(args) == 2 {
+		return args[1], nil, nil
+	}
+	var params json.RawMessage
+	if err := json.Unmarshal([]byte(args[2]), &params); err != nil {
+		return "", nil, fmt.Errorf("invalid json params: %w", err)
+	}
+	return args[1], params, nil
+}
+
+func dialConnectTarget(target connectTarget, timeout time.Duration) (io.ReadWriteCloser, error) {
+	var d net.Dialer
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return d.DialContext(ctx, target.Network, target.Address)
+}
+
+func callRPC(rw io.ReadWriter, method string, params json.RawMessage) (json.RawMessage, error) {
+	req := rpc.Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  method,
+		Params:  params,
+	}
+	if len(req.Params) == 0 {
+		req.Params = nil
+	}
+	if err := json.NewEncoder(rw).Encode(req); err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	var resp struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  json.RawMessage `json:"result,omitempty"`
+		Error   *rpc.RPCError   `json:"error,omitempty"`
+	}
+	if err := json.NewDecoder(rw).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.Error != nil {
+		return nil, fmt.Errorf("daemon error: %s", resp.Error.Message)
+	}
+	if len(resp.Result) == 0 {
+		return json.RawMessage(`null`), nil
+	}
+	return resp.Result, nil
+}

--- a/cmd/spectra/connect_test.go
+++ b/cmd/spectra/connect_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/rpc"
+)
+
+func TestParseConnectTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want connectTarget
+	}{
+		{
+			name: "unix prefix",
+			raw:  "unix:/tmp/spectra.sock",
+			want: connectTarget{Network: "unix", Address: "/tmp/spectra.sock"},
+		},
+		{
+			name: "absolute path",
+			raw:  "/tmp/spectra.sock",
+			want: connectTarget{Network: "unix", Address: "/tmp/spectra.sock"},
+		},
+		{
+			name: "host port",
+			raw:  "work-mac:9000",
+			want: connectTarget{Network: "tcp", Address: "work-mac:9000"},
+		},
+		{
+			name: "host default port",
+			raw:  "work-mac",
+			want: connectTarget{Network: "tcp", Address: "work-mac:7878"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseConnectTarget(tt.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("target = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConnectCall(t *testing.T) {
+	method, params, err := parseConnectCall([]string{"call", "inspect.app", `{"path":"/Applications/Slack.app"}`})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if method != "inspect.app" {
+		t.Fatalf("method = %q", method)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(params, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["path"] != "/Applications/Slack.app" {
+		t.Fatalf("path = %q", decoded["path"])
+	}
+
+	method, params, err = parseConnectCall(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if method != "health" || params != nil {
+		t.Fatalf("default call = %q %s, want health nil", method, string(params))
+	}
+}
+
+func TestCallRPC(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+
+	d := rpc.NewDispatcher()
+	d.Register("echo", func(params json.RawMessage) (any, error) {
+		var p map[string]string
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, err
+		}
+		return p, nil
+	})
+	go d.Serve(server)
+
+	got, err := callRPC(client, "echo", json.RawMessage(`{"value":"ok"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(got, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["value"] != "ok" {
+		t.Fatalf("value = %q, want ok", decoded["value"])
+	}
+}
+
+func TestLoopbackListenAddr(t *testing.T) {
+	for _, addr := range []string{"127.0.0.1:7878", "[::1]:7878", "localhost:7878"} {
+		if !isLoopbackListenAddr(addr) {
+			t.Fatalf("%s should be loopback", addr)
+		}
+	}
+	for _, addr := range []string{":7878", "0.0.0.0:7878", "100.64.0.5:7878"} {
+		if isLoopbackListenAddr(addr) {
+			t.Fatalf("%s should not be loopback", addr)
+		}
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -47,6 +47,7 @@ func subcommandList() []subcommand {
 		{"issues", "List, check, or update persisted issues from the recommendations engine", runIssues},
 		{"baseline", "Manage baseline snapshots (list, drop)", runSnapshotBaseline},
 		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},
+		{"connect", "Call a Spectra daemon over Unix socket or TCP JSON-RPC", runConnect},
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},

--- a/cmd/spectra/main_test.go
+++ b/cmd/spectra/main_test.go
@@ -20,6 +20,15 @@ func TestSubcommandListIncludesBaseline(t *testing.T) {
 	t.Fatal("subcommandList missing baseline alias")
 }
 
+func TestSubcommandListIncludesConnect(t *testing.T) {
+	for _, sc := range subcommandList() {
+		if sc.name == "connect" {
+			return
+		}
+	}
+	t.Fatal("subcommandList missing connect")
+}
+
 func TestListInspectArgsPrependsAll(t *testing.T) {
 	got := listInspectArgs([]string{"-v", "--json"})
 	want := []string{"--all", "-v", "--json"}

--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -19,7 +20,13 @@ func runServe(args []string) int {
 	fs := flag.NewFlagSet("spectra serve", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	sockPath := fs.String("sock", "", "Unix socket path (default: ~/.spectra/sock)")
+	tcpAddr := fs.String("tcp", "", "Optional TCP listen address, such as 127.0.0.1:7878")
+	allowRemote := fs.Bool("allow-remote", false, "Allow --tcp to bind a non-loopback address")
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *tcpAddr != "" && !*allowRemote && !isLoopbackListenAddr(*tcpAddr) {
+		fmt.Fprintln(os.Stderr, "spectra serve: --tcp is limited to loopback unless --allow-remote is set")
 		return 2
 	}
 
@@ -36,6 +43,12 @@ func runServe(args []string) int {
 		}
 	}
 	fmt.Fprintf(os.Stderr, "spectra serve: listening on %s\n", sock)
+	if *tcpAddr != "" {
+		if *allowRemote {
+			fmt.Fprintln(os.Stderr, "spectra serve: warning: TCP RPC has no Spectra-layer authentication; rely on SSH/Tailscale/firewall controls")
+		}
+		fmt.Fprintf(os.Stderr, "spectra serve: listening on tcp %s\n", *tcpAddr)
+	}
 
 	var detectStore *cache.ShardedStore
 	if cacheStores != nil {
@@ -43,6 +56,7 @@ func runServe(args []string) int {
 	}
 	if err := serve.Run(ctx, serve.Options{
 		SockPath:       sock,
+		TCPAddr:        *tcpAddr,
 		SpectraVersion: version,
 		DetectStore:    detectStore,
 	}); err != nil {
@@ -50,6 +64,18 @@ func runServe(args []string) int {
 		return 1
 	}
 	return 0
+}
+
+func isLoopbackListenAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil || host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // runStatus sends a health request to the running daemon and prints the result.

--- a/docs/design/remote-portal.md
+++ b/docs/design/remote-portal.md
@@ -28,7 +28,9 @@ Three consequences:
    daemon becomes a tailnet node directly — no port forwarding, no
    firewall rules, no `ssh -L`. The spectra binary on the remote Mac
    registers as `work-mac.tailnet-name.ts.net`, and `spectra connect work-mac`
-   Just Works with MagicDNS.
+   Just Works with MagicDNS. The current implementation stops one step
+   earlier: the daemon can opt into an explicit TCP listener and the
+   client can call JSON-RPC methods with `spectra connect <host> call ...`.
 
 ## Authentication
 
@@ -91,12 +93,14 @@ These will get pinned down before the first daemon commit:
 1. Refactor `Detect()` and live collectors behind an `Inspector` interface
    so the same code path serves CLI and daemon.
 2. `spectra serve` over a local Unix socket first. Validates the RPC shape
-   without touching networking.
-3. Add `tsnet` integration. Daemon becomes a tailnet node; client uses
+   without touching networking. **Implemented.**
+3. Add explicit TCP JSON-RPC transport for `spectra connect <host> call`.
+   **Implemented; authentication is still delegated to the network path.**
+4. Add `tsnet` integration. Daemon becomes a tailnet node; client uses
    Tailscale's discovery.
-4. TUI client. Bubble Tea, talks to local-or-remote daemon identically.
-5. Privileged helper as `spectra install-helper` subcommand. Same binary
+5. TUI client. Bubble Tea, talks to local-or-remote daemon identically.
+6. Privileged helper as `spectra install-helper` subcommand. Same binary
    ships the helper; SMAppService-registered LaunchDaemon.
-6. Ring buffer + history for replay (requires SQLite from
+7. Ring buffer + history for replay (requires SQLite from
    [storage.md](storage.md)).
-7. Native GUI after the TUI proves the data model.
+8. Native GUI after the TUI proves the data model.

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -30,6 +30,7 @@ spectra [flags] <App.app>...     # routes to `inspect` (default)
 | `storage` | Show disk volumes and `~/Library` footprint |
 | `process` | List running processes sorted by memory |
 | `serve` | Run the local Unix-socket JSON-RPC daemon |
+| `connect` | Call a Spectra daemon over Unix socket or TCP JSON-RPC |
 | `status` | Check whether the local daemon is running |
 | `metrics` | Show stored process metrics from daemon sampling |
 | `sample` | Collect a user-space CPU sample of a process |
@@ -186,6 +187,23 @@ spectra diff baseline pre-incident live
 to a baseline by ID first, then by baseline name. When the name/id is
 omitted, the newest baseline is used.
 
+## `spectra snapshot prune`
+
+Deletes old live snapshots beyond the retention limit. Baselines are
+never pruned.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--keep` | `100` | Number of newest live snapshots to retain |
+| `--json` | false | Emit JSON |
+
+### Examples
+
+```bash
+spectra snapshot prune
+spectra snapshot prune --keep 25 --json
+```
+
 ## `spectra baseline`
 
 Convenience alias for `spectra snapshot baseline`.
@@ -195,6 +213,58 @@ Convenience alias for `spectra snapshot baseline`.
 ```bash
 spectra baseline list
 spectra baseline drop snap-20260504T095749Z-4829
+```
+
+## `spectra serve`
+
+Runs the JSON-RPC daemon. By default it listens only on the current
+user's Unix socket at `~/.spectra/sock`.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--sock` | `~/.spectra/sock` | Unix socket path |
+| `--tcp` | empty | Optional TCP listen address, such as `127.0.0.1:7878` |
+| `--allow-remote` | false | Allow `--tcp` to bind a non-loopback address |
+
+TCP RPC has no Spectra-layer authentication today. Keep it on loopback
+for local use or expose it only through SSH, Tailscale, or firewall
+controls you trust.
+
+### Examples
+
+```bash
+spectra serve
+spectra serve --tcp 127.0.0.1:7878
+spectra serve --tcp 100.64.0.5:7878 --allow-remote
+```
+
+## `spectra connect`
+
+Calls a running daemon using the same JSON-RPC protocol as the local
+Unix-socket client. This is the implemented remote transport today;
+automatic tsnet registration and cross-host fan-out remain future work.
+
+| Target | Meaning |
+|---|---|
+| `local` | Default local Unix socket |
+| `unix:/path/to/sock` | Explicit Unix socket |
+| `/path/to/sock` | Explicit Unix socket shorthand |
+| `host:port` | TCP daemon |
+| `host` | TCP daemon on port `7878` |
+
+| Form | Description |
+|---|---|
+| `spectra connect <target>` | Call `health` |
+| `spectra connect <target> status` | Call `health` |
+| `spectra connect <target> call <method> [json-params]` | Call an RPC method directly |
+
+### Examples
+
+```bash
+spectra connect local
+spectra connect 127.0.0.1:7878 status
+spectra connect work-mac call snapshot.create
+spectra connect work-mac call inspect.app '{"path":"/Applications/Slack.app"}'
 ```
 
 ## `spectra version`
@@ -210,12 +280,3 @@ Prints the build version (typically a git describe from `make build`).
 
 Per-app errors are written to stderr; the offending entry is dropped
 and processing continues for other paths.
-
-## Remaining planned subcommands
-
-```
-spectra connect <host>              # client targeting a remote daemon
-```
-
-See [../design/architecture.md](../design/architecture.md) for the
-shape of the daemon RPC.

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -1,6 +1,9 @@
 # Remote operation
 
-> **Status: planned.** Captures the design for `spectra connect <host>`.
+Spectra has an initial remote transport: `spectra serve --tcp ...`
+exposes the daemon JSON-RPC API on an explicit TCP listener, and
+`spectra connect <host>` calls that daemon. The default daemon remains
+local-only on `~/.spectra/sock`; TCP must be opted into.
 
 The remote portal is Spectra's defining workflow: running diagnostic
 operations on someone else's Mac to find configuration drift,
@@ -12,32 +15,40 @@ architecture; this page is the operator-facing reference.
 ## Connecting
 
 ```bash
-spectra connect work-mac          # MagicDNS hostname on your tailnet
-spectra connect alice@laptop      # via Tailscale ACL identity
-spectra connect 100.64.0.5        # raw tailnet IP
+spectra serve --tcp 127.0.0.1:7878                 # local TCP, useful for smoke tests
+spectra serve --tcp 100.64.0.5:7878 --allow-remote # explicit tailnet bind
+
+spectra connect local                              # default Unix socket
+spectra connect work-mac                           # TCP port 7878
+spectra connect 100.64.0.5:7878                    # raw address
 ```
 
 The remote Mac must:
-1. Have `spectra serve --tailscale` running (or set up as a launchd agent).
-2. Be on the same tailnet as the client.
-3. Be reachable per Tailscale ACLs.
+1. Have `spectra serve --tcp <addr>:7878 --allow-remote` running.
+2. Be reachable through SSH forwarding, a Tailscale interface, or another
+   trusted network path.
+3. Be protected by network-layer controls. TCP RPC has no Spectra-layer
+   authentication yet.
 
 ## What you can do
 
-Any RPC method the daemon exposes is available remotely, gated by
-Tailscale ACLs. The CLI presents them as flat subcommands:
+Any RPC method the daemon exposes is available remotely through the
+generic `call` form:
 
 ```bash
-spectra connect work-mac inspect /Applications/Slack.app
-spectra connect work-mac jvm 4012
-spectra connect work-mac jvm threadDump 4012
-spectra connect work-mac diff baseline-2024-01-15
-spectra connect work-mac snapshot create
+spectra connect work-mac status
+spectra connect work-mac call inspect.app '{"path":"/Applications/Slack.app"}'
+spectra connect work-mac call jvm.list
+spectra connect work-mac call jvm.thread_dump '{"pid":4012}'
+spectra connect work-mac call snapshot.create
 ```
+
+Typed remote subcommands like `spectra connect work-mac jvm` are still
+planned; today `call` is the stable escape hatch.
 
 ## Cross-host operations
 
-The killer feature: ops that fan out across multiple tailnet nodes.
+Cross-host fan-out is still planned. The intended shape is:
 
 ```bash
 spectra hosts                                # list discovered Spectra daemons
@@ -51,17 +62,19 @@ results locally.
 
 ## TUI mode
 
-`spectra tui` opens the Bubble Tea TUI against the local daemon.
-`spectra tui work-mac` opens it against a remote daemon. Same UI
-either way — the data layer doesn't care whether the daemon is on
-the same machine.
+Planned: `spectra tui` opens the Bubble Tea TUI against the local daemon.
+`spectra tui work-mac` opens it against a remote daemon. Same UI either
+way — the data layer doesn't care whether the daemon is on the same
+machine.
 
 ## Authentication
 
-V1 trusts Tailscale. If a peer can reach the daemon's tsnet listener
-per ACLs, it can call any read-only RPC method. State-changing methods
-require explicit consent — for example, `jvm.heapDump` writes to the
-remote machine's blob cache and is gated.
+The current TCP transport trusts the network path. If a peer can reach
+the listener, it can call daemon RPC methods. Use loopback, SSH tunnels,
+Tailscale ACLs, or firewall rules to limit access.
+
+The planned tsnet mode will make Tailscale identity the default
+authorization layer. The Tailscale ACL example for a personal tailnet:
 
 The Tailscale ACL example for a personal tailnet:
 
@@ -106,10 +119,10 @@ the full RPC surface.
 ### "Why is my teammate's IDE slow?"
 
 ```bash
-spectra connect alice-laptop jvm
+spectra connect alice-laptop call jvm.list
 # → see all JVMs running, GC stats, heap usage
 
-spectra connect alice-laptop jvm threadDump 4012 > intellij-threads.txt
+spectra connect alice-laptop call jvm.thread_dump '{"pid":4012}' > intellij-threads.json
 # → captured to local disk for analysis
 ```
 
@@ -137,7 +150,12 @@ spectra fan snapshot create --name pre-incident
 
 ## Implementation order
 
-Same as the daemon (see [daemon.md](daemon.md)) — remote operation is
-a property of the daemon's transport layer, not a separate feature
-track. Once the daemon listens on `tsnet`, all client subcommands
-work remotely.
+The local daemon and explicit TCP transport are implemented. Remaining
+remote work:
+
+1. Add tsnet integration so the daemon can join a tailnet without an
+   externally managed listener.
+2. Add typed `spectra connect <host> <subcommand>` adapters over the
+   generic JSON-RPC `call` command.
+3. Add host discovery and fan-out commands.
+4. Add TUI support against local-or-remote daemon targets.

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -153,3 +153,10 @@ func isClosedErr(err error) bool {
 func DialUnix(sockPath string) (io.ReadWriteCloser, error) {
 	return net.Dial("unix", sockPath)
 }
+
+// DialNetwork connects to a Spectra daemon over any net.Dial-supported
+// network/address pair. It is used by remote clients once a daemon is
+// intentionally listening beyond its local Unix socket.
+func DialNetwork(network, address string) (io.ReadWriteCloser, error) {
+	return net.Dial(network, address)
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -50,6 +50,7 @@ func DefaultSockPath() (string, error) {
 // Options configures the daemon.
 type Options struct {
 	SockPath       string
+	TCPAddr        string
 	SpectraVersion string
 	DBPath         string              // empty = store.DefaultPath()
 	CacheRegistry  *cache.Registry     // nil = cache.Default
@@ -82,10 +83,19 @@ func Run(ctx context.Context, opts Options) error {
 		ln.Close()
 		return fmt.Errorf("serve: chmod %s: %w", sockPath, err)
 	}
-	defer func() {
-		ln.Close()
-		os.Remove(sockPath)
-	}()
+
+	listeners := []net.Listener{ln}
+	if opts.TCPAddr != "" {
+		tcpLn, err := net.Listen("tcp", opts.TCPAddr)
+		if err != nil {
+			ln.Close()
+			os.Remove(sockPath)
+			return fmt.Errorf("serve: listen tcp %s: %w", opts.TCPAddr, err)
+		}
+		listeners = append(listeners, tcpLn)
+	}
+	defer os.Remove(sockPath)
+	defer closeListeners(listeners)
 
 	dbPath := opts.DBPath
 	if dbPath == "" {
@@ -122,10 +132,32 @@ func Run(ctx context.Context, opts Options) error {
 	// Close the listener when ctx is cancelled to unblock Accept.
 	go func() {
 		<-ctx.Done()
-		ln.Close()
+		closeListeners(listeners)
 	}()
 
-	return d.ServeListener(ln)
+	return serveAll(d, listeners)
+}
+
+func serveAll(d *rpc.Dispatcher, listeners []net.Listener) error {
+	errCh := make(chan error, len(listeners))
+	for _, ln := range listeners {
+		go func(ln net.Listener) {
+			errCh <- d.ServeListener(ln)
+		}(ln)
+	}
+	for range listeners {
+		if err := <-errCh; err != nil {
+			closeListeners(listeners)
+			return err
+		}
+	}
+	return nil
+}
+
+func closeListeners(listeners []net.Listener) {
+	for _, ln := range listeners {
+		_ = ln.Close()
+	}
 }
 
 // flushMetricsLoop writes 1-minute aggregates from the ring buffer to SQLite


### PR DESCRIPTION
## Summary
- add `spectra connect` for Unix-socket or TCP JSON-RPC calls to a running daemon
- add optional `spectra serve --tcp` listener with loopback-only default and explicit `--allow-remote` for non-loopback binds
- document the implemented remote transport and keep tsnet/fan-out/TUI remote work marked as future

## Validation
- go test ./... -count=1
- go build ./... && go vet ./...
- make docs-validate
- live smoke: `serve --tcp 127.0.0.1:18787`, then `connect unix:<sock>` and `connect 127.0.0.1:18787`
