### PR TITLE
Update threat model for current daemon transport

### DIFF
--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -1,13 +1,14 @@
 # Threat model
 
-> **Status: planned, evolving.** Captures Spectra's intended security
-> posture as the daemon, helper, and remote-portal features land.
+This document tracks Spectra's current security posture and the hardening
+still required before a v1 release.
 
 Spectra reads sensitive system state (TCC permissions, code-signing
-metadata, process tables), optionally installs a root helper, and
-exposes a network-reachable RPC surface over Tailscale. This is a
-non-trivial attack surface and warrants a real threat-model document
-even at the planning stage.
+metadata, process tables), optionally installs a root helper, and can
+expose a network-reachable JSON-RPC surface when `spectra serve --tcp`
+is explicitly enabled. This is a non-trivial attack surface and warrants
+a real threat-model document while the daemon and remote-portal features
+continue to mature.
 
 ## Assets
 
@@ -22,7 +23,8 @@ What Spectra holds or mediates that's worth protecting:
 | Network endpoints embedded in binaries | low | already in the user's bundles |
 | App entitlements + signing identities | low (public-by-bundle) | already in `codesign` |
 | Snapshot history | medium | growing aggregate of the above |
-| Tailnet auth identity | medium | embedded `tsnet` state for the daemon |
+| TCP RPC listener | medium-high | opt-in `spectra serve --tcp` |
+| Tailnet auth identity | medium | planned embedded `tsnet` state for the daemon |
 
 ## Trust boundaries
 
@@ -35,16 +37,16 @@ What Spectra holds or mediates that's worth protecting:
                       │ Unix socket (0600, user-owned)
 ┌─────────────────────▼───────────────────────┐
 │  Unprivileged daemon                        │
-│  Holds: snapshots, blob cache, tsnet state  │
+│  Holds: snapshots, blob cache               │
 └─────────────────┬─────────────┬─────────────┘
                   │             │
-                  │             │ tsnet (TLS, Tailscale-ACL'd)
+                  │             │ optional TCP JSON-RPC
                   │             ▼
                   │   ┌───────────────────────┐
                   │   │  Remote Spectra peers │
                   │   └───────────────────────┘
                   │
-                  │ Unix socket (root:_spectra, 0660)
+                  │ Unix socket (0660; group hardening planned)
 ┌─────────────────▼───────────────────────────┐
 │  Privileged helper                          │
 │  Holds: nothing persistent                  │
@@ -52,22 +54,25 @@ What Spectra holds or mediates that's worth protecting:
 └─────────────────────────────────────────────┘
 ```
 
-Each arrow is an authenticated, scoped channel. Each box is
+Each local arrow is a scoped Unix-socket channel. The optional TCP arrow
+is scoped only by the network path that exposes it. Each box is
 independently reviewable.
 
 ## In scope
 
-Spectra defends against:
+Spectra is designed to defend against:
 
 1. **Untrusted local users on the same machine.** A non-admin user
    should not be able to read another user's snapshots, query the
    privileged helper, or talk to the daemon's Unix socket.
-2. **Untrusted tailnet peers.** A peer not allowed by Tailscale ACLs
-   should be unable to reach the daemon's tsnet listener at all.
-3. **Compromised peers within the tailnet.** A trusted peer turned
-   adversarial should be unable to escalate beyond what the daemon's
-   read-only RPC exposes — no arbitrary command execution, no
-   arbitrary file reads, no helper passthrough without consent.
+2. **Untrusted network peers.** TCP RPC is disabled by default and
+   loopback-only unless `--allow-remote` is explicitly supplied. When
+   exposed remotely, access must be constrained by SSH forwarding,
+   Tailscale ACLs, or firewall rules.
+3. **Compromised peers on a trusted network path.** A reachable peer
+   should be unable to escalate beyond what the daemon's RPC exposes —
+   no arbitrary command execution, no arbitrary file reads, and no
+   direct helper socket access.
 4. **Replay of captured artifacts.** Heap dumps and JFR recordings are
    stored content-hashed and access-controlled by filesystem
    permissions on the cache directory.
@@ -93,9 +98,10 @@ Spectra does **not** defend against:
    by Developer ID code signing, notarization, and reproducible builds
    from a public Git repo, but a determined supply-chain adversary
    isn't in our threat model.
-6. **Tailscale's threat model.** We rely on Tailscale's identity,
-   ACLs, and transport security. If Tailscale is compromised, our
-   tailnet exposure is compromised.
+6. **The chosen network tunnel's threat model.** The current TCP
+   transport relies on SSH, Tailscale, or firewall controls outside
+   Spectra. If that path is exposed to an attacker, Spectra's TCP RPC
+   listener is exposed too.
 
 ## Specific threats and mitigations
 
@@ -105,10 +111,13 @@ Spectra does **not** defend against:
 operation as root, escalating privilege.
 
 **Mitigation:**
-- Helper Unix socket is `0660 root:_spectra`; only `_spectra` group
-  members connect.
-- Joining `_spectra` requires admin privilege (set during `install-helper`).
-- Helper uses `getpeereid(2)` and logs the calling UID on every call.
+- Helper Unix socket is `0660`; the current installer starts it as a
+  LaunchDaemon and relies on filesystem permissions around
+  `/var/run/spectra-helper.sock`.
+- Hardened `_spectra` group provisioning and socket group ownership are
+  planned but not implemented yet.
+- Helper uses `getpeereid(2)` and passes the calling UID to method
+  handlers.
 - Helper has a hardcoded method allowlist; no method exposes
   arbitrary execution or file reads.
 - Helper observes only — never mutates system state.
@@ -116,9 +125,9 @@ operation as root, escalating privilege.
 **Residual risk:** A local admin (already privileged) can use the
 helper as intended. Acceptable; admins already had root.
 
-### T2: Remote command execution via tsnet RPC
+### T2: Remote command execution via daemon RPC
 
-**Threat:** A tailnet peer crafts an RPC call that causes the
+**Threat:** A network peer crafts an RPC call that causes the
 unprivileged daemon to execute attacker-controlled code or read
 attacker-chosen files.
 
@@ -132,6 +141,9 @@ attacker-chosen files.
   `validBundleID`).
 - RPC handler dispatch is method-allowlist; unknown methods return
   errors rather than passing through.
+- TCP listen is opt-in. Non-loopback binds require `--allow-remote`,
+  which prints an explicit warning that Spectra does not add its own
+  authentication layer.
 
 **Residual risk:** A bug in input validation. Mitigated by
 fuzz-testing the RPC layer (planned) and keeping the surface
@@ -143,17 +155,18 @@ intentionally narrow.
 secrets, then reads the resulting `.hprof` from the blob cache.
 
 **Mitigation:**
-- `jvm.heapDump` requires explicit consent on the calling side and an
-  audit log entry on the daemon.
-- Heap dumps are stored under user-only filesystem permissions
-  (`0600`).
-- Heap dumps can be marked sensitive in the manifest; the daemon
-  refuses to serve them over remote RPC unless explicitly allowed.
+- Local CLI heap dumps default to `~/.spectra/`, created with user-only
+  directory permissions.
+- Daemon RPC exposes `jvm.heap_dump` and `jvm.jfr.*` only to clients
+  that can already reach the daemon. Until consent prompts land, do not
+  expose TCP RPC to peers that should not be allowed to request these
+  operations.
+- Heap-dump consent, sensitive artifact manifests, and remote-serving
+  restrictions are planned hardening items.
 
-**Residual risk:** A peer with consent and ACL access to the daemon
-*can* request and read heap dumps — that's the intended capability.
-Users delegating diagnostic access to teammates should treat that
-delegation as access to live process memory.
+**Residual risk:** A peer with network access to daemon RPC can request
+heap dumps. Users delegating diagnostic access to teammates should treat
+that delegation as access to live process memory.
 
 ### T4: Snapshot leak across users
 
@@ -176,13 +189,13 @@ attacker-controlled data into a downstream parser.
   content. Mismatch fails verification.
 - Cache directory is `0700` (user-only).
 
-### T6: tsnet credential theft
+### T6: future tsnet credential theft
 
-**Threat:** A local attacker steals the daemon's tsnet state directory
+**Threat:** A local attacker steals the daemon's planned tsnet state directory
 and impersonates the daemon as that tailnet node.
 
 **Mitigation:**
-- tsnet state lives under `~/.spectra/tsnet/`, `0700`.
+- Planned tsnet state should live under `~/.spectra/tsnet/`, `0700`.
 - A user who can read the file already has full read access to the
   user's home — same residual risk as theft of the user's
   Tailscale-on-Mac state (already a known property of Tailscale).
@@ -193,16 +206,15 @@ and impersonates the daemon as that tailnet node.
 |---|---|---|
 | CLI → local daemon (Unix socket) | filesystem perms (`0600`, user-owned) | full RPC surface |
 | Daemon → privileged helper (Unix socket) | filesystem perms + `getpeereid` UID check | hardcoded method allowlist |
-| Remote client → daemon (tsnet) | Tailscale identity | full read-only surface; state-changing methods require consent flag |
-| Daemon → tailnet peers (tsnet) | Tailscale ACL | reciprocal — same posture as inbound |
+| Remote client → daemon (TCP, opt-in) | external network controls only | full RPC surface |
+| Remote client → daemon (planned tsnet) | Tailscale identity | full read-only surface; state-changing methods require consent flag |
 
 ## Logging
 
-- Helper writes structured calls to `/var/log/spectra-helper.log`
-  with rotation. Includes UID, method, args (excluding sensitive
-  payloads), result.
-- Daemon writes to `~/Library/Logs/Spectra/`. Tailnet RPC calls
-  include the calling identity.
+- Helper stderr is written by launchd to `/var/log/spectra-helper.log`.
+  Structured per-call audit logging and rotation are planned.
+- Daemon logs currently go to the foreground process. Structured daemon
+  logs under `~/Library/Logs/Spectra/` are planned.
 - Logs do **not** include heap-dump contents, JFR contents, or
   process command-line arguments (which may contain secrets).
 
@@ -212,10 +224,11 @@ Things Spectra commits to before v1 release:
 
 - [ ] All binaries signed with Developer ID, hardened runtime on.
 - [ ] All distributed binaries notarized.
-- [ ] Helper installs only via `SMAppService` or `SMJobBless`,
-      both of which verify code-signing requirements.
+- [ ] Helper install path provisions `_spectra` and sets socket group
+      ownership, or moves to `SMAppService` / `SMJobBless` with
+      code-signing requirement checks.
 - [ ] Fuzz-test the JSON-RPC dispatcher for malformed payloads.
-- [ ] Static analysis (`gosec`) clean.
+- [x] Static analysis (`gosec`) runs in CI.
 - [ ] No `os/exec` calls take user-supplied arguments without an
       allowlist.
 - [ ] No `database/sql` queries take user-supplied strings without


### PR DESCRIPTION
## Summary
- update the threat model from planned tsnet-only language to the current explicit TCP JSON-RPC transport
- document current helper socket/auth/logging behavior separately from planned `_spectra`, audit, and tsnet hardening
- correct heap dump/JFR remote-risk language to match the implemented daemon RPC surface

## Validation
- make docs-validate
