### PR TITLE
Rate limit helper requests by UID

### DIFF
--- a/cmd/spectra-helper/main.go
+++ b/cmd/spectra-helper/main.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/helper"
 )
@@ -75,6 +76,7 @@ func run() int {
 
 	d := helper.NewDispatcher()
 	d.SetAuditWriter(os.Stderr)
+	d.SetRateLimit(120, time.Minute)
 	helper.RegisterAll(d, nil) // nil → real commands
 
 	fmt.Fprintf(os.Stderr, "spectra-helper %s: listening on %s\n", version, sockPath)

--- a/docs/design/privileged-helper.md
+++ b/docs/design/privileged-helper.md
@@ -104,8 +104,9 @@ streams: framing makes recovery from partial reads trivial.
   socket is implemented and passed to method handlers.
 - **Method allowlist** is hardcoded in the helper. There is no dynamic
   capability negotiation.
-- **Rate limiting** per UID is planned to prevent a compromised
-  unprivileged daemon from DOSing the system.
+- **Rate limiting** is enforced per caller UID in the helper dispatcher.
+  The installed helper allows 120 requests per minute per UID before
+  returning a JSON-RPC rate-limit error.
 
 ## What the unprivileged daemon does without the helper
 

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -163,6 +163,8 @@ secrets, then reads the resulting `.hprof` from the blob cache.
   operations.
 - Heap-dump consent, sensitive artifact manifests, and remote-serving
   restrictions are planned hardening items.
+- The privileged helper enforces a per-UID request limit so a compromised
+  unprivileged daemon cannot hammer root-only commands indefinitely.
 
 **Residual risk:** A peer with network access to daemon RPC can request
 heap dumps. Users delegating diagnostic access to teammates should treat

--- a/internal/helper/dispatcher.go
+++ b/internal/helper/dispatcher.go
@@ -42,6 +42,8 @@ type Dispatcher struct {
 	auditMu  sync.Mutex
 	audit    io.Writer
 	now      func() time.Time
+	limitMu  sync.Mutex
+	limit    *rateLimiter
 }
 
 // NewDispatcher returns an empty Dispatcher.
@@ -77,6 +79,22 @@ func (d *Dispatcher) SetClock(now func() time.Time) {
 	d.now = now
 }
 
+// SetRateLimit enables a per-UID sliding-window request limit. Passing
+// maxRequests <= 0 or window <= 0 disables rate limiting.
+func (d *Dispatcher) SetRateLimit(maxRequests int, window time.Duration) {
+	d.limitMu.Lock()
+	defer d.limitMu.Unlock()
+	if maxRequests <= 0 || window <= 0 {
+		d.limit = nil
+		return
+	}
+	d.limit = &rateLimiter{
+		maxRequests: maxRequests,
+		window:      window,
+		seen:        make(map[uint32][]time.Time),
+	}
+}
+
 // Serve handles one connection using the length-framed protocol.
 func (d *Dispatcher) Serve(conn net.Conn) {
 	defer conn.Close()
@@ -110,6 +128,10 @@ func (d *Dispatcher) handle(uid uint32, raw []byte) Response {
 	if req.JSONRPC != "2.0" || req.Method == "" {
 		d.auditRequest(start, uid, req.Method, false, "invalid request")
 		return Response{JSONRPC: "2.0", ID: req.ID, Error: &RPCError{Code: -32600, Message: "invalid request"}}
+	}
+	if !d.allowRequest(uid, start) {
+		d.auditRequest(start, uid, req.Method, false, "rate limit exceeded")
+		return Response{JSONRPC: "2.0", ID: req.ID, Error: &RPCError{Code: -32001, Message: "rate limit exceeded"}}
 	}
 
 	d.mu.RLock()
@@ -156,6 +178,35 @@ func (d *Dispatcher) auditRequest(start time.Time, uid uint32, method string, ok
 		Error:      msg,
 	}
 	_ = json.NewEncoder(d.audit).Encode(event)
+}
+
+type rateLimiter struct {
+	maxRequests int
+	window      time.Duration
+	seen        map[uint32][]time.Time
+}
+
+func (d *Dispatcher) allowRequest(uid uint32, now time.Time) bool {
+	d.limitMu.Lock()
+	defer d.limitMu.Unlock()
+	if d.limit == nil {
+		return true
+	}
+	cutoff := now.Add(-d.limit.window)
+	hits := d.limit.seen[uid]
+	keep := hits[:0]
+	for _, ts := range hits {
+		if ts.After(cutoff) {
+			keep = append(keep, ts)
+		}
+	}
+	if len(keep) >= d.limit.maxRequests {
+		d.limit.seen[uid] = keep
+		return false
+	}
+	keep = append(keep, now)
+	d.limit.seen[uid] = keep
+	return true
 }
 
 // ServeListener accepts connections and serves each in its own goroutine.

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -177,6 +177,35 @@ func TestDispatcherAuditLogSuccessAndFailure(t *testing.T) {
 	}
 }
 
+func TestDispatcherRateLimitsPerUID(t *testing.T) {
+	d := NewDispatcher()
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	d.SetClock(func() time.Time { return now })
+	d.SetRateLimit(2, time.Minute)
+	d.Register("helper.ok", func(uint32, json.RawMessage) (any, error) {
+		return map[string]any{"ok": true}, nil
+	})
+	req := []byte(`{"jsonrpc":"2.0","id":1,"method":"helper.ok"}`)
+
+	if resp := d.handle(501, req); resp.Error != nil {
+		t.Fatalf("first request error: %+v", resp.Error)
+	}
+	if resp := d.handle(501, req); resp.Error != nil {
+		t.Fatalf("second request error: %+v", resp.Error)
+	}
+	if resp := d.handle(502, req); resp.Error != nil {
+		t.Fatalf("different UID should not be limited: %+v", resp.Error)
+	}
+	if resp := d.handle(501, req); resp.Error == nil || resp.Error.Code != -32001 {
+		t.Fatalf("third request error = %+v, want rate limit", resp.Error)
+	}
+
+	now = now.Add(time.Minute + time.Millisecond)
+	if resp := d.handle(501, req); resp.Error != nil {
+		t.Fatalf("request after window error: %+v", resp.Error)
+	}
+}
+
 func TestTCCQueryRequiresBundleID(t *testing.T) {
 	d := NewDispatcher()
 	RegisterAll(d, func(string, ...string) ([]byte, error) {


### PR DESCRIPTION
## What changed

- Adds a per-UID sliding-window request limiter to the privileged helper dispatcher.
- Enables the installed helper at 120 requests per minute per caller UID.
- Returns JSON-RPC `-32001` when a caller exceeds the helper rate limit.
- Updates privileged helper and threat-model docs to mark helper rate limiting implemented.

## Validation

- `go test ./internal/helper ./cmd/spectra-helper -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
