### PR TITLE
Add typed remote connect shortcuts

### DIFF
--- a/cmd/spectra/connect.go
+++ b/cmd/spectra/connect.go
@@ -72,7 +72,8 @@ func runConnect(args []string) int {
 }
 
 func printConnectUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: spectra connect [--timeout 3s] <target> [status|health]")
+	fmt.Fprintln(w, "usage: spectra connect [--timeout 3s] <target> [status|health|jvm|processes|network|toolchains]")
+	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> inspect <App.app>")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> call <method> [json-params]")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "targets: local, unix:/path/to/sock, /path/to/sock, host:port, host")
@@ -104,6 +105,34 @@ func parseConnectTarget(raw string) (connectTarget, error) {
 func parseConnectCall(args []string) (string, json.RawMessage, error) {
 	if len(args) == 0 || args[0] == "status" || args[0] == "health" {
 		return "health", nil, nil
+	}
+	switch args[0] {
+	case "jvm":
+		if len(args) != 1 {
+			return "", nil, fmt.Errorf("connect jvm takes no extra arguments")
+		}
+		return "jvm.list", nil, nil
+	case "process", "processes":
+		if len(args) != 1 {
+			return "", nil, fmt.Errorf("connect processes takes no extra arguments")
+		}
+		return "process.list", nil, nil
+	case "network":
+		if len(args) != 1 {
+			return "", nil, fmt.Errorf("connect network takes no extra arguments")
+		}
+		return "network.state", nil, nil
+	case "toolchain", "toolchains":
+		if len(args) != 1 {
+			return "", nil, fmt.Errorf("connect toolchains takes no extra arguments")
+		}
+		return "toolchain.scan", nil, nil
+	case "inspect":
+		if len(args) != 2 {
+			return "", nil, fmt.Errorf("connect inspect requires <App.app>")
+		}
+		params, _ := json.Marshal(map[string]string{"path": args[1]})
+		return "inspect.app", json.RawMessage(params), nil
 	}
 	if args[0] != "call" || len(args) < 2 || len(args) > 3 {
 		return "", nil, fmt.Errorf("invalid connect command")

--- a/cmd/spectra/connect_test.go
+++ b/cmd/spectra/connect_test.go
@@ -73,6 +73,34 @@ func TestParseConnectCall(t *testing.T) {
 	}
 }
 
+func TestParseConnectTypedCalls(t *testing.T) {
+	tests := []struct {
+		args       []string
+		wantMethod string
+		wantParams string
+	}{
+		{args: []string{"jvm"}, wantMethod: "jvm.list"},
+		{args: []string{"processes"}, wantMethod: "process.list"},
+		{args: []string{"network"}, wantMethod: "network.state"},
+		{args: []string{"toolchains"}, wantMethod: "toolchain.scan"},
+		{args: []string{"inspect", "/Applications/Slack.app"}, wantMethod: "inspect.app", wantParams: `{"path":"/Applications/Slack.app"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.wantMethod, func(t *testing.T) {
+			method, params, err := parseConnectCall(tt.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if method != tt.wantMethod {
+				t.Fatalf("method = %q, want %q", method, tt.wantMethod)
+			}
+			if tt.wantParams != "" && string(params) != tt.wantParams {
+				t.Fatalf("params = %s, want %s", string(params), tt.wantParams)
+			}
+		})
+	}
+}
+
 func TestCallRPC(t *testing.T) {
 	server, client := net.Pipe()
 	defer client.Close()

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -291,6 +291,11 @@ automatic tsnet registration and cross-host fan-out remain future work.
 |---|---|
 | `spectra connect <target>` | Call `health` |
 | `spectra connect <target> status` | Call `health` |
+| `spectra connect <target> inspect <App.app>` | Call `inspect.app` |
+| `spectra connect <target> jvm` | Call `jvm.list` |
+| `spectra connect <target> processes` | Call `process.list` |
+| `spectra connect <target> network` | Call `network.state` |
+| `spectra connect <target> toolchains` | Call `toolchain.scan` |
 | `spectra connect <target> call <method> [json-params]` | Call an RPC method directly |
 
 ### Examples
@@ -298,6 +303,11 @@ automatic tsnet registration and cross-host fan-out remain future work.
 ```bash
 spectra connect local
 spectra connect 127.0.0.1:7878 status
+spectra connect work-mac inspect /Applications/Slack.app
+spectra connect work-mac jvm
+spectra connect work-mac processes
+spectra connect work-mac network
+spectra connect work-mac toolchains
 spectra connect work-mac call snapshot.create
 spectra connect work-mac call inspect.app '{"path":"/Applications/Slack.app"}'
 ```

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -43,8 +43,17 @@ spectra connect work-mac call jvm.thread_dump '{"pid":4012}'
 spectra connect work-mac call snapshot.create
 ```
 
-Typed remote subcommands like `spectra connect work-mac jvm` are still
-planned; today `call` is the stable escape hatch.
+Common typed remote shortcuts are available for frequent read-only calls:
+
+```bash
+spectra connect work-mac inspect /Applications/Slack.app
+spectra connect work-mac jvm
+spectra connect work-mac processes
+spectra connect work-mac network
+spectra connect work-mac toolchains
+```
+
+Use `call` for everything else.
 
 ## Cross-host operations
 


### PR DESCRIPTION
## Summary
- add typed `spectra connect` shortcuts for common read-only daemon RPCs
- route `inspect`, `jvm`, `processes`, `network`, and `toolchains` through existing JSON-RPC methods
- update CLI and remote operation docs now that these shortcuts exist

## Validation
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `git diff --check`
