### PR TITLE
Attribute JVMs to installed JDKs

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
 func runJVM(args []string) int {
@@ -41,10 +42,11 @@ func runJVM(args []string) int {
 	}
 
 	ctx := context.Background()
+	jvmOpts := jvmOptions(ctx)
 	var infos []jvm.Info
 
 	if fs.NArg() == 0 {
-		infos = jvm.CollectAll(ctx, jvm.CollectOptions{})
+		infos = jvm.CollectAll(ctx, jvmOpts)
 		if len(infos) == 0 {
 			fmt.Fprintln(os.Stderr, "no running JVMs found (is jps in your PATH?)")
 			return 0
@@ -56,7 +58,7 @@ func runJVM(args []string) int {
 			fmt.Fprintf(os.Stderr, "invalid PID %q\n", pidStr)
 			return 2
 		}
-		info := jvm.InspectPID(ctx, pid, jvm.CollectOptions{})
+		info := jvm.InspectPID(ctx, pid, jvmOpts)
 		if info == nil {
 			fmt.Fprintf(os.Stderr, "could not inspect PID %d (process not found or jcmd unavailable)\n", pid)
 			return 1
@@ -77,6 +79,10 @@ func runJVM(args []string) int {
 		printJVMDetail(infos[0])
 	}
 	return 0
+}
+
+func jvmOptions(ctx context.Context) jvm.CollectOptions {
+	return jvm.CollectOptions{JDKs: toolchain.CollectJDKs(ctx, toolchain.CollectOptions{})}
 }
 
 func runJVMThreadDump(args []string) int {
@@ -360,6 +366,8 @@ func printJVMDetail(info jvm.Info) {
 	fmt.Printf("JDK vendor    %s\n", strOrDash(info.JDKVendor))
 	fmt.Printf("JDK version   %s\n", strOrDash(info.JDKVersion))
 	fmt.Printf("Java home     %s\n", strOrDash(info.JavaHome))
+	fmt.Printf("JDK install   %s\n", strOrDash(info.JDKInstallID))
+	fmt.Printf("JDK source    %s\n", strOrDash(info.JDKSource))
 	fmt.Printf("VM args       %s\n", strOrDash(info.VMArgs))
 	fmt.Printf("VM flags      %s\n", strOrDash(info.VMFlags))
 	fmt.Printf("Threads       %s\n", intOrDash(info.ThreadCount))

--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -90,6 +90,9 @@ JVMInfo {
   java_home
   jdk_vendor
   jdk_version
+  jdk_install_id
+  jdk_source
+  jdk_path
   vm_args
   vm_flags
   thread_count

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -3,7 +3,9 @@
 Spectra implements the JDK shell-tool layer of JVM inspection today:
 running-process discovery, structured per-PID metadata, thread dumps,
 heap histograms, heap dumps, one-shot GC stats, and JFR start/dump/stop.
-The planned in-process Java agent layer is still future work.
+It also attributes running JVMs back to the installed-JDK inventory when
+`java.home` matches a discovered JDK path. The in-process Java agent
+layer remains future work.
 
 Spectra is intended to **supplant VisualVM** for the day-to-day
 "what's this Java process doing" question. JVM inspection is a
@@ -110,8 +112,9 @@ JAVA_RUNTIME_VERSION="21.0.6+7-LTS"
 
 Running Java processes expose their `java.home`, `java.vendor`, and
 `java.version` properties through `jcmd VM.system_properties`. Spectra
-prints and serializes those fields today; explicit matching back to the
-installed-JDK inventory is still a higher-level correlation step.
+prints and serializes those fields today, and uses `java.home` to attach
+`jdk_install_id`, `jdk_source`, and `jdk_path` when the running JVM
+matches a discovered install.
 
 ## Sample output
 
@@ -128,6 +131,8 @@ Main class    com.intellij.idea.Main
 JDK vendor    JetBrains s.r.o.
 JDK version   21.0.6
 Java home     /Users/me/Library/Application Support/JetBrains/Toolbox/apps/.../jbr/Contents/Home
+JDK install   jbr-toolbox-jetbrains-s-r-o-21.0.6
+JDK source    jbr-toolbox
 VM args       -Xmx4g -Xms256m ...
 VM flags      -XX:+UseG1GC ...
 Threads       87
@@ -159,10 +164,11 @@ Implemented:
    thread count, thread dump, class histogram, heap dump, and JFR control.
 4. `jstat -gc` one-shot GC counter parsing.
 5. CLI and daemon RPC surfaces for the implemented collectors.
+6. Path-based attribution from each running JVM's `java.home` to the
+   installed-JDK inventory.
 
 Future:
 
 1. Java agent JAR for in-process capabilities.
 2. Async-profiler / flamegraph integration.
 3. JFR file parser and structured JFR summaries.
-4. Higher-level JDK install attribution for each running process.

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -89,8 +89,9 @@ helper is installed and reachable.
 
 All require a JDK in `$PATH` — see [toolchains.md](toolchains.md) for
 JDK discovery. Running JVM inspection records each process's `java.home`,
-`java.vendor`, and `java.version`; higher-level attribution back to a
-discovered JDK install is still future work.
+`java.vendor`, and `java.version`. When `java.home` matches a discovered
+JDK path, Spectra also records `jdk_install_id`, `jdk_source`, and
+`jdk_path`.
 
 ## Code-signing and entitlements
 

--- a/internal/jvm/collect.go
+++ b/internal/jvm/collect.go
@@ -3,13 +3,19 @@ package jvm
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sync"
+
+	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
 // CollectOptions configure the JVM collector.
 type CollectOptions struct {
 	// CmdRunner is used for all subprocess calls. Nil means DefaultRunner.
 	CmdRunner CmdRunner
+	// JDKs is the already-discovered JDK inventory used to attribute each
+	// running JVM's java.home back to an installed toolchain.
+	JDKs []toolchain.JDKInstall
 }
 
 // CollectAll discovers all running JVM processes and collects per-process
@@ -35,7 +41,7 @@ func CollectAll(ctx context.Context, opts CollectOptions) []Info {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			info := collectOne(ctx, pid, main, run)
+			info := collectOne(ctx, pid, main, run, opts.JDKs)
 			mu.Lock()
 			results = append(results, info)
 			mu.Unlock()
@@ -56,12 +62,20 @@ func InspectPID(_ context.Context, pid int, opts CollectOptions) *Info {
 	if _, err := run("jcmd", fmt.Sprint(pid), "VM.version"); err != nil {
 		return nil
 	}
-	info := collectOne(context.Background(), pid, "", run)
+	info := collectOne(context.Background(), pid, "", run, opts.JDKs)
 	return &info
 }
 
+// AttributeJDKs attaches installed-JDK identity fields to already-collected
+// JVM process snapshots when java.home matches a discovered JDK path.
+func AttributeJDKs(infos []Info, jdks []toolchain.JDKInstall) {
+	for i := range infos {
+		attributeJDK(&infos[i], jdks)
+	}
+}
+
 // collectOne gathers Info for a single PID.
-func collectOne(_ context.Context, pid int, main string, run CmdRunner) Info {
+func collectOne(_ context.Context, pid int, main string, run CmdRunner, jdks []toolchain.JDKInstall) Info {
 	info := Info{PID: pid, MainClass: main}
 
 	props := collectSysProps(pid, run)
@@ -74,6 +88,26 @@ func collectOne(_ context.Context, pid int, main string, run CmdRunner) Info {
 
 	info.VMFlags, info.VMArgs = collectCommandLine(pid, run)
 	info.ThreadCount = collectThreadCount(pid, run)
+	attributeJDK(&info, jdks)
 
 	return info
+}
+
+func attributeJDK(info *Info, jdks []toolchain.JDKInstall) {
+	if info == nil || info.JavaHome == "" || len(jdks) == 0 {
+		return
+	}
+	javaHome := filepath.Clean(info.JavaHome)
+	for _, install := range jdks {
+		if install.Path == "" {
+			continue
+		}
+		if filepath.Clean(install.Path) != javaHome {
+			continue
+		}
+		info.JDKInstallID = install.InstallID
+		info.JDKSource = install.Source
+		info.JDKPath = install.Path
+		return
+	}
 }

--- a/internal/jvm/jvm_test.go
+++ b/internal/jvm/jvm_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
 // --- jps parsing ---
@@ -332,5 +334,67 @@ java_command: com.example.Server
 	}
 	if info.SysProps["java.home"] != "/usr/lib/jvm/temurin-21" {
 		t.Errorf("java.home = %q", info.SysProps["java.home"])
+	}
+}
+
+func TestCollectAllAttributesJDKInstall(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "jps":
+			return []byte("4012 com.example.Server\n"), nil
+		case "jcmd":
+			if len(args) < 2 {
+				return nil, fmt.Errorf("jcmd needs args")
+			}
+			switch args[1] {
+			case "VM.system_properties":
+				return []byte(`java.home=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
+java.vendor=Eclipse Adoptium
+java.version=21.0.6
+`), nil
+			case "VM.command_line":
+				return []byte("jvm_args: -Xmx2g\n"), nil
+			case "Thread.print":
+				return []byte("\"main\" #1 prio=5\n"), nil
+			}
+		}
+		return nil, fmt.Errorf("unexpected: %s %v", name, args)
+	}
+
+	got := CollectAll(context.Background(), CollectOptions{
+		CmdRunner: run,
+		JDKs: []toolchain.JDKInstall{{
+			InstallID: "system-eclipse-adoptium-21.0.6",
+			Path:      "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home",
+			Source:    "system",
+		}},
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 JVM info, got %d", len(got))
+	}
+	info := got[0]
+	if info.JDKInstallID != "system-eclipse-adoptium-21.0.6" {
+		t.Errorf("JDKInstallID = %q", info.JDKInstallID)
+	}
+	if info.JDKSource != "system" {
+		t.Errorf("JDKSource = %q", info.JDKSource)
+	}
+	if info.JDKPath != "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home" {
+		t.Errorf("JDKPath = %q", info.JDKPath)
+	}
+}
+
+func TestAttributeJDKsUpdatesExistingInfos(t *testing.T) {
+	infos := []Info{{
+		PID:      4012,
+		JavaHome: "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home",
+	}}
+	AttributeJDKs(infos, []toolchain.JDKInstall{{
+		InstallID: "system-eclipse-adoptium-21.0.6",
+		Path:      "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home",
+		Source:    "system",
+	}})
+	if infos[0].JDKInstallID != "system-eclipse-adoptium-21.0.6" {
+		t.Errorf("JDKInstallID = %q", infos[0].JDKInstallID)
 	}
 }

--- a/internal/jvm/types.go
+++ b/internal/jvm/types.go
@@ -10,15 +10,18 @@ type CmdRunner func(name string, args ...string) ([]byte, error)
 
 // Info is the snapshot of one running JVM process.
 type Info struct {
-	PID         int               `json:"pid"`
-	MainClass   string            `json:"main_class,omitempty"`  // from jps -l
-	JavaHome    string            `json:"java_home,omitempty"`   // java.home system property
-	JDKVendor   string            `json:"jdk_vendor,omitempty"`  // java.vendor
-	JDKVersion  string            `json:"jdk_version,omitempty"` // java.version
-	VMArgs      string            `json:"vm_args,omitempty"`     // from jcmd VM.command_line
-	VMFlags     string            `json:"vm_flags,omitempty"`    // JVM flags (XX: flags)
-	ThreadCount int               `json:"thread_count,omitempty"`
-	SysProps    map[string]string `json:"sys_props,omitempty"` // selected system properties
+	PID          int               `json:"pid"`
+	MainClass    string            `json:"main_class,omitempty"`  // from jps -l
+	JavaHome     string            `json:"java_home,omitempty"`   // java.home system property
+	JDKVendor    string            `json:"jdk_vendor,omitempty"`  // java.vendor
+	JDKVersion   string            `json:"jdk_version,omitempty"` // java.version
+	JDKInstallID string            `json:"jdk_install_id,omitempty"`
+	JDKSource    string            `json:"jdk_source,omitempty"`
+	JDKPath      string            `json:"jdk_path,omitempty"`
+	VMArgs       string            `json:"vm_args,omitempty"`  // from jcmd VM.command_line
+	VMFlags      string            `json:"vm_flags,omitempty"` // JVM flags (XX: flags)
+	ThreadCount  int               `json:"thread_count,omitempty"`
+	SysProps     map[string]string `json:"sys_props,omitempty"` // selected system properties
 }
 
 // selectedProps is the allowlist of java system properties captured in SysProps.

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -35,6 +35,7 @@ import (
 
 var (
 	collectToolchains = toolchain.Collect
+	collectJDKs       = toolchain.CollectJDKs
 	runJFRDump        = jvm.JFRDump
 )
 
@@ -542,14 +543,15 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			PID int `json:"pid"`
 		}
 		_ = json.Unmarshal(params, &p)
+		jvmOpts := daemonJVMOptions()
 		if p.PID != 0 {
-			info := jvm.InspectPID(context.Background(), p.PID, jvm.CollectOptions{})
+			info := jvm.InspectPID(context.Background(), p.PID, jvmOpts)
 			if info == nil {
 				return nil, fmt.Errorf("JVM PID %d not found", p.PID)
 			}
 			return info, nil
 		}
-		return jvm.CollectAll(context.Background(), jvm.CollectOptions{}), nil
+		return jvm.CollectAll(context.Background(), jvmOpts), nil
 	})
 
 	// jvm.thread_dump — run `jcmd <pid> Thread.print` and return the raw text.
@@ -675,7 +677,7 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err := json.Unmarshal(params, &p); err != nil || p.PID == 0 {
 			return nil, fmt.Errorf("jvm.inspect requires {\"pid\": <pid>}")
 		}
-		info := jvm.InspectPID(context.Background(), p.PID, jvm.CollectOptions{})
+		info := jvm.InspectPID(context.Background(), p.PID, daemonJVMOptions())
 		if info == nil {
 			return nil, fmt.Errorf("JVM PID %d not found or not a Java process", p.PID)
 		}
@@ -937,6 +939,10 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		}
 		return result, nil
 	})
+}
+
+func daemonJVMOptions() jvm.CollectOptions {
+	return jvm.CollectOptions{JDKs: collectJDKs(context.Background(), toolchain.CollectOptions{})}
 }
 
 // runSampleCmd runs `sample <pid> <duration> <interval>` and returns stdout.

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -40,6 +40,7 @@ func testDaemon(t *testing.T) (*json.Encoder, *json.Decoder, context.CancelFunc)
 
 	d := rpc.NewDispatcher()
 	origCollectToolchains := collectToolchains
+	origCollectJDKs := collectJDKs
 	collectToolchains = func(context.Context, toolchain.CollectOptions) toolchain.Toolchains {
 		return toolchain.Toolchains{
 			Brew: toolchain.BrewInventory{
@@ -56,7 +57,13 @@ func testDaemon(t *testing.T) (*json.Encoder, *json.Decoder, context.CancelFunc)
 			BuildTools: []toolchain.BuildTool{},
 		}
 	}
-	t.Cleanup(func() { collectToolchains = origCollectToolchains })
+	collectJDKs = func(context.Context, toolchain.CollectOptions) []toolchain.JDKInstall {
+		return nil
+	}
+	t.Cleanup(func() {
+		collectToolchains = origCollectToolchains
+		collectJDKs = origCollectJDKs
+	})
 	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default, nil)
 
 	ln, err := net.Listen("unix", sockPath)

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -191,6 +191,7 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	}
 
 	wg.Wait()
+	jvm.AttributeJDKs(s.JVMs, s.Toolchains.JDKs)
 	return s
 }
 

--- a/internal/toolchain/collect.go
+++ b/internal/toolchain/collect.go
@@ -129,6 +129,25 @@ func Collect(ctx context.Context, opts CollectOptions) Toolchains {
 	return out
 }
 
+// CollectJDKs enumerates only installed JDKs. Use this from JVM inspection
+// paths that need attribution without paying for the full toolchain inventory.
+func CollectJDKs(ctx context.Context, opts CollectOptions) []JDKInstall {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return nil
+	default:
+	}
+	opts = withDefaults(opts)
+	jdks, err := discoverJDKs(opts)
+	if err != nil {
+		return nil
+	}
+	return jdks
+}
+
 func withDefaults(o CollectOptions) CollectOptions {
 	if o.Home == "" {
 		h, _ := os.UserHomeDir()

--- a/internal/toolchain/collect_test.go
+++ b/internal/toolchain/collect_test.go
@@ -61,3 +61,22 @@ JAVA_RUNTIME_VERSION="21.0.6+7-LTS"
 		t.Errorf("ActiveJVMManager: got %q, want jenv", tc.ActiveJVMManager)
 	}
 }
+
+func TestCollectJDKsOnly(t *testing.T) {
+	home := t.TempDir()
+	sdkBase := filepath.Join(home, ".sdkman", "candidates", "java")
+	makeJDK(t, sdkBase, "21.0.6-tem", "21.0.6", "21.0.6+7-LTS", "Eclipse Adoptium")
+
+	jdks := CollectJDKs(context.Background(), CollectOptions{
+		Home:          home,
+		BrewCellars:   []string{filepath.Join(home, "cellar")},
+		SystemJVMRoot: filepath.Join(home, "nope"),
+		UserJVMRoot:   filepath.Join(home, "nope2"),
+	})
+	if len(jdks) != 1 {
+		t.Fatalf("JDKs: got %d, want 1", len(jdks))
+	}
+	if jdks[0].Source != "sdkman" {
+		t.Errorf("Source = %q, want sdkman", jdks[0].Source)
+	}
+}


### PR DESCRIPTION
## What changed

- Adds JDK attribution fields to `jvm.Info`: `jdk_install_id`, `jdk_source`, and `jdk_path`.
- Matches running JVMs to installed JDK inventory via exact normalized `java.home` path.
- Adds a JDK-only toolchain collector so `spectra jvm` can enrich JVMs without running the full toolchain scan.
- Wires attribution into CLI output, daemon `jvm.list` / `jvm.inspect`, and snapshot assembly.
- Updates JVM, live data source, and system inventory docs to mark running-JVM-to-JDK attribution implemented.

## Validation

- `go test ./internal/jvm ./internal/toolchain ./internal/snapshot ./internal/serve -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
