### PR TITLE
Add helper audit logging

### DIFF
--- a/cmd/spectra-helper/main.go
+++ b/cmd/spectra-helper/main.go
@@ -74,6 +74,7 @@ func run() int {
 	}()
 
 	d := helper.NewDispatcher()
+	d.SetAuditWriter(os.Stderr)
 	helper.RegisterAll(d, nil) // nil → real commands
 
 	fmt.Fprintf(os.Stderr, "spectra-helper %s: listening on %s\n", version, sockPath)

--- a/docs/design/privileged-helper.md
+++ b/docs/design/privileged-helper.md
@@ -159,14 +159,19 @@ internal/
 ## Audit log
 
 The LaunchDaemon plist sends stderr to `/var/log/spectra-helper.log`.
-Structured per-call audit logging and rotation are planned.
+The helper writes one JSON object per handled request to stderr, so the
+LaunchDaemon log captures caller UID, method, status, duration, and error
+summary without recording request parameters.
 
 ```
-2026-05-04T18:33:21Z uid=501 method=tcc.system.query bundleID=com.anthropic.claudefordesktop result=ok rows=2
+{"time":"2026-05-05T17:33:21Z","uid":501,"method":"helper.tcc.system.query","ok":true,"duration_ms":4}
+{"time":"2026-05-05T17:33:24Z","uid":501,"method":"helper.unknown","ok":false,"duration_ms":0,"error":"method not found"}
 ```
 
 Users running with the helper installed can audit what got asked of
 it. The unprivileged daemon never writes to this log directly.
+Rotation is still handled by the host's `/var/log` policy; a dedicated
+Spectra log rotation policy is future hardening work.
 
 ## Code signing and notarization
 

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -212,7 +212,8 @@ and impersonates the daemon as that tailnet node.
 ## Logging
 
 - Helper stderr is written by launchd to `/var/log/spectra-helper.log`.
-  Structured per-call audit logging and rotation are planned.
+  The helper emits structured per-call JSON audit records there. Dedicated
+  rotation remains planned.
 - Daemon logs currently go to the foreground process. Structured daemon
   logs under `~/Library/Logs/Spectra/` are planned.
 - Logs do **not** include heap-dump contents, JFR contents, or

--- a/internal/helper/dispatcher.go
+++ b/internal/helper/dispatcher.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"sync"
+	"time"
 )
 
 // Request is a JSON-RPC 2.0 request.
@@ -37,11 +39,14 @@ type HandlerFunc func(callerUID uint32, params json.RawMessage) (any, error)
 type Dispatcher struct {
 	mu       sync.RWMutex
 	handlers map[string]HandlerFunc
+	auditMu  sync.Mutex
+	audit    io.Writer
+	now      func() time.Time
 }
 
 // NewDispatcher returns an empty Dispatcher.
 func NewDispatcher() *Dispatcher {
-	return &Dispatcher{handlers: make(map[string]HandlerFunc)}
+	return &Dispatcher{handlers: make(map[string]HandlerFunc), now: time.Now}
 }
 
 // Register adds a handler for method. Panics if method already registered.
@@ -52,6 +57,24 @@ func (d *Dispatcher) Register(method string, fn HandlerFunc) {
 		panic("helper: duplicate method: " + method)
 	}
 	d.handlers[method] = fn
+}
+
+// SetAuditWriter enables JSON-lines audit logging for handled requests.
+func (d *Dispatcher) SetAuditWriter(w io.Writer) {
+	d.auditMu.Lock()
+	defer d.auditMu.Unlock()
+	d.audit = w
+}
+
+// SetClock injects the clock used by audit logging.
+func (d *Dispatcher) SetClock(now func() time.Time) {
+	d.auditMu.Lock()
+	defer d.auditMu.Unlock()
+	if now == nil {
+		d.now = time.Now
+		return
+	}
+	d.now = now
 }
 
 // Serve handles one connection using the length-framed protocol.
@@ -75,14 +98,17 @@ func (d *Dispatcher) Serve(conn net.Conn) {
 }
 
 func (d *Dispatcher) handle(uid uint32, raw []byte) Response {
+	start := d.now()
 	var req Request
 	if err := json.Unmarshal(raw, &req); err != nil {
+		d.auditRequest(start, uid, "", false, "parse error")
 		return Response{
 			JSONRPC: "2.0",
 			Error:   &RPCError{Code: -32700, Message: "parse error"},
 		}
 	}
 	if req.JSONRPC != "2.0" || req.Method == "" {
+		d.auditRequest(start, uid, req.Method, false, "invalid request")
 		return Response{JSONRPC: "2.0", ID: req.ID, Error: &RPCError{Code: -32600, Message: "invalid request"}}
 	}
 
@@ -91,6 +117,7 @@ func (d *Dispatcher) handle(uid uint32, raw []byte) Response {
 	d.mu.RUnlock()
 
 	if !ok {
+		d.auditRequest(start, uid, req.Method, false, "method not found")
 		return Response{
 			JSONRPC: "2.0", ID: req.ID,
 			Error: &RPCError{Code: -32601, Message: fmt.Sprintf("method not found: %s", req.Method)},
@@ -98,9 +125,37 @@ func (d *Dispatcher) handle(uid uint32, raw []byte) Response {
 	}
 	result, err := fn(uid, req.Params)
 	if err != nil {
+		d.auditRequest(start, uid, req.Method, false, err.Error())
 		return Response{JSONRPC: "2.0", ID: req.ID, Error: &RPCError{Code: -32603, Message: err.Error()}}
 	}
+	d.auditRequest(start, uid, req.Method, true, "")
 	return Response{JSONRPC: "2.0", ID: req.ID, Result: result}
+}
+
+type auditEvent struct {
+	Time       string `json:"time"`
+	UID        uint32 `json:"uid"`
+	Method     string `json:"method"`
+	OK         bool   `json:"ok"`
+	DurationMS int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+func (d *Dispatcher) auditRequest(start time.Time, uid uint32, method string, ok bool, msg string) {
+	d.auditMu.Lock()
+	defer d.auditMu.Unlock()
+	if d.audit == nil {
+		return
+	}
+	event := auditEvent{
+		Time:       start.UTC().Format(time.RFC3339Nano),
+		UID:        uid,
+		Method:     method,
+		OK:         ok,
+		DurationMS: d.now().Sub(start).Milliseconds(),
+		Error:      msg,
+	}
+	_ = json.NewEncoder(d.audit).Encode(event)
 }
 
 // ServeListener accepts connections and serves each in its own goroutine.

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -132,6 +132,51 @@ func TestDispatcherMethodNotFound(t *testing.T) {
 	}
 }
 
+func TestDispatcherAuditLogSuccessAndFailure(t *testing.T) {
+	d := NewDispatcher()
+	var log bytes.Buffer
+	d.SetAuditWriter(&log)
+	base := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	tick := 0
+	d.SetClock(func() time.Time {
+		tick++
+		return base.Add(time.Duration(tick) * time.Millisecond)
+	})
+	d.Register("helper.ok", func(uid uint32, _ json.RawMessage) (any, error) {
+		if uid != 501 {
+			t.Fatalf("uid = %d, want 501", uid)
+		}
+		return map[string]any{"ok": true}, nil
+	})
+
+	okReq := []byte(`{"jsonrpc":"2.0","id":1,"method":"helper.ok"}`)
+	if resp := d.handle(501, okReq); resp.Error != nil {
+		t.Fatalf("unexpected response error: %+v", resp.Error)
+	}
+	badReq := []byte(`{"jsonrpc":"2.0","id":2,"method":"helper.missing"}`)
+	if resp := d.handle(501, badReq); resp.Error == nil {
+		t.Fatal("expected missing method error")
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(log.Bytes()), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("audit lines = %d, want 2: %s", len(lines), log.String())
+	}
+	var first, second auditEvent
+	if err := json.Unmarshal(lines[0], &first); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(lines[1], &second); err != nil {
+		t.Fatal(err)
+	}
+	if !first.OK || first.Method != "helper.ok" || first.UID != 501 {
+		t.Errorf("first audit event = %+v", first)
+	}
+	if second.OK || second.Method != "helper.missing" || second.Error != "method not found" {
+		t.Errorf("second audit event = %+v", second)
+	}
+}
+
 func TestTCCQueryRequiresBundleID(t *testing.T) {
 	d := NewDispatcher()
 	RegisterAll(d, func(string, ...string) ([]byte, error) {


### PR DESCRIPTION
## What changed

- Adds JSON-lines audit logging to the privileged helper dispatcher.
- Logs timestamp, caller UID, method, success status, duration, and error summary without logging request parameters.
- Wires `spectra-helper` audit output to stderr, which the LaunchDaemon already sends to `/var/log/spectra-helper.log`.
- Updates helper and threat-model docs to mark structured per-call helper audit logging implemented, with rotation still future work.

## Validation

- `go test ./internal/helper ./cmd/spectra-helper -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
