### PR TITLE
Add structured JFR summaries

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -226,11 +226,41 @@ func runJVMGCStats(args []string) int {
 }
 
 func runJVMJFR(args []string) int {
+	if len(args) > 0 && args[0] == "summary" {
+		return runJFRSummary(args[1:])
+	}
 	sub, pid, name, outPath, code := parseJFRArgs(args)
 	if code != 0 {
 		return code
 	}
 	return executeJFR(sub, pid, name, outPath)
+}
+
+func runJFRSummary(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm jfr summary", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm jfr summary [--json] <recording.jfr>")
+		return 2
+	}
+
+	summary, err := jvm.SummarizeJFR(fs.Arg(0), nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jfr summary failed for %s: %v\n", fs.Arg(0), err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(summary)
+		return 0
+	}
+	printJFRSummary(summary)
+	return 0
 }
 
 func parseJFRArgs(args []string) (string, int, string, string, int) {
@@ -336,6 +366,23 @@ func runJFRStop(pid int, name, dest string) int {
 		fmt.Println(dest)
 	}
 	return 0
+}
+
+func printJFRSummary(summary jvm.JFRSummary) {
+	fmt.Printf("File      %s\n", strOrDash(summary.Path))
+	fmt.Printf("Version   %s\n", strOrDash(summary.Version))
+	fmt.Printf("Chunks    %s\n", intOrDash(summary.Chunks))
+	fmt.Printf("Start     %s\n", strOrDash(summary.Start))
+	fmt.Printf("Duration  %s\n", strOrDash(summary.Duration))
+	if len(summary.Events) == 0 {
+		return
+	}
+	fmt.Println("\nEvents:")
+	fmt.Printf("%-48s %10s %12s\n", "TYPE", "COUNT", "BYTES")
+	fmt.Println(strings.Repeat("-", 74))
+	for _, event := range summary.Events {
+		fmt.Printf("%-48s %10d %12d\n", truncate(event.Type, 48), event.Count, event.SizeBytes)
+	}
 }
 
 func printJVMList(infos []jvm.Info) {

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -3,9 +3,10 @@
 Spectra implements the JDK shell-tool layer of JVM inspection today:
 running-process discovery, structured per-PID metadata, thread dumps,
 heap histograms, heap dumps, one-shot GC stats, and JFR start/dump/stop.
-It also attributes running JVMs back to the installed-JDK inventory when
-`java.home` matches a discovered JDK path. The in-process Java agent
-layer remains future work.
+It also parses `jfr summary` output into structured event counts and
+attributes running JVMs back to the installed-JDK inventory when
+`java.home` matches a discovered JDK path. The in-process Java agent layer
+remains future work.
 
 Spectra is intended to **supplant VisualVM** for the day-to-day
 "what's this Java process doing" question. JVM inspection is a
@@ -24,6 +25,7 @@ spectra jvm gc-stats [--json] <pid>
 spectra jvm jfr start <pid> [--name spectra]
 spectra jvm jfr dump <pid> [--name spectra] [--out <path>]
 spectra jvm jfr stop <pid> [--name spectra] [--out <path>]
+spectra jvm jfr summary [--json] <recording.jfr>
 ```
 
 Daemon methods:
@@ -37,6 +39,7 @@ Daemon methods:
 - `jvm.jfr.start`
 - `jvm.jfr.dump`
 - `jvm.jfr.stop`
+- `jvm.jfr.summary`
 - `jdk.list`
 - `jdk.scan`
 
@@ -60,11 +63,14 @@ JDK commands:
 | Heap histogram | `jcmd <pid> GC.class_histogram` |
 | Heap dump | `jcmd <pid> GC.heap_dump <path>` |
 | JFR start / stop / dump | `jcmd <pid> JFR.start`, `JFR.dump` |
+| JFR summary | `jfr summary <recording.jfr>` |
 
 `spectra jvm` and `spectra jvm <pid>` parse output into structured JSON
-when `--json` is passed. Thread dump text and JFR dump files are copied
-into the [sharded blob store](../design/storage.md) when the cache stores
-are initialized. Heap dumps are written to the requested path or to
+when `--json` is passed. `spectra jvm jfr summary --json <file>` returns
+recording metadata plus per-event counts and byte sizes. Thread dump text
+and JFR dump files are copied into the
+[sharded blob store](../design/storage.md) when the cache stores are
+initialized. Heap dumps are written to the requested path or to
 `~/.spectra/<pid>-<timestamp>.hprof`.
 
 ### Layer 2 — Java agent (in-process)
@@ -166,9 +172,10 @@ Implemented:
 5. CLI and daemon RPC surfaces for the implemented collectors.
 6. Path-based attribution from each running JVM's `java.home` to the
    installed-JDK inventory.
+7. `jfr summary` parsing for structured recording metadata and event
+   counts.
 
 Future:
 
 1. Java agent JAR for in-process capabilities.
 2. Async-profiler / flamegraph integration.
-3. JFR file parser and structured JFR summaries.

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -85,6 +85,7 @@ helper is installed and reachable.
 | `jcmd <pid> GC.heap_dump <path>` | full heap dump | same UID | seconds-minutes, GBs | `jvm.heapDump` artifact |
 | `jcmd <pid> JFR.start name=spectra` | start JFR recording | same UID | low | `jvm.jfr.start` |
 | `jcmd <pid> JFR.dump name=spectra filename=...` | stop+dump JFR | same UID | low | `jvm.jfr.dump` |
+| `jfr summary <path>` | JFR recording metadata + event counts | user | low | `jvm.jfr.summary` |
 | `jstat -gc <pid>` | GC counters snapshot | same UID | low | `jvm.gc_stats` |
 
 All require a JDK in `$PATH` — see [toolchains.md](toolchains.md) for

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -215,6 +215,26 @@ spectra baseline list
 spectra baseline drop snap-20260504T095749Z-4829
 ```
 
+## `spectra jvm`
+
+Lists or inspects running JVM processes and exposes JDK-tool diagnostics.
+
+### Examples
+
+```bash
+spectra jvm
+spectra jvm --json
+spectra jvm 4012
+spectra jvm thread-dump 4012
+spectra jvm heap-histogram 4012
+spectra jvm heap-dump --out /tmp/app.hprof 4012
+spectra jvm gc-stats --json 4012
+spectra jvm jfr start 4012 --name spectra
+spectra jvm jfr dump 4012 --name spectra --out /tmp/app.jfr
+spectra jvm jfr summary --json /tmp/app.jfr
+spectra jvm jfr stop 4012 --name spectra
+```
+
 ## `spectra serve`
 
 Runs the JSON-RPC daemon. By default it listens only on the current

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -50,7 +50,7 @@ JSON-RPC 2.0 methods, organized by concern:
   `process.tree`, `process.sample`
 - **JVM** — `jvm.list`, `jvm.inspect`, `jvm.threadDump`, `jvm.heapDump`,
   `jvm.heapHistogram`, `jvm.gcStats`, `jvm.jfr.start`, `jvm.jfr.stop`,
-  `jvm.jfr.dump`
+  `jvm.jfr.dump`, `jvm.jfr.summary`
 - **JDK** — `jdk.list`, `jdk.scan`
 - **Toolchain** — `toolchain.scan`, `toolchain.brew`,
   `toolchain.runtimes`, `toolchain.build_tools`

--- a/internal/jvm/jfr_summary.go
+++ b/internal/jvm/jfr_summary.go
@@ -1,0 +1,104 @@
+package jvm
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// JFRSummary is the structured form of `jfr summary <recording.jfr>`.
+type JFRSummary struct {
+	Path     string            `json:"path,omitempty"`
+	Version  string            `json:"version,omitempty"`
+	Chunks   int               `json:"chunks,omitempty"`
+	Start    string            `json:"start,omitempty"`
+	Duration string            `json:"duration,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+	Events   []JFREventSummary `json:"events,omitempty"`
+}
+
+// JFREventSummary is one event row from a JFR summary.
+type JFREventSummary struct {
+	Type      string `json:"type"`
+	Count     int64  `json:"count"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// SummarizeJFR runs the JDK `jfr summary` command and parses its output.
+func SummarizeJFR(path string, run CmdRunner) (JFRSummary, error) {
+	if run == nil {
+		run = DefaultRunner
+	}
+	out, err := run("jfr", "summary", path)
+	if err != nil {
+		return JFRSummary{}, err
+	}
+	summary := ParseJFRSummary(path, string(out))
+	return summary, nil
+}
+
+// ParseJFRSummary parses the stable text shape emitted by `jfr summary`.
+func ParseJFRSummary(path, out string) JFRSummary {
+	summary := JFRSummary{
+		Path:     path,
+		Metadata: make(map[string]string),
+	}
+	for _, raw := range strings.Split(out, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "-") {
+			continue
+		}
+		if k, v, ok := strings.Cut(line, ":"); ok {
+			key := strings.TrimSpace(k)
+			val := strings.TrimSpace(v)
+			switch strings.ToLower(key) {
+			case "version":
+				summary.Version = val
+			case "chunks":
+				summary.Chunks, _ = strconv.Atoi(strings.ReplaceAll(val, ",", ""))
+			case "start":
+				summary.Start = val
+			case "duration":
+				summary.Duration = val
+			default:
+				summary.Metadata[key] = val
+			}
+			continue
+		}
+		if event, ok := parseJFREventSummary(line); ok {
+			summary.Events = append(summary.Events, event)
+		}
+	}
+	if len(summary.Metadata) == 0 {
+		summary.Metadata = nil
+	}
+	return summary
+}
+
+func parseJFREventSummary(line string) (JFREventSummary, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 3 {
+		return JFREventSummary{}, false
+	}
+	count, err := parseJFRInt(fields[len(fields)-2])
+	if err != nil {
+		return JFREventSummary{}, false
+	}
+	size, err := parseJFRInt(fields[len(fields)-1])
+	if err != nil {
+		return JFREventSummary{}, false
+	}
+	eventType := strings.Join(fields[:len(fields)-2], " ")
+	if eventType == "" || eventType == "Event Type" {
+		return JFREventSummary{}, false
+	}
+	return JFREventSummary{Type: eventType, Count: count, SizeBytes: size}, true
+}
+
+func parseJFRInt(s string) (int64, error) {
+	n, err := strconv.ParseInt(strings.ReplaceAll(s, ",", ""), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse jfr integer %q: %w", s, err)
+	}
+	return n, nil
+}

--- a/internal/jvm/jfr_summary_test.go
+++ b/internal/jvm/jfr_summary_test.go
@@ -1,0 +1,67 @@
+package jvm
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseJFRSummary(t *testing.T) {
+	out := `Version: 2.1
+Chunks: 1
+Start: 2026-05-05 21:00:00 (UTC)
+Duration: 60 s
+
+Event Type                                   Count  Size (bytes)
+---------------------------------------------------------------
+jdk.CPULoad                                     60        1,920
+jdk.ExecutionSample                          1,234       98,765
+`
+	got := ParseJFRSummary("/tmp/test.jfr", out)
+	if got.Path != "/tmp/test.jfr" {
+		t.Errorf("Path = %q", got.Path)
+	}
+	if got.Version != "2.1" {
+		t.Errorf("Version = %q", got.Version)
+	}
+	if got.Chunks != 1 {
+		t.Errorf("Chunks = %d", got.Chunks)
+	}
+	if got.Duration != "60 s" {
+		t.Errorf("Duration = %q", got.Duration)
+	}
+	if len(got.Events) != 2 {
+		t.Fatalf("Events = %d, want 2: %+v", len(got.Events), got.Events)
+	}
+	if got.Events[1].Type != "jdk.ExecutionSample" || got.Events[1].Count != 1234 || got.Events[1].SizeBytes != 98765 {
+		t.Errorf("event[1] = %+v", got.Events[1])
+	}
+}
+
+func TestSummarizeJFRFakeRunner(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	run := func(name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = args
+		return []byte("Version: 2.1\nChunks: 1\njdk.CPULoad 3 96\n"), nil
+	}
+	summary, err := SummarizeJFR("/tmp/test.jfr", run)
+	if err != nil {
+		t.Fatalf("SummarizeJFR: %v", err)
+	}
+	if gotName != "jfr" || len(gotArgs) != 2 || gotArgs[0] != "summary" || gotArgs[1] != "/tmp/test.jfr" {
+		t.Fatalf("command = %s %v", gotName, gotArgs)
+	}
+	if len(summary.Events) != 1 || summary.Events[0].Count != 3 {
+		t.Fatalf("summary events = %+v", summary.Events)
+	}
+}
+
+func TestSummarizeJFRPropagatesRunnerError(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("no jfr")
+	}
+	if _, err := SummarizeJFR("/tmp/test.jfr", run); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -37,6 +37,7 @@ var (
 	collectToolchains = toolchain.Collect
 	collectJDKs       = toolchain.CollectJDKs
 	runJFRDump        = jvm.JFRDump
+	runJFRSummary     = jvm.SummarizeJFR
 )
 
 // DefaultSockPath returns the canonical Unix socket path (~/.spectra/sock).
@@ -666,6 +667,21 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, fmt.Errorf("jfr stop pid %d: %w", p.PID, err)
 		}
 		return map[string]any{"pid": p.PID, "name": name, "dest": p.Dest, "stopped": true}, nil
+	})
+
+	// jvm.jfr.summary — run `jfr summary <path>` and return parsed event counts.
+	d.Register("jvm.jfr.summary", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.Path == "" {
+			return nil, fmt.Errorf("jvm.jfr.summary requires {\"path\": \"...\"}")
+		}
+		summary, err := runJFRSummary(p.Path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("jfr summary %s: %w", p.Path, err)
+		}
+		return summary, nil
 	})
 
 	// jvm.inspect — structured inspection of one JVM process.

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -501,6 +501,46 @@ func TestDaemonJVMJFRStopMissingPID(t *testing.T) {
 	}
 }
 
+func TestDaemonJVMJFRSummaryMissingPath(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 38, "jvm.jfr.summary", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when path missing")
+	}
+}
+
+func TestDaemonJVMJFRSummaryUsesRunner(t *testing.T) {
+	var gotPath string
+	orig := runJFRSummary
+	runJFRSummary = func(path string, _ jvm.CmdRunner) (jvm.JFRSummary, error) {
+		gotPath = path
+		return jvm.JFRSummary{
+			Path:    path,
+			Version: "2.1",
+			Events:  []jvm.JFREventSummary{{Type: "jdk.CPULoad", Count: 2, SizeBytes: 64}},
+		}, nil
+	}
+	t.Cleanup(func() { runJFRSummary = orig })
+
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 39, "jvm.jfr.summary", `{"path":"/tmp/out.jfr"}`)
+	if resp.Error != nil {
+		t.Fatalf("jvm.jfr.summary: %v", resp.Error)
+	}
+	if gotPath != "/tmp/out.jfr" {
+		t.Fatalf("path = %q, want /tmp/out.jfr", gotPath)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	if m["version"] != "2.1" {
+		t.Errorf("version = %v, want 2.1", m["version"])
+	}
+}
+
 func TestDaemonCacheStatsReturnsSlice(t *testing.T) {
 	enc, dec, cancel := testDaemon(t)
 	defer cancel()


### PR DESCRIPTION
## What changed

- Adds `jvm.SummarizeJFR` and a parser for `jfr summary <recording.jfr>` output.
- Adds `spectra jvm jfr summary [--json] <recording.jfr>` for human and structured JFR summaries.
- Exposes the same summary through daemon RPC as `jvm.jfr.summary`.
- Updates JVM, live-source, daemon, and CLI docs so structured JFR summaries are marked implemented.

## Validation

- `go test ./internal/jvm ./internal/serve ./cmd/spectra -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
