### PR TITLE
Update source install flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 junit-report.xml
 gosec-report.xml
 site/
-spectra-helper
+/spectra-helper

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
-.PHONY: build test vet fmt lint complexity security licenses tidy ci clean all \
+.PHONY: build build-helper build-all test vet fmt lint complexity security licenses tidy ci clean all \
 	release-check validate-workflows \
 	docs-validate docs-nav docs-lychee docs-build docs-serve docs-install
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS = -s -w -X main.version=$(VERSION)
 BIN ?= spectra
+HELPER_BIN ?= spectra-helper
 
 # --- Build -------------------------------------------------------------------
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BIN) ./cmd/spectra/
+
+build-helper:
+	go build -ldflags "$(LDFLAGS)" -o $(HELPER_BIN) ./cmd/spectra-helper/
+
+build-all: build build-helper
 
 # --- Quality -----------------------------------------------------------------
 
@@ -68,7 +74,7 @@ docs-validate: docs-nav docs-lychee docs-build
 # --- Cleanup -----------------------------------------------------------------
 
 clean:
-	rm -f $(BIN) junit-report.xml gosec-report.xml
+	rm -f $(BIN) $(HELPER_BIN) junit-report.xml gosec-report.xml
 	rm -rf site/
 
 all: build vet test docs-validate

--- a/cmd/spectra-helper/main.go
+++ b/cmd/spectra-helper/main.go
@@ -29,7 +29,19 @@ var version = "dev"
 const sockPath = "/var/run/spectra-helper.sock"
 
 func main() {
-	os.Exit(run())
+	os.Exit(runWithArgs(os.Args[1:]))
+}
+
+func runWithArgs(args []string) int {
+	if helperVersionArg(args) {
+		fmt.Println(version)
+		return 0
+	}
+	return run()
+}
+
+func helperVersionArg(args []string) bool {
+	return len(args) == 1 && (args[0] == "--version" || args[0] == "version")
 }
 
 func run() int {

--- a/cmd/spectra-helper/main_test.go
+++ b/cmd/spectra-helper/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import "testing"
+
+func TestHelperVersionArg(t *testing.T) {
+	for _, args := range [][]string{{"--version"}, {"version"}} {
+		if !helperVersionArg(args) {
+			t.Fatalf("%v should be a version arg", args)
+		}
+	}
+	for _, args := range [][]string{nil, {"--help"}, {"version", "extra"}} {
+		if helperVersionArg(args) {
+			t.Fatalf("%v should not be a version arg", args)
+		}
+	}
+}

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -15,18 +15,26 @@ make build
 ./spectra /Applications/Slack.app
 ```
 
+To build the optional privileged helper next to the CLI:
+
+```bash
+make build-all
+```
+
 ## Make targets
 
 | Target | What it does |
 |---|---|
 | `make build` | Build the `spectra` binary |
+| `make build-helper` | Build the `spectra-helper` binary |
+| `make build-all` | Build both binaries |
 | `make test` | Run the test suite (`go test ./... -count=1`) |
 | `make vet` | `go vet ./...` |
 | `make fmt` | `gofmt -s -w .` |
 | `make lint` | `golangci-lint run` |
-| `make complexity` | `gocyclo -over 10` |
+| `make complexity` | `gocyclo -over 15` |
 | `make tidy` | `go mod tidy` |
-| `make ci` | vet + test + complexity, the local CI mirror |
+| `make ci` | vet + test + complexity + lint + security + licenses + docs |
 | `make clean` | Remove build artifacts |
 
 ## Cross-compiling

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,10 +18,13 @@ Spectra exists to answer questions Activity Monitor structurally cannot:
 - "Which engineers on my tailnet have Slack running right now, with how much
   RSS, talking to which hosts?"
 
-## What's here today
+## What's Here Today
 
-The current implementation is a single-binary CLI (`spectra`) that does deep,
-single-host inspection of `.app` bundles. See
+The current implementation is a CLI (`spectra`) plus an optional daemon
+and privileged helper. It does deep single-host inspection of `.app`
+bundles, live process/network/storage/toolchain inventory, snapshots,
+baseline diffs, recommendations, and JSON-RPC calls to a local or explicit
+TCP daemon. See
 [detection/overview.md](detection/overview.md) for the framework detection
 model, [inspection/](inspection/) for what we extract from each bundle, and
 [design/architecture.md](design/architecture.md) for where this is heading.
@@ -31,31 +34,30 @@ model, [inspection/](inspection/) for what we extract from each bundle, and
 ./spectra -v /Applications/Claude.app       # full inspection
 ./spectra --all                             # scan /Applications
 ./spectra --json --network /Applications/*  # JSON, with embedded URL hosts
+./spectra snapshot --baseline pre-incident  # save a baseline
+./spectra diff baseline pre-incident live   # compare baseline to now
+./spectra serve --tcp 127.0.0.1:7878        # opt-in TCP JSON-RPC
+./spectra connect 127.0.0.1:7878            # health check over RPC
 ```
 
-## What's planned
+## What's Planned
 
-- **Daemon mode** — `spectra serve` exposes the inspection RPC over a Unix
-  socket and over Tailscale via `tsnet`. See
-  [design/architecture.md](design/architecture.md).
-- **Remote portal** — `spectra connect work-mac` from your laptop to inspect a
-  teammate's machine over the tailnet. See
+- **tsnet remote portal** — `spectra connect work-mac` from your laptop to
+  inspect a teammate's machine over the tailnet without manually exposing a
+  TCP listener. See
   [design/remote-portal.md](design/remote-portal.md).
-- **JVM inspection** — VisualVM-class introspection of running JVMs and
-  installed JDKs. See [inspection/jvm.md](inspection/jvm.md).
-- **Cross-host snapshot diff** — "diff my Mac vs your Mac" on apps,
-  toolchains, env, and config drift.
-- **Recommendations engine** — rules-driven catalog of issues with severity
-  and remediation steps. See
-  [design/recommendations-engine.md](design/recommendations-engine.md).
-- **Persistent storage** — SQLite for relational facts, krit-style sharded
-  blob store for heap dumps and JFR recordings. See
-  [design/storage.md](design/storage.md).
+- **Typed remote commands and fan-out** — ergonomic wrappers around the
+  generic `spectra connect <host> call <method>` escape hatch, plus
+  cross-host aggregation.
+- **TUI client** — Bubble Tea UI against the same local-or-remote daemon
+  RPC surface.
+- **Release packaging** — Homebrew formula, prebuilt binaries, signing, and
+  notarization.
 
 ## Distribution
 
-Spectra ships through Homebrew, with an optional `sudo` step that installs a
-privileged helper for root-only telemetry (Full Disk Access, `fs_usage`,
-`powermetrics`). The Mac App Store is incompatible with the live-monitoring
-features. See [design/distribution.md](design/distribution.md) for the full
-analysis.
+Spectra currently installs from source. Homebrew and prebuilt binaries are
+planned, with an optional `sudo` step that installs a privileged helper for
+root-only telemetry (Full Disk Access, `fs_usage`, `powermetrics`). The Mac
+App Store is incompatible with the live-monitoring features. See
+[design/distribution.md](design/distribution.md) for the full analysis.

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,25 +17,44 @@ make build
 ./spectra /Applications/Slack.app
 ```
 
-## Planned: Homebrew
+To build both the CLI and optional privileged helper:
+
+```bash
+make build-all
+./spectra version
+./spectra-helper --version
+```
+
+`spectra install-helper` expects the `spectra-helper` binary to live next
+to the `spectra` binary that is running, which `make build-all` does in
+the repo root.
+
+## Homebrew
 
 ```bash
 brew install kaeawc/tap/spectra
 spectra /Applications/Slack.app
 ```
 
-## Planned: Privileged helper
+The formula is not published yet; source build is the supported path for
+now.
+
+## Privileged helper
 
 For telemetry that requires root (system TCC.db, `fs_usage`, `powermetrics`),
-Spectra will ship an optional helper installable via:
+Spectra has an optional helper installable from a source build:
 
 ```bash
+make build-all
 sudo spectra install-helper
+spectra install-helper --status
 ```
 
-The helper registers as a `SMAppService.daemon` (macOS 13+) and exposes
-root-only data over a local Unix socket to the unprivileged daemon. The
-unprivileged tier still works without it for everything we currently scan.
+The current installer copies `spectra-helper` to
+`/Library/PrivilegedHelperTools/`, writes a LaunchDaemon plist, and starts
+it with `launchctl`. It exposes root-only data over a local Unix socket to
+the unprivileged daemon. The unprivileged tier still works without it for
+everything that does not require root.
 
 See [design/distribution.md](design/distribution.md) for the full
 capability-vs-channel matrix.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,7 +53,18 @@ spectra --json /Applications/Cursor.app | jq '.[] | {name, UI, GrantedPermission
 ```
 
 Stable structured output for scripting, CI, or feeding into the
-not-yet-built recommendations engine.
+recommendations engine.
+
+## Local daemon and remote calls
+
+```bash
+spectra serve --tcp 127.0.0.1:7878
+spectra connect 127.0.0.1:7878
+spectra connect 127.0.0.1:7878 call snapshot.create
+```
+
+The daemon always listens on the local Unix socket. TCP is opt-in and is
+limited to loopback unless `--allow-remote` is supplied.
 
 ## Common workflows
 
@@ -64,4 +75,4 @@ not-yet-built recommendations engine.
 | What can this app do to my machine? | `spectra -v APP.app` (entitlements + granted) |
 | What hosts does this app talk to? | `spectra -v --network APP.app` |
 | Is anything new on my machine since last week? | `spectra diff baseline pre-incident live` |
-| What's running on my work Mac right now? | _planned: `spectra connect work-mac`_ |
+| What's running on my work Mac right now? | `spectra connect work-mac call process.list` |


### PR DESCRIPTION
## Summary
- add Makefile targets to build the optional `spectra-helper` next to the CLI
- add `spectra-helper --version` and a focused unit test for the version argument
- update install, quickstart, index, and build docs to match the current source-build, helper, daemon, and connect flows
- narrow `.gitignore` so the helper package directory is not ignored

## Validation
- make build-all
- ./spectra version
- ./spectra-helper --version
- go test ./... -count=1
- go build ./... && go vet ./...
- make docs-validate
