### PR TITLE
Add netstat socket fallback

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -48,7 +48,7 @@ limiting (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `nettop -P -L 0 -t external` | per-process network bytes/sec | user (limited) | streaming, low | future live throughput counters |
 | `lsof -i -P -n -sTCP:LISTEN` | current listening TCP sockets | user | one-shot | `network.listening_ports` |
 | `lsof -i -P -n` | current TCP/UDP sockets | user | one-shot | `network.connections`, `network.byApp`, established count |
-| `netstat -an` | system-wide socket state | user | low | future fallback when `lsof` unavailable |
+| `netstat -an` | system-wide TCP/UDP socket state without PID/app attribution | user | low | fallback when `lsof` unavailable |
 | `scutil --proxy` | system proxy config | user | <10ms | `network.proxy_config` |
 | `scutil --dns` | DNS resolver config | user | <10ms | `network.dns_servers` |
 | `route -n get default` | default route + interface | user | <10ms | `network.default_route_*` |

--- a/docs/inspection/network-endpoints.md
+++ b/docs/inspection/network-endpoints.md
@@ -101,7 +101,9 @@ Useful for:
 - **Bundle-only.** This isn't live network observation. For current live
   sockets use `spectra network connections` or the daemon's
   `network.connections` / `network.byApp` methods, which are backed by
-  `lsof -i -P -n`. Per-process throughput via `nettop` is still future work.
+  `lsof -i -P -n` with a `netstat -an` fallback when `lsof` is unavailable.
+  The fallback is system-wide and does not include PID or app attribution.
+  Per-process throughput via `nettop` is still future work.
 
 ## Implementation reference
 
@@ -112,7 +114,8 @@ Useful for:
 - Deduped via map, then sorted for stable output.
 
 Related live-network collectors:
-- `internal/netstate/connections.go` — `lsof -i -P -n` socket list.
+- `internal/netstate/connections.go` — `lsof -i -P -n` socket list with
+  `netstat -an` fallback.
 - `internal/netstate/netstate.go` — routes, DNS, proxy config, VPN state,
   listening ports, and connection counts.
 

--- a/internal/netstate/connections.go
+++ b/internal/netstate/connections.go
@@ -19,10 +19,14 @@ type Connection struct {
 // LISTEN entries are omitted — those appear in State.ListeningPorts.
 func CollectConnections(run CmdRunner) []Connection {
 	out, err := run("lsof", "-i", "-P", "-n")
+	if err == nil {
+		return parseLSOFConnections(string(out))
+	}
+	out, err = run("netstat", "-an")
 	if err != nil {
 		return nil
 	}
-	return parseLSOFConnections(string(out))
+	return parseNetstatConnections(string(out))
 }
 
 // parseLSOFConnections extracts active connections from `lsof -i -P -n` output.
@@ -92,4 +96,72 @@ func parseLSOFConnections(out string) []Connection {
 		})
 	}
 	return conns
+}
+
+// parseNetstatConnections extracts system-wide active sockets from
+// `netstat -an` output. netstat has no PID/command columns, so callers receive
+// socket state only.
+func parseNetstatConnections(out string) []Connection {
+	var conns []Connection
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		proto := strings.ToLower(fields[0])
+		if !strings.HasPrefix(proto, "tcp") && !strings.HasPrefix(proto, "udp") {
+			continue
+		}
+		state := ""
+		if strings.HasPrefix(proto, "tcp") && len(fields) >= 6 {
+			state = strings.ToLower(fields[5])
+		}
+		if state == "listen" {
+			continue
+		}
+		conns = append(conns, Connection{
+			Proto:      trimProtoFamily(proto),
+			LocalAddr:  normalizeNetstatAddr(fields[3]),
+			RemoteAddr: netstatRemoteAddr(fields),
+			State:      state,
+		})
+	}
+	return conns
+}
+
+func trimProtoFamily(proto string) string {
+	switch {
+	case strings.HasPrefix(proto, "tcp"):
+		return "tcp"
+	case strings.HasPrefix(proto, "udp"):
+		return "udp"
+	default:
+		return proto
+	}
+}
+
+func netstatRemoteAddr(fields []string) string {
+	if len(fields) < 5 {
+		return ""
+	}
+	return normalizeNetstatAddr(fields[4])
+}
+
+func normalizeNetstatAddr(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if addr == "" || addr == "*.*" {
+		return ""
+	}
+	idx := strings.LastIndex(addr, ".")
+	if idx < 0 {
+		return addr
+	}
+	host, port := addr[:idx], addr[idx+1:]
+	if port == "*" {
+		return host
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return addr
+	}
+	return host + ":" + port
 }

--- a/internal/netstate/connections_test.go
+++ b/internal/netstate/connections_test.go
@@ -13,6 +13,14 @@ firefox    789   alice  41u  IPv4 0xdef          0t0  UDP  192.168.1.100:54812->
 netbiosd   999   root   6u   IPv4 0x111          0t0  UDP  *:138
 `
 
+const netstatFixture = `Active Internet connections (including servers)
+Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)
+tcp4       0      0  192.168.1.100.55123   52.1.2.3.443          ESTABLISHED
+tcp4       0      0  *.3000                *.*                   LISTEN
+udp4       0      0  192.168.1.100.54812   8.8.8.8.53
+udp4       0      0  *.138                 *.*
+`
+
 func TestParseLSOFConnectionsCount(t *testing.T) {
 	conns := parseLSOFConnections(lsofFixture)
 	// Expect 3: the LISTEN entry is excluded.
@@ -72,12 +80,45 @@ func TestParseLSOFConnectionsEmpty(t *testing.T) {
 	}
 }
 
+func TestParseNetstatConnections(t *testing.T) {
+	conns := parseNetstatConnections(netstatFixture)
+	if len(conns) != 3 {
+		t.Fatalf("got %d connections, want 3; conns: %+v", len(conns), conns)
+	}
+	if conns[0].PID != 0 || conns[0].Command != "" {
+		t.Fatalf("netstat connection has attribution: %+v", conns[0])
+	}
+	if conns[0].Proto != "tcp" || conns[0].LocalAddr != "192.168.1.100:55123" || conns[0].RemoteAddr != "52.1.2.3:443" || conns[0].State != "established" {
+		t.Fatalf("tcp connection = %+v", conns[0])
+	}
+	if conns[1].Proto != "udp" || conns[1].RemoteAddr != "8.8.8.8:53" {
+		t.Fatalf("udp connection = %+v", conns[1])
+	}
+}
+
 func TestCollectConnectionsError(t *testing.T) {
 	run := func(string, ...string) ([]byte, error) {
 		return nil, errors.New("lsof failed")
 	}
 	if conns := CollectConnections(run); len(conns) != 0 {
 		t.Errorf("expected nil on lsof error, got %d conns", len(conns))
+	}
+}
+
+func TestCollectConnectionsFallsBackToNetstat(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "lsof":
+			return nil, errors.New("lsof failed")
+		case "netstat":
+			return []byte(netstatFixture), nil
+		default:
+			return nil, errors.New("unexpected command")
+		}
+	}
+	conns := CollectConnections(run)
+	if len(conns) != 3 {
+		t.Errorf("CollectConnections fallback: got %d, want 3", len(conns))
 	}
 }
 

--- a/internal/netstate/netstate.go
+++ b/internal/netstate/netstate.go
@@ -80,10 +80,18 @@ func Collect(run CmdRunner) State {
 		s.VPNInterfaces = parseVPNInterfaces(string(out))
 		s.VPNActive = len(s.VPNInterfaces) > 0
 	}
-	if out, err := run("lsof", "-i", "-P", "-n"); err == nil {
-		s.EstablishedConnectionsCount = len(parseLSOFConnections(string(out)))
-	}
+	s.EstablishedConnectionsCount = len(collectConnectionRows(run))
 	return s
+}
+
+func collectConnectionRows(run CmdRunner) []Connection {
+	if out, err := run("lsof", "-i", "-P", "-n"); err == nil {
+		return parseLSOFConnections(string(out))
+	}
+	if out, err := run("netstat", "-an"); err == nil {
+		return parseNetstatConnections(string(out))
+	}
+	return nil
 }
 
 // parseRoute extracts interface and gateway from `route -n get default`.

--- a/internal/netstate/netstate_test.go
+++ b/internal/netstate/netstate_test.go
@@ -256,3 +256,21 @@ func TestCollectAllFail(t *testing.T) {
 		t.Error("VPNActive should be false when ifconfig fails")
 	}
 }
+
+func TestCollectConnectionsCountFallsBackToNetstat(t *testing.T) {
+	stub := func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "route", "scutil", "ifconfig":
+			return []byte(""), nil
+		case "lsof":
+			return nil, errors.New("lsof failed")
+		case "netstat":
+			return []byte(netstatFixture), nil
+		}
+		return nil, errors.New("unexpected command")
+	}
+	s := Collect(stub)
+	if s.EstablishedConnectionsCount != 3 {
+		t.Errorf("EstablishedConnectionsCount = %d, want 3", s.EstablishedConnectionsCount)
+	}
+}


### PR DESCRIPTION
## Summary
- add `netstat -an` fallback parsing for TCP/UDP socket rows when `lsof` is unavailable
- use the fallback for `spectra network connections` and network state connection counts
- document that fallback rows are system-wide and do not include PID/app attribution

## Validation
- `go test ./internal/netstate -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
