### PR TITLE
Add framework version metadata

### DIFF
--- a/docs/detection/overview.md
+++ b/docs/detection/overview.md
@@ -114,6 +114,8 @@ See [native-modules.md](native-modules.md).
 
 - **Specific Electron app frameworks** (Forge, electron-builder,
   electron-packager). Not visible from the bundle layout.
-- **Specific Flutter / Tauri / Qt versions.** Possible but not yet useful.
+- **Framework versions.** Electron, Flutter, Qt, and Tauri versions are
+  populated best-effort in `FrameworkVersions` when the bundle exposes
+  framework plists or Tauri config metadata.
 - **Game engines** (Unity, Unreal, Godot's own classification). Treat
   as "AppKit native" — game apps don't fit the framework taxonomy.

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -26,6 +26,7 @@ Source of truth: `internal/detect/detect.go`.
 | `AppVersion` | string | `Info.plist` `CFBundleShortVersionString` |
 | `BuildNumber` | string | `Info.plist` `CFBundleVersion` |
 | `ElectronVersion` | string | Electron framework's own Info.plist |
+| `FrameworkVersions` | map[string]string | Best-effort framework version map, such as Electron, Flutter, Qt, Tauri |
 | `Architectures` | []string | `arm64`, `x86_64`, or both |
 | `BundleSizeBytes` | int64 | Sparse-file-correct on-disk allocation |
 | `TeamID` | string | `codesign -dv` TeamIdentifier |

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -11,6 +11,7 @@ package detect
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -36,10 +37,11 @@ type Result struct {
 
 	// Metadata pulled from Info.plist and frameworks. Best-effort; any
 	// field may be empty if the bundle doesn't expose it.
-	BundleID          string   // CFBundleIdentifier (com.example.app)
-	AppVersion        string   // CFBundleShortVersionString
-	BuildNumber       string   // CFBundleVersion
-	ElectronVersion   string   // version of bundled Electron Framework, if any
+	BundleID          string // CFBundleIdentifier (com.example.app)
+	AppVersion        string // CFBundleShortVersionString
+	BuildNumber       string // CFBundleVersion
+	ElectronVersion   string // version of bundled Electron Framework, if any
+	FrameworkVersions map[string]string
 	Architectures     []string // arm64, x86_64
 	BundleSizeBytes   int64    // total disk usage of the .app (sparse-aware: Blocks*512)
 	ApparentSizeBytes int64    // logical size of the .app (fi.Size() sum; may be >> BundleSizeBytes for sparse images)
@@ -237,6 +239,7 @@ func populateMetadata(appPath, exe string, r *Result) {
 		efw := filepath.Join(appPath, "Contents", "Frameworks", "Electron Framework.framework", "Resources", "Info.plist")
 		r.ElectronVersion = readPlistString(efw, "CFBundleVersion")
 	}
+	r.FrameworkVersions = frameworkVersions(appPath, r)
 
 	if exe != "" {
 		r.Architectures = readArchitectures(exe)
@@ -246,6 +249,62 @@ func populateMetadata(appPath, exe string, r *Result) {
 	r.Sandboxed, r.Entitlements = readEntitlements(appPath)
 	r.MASReceipt = exists(filepath.Join(appPath, "Contents", "_MASReceipt"))
 	r.Storage = scanStorage(appPath, r.BundleID)
+}
+
+func frameworkVersions(appPath string, r *Result) map[string]string {
+	versions := make(map[string]string)
+	if r.ElectronVersion != "" {
+		versions["Electron"] = r.ElectronVersion
+	}
+	flutterPlist := filepath.Join(appPath, "Contents", "Frameworks", "FlutterMacOS.framework", "Resources", "Info.plist")
+	if v := firstPlistString(flutterPlist, "CFBundleShortVersionString", "CFBundleVersion"); v != "" {
+		versions["Flutter"] = v
+	}
+	qtPlist := filepath.Join(appPath, "Contents", "Frameworks", "QtCore.framework", "Resources", "Info.plist")
+	if v := firstPlistString(qtPlist, "CFBundleShortVersionString", "CFBundleVersion"); v != "" {
+		versions["Qt"] = v
+	}
+	if v := readTauriVersion(appPath); v != "" {
+		versions["Tauri"] = v
+	}
+	if len(versions) == 0 {
+		return nil
+	}
+	return versions
+}
+
+func firstPlistString(plist string, keys ...string) string {
+	for _, key := range keys {
+		if v := readPlistString(plist, key); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func readTauriVersion(appPath string) string {
+	for _, rel := range []string{
+		filepath.Join("Contents", "Resources", "tauri.conf.json"),
+		filepath.Join("Contents", "Resources", "tauri.conf.json5"),
+	} {
+		data, err := os.ReadFile(filepath.Join(appPath, rel))
+		if err != nil {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			continue
+		}
+		if pkg, ok := m["package"].(map[string]any); ok {
+			if v, ok := pkg["version"].(string); ok && v != "" {
+				return v
+			}
+		}
+		if v, ok := m["version"].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // scanStorage measures user-data sizes under ~/Library for this bundle.

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -43,6 +43,22 @@ func touch(t *testing.T, path string) {
 	}
 }
 
+func writeFrameworkPlist(t *testing.T, path, version string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleShortVersionString</key><string>` + version + `</string>
+<key>CFBundleVersion</key><string>` + version + `</string>
+</dict></plist>`
+	if err := os.WriteFile(path, []byte(plist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDetectElectron(t *testing.T) {
 	app := makeBundle(t, "FakeElectron")
 	if err := os.MkdirAll(filepath.Join(app, "Contents/Frameworks/Electron Framework.framework"), 0o755); err != nil {
@@ -70,9 +86,13 @@ func TestDetectFlutter(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(app, "Contents/Frameworks/FlutterMacOS.framework"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	writeFrameworkPlist(t, filepath.Join(app, "Contents/Frameworks/FlutterMacOS.framework/Resources/Info.plist"), "3.22.0")
 	r, _ := Detect(app)
 	if r.UI != "Flutter" || r.Language != "Dart" {
 		t.Errorf("got UI=%q lang=%q", r.UI, r.Language)
+	}
+	if r.FrameworkVersions["Flutter"] != "3.22.0" {
+		t.Errorf("Flutter version = %q", r.FrameworkVersions["Flutter"])
 	}
 }
 
@@ -81,9 +101,24 @@ func TestDetectQt(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(app, "Contents/Frameworks/QtCore.framework"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	writeFrameworkPlist(t, filepath.Join(app, "Contents/Frameworks/QtCore.framework/Resources/Info.plist"), "6.7.2")
 	r, _ := Detect(app)
 	if r.UI != "Qt" {
 		t.Errorf("UI = %q, want Qt", r.UI)
+	}
+	if r.FrameworkVersions["Qt"] != "6.7.2" {
+		t.Errorf("Qt version = %q", r.FrameworkVersions["Qt"])
+	}
+}
+
+func TestReadTauriVersion(t *testing.T) {
+	app := makeBundle(t, "FakeTauri")
+	conf := filepath.Join(app, "Contents", "Resources", "tauri.conf.json")
+	if err := os.WriteFile(conf, []byte(`{"package":{"version":"2.1.0"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readTauriVersion(app); got != "2.1.0" {
+		t.Errorf("readTauriVersion = %q, want 2.1.0", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Adds `FrameworkVersions` to `detect.Result` for best-effort framework version metadata.
- Populates Electron, Flutter, Qt, and Tauri versions from framework plists or Tauri config metadata when present.
- Keeps the existing `ElectronVersion` field for compatibility.
- Updates detection overview and result schema docs to mark framework version extraction implemented.

## Validation

- `go test ./internal/detect -run 'TestDetectFlutter|TestDetectQt|TestReadTauriVersion|TestDetectElectron' -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
