### PR TITLE
Add helper firewall rules command

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -8,12 +8,16 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/netstate"
 )
 
 func runNetwork(args []string) int {
 	if len(args) > 0 && args[0] == "connections" {
 		return runNetworkConnections(args[1:])
+	}
+	if len(args) > 0 && args[0] == "firewall" {
+		return runNetworkFirewall(args[1:])
 	}
 
 	fs := flag.NewFlagSet("spectra network", flag.ContinueOnError)
@@ -33,6 +37,40 @@ func runNetwork(args []string) int {
 	}
 
 	printNetworkState(state)
+	return 0
+}
+
+func runNetworkFirewall(args []string) int {
+	fs := flag.NewFlagSet("spectra network firewall", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of raw pf rules")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	result, err := helperclient.New().FirewallRules()
+	if err != nil {
+		if helperclient.IsUnavailable(err) {
+			fmt.Fprintln(os.Stderr, "privileged helper not running; install with: sudo spectra install-helper")
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "firewall rules: %v\n", err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return 0
+	}
+	if raw, _ := result["raw_rules"].(string); raw != "" {
+		fmt.Print(raw)
+		if !strings.HasSuffix(raw, "\n") {
+			fmt.Println()
+		}
+		return 0
+	}
+	fmt.Println("no firewall rules")
 	return 0
 }
 

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -52,7 +52,7 @@ limiting (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `scutil --proxy` | system proxy config | user | <10ms | `network.proxy_config` |
 | `scutil --dns` | DNS resolver config | user | <10ms | `network.dns_servers` |
 | `route -n get default` | default route + interface | user | <10ms | `network.default_route_*` |
-| `pfctl -s rules` | firewall rules | helper | one-shot | (planned) fw audit |
+| `pfctl -s rules` | firewall rules | helper | one-shot | `helper.firewall.rules`, `spectra network firewall` |
 | `tcpdump -i <iface>` | raw packet capture | helper | streaming, high | (planned) targeted capture |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -235,6 +235,21 @@ spectra jvm jfr summary --json /tmp/app.jfr
 spectra jvm jfr stop 4012 --name spectra
 ```
 
+## `spectra network`
+
+Shows unprivileged network state by default. `spectra network firewall`
+asks the privileged helper for current pf firewall rules.
+
+### Examples
+
+```bash
+spectra network
+spectra network --json
+spectra network connections --proto tcp --state established
+spectra network firewall
+spectra network firewall --json
+```
+
 ## `spectra serve`
 
 Runs the JSON-RPC daemon. By default it listens only on the current

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -48,6 +48,8 @@ JSON-RPC 2.0 methods, organized by concern:
   `snapshot.granted_perms`, `snapshot.prune`
 - **Live state** — `process.live`, `process.history`, `process.list`,
   `process.tree`, `process.sample`
+- **Helper** — `helper.health`, `helper.powermetrics.sample`,
+  `helper.tcc.system.query`, `helper.firewall.rules`
 - **JVM** — `jvm.list`, `jvm.inspect`, `jvm.threadDump`, `jvm.heapDump`,
   `jvm.heapHistogram`, `jvm.gcStats`, `jvm.jfr.start`, `jvm.jfr.stop`,
   `jvm.jfr.dump`, `jvm.jfr.summary`

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -233,3 +233,30 @@ func TestTCCQueryRequiresBundleID(t *testing.T) {
 		t.Error("expected error when bundle_id missing")
 	}
 }
+
+func TestFirewallRulesUsesPFCTL(t *testing.T) {
+	d := NewDispatcher()
+	var gotName string
+	var gotArgs []string
+	RegisterAll(d, func(name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = args
+		return []byte("block drop all\npass out all\n"), nil
+	})
+
+	req := []byte(`{"jsonrpc":"2.0","id":4,"method":"helper.firewall.rules"}`)
+	resp := d.handle(501, req)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	if gotName != "pfctl" || len(gotArgs) != 2 || gotArgs[0] != "-s" || gotArgs[1] != "rules" {
+		t.Fatalf("command = %s %v, want pfctl -s rules", gotName, gotArgs)
+	}
+	m, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type %T, want map", resp.Result)
+	}
+	if m["raw_rules"] != "block drop all\npass out all\n" {
+		t.Errorf("raw_rules = %q", m["raw_rules"])
+	}
+}

--- a/internal/helper/methods.go
+++ b/internal/helper/methods.go
@@ -55,6 +55,14 @@ func RegisterAll(d *Dispatcher, run CmdRunner) {
 		return map[string]any{"raw_ps": string(out)}, nil
 	})
 
+	d.Register("helper.firewall.rules", func(_ uint32, _ json.RawMessage) (any, error) {
+		out, err := run("pfctl", "-s", "rules")
+		if err != nil {
+			return nil, fmt.Errorf("pfctl rules: %w", err)
+		}
+		return map[string]any{"raw_rules": string(out)}, nil
+	})
+
 	d.Register("helper.tcc.system.query", func(_ uint32, params json.RawMessage) (any, error) {
 		var p struct {
 			BundleID string `json:"bundle_id"`

--- a/internal/helperclient/client.go
+++ b/internal/helperclient/client.go
@@ -134,3 +134,13 @@ func (c *Client) ProcessTree() (map[string]any, error) {
 	var m map[string]any
 	return m, json.Unmarshal(raw, &m)
 }
+
+// FirewallRules returns the current pf firewall rules via the helper.
+func (c *Client) FirewallRules() (map[string]any, error) {
+	raw, err := c.call("helper.firewall.rules", nil)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	return m, json.Unmarshal(raw, &m)
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -939,6 +939,17 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		return result, nil
 	})
 
+	d.Register("helper.firewall.rules", func(_ json.RawMessage) (any, error) {
+		result, err := hc.FirewallRules()
+		if err != nil {
+			if helperclient.IsUnavailable(err) {
+				return nil, fmt.Errorf("privileged helper not running; install with: sudo spectra install-helper")
+			}
+			return nil, err
+		}
+		return result, nil
+	})
+
 	d.Register("helper.tcc.system.query", func(params json.RawMessage) (any, error) {
 		var p struct {
 			BundleID string `json:"bundle_id"`

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -648,6 +648,15 @@ func TestDaemonHelperPowermetricsRequiresHelper(t *testing.T) {
 	}
 }
 
+func TestDaemonHelperFirewallRulesRequiresHelper(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 155, "helper.firewall.rules", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when helper not running")
+	}
+}
+
 func TestDaemonHelperTCCRequiresBundleID(t *testing.T) {
 	enc, dec, cancel := testDaemon(t)
 	defer cancel()


### PR DESCRIPTION
## What changed

- Adds `helper.firewall.rules`, backed by `pfctl -s rules`, to the privileged helper.
- Adds helperclient and daemon proxy support for `helper.firewall.rules`.
- Adds `spectra network firewall [--json]` to retrieve current pf firewall rules through the helper.
- Updates live data source, CLI, and daemon docs to mark the firewall rules audit path implemented.

## Validation

- `go test ./internal/helper ./internal/serve ./cmd/spectra -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
