### PR TITLE
Update daemon transport docs

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -4,9 +4,9 @@ Spectra is heading toward a daemon-with-clients model where the same Go
 binary acts as either a long-lived collector or as a lightweight client
 that queries a local or remote daemon over JSON-RPC.
 
-## Today: single-binary CLI
+## Today: CLI plus optional daemon
 
-The current `spectra` binary runs static inspection in a single pass per
+The current `spectra` binary can run static inspection in a single pass per
 invocation:
 
 ```
@@ -28,20 +28,29 @@ Each sub-detection is independent. Results accumulate into a single
 `detect.Result` struct (see
 [reference/result-schema.md](../reference/result-schema.md)).
 
-## Planned: daemon-with-clients
+It can also run a JSON-RPC daemon:
+
+```bash
+spectra serve                         # Unix socket at ~/.spectra/sock
+spectra serve --tcp 127.0.0.1:7878    # opt-in TCP listener
+spectra connect 127.0.0.1:7878        # health check
+spectra connect 127.0.0.1:7878 call snapshot.create
+```
+
+## Daemon-with-clients
 
 Spectra is shaping into three roles played by the same binary:
 
 ```
 ┌─ Collector (long-lived) ───────────────────────────────────┐
 │  spectra serve                                              │
-│  ├ Listens on Unix socket and tsnet (Tailscale)            │
+│  ├ Listens on Unix socket and optional TCP JSON-RPC         │
 │  ├ Caches Detect() results keyed by content hash           │
 │  ├ Periodically samples live state (ps, lsof, nettop)      │
 │  ├ Writes snapshots to SQLite                              │
 │  └ Talks to optional privileged helper for root-only data  │
 └────────────────────────────────────────────────────────────┘
-        ↑ JSON-RPC over Unix socket / tsnet
+        ↑ JSON-RPC over Unix socket / explicit TCP
 ┌─ Client (interactive) ─────────────────────────────────────┐
 │  spectra list / spectra inspect / spectra connect host     │
 │  ├ Renders to terminal (table or JSON)                     │
@@ -50,8 +59,8 @@ Spectra is shaping into three roles played by the same binary:
         ↑ same RPC surface, talks to local or remote daemon
 ┌─ Privileged helper (optional, root) ───────────────────────┐
 │  Installed by `sudo spectra install-helper`                 │
-│  ├ Registered as SMAppService.daemon (macOS 13+)           │
-│  ├ Reads system TCC.db, runs fs_usage / powermetrics       │
+│  ├ Installed as a LaunchDaemon                             │
+│  ├ Reads system TCC.db, runs powermetrics                  │
 │  └ Exposes data over a local Unix socket to the daemon     │
 └────────────────────────────────────────────────────────────┘
 ```
@@ -72,7 +81,7 @@ required only for root-grade visibility.
   imply a single owner of the SQLite database — that's the daemon.
 - **Remote portal is the primary use case.** See
   [remote-portal.md](remote-portal.md). A long-lived daemon that's a
-  tailnet node makes "inspect a teammate's Mac" a one-line command.
+  tailnet node will make "inspect a teammate's Mac" a one-line command.
 
 ## Why not native macOS GUI from the start
 
@@ -86,14 +95,9 @@ incompatible with this architecture.
 
 ## RPC protocol
 
-Decision pending. Strong candidates:
+The implemented daemon protocol is newline-delimited JSON-RPC 2.0 over
+Unix sockets or explicit TCP. `tsnet` remains the planned Tailscale
+transport; it should carry the same RPC method surface rather than create
+a separate API.
 
-- **JSON-RPC 2.0 over HTTP** (carried by `tsnet` for transport): boring,
-  portable, debuggable with `curl`. Future SwiftUI client can hit it
-  natively.
-- **gRPC**: more typed, harder to cross-language without codegen.
-- **Custom framed JSON over Unix socket**: simplest, least debuggable.
-
-Leaning toward JSON-RPC over HTTP for protocol stability and ease of
-manual debugging. See [design/storage.md](storage.md) for the data the
-RPC will be moving.
+See [storage.md](storage.md) for the data the RPC moves.

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -1,8 +1,8 @@
 # Daemon mode
 
 `spectra serve` runs the local long-lived collector and JSON-RPC server.
-It is implemented today for the Unix-socket local workflow; remote tsnet
-and TCP listeners remain future work.
+It is implemented today for the Unix-socket local workflow and optional
+explicit TCP JSON-RPC. Remote tsnet integration remains future work.
 
 Most CLI commands still run in-process. `spectra status`, `spectra metrics`,
 and direct JSON-RPC clients use the daemon socket today; the same RPC surface
@@ -18,6 +18,7 @@ Tailscale integration that makes remote operation a first-class case.
 ```bash
 spectra serve              # foreground, logs to stdout
 spectra serve --sock /tmp/spectra.sock
+spectra serve --tcp 127.0.0.1:7878
 ```
 
 The current CLI runs in the foreground until interrupted. A launchd-managed
@@ -28,11 +29,14 @@ agent or detached `--daemon` mode is still future packaging work.
 | Surface | Default | Use |
 |---|---|---|
 | Unix socket | `~/.spectra/sock` | local CLI, local TUI/GUI clients |
+| TCP localhost | opt-in via `--tcp 127.0.0.1:7878` | explicit local/forwarded JSON-RPC clients |
+| TCP remote | opt-in via `--tcp <addr>:7878 --allow-remote` | trusted SSH/Tailscale/firewall paths |
 | Tailscale `tsnet` | _not implemented_ | future remote clients via Tailscale |
-| TCP localhost | _not implemented_ | future explicit loopback listener |
 
 The Unix socket is created with `0600` permissions and removed on clean
-shutdown.
+shutdown. TCP RPC has no Spectra-layer authentication; non-loopback
+binds require `--allow-remote` and should only be used on a trusted
+network path.
 
 ## RPC surface
 
@@ -93,7 +97,8 @@ mediates and applies its own access control.
 
 ## Authentication
 
-Current local mode relies on Unix socket filesystem permissions. Remote
+Current local mode relies on Unix socket filesystem permissions. Current
+TCP mode relies on the network path that exposes it. Spectra-layer remote
 authentication is future work with the remote portal.
 
 ## Security posture
@@ -111,9 +116,11 @@ authentication is future work with the remote portal.
 ## Health
 
 Each daemon exposes a JSON-RPC `health` method returning
-`{ ok: true, version: ... }` on the Unix socket. Used by:
+`{ ok: true, version: ... }` on the Unix socket and any opted-in TCP
+listener. Used by:
 
 - `spectra status` — local health check.
+- `spectra connect <target>` — Unix or TCP health check.
 - future TUI/GUI clients — show connection state.
 
 ## Implementation order
@@ -127,10 +134,11 @@ Implemented:
 4. Live process metrics ring buffer and periodic live snapshots.
 5. Local `spectra status` and `spectra metrics` clients.
 6. Privileged helper proxy methods for implemented helper capabilities.
+7. Optional TCP JSON-RPC listener and `spectra connect <target> call`.
 
 Future:
 
 1. CLI-wide RPC dispatch instead of in-process command execution.
 2. launchd or detached daemon lifecycle.
-3. tsnet and optional TCP listeners.
+3. tsnet listener and Tailscale identity integration.
 4. TUI/GUI clients.


### PR DESCRIPTION
## Summary
- update daemon docs to describe implemented Unix socket plus opt-in TCP JSON-RPC listeners
- update architecture docs from planned protocol language to the current newline-delimited JSON-RPC over Unix/TCP design
- keep tsnet and full typed remote clients clearly marked as future work

## Validation
- make docs-validate
