### PR TITLE
Write daemon lifecycle logs to JSONL

### DIFF
--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/cache"
+	"github.com/kaeawc/spectra/internal/logger"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/serve"
 )
@@ -22,6 +23,8 @@ func runServe(args []string) int {
 	sockPath := fs.String("sock", "", "Unix socket path (default: ~/.spectra/sock)")
 	tcpAddr := fs.String("tcp", "", "Optional TCP listen address, such as 127.0.0.1:7878")
 	allowRemote := fs.Bool("allow-remote", false, "Allow --tcp to bind a non-loopback address")
+	logFile := fs.String("log-file", "", "JSONL daemon log path (default: ~/Library/Logs/Spectra/daemon.jsonl)")
+	noLogFile := fs.Bool("no-log-file", false, "Disable the daemon JSONL log file")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -42,7 +45,19 @@ func runServe(args []string) int {
 			return 1
 		}
 	}
+
+	daemonLog, closeLog, resolvedLogPath, err := openDaemonLogger(*logFile, *noLogFile)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if closeLog != nil {
+		defer closeLog()
+	}
 	fmt.Fprintf(os.Stderr, "spectra serve: listening on %s\n", sock)
+	if resolvedLogPath != "" {
+		fmt.Fprintf(os.Stderr, "spectra serve: logging to %s\n", resolvedLogPath)
+	}
 	if *tcpAddr != "" {
 		if *allowRemote {
 			fmt.Fprintln(os.Stderr, "spectra serve: warning: TCP RPC has no Spectra-layer authentication; rely on SSH/Tailscale/firewall controls")
@@ -59,11 +74,31 @@ func runServe(args []string) int {
 		TCPAddr:        *tcpAddr,
 		SpectraVersion: version,
 		DetectStore:    detectStore,
+		Logger:         daemonLog,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
 	return 0
+}
+
+func openDaemonLogger(path string, disabled bool) (logger.Logger, func(), string, error) {
+	if disabled {
+		return nil, nil, "", nil
+	}
+	if path == "" {
+		var err error
+		path, err = serve.DefaultLogPath()
+		if err != nil {
+			return nil, nil, "", err
+		}
+	}
+	f, err := serve.OpenLogFile(path)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	log := logger.New(logger.Config{Writer: f, Format: logger.FormatJSON})
+	return log, func() { _ = f.Close() }, path, nil
 }
 
 func isLoopbackListenAddr(addr string) bool {

--- a/cmd/spectra/serve_test.go
+++ b/cmd/spectra/serve_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenDaemonLoggerDisabled(t *testing.T) {
+	log, closeFn, path, err := openDaemonLogger("", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if log != nil || closeFn != nil || path != "" {
+		t.Fatalf("disabled logger = (%v, closeFn nil %t, %q), want nil true empty", log, closeFn == nil, path)
+	}
+}
+
+func TestOpenDaemonLoggerCreatesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.jsonl")
+	log, closeFn, gotPath, err := openDaemonLogger(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closeFn == nil {
+		t.Fatal("closeFn is nil")
+	}
+	defer closeFn()
+	if log == nil {
+		t.Fatal("log is nil")
+	}
+	if gotPath != path {
+		t.Fatalf("path = %q, want %q", gotPath, path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -216,8 +216,10 @@ and impersonates the daemon as that tailnet node.
 - Helper stderr is written by launchd to `/var/log/spectra-helper.log`.
   The helper emits structured per-call JSON audit records there. Dedicated
   rotation remains planned.
-- Daemon logs currently go to the foreground process. Structured daemon
-  logs under `~/Library/Logs/Spectra/` are planned.
+- Daemon lifecycle logs are written as JSONL to
+  `~/Library/Logs/Spectra/daemon.jsonl` by default, with `0600`
+  permissions. Foreground status lines still go to stderr for interactive
+  use.
 - Logs do **not** include heap-dump contents, JFR contents, or
   process command-line arguments (which may contain secrets).
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -269,6 +269,8 @@ controls you trust.
 
 ```bash
 spectra serve
+spectra serve --log-file /tmp/spectra-daemon.jsonl
+spectra serve --no-log-file
 spectra serve --tcp 127.0.0.1:7878
 spectra serve --tcp 100.64.0.5:7878 --allow-remote
 ```

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -16,13 +16,20 @@ Tailscale integration that makes remote operation a first-class case.
 ## Lifecycle
 
 ```bash
-spectra serve              # foreground, logs to stdout
+spectra serve              # foreground, JSONL log file enabled
 spectra serve --sock /tmp/spectra.sock
 spectra serve --tcp 127.0.0.1:7878
+spectra serve --log-file /tmp/spectra-daemon.jsonl
+spectra serve --no-log-file
 ```
 
 The current CLI runs in the foreground until interrupted. A launchd-managed
 agent or detached `--daemon` mode is still future packaging work.
+
+By default, structured daemon lifecycle logs are appended to
+`~/Library/Logs/Spectra/daemon.jsonl` with `0600` permissions. Foreground
+status lines still go to stderr for interactive use. Use `--log-file` to
+choose another JSONL path or `--no-log-file` for short-lived test runs.
 
 ## Listening surfaces
 
@@ -124,6 +131,14 @@ listener. Used by:
 - `spectra status` — local health check.
 - `spectra connect <target>` — Unix or TCP health check.
 - future TUI/GUI clients — show connection state.
+
+## Logs
+
+The daemon writes JSONL records for listener startup, storage readiness,
+serving start, and shutdown/error events. These records include socket paths,
+TCP listen addresses, database path, version, and listener count. They do not
+include heap-dump contents, JFR contents, process command-line arguments, or
+RPC payloads.
 
 ## Implementation order
 

--- a/internal/serve/log.go
+++ b/internal/serve/log.go
@@ -1,0 +1,40 @@
+package serve
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DefaultLogPath returns the canonical daemon JSONL log path.
+func DefaultLogPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "Logs", "Spectra", "daemon.jsonl"), nil
+}
+
+// OpenLogFile creates parent directories and opens path for append-only daemon
+// logging. Callers own the returned file.
+func OpenLogFile(path string) (*os.File, error) {
+	if path == "" {
+		var err error
+		path, err = DefaultLogPath()
+		if err != nil {
+			return nil, fmt.Errorf("resolve daemon log path: %w", err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create daemon log dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open daemon log file: %w", err)
+	}
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("set daemon log file mode: %w", err)
+	}
+	return f, nil
+}

--- a/internal/serve/log_test.go
+++ b/internal/serve/log_test.go
@@ -1,0 +1,57 @@
+package serve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenLogFileCreatesPrivateJSONLFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Logs", "Spectra", "daemon.jsonl")
+	f, err := OpenLogFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("{}\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("log file mode = %o, want 0600", info.Mode().Perm())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "{}\n" {
+		t.Fatalf("log contents = %q", string(data))
+	}
+}
+
+func TestOpenLogFileTightensExistingMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.jsonl")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := OpenLogFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("log file mode = %o, want 0600", info.Mode().Perm())
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kaeawc/spectra/internal/diff"
 	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/logger"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/process"
@@ -57,11 +58,16 @@ type Options struct {
 	DBPath         string              // empty = store.DefaultPath()
 	CacheRegistry  *cache.Registry     // nil = cache.Default
 	DetectStore    *cache.ShardedStore // nil = no detect caching
+	Logger         logger.Logger       // nil = discard
 }
 
 // Run starts the daemon: listens on the Unix socket and serves requests until
 // ctx is cancelled. Run blocks until the listener is shut down.
 func Run(ctx context.Context, opts Options) error {
+	log := opts.Logger
+	if log == nil {
+		log = logger.Discard()
+	}
 	sockPath := opts.SockPath
 	if sockPath == "" {
 		var err error
@@ -85,6 +91,7 @@ func Run(ctx context.Context, opts Options) error {
 		ln.Close()
 		return fmt.Errorf("serve: chmod %s: %w", sockPath, err)
 	}
+	log.Info("daemon unix listener ready", "socket", sockPath)
 
 	listeners := []net.Listener{ln}
 	if opts.TCPAddr != "" {
@@ -95,6 +102,7 @@ func Run(ctx context.Context, opts Options) error {
 			return fmt.Errorf("serve: listen tcp %s: %w", opts.TCPAddr, err)
 		}
 		listeners = append(listeners, tcpLn)
+		log.Warn("daemon tcp listener ready", "address", opts.TCPAddr)
 	}
 	defer os.Remove(sockPath)
 	defer closeListeners(listeners)
@@ -111,6 +119,7 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("serve: open db: %w", err)
 	}
 	defer db.Close()
+	log.Info("daemon storage ready", "db", dbPath)
 
 	// Start the ~1Hz process metrics sampler.
 	collector := metrics.NewCollector()
@@ -130,6 +139,7 @@ func Run(ctx context.Context, opts Options) error {
 
 	d := rpc.NewDispatcher()
 	registerHandlers(d, opts.SpectraVersion, db, collector, cacheReg, opts.DetectStore)
+	log.Info("daemon serving", "version", opts.SpectraVersion, "listeners", len(listeners))
 
 	// Close the listener when ctx is cancelled to unblock Accept.
 	go func() {
@@ -137,7 +147,12 @@ func Run(ctx context.Context, opts Options) error {
 		closeListeners(listeners)
 	}()
 
-	return serveAll(d, listeners)
+	if err := serveAll(d, listeners); err != nil {
+		log.Error("daemon stopped with error", "error", err.Error())
+		return err
+	}
+	log.Info("daemon stopped")
+	return nil
 }
 
 func serveAll(d *rpc.Dispatcher, listeners []net.Listener) error {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/logger"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/rpc"
 	"github.com/kaeawc/spectra/internal/store"
@@ -117,6 +119,62 @@ func TestDaemonHealthEndpoint(t *testing.T) {
 	if m["version"] != "test-version" {
 		t.Errorf("version = %v, want test-version", m["version"])
 	}
+}
+
+func TestRunLogsLifecycle(t *testing.T) {
+	dir, err := os.MkdirTemp("", "sp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	sockPath := filepath.Join(dir, "s.sock")
+	dbPath := filepath.Join(dir, "t.db")
+	logs := logger.NewCapture(slog.LevelInfo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, Options{
+			SockPath:       sockPath,
+			DBPath:         dbPath,
+			SpectraVersion: "test-version",
+			CacheRegistry:  cache.Default,
+			Logger:         logs,
+		})
+	}()
+
+	waitForSocket(t, sockPath)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not stop after context cancellation")
+	}
+	if !logs.HasMessage("daemon unix listener ready") {
+		t.Fatalf("missing listener log: %+v", logs.Records())
+	}
+	if !logs.HasMessage("daemon storage ready") {
+		t.Fatalf("missing storage log: %+v", logs.Records())
+	}
+	if !logs.HasMessage("daemon stopped") {
+		t.Fatalf("missing stopped log: %+v", logs.Records())
+	}
+}
+
+func waitForSocket(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("socket %s was not created", path)
 }
 
 func TestDaemonSnapshotList(t *testing.T) {


### PR DESCRIPTION
## Summary
- add default JSONL daemon lifecycle logs at `~/Library/Logs/Spectra/daemon.jsonl`
- add `spectra serve --log-file` and `--no-log-file`
- inject structured serve logging for listener/storage/start/stop events
- document the implemented daemon log behavior in operations and threat-model docs

## Validation
- `go test ./internal/serve ./cmd/spectra -run 'TestRunLogsLifecycle|TestOpenLogFile|TestOpenDaemonLogger' -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
