### PR TITLE
Populate process thread counts on Darwin

### DIFF
--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -67,7 +67,7 @@ ProcessInfo {
   command, full_command_line
   cpu_pct                  # over the last sample interval
   rss_kib, vsize_kib
-  thread_count             # currently 0; future libproc/proc_pidinfo
+  thread_count             # proc_pidinfo on Darwin when visible
   start_time
   app_path                 # nullable; populated when bundle attribution succeeds
   open_fds                 # via lsof, only when --deep

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -13,8 +13,8 @@ fork cost twice.
 | Source | Output | Privilege | Cost | Used by |
 |---|---|---|---|---|
 | `ps -axwwo pid,ppid,pcpu,rss,vsz,uid,user,lstart,command` | full process table | user | ~30ms / call | `process.CollectAll`, snapshots, daemon ring buffer |
-| `libproc` (cgo) | richer per-process: thread count, fd count, region info | user | ~per-process | future replacement for `ps` |
-| `proc_pidinfo` (syscall) | structured per-process, no fork | user | microseconds | future ring buffer |
+| `proc_pidinfo(PROC_PIDTASKINFO)` | per-process thread count | user | microseconds / process | `process.CollectAll`, snapshots |
+| `libproc` (cgo) | richer per-process: fd count, region info | user | ~per-process | future replacement for `ps` |
 | `top -l 1 -n 10 -o power -stats pid,power,command` | flat per-process energy attribution | user | ~200ms | `power.energy_top_users` |
 | `sample <pid> 1` | one-second user-space sample, kernel sample optional | user (own procs); root (others) | ~1s + binding cost | `spectra sample` |
 
@@ -22,8 +22,8 @@ fork cost twice.
 daemon's ~1Hz metrics sampler. `--deep` process scans add one batched
 `lsof -p pid1,pid2,...` call to populate open file descriptor counts,
 listening ports, and outbound remote addresses. The natural upgrade path
-is direct syscalls via `libproc` / `proc_pidinfo`, which would eliminate
-the fork cost and add richer per-process detail.
+is expanding the direct `libproc` / `proc_pidinfo` coverage, which would
+eliminate more fork cost and add richer per-process detail.
 
 ## File and disk activity
 

--- a/docs/inspection/running-processes.md
+++ b/docs/inspection/running-processes.md
@@ -87,9 +87,11 @@ The `RunningProcesses` field on the JSON result holds the full list:
   Activity Monitor has the same issue.
 - **CPU% is point-in-time.** It is useful for "what is hot right now,"
   but trends require the daemon metrics ring buffer.
-- **No thread counts yet.** macOS `ps` does not expose Linux-style
-  `nlwp`/`thcount` fields on this host. Thread counts are still a
-  future `libproc`/`proc_pidinfo` collector.
+- **Thread counts are best effort.** macOS `ps` does not expose
+  Linux-style `nlwp`/`thcount` fields on this host, so Spectra fills
+  `thread_count` with `proc_pidinfo(PROC_PIDTASKINFO)` on Darwin when
+  the process is visible to the current user. Processes that cannot be
+  queried keep `thread_count: 0`.
 
 ## Implementation reference
 
@@ -101,12 +103,14 @@ Per-app attribution in `internal/detect/detect.go`:
 
 Full process inventory in `internal/process/`:
 - `CollectAll(ctx, opts)` — parses `ps` rows, including `pcpu`
+- `collectThreadCounts(procs)` — Darwin `proc_pidinfo` enrichment for
+  per-process thread counts
 - `enrichDeep(procs, run)` — one batched `lsof -p` call for FD and
   socket detail when `--deep` is set
 
 ## Future ideas
 
 - Switch to `libproc` via cgo (or `process.NewProcess` from
-  `gopsutil`) to get richer per-process data without forking.
-- Add thread count via `proc_pidinfo`.
+  `gopsutil`) to get richer per-process data without forking the
+  initial `ps` inventory.
 - Compute "app uptime" from the oldest matching process's start time.

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -3,8 +3,8 @@
 // docs/design/system-inventory.md and docs/inspection/running-processes.md.
 //
 // Collection is a single fork of `ps`; per-app attribution is a string-prefix
-// match (no extra forks). CPU% is captured from ps; thread counts land with a
-// future libproc/proc_pidinfo collector.
+// match (no extra forks). CPU% is captured from ps; thread counts are filled
+// from proc_pidinfo on Darwin when available.
 package process
 
 import (
@@ -25,7 +25,7 @@ type Info struct {
 	FullCommandLine string    `json:"full_command_line"` // full argv[0...] string
 	RSSKiB          int64     `json:"rss_kib"`
 	VSizeKiB        int64     `json:"vsize_kib"`
-	ThreadCount     int       `json:"thread_count"`         // number of threads (nlwp)
+	ThreadCount     int       `json:"thread_count"`         // number of process threads
 	CPUPct          float64   `json:"cpu_pct"`              // CPU % at sample time (pcpu)
 	StartTime       time.Time `json:"start_time,omitempty"` // process start time (lstart)
 
@@ -53,6 +53,9 @@ type CollectOptions struct {
 
 	// CmdRunner overrides exec.Command for testing.
 	CmdRunner func(name string, args ...string) ([]byte, error)
+
+	// ThreadCounter overrides the platform thread-count collector for testing.
+	ThreadCounter func([]Info) map[int]int
 }
 
 // CollectAll returns all running processes. Any parse errors for individual
@@ -64,13 +67,14 @@ func CollectAll(_ context.Context, opts CollectOptions) []Info {
 	}
 	// Column order: pid ppid pcpu rss vsz uid user lstart command...
 	// lstart produces a 5-token date "Dow Mon DD HH:MM:SS YYYY".
-	// macOS ps does not support nlwp; ThreadCount is populated by separate
-	// collectors when available.
+	// macOS ps does not support nlwp; ThreadCount is populated below by the
+	// platform collector when available.
 	out, err := run("ps", "-axwwo", "pid=,ppid=,pcpu=,rss=,vsz=,uid=,user=,lstart=,command=")
 	if err != nil {
 		return nil
 	}
 	procs := parsePS(string(out))
+	applyThreadCounts(procs, opts.ThreadCounter)
 	if len(opts.BundlePaths) > 0 {
 		attributeBundles(procs, opts.BundlePaths)
 	}
@@ -78,6 +82,21 @@ func CollectAll(_ context.Context, opts CollectOptions) []Info {
 		enrichDeep(procs, run)
 	}
 	return procs
+}
+
+func applyThreadCounts(procs []Info, counter func([]Info) map[int]int) {
+	if len(procs) == 0 {
+		return
+	}
+	if counter == nil {
+		counter = collectThreadCounts
+	}
+	counts := counter(procs)
+	for i := range procs {
+		if count := counts[procs[i].PID]; count > 0 {
+			procs[i].ThreadCount = count
+		}
+	}
 }
 
 // defaultRunner runs the real ps command.

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -97,6 +97,31 @@ func TestCollectAll(t *testing.T) {
 	}
 }
 
+func TestCollectAllAppliesThreadCounts(t *testing.T) {
+	opts := CollectOptions{
+		CmdRunner: fakePS(psFixture),
+		ThreadCounter: func(procs []Info) map[int]int {
+			if len(procs) != 4 {
+				t.Fatalf("thread counter saw %d procs, want 4", len(procs))
+			}
+			return map[int]int{
+				412: 13,
+				415: 7,
+			}
+		},
+	}
+	procs := CollectAll(context.Background(), opts)
+	if procs[1].ThreadCount != 13 {
+		t.Errorf("Slack ThreadCount = %d, want 13", procs[1].ThreadCount)
+	}
+	if procs[2].ThreadCount != 7 {
+		t.Errorf("Slack Helper ThreadCount = %d, want 7", procs[2].ThreadCount)
+	}
+	if procs[0].ThreadCount != 0 {
+		t.Errorf("launchd ThreadCount = %d, want 0", procs[0].ThreadCount)
+	}
+}
+
 func TestCollectAllPSError(t *testing.T) {
 	opts := CollectOptions{
 		CmdRunner: func(name string, args ...string) ([]byte, error) {

--- a/internal/process/thread_darwin.go
+++ b/internal/process/thread_darwin.go
@@ -1,0 +1,26 @@
+//go:build darwin && cgo
+
+package process
+
+/*
+#cgo darwin LDFLAGS: -lproc
+#include <libproc.h>
+*/
+import "C"
+import "unsafe"
+
+func collectThreadCounts(procs []Info) map[int]int {
+	counts := make(map[int]int, len(procs))
+	for _, p := range procs {
+		if p.PID <= 0 {
+			continue
+		}
+		var taskInfo C.struct_proc_taskinfo
+		size := C.int(unsafe.Sizeof(taskInfo))
+		n := C.proc_pidinfo(C.int(p.PID), C.PROC_PIDTASKINFO, 0, unsafe.Pointer(&taskInfo), size)
+		if n == size && taskInfo.pti_threadnum > 0 {
+			counts[p.PID] = int(taskInfo.pti_threadnum)
+		}
+	}
+	return counts
+}

--- a/internal/process/thread_stub.go
+++ b/internal/process/thread_stub.go
@@ -1,0 +1,7 @@
+//go:build !darwin || !cgo
+
+package process
+
+func collectThreadCounts(_ []Info) map[int]int {
+	return nil
+}


### PR DESCRIPTION
## Summary
- add Darwin `proc_pidinfo(PROC_PIDTASKINFO)` enrichment for process thread counts
- keep non-Darwin and non-cgo builds on a no-op collector
- add an injectable thread counter and unit coverage for process collection
- update docs that previously described thread counts as future work

## Validation
- `go test ./internal/process -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
- `go run ./cmd/spectra process --top 3`
