### PR TITLE
Harden helper socket group ownership

### DIFF
--- a/cmd/spectra-helper/main.go
+++ b/cmd/spectra-helper/main.go
@@ -18,7 +18,9 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -26,8 +28,10 @@ import (
 )
 
 var version = "dev"
+var lookupGroup = user.LookupGroup
 
 const sockPath = "/var/run/spectra-helper.sock"
+const helperGroup = "_spectra"
 
 func main() {
 	os.Exit(runWithArgs(os.Args[1:]))
@@ -62,11 +66,9 @@ func run() int {
 		fmt.Fprintf(os.Stderr, "spectra-helper: listen: %v\n", err)
 		return 1
 	}
-	// 0660: accessible to root and _spectra group members only.
-	// #nosec G302 -- helper socket intentionally grants _spectra group access.
-	if err := os.Chmod(sockPath, 0o660); err != nil {
+	if err := secureSocket(sockPath, helperGroup, os.Chown, os.Chmod); err != nil {
 		ln.Close()
-		fmt.Fprintf(os.Stderr, "spectra-helper: chmod: %v\n", err)
+		fmt.Fprintf(os.Stderr, "spectra-helper: secure socket: %v\n", err)
 		return 1
 	}
 	defer func() {
@@ -91,4 +93,32 @@ func run() int {
 		return 1
 	}
 	return 0
+}
+
+func secureSocket(path, group string, chown func(string, int, int) error, chmod func(string, os.FileMode) error) error {
+	gid, err := groupID(group)
+	if err != nil {
+		return err
+	}
+	if err := chown(path, 0, gid); err != nil {
+		return fmt.Errorf("chown root:%s: %w", group, err)
+	}
+	// 0660: accessible to root and _spectra group members only.
+	// #nosec G302 -- helper socket intentionally grants _spectra group access.
+	if err := chmod(path, 0o660); err != nil {
+		return fmt.Errorf("chmod 0660: %w", err)
+	}
+	return nil
+}
+
+func groupID(name string) (int, error) {
+	g, err := lookupGroup(name)
+	if err != nil {
+		return 0, fmt.Errorf("lookup group %s: %w", name, err)
+	}
+	gid, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return 0, fmt.Errorf("parse group %s gid %q: %w", name, g.Gid, err)
+	}
+	return gid, nil
 }

--- a/cmd/spectra-helper/main_test.go
+++ b/cmd/spectra-helper/main_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"os/user"
+	"testing"
+)
 
 func TestHelperVersionArg(t *testing.T) {
 	for _, args := range [][]string{{"--version"}, {"version"}} {
@@ -12,5 +17,81 @@ func TestHelperVersionArg(t *testing.T) {
 		if helperVersionArg(args) {
 			t.Fatalf("%v should not be a version arg", args)
 		}
+	}
+}
+
+func TestGroupIDParsesLookupResult(t *testing.T) {
+	orig := lookupGroup
+	lookupGroup = func(name string) (*user.Group, error) {
+		if name != helperGroup {
+			t.Fatalf("lookup name = %q, want %q", name, helperGroup)
+		}
+		return &user.Group{Gid: "123"}, nil
+	}
+	t.Cleanup(func() { lookupGroup = orig })
+
+	gid, err := groupID(helperGroup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gid != 123 {
+		t.Fatalf("gid = %d, want 123", gid)
+	}
+}
+
+func TestGroupIDRejectsInvalidGID(t *testing.T) {
+	orig := lookupGroup
+	lookupGroup = func(string) (*user.Group, error) {
+		return &user.Group{Gid: "not-a-number"}, nil
+	}
+	t.Cleanup(func() { lookupGroup = orig })
+
+	if _, err := groupID(helperGroup); err == nil {
+		t.Fatal("expected invalid gid error")
+	}
+}
+
+func TestSecureSocketAppliesGroupAndMode(t *testing.T) {
+	orig := lookupGroup
+	lookupGroup = func(string) (*user.Group, error) {
+		return &user.Group{Gid: "456"}, nil
+	}
+	t.Cleanup(func() { lookupGroup = orig })
+
+	var gotPath string
+	var gotUID, gotGID int
+	var gotMode os.FileMode
+	err := secureSocket("sock", helperGroup,
+		func(path string, uid, gid int) error {
+			gotPath, gotUID, gotGID = path, uid, gid
+			return nil
+		},
+		func(_ string, mode os.FileMode) error {
+			gotMode = mode
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "sock" || gotUID != 0 || gotGID != 456 || gotMode != 0o660 {
+		t.Fatalf("secureSocket applied path=%q uid=%d gid=%d mode=%o", gotPath, gotUID, gotGID, gotMode)
+	}
+}
+
+func TestSecureSocketReturnsChownError(t *testing.T) {
+	orig := lookupGroup
+	lookupGroup = func(string) (*user.Group, error) {
+		return &user.Group{Gid: "456"}, nil
+	}
+	t.Cleanup(func() { lookupGroup = orig })
+
+	want := errors.New("chown failed")
+	err := secureSocket("sock", helperGroup,
+		func(string, int, int) error { return want },
+		func(string, os.FileMode) error { return nil },
+	)
+	if !errors.Is(err, want) {
+		t.Fatalf("err = %v, want wrapped chown error", err)
 	}
 }

--- a/cmd/spectra/helper.go
+++ b/cmd/spectra/helper.go
@@ -16,6 +16,8 @@ const helperBinaryDest = "/Library/PrivilegedHelperTools/spectra-helper"
 // helperPlist is the LaunchDaemon plist path.
 const helperPlist = "/Library/LaunchDaemons/dev.spectra.helper.plist"
 
+const helperGroup = "_spectra"
+
 // helperPlistContent is the LaunchDaemon plist that starts spectra-helper
 // at boot and keeps it alive.
 const helperPlistContent = `<?xml version="1.0" encoding="UTF-8"?>
@@ -64,6 +66,14 @@ func runInstallHelper(args []string) int {
 		name string
 		fn   func() error
 	}{
+		{"Create _spectra group", ensureHelperGroup},
+		{"Add current user to _spectra group", func() error {
+			user := helperInstallUser(os.Getenv)
+			if user == "" || user == "root" {
+				return nil
+			}
+			return sudoRun("dseditgroup", "-o", "edit", "-a", user, "-t", "user", helperGroup)
+		}},
 		{"Create /Library/PrivilegedHelperTools/", func() error {
 			return sudoRun("mkdir", "-p", "/Library/PrivilegedHelperTools")
 		}},
@@ -110,8 +120,24 @@ func runInstallHelper(args []string) int {
 	fmt.Println("To grant Full Disk Access (required for TCC.db queries):")
 	fmt.Println("  System Settings → Privacy & Security → Full Disk Access → add spectra-helper")
 	fmt.Println()
+	fmt.Println("If this is the first install, log out and back in so group membership is refreshed.")
+	fmt.Println()
 	fmt.Println("Verify with: spectra install-helper --status")
 	return 0
+}
+
+func ensureHelperGroup() error {
+	if err := sudoRun("dseditgroup", "-o", "read", helperGroup); err == nil {
+		return nil
+	}
+	return sudoRun("dseditgroup", "-o", "create", helperGroup)
+}
+
+func helperInstallUser(getenv func(string) string) string {
+	if user := getenv("SUDO_USER"); user != "" {
+		return user
+	}
+	return getenv("USER")
 }
 
 func runUninstallHelper(args []string) int {

--- a/cmd/spectra/helper_test.go
+++ b/cmd/spectra/helper_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestHelperInstallUserPrefersSudoUser(t *testing.T) {
+	env := map[string]string{"SUDO_USER": "alice", "USER": "root"}
+	got := helperInstallUser(func(key string) string { return env[key] })
+	if got != "alice" {
+		t.Fatalf("helperInstallUser = %q, want alice", got)
+	}
+}
+
+func TestHelperInstallUserFallsBackToUser(t *testing.T) {
+	env := map[string]string{"USER": "bob"}
+	got := helperInstallUser(func(key string) string { return env[key] })
+	if got != "bob" {
+		t.Fatalf("helperInstallUser = %q, want bob", got)
+	}
+}

--- a/docs/design/privileged-helper.md
+++ b/docs/design/privileged-helper.md
@@ -73,7 +73,6 @@ Planned but not implemented yet:
 
 - `helper.fs_usage.start(filter)`
 - `helper.fs_usage.stop(handle)`
-- `_spectra` group provisioning and socket group ownership hardening
 
 Notably absent:
 
@@ -98,8 +97,9 @@ streams: framing makes recovery from partial reads trivial.
 ## Authentication and authorization
 
 - **Filesystem permissions** on `/var/run/spectra-helper.sock` gate which
-  users can connect. The planned hardened install creates an `_spectra`
-  group and assigns the socket to it.
+  users can connect. The installer creates an `_spectra` group, adds the
+  invoking user, and the helper assigns the socket to `root:_spectra`
+  with `0660` permissions at startup.
 - **Caller credential check** via `getpeereid(2)` on the connected
   socket is implemented and passed to method handlers.
 - **Method allowlist** is hardcoded in the helper. There is no dynamic

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -46,7 +46,7 @@ What Spectra holds or mediates that's worth protecting:
                   │   │  Remote Spectra peers │
                   │   └───────────────────────┘
                   │
-                  │ Unix socket (0660; group hardening planned)
+                  │ Unix socket (0660 root:_spectra)
 ┌─────────────────▼───────────────────────────┐
 │  Privileged helper                          │
 │  Holds: nothing persistent                  │
@@ -111,11 +111,9 @@ Spectra does **not** defend against:
 operation as root, escalating privilege.
 
 **Mitigation:**
-- Helper Unix socket is `0660`; the current installer starts it as a
-  LaunchDaemon and relies on filesystem permissions around
-  `/var/run/spectra-helper.sock`.
-- Hardened `_spectra` group provisioning and socket group ownership are
-  planned but not implemented yet.
+- Helper Unix socket is `0660 root:_spectra`; the installer provisions
+  `_spectra`, adds the invoking user, and the helper assigns socket group
+  ownership at startup.
 - Helper uses `getpeereid(2)` and passes the calling UID to method
   handlers.
 - Helper has a hardcoded method allowlist; no method exposes
@@ -229,7 +227,7 @@ Things Spectra commits to before v1 release:
 
 - [ ] All binaries signed with Developer ID, hardened runtime on.
 - [ ] All distributed binaries notarized.
-- [ ] Helper install path provisions `_spectra` and sets socket group
+- [x] Helper install path provisions `_spectra` and sets socket group
       ownership, or moves to `SMAppService` / `SMJobBless` with
       code-signing requirement checks.
 - [ ] Fuzz-test the JSON-RPC dispatcher for malformed payloads.

--- a/docs/install.md
+++ b/docs/install.md
@@ -50,11 +50,14 @@ sudo spectra install-helper
 spectra install-helper --status
 ```
 
-The current installer copies `spectra-helper` to
-`/Library/PrivilegedHelperTools/`, writes a LaunchDaemon plist, and starts
-it with `launchctl`. It exposes root-only data over a local Unix socket to
-the unprivileged daemon. The unprivileged tier still works without it for
-everything that does not require root.
+The current installer provisions the `_spectra` group, adds the invoking
+user to it, copies `spectra-helper` to `/Library/PrivilegedHelperTools/`,
+writes a LaunchDaemon plist, and starts it with `launchctl`. The helper
+exposes root-only data over `/var/run/spectra-helper.sock` as
+`0660 root:_spectra`. On first install, log out and back in so the user's
+new group membership is visible to shells and long-running processes. The
+unprivileged tier still works without the helper for everything that does
+not require root.
 
 See [design/distribution.md](design/distribution.md) for the full
 capability-vs-channel matrix.


### PR DESCRIPTION
## Summary
- provision the `_spectra` group during `spectra install-helper`
- add the invoking user to `_spectra` and document the first-install relogin requirement
- have `spectra-helper` assign `/var/run/spectra-helper.sock` to `root:_spectra` with `0660` permissions at startup
- update helper/threat-model/install docs now that group ownership hardening is implemented

## Validation
- `go test ./cmd/spectra ./cmd/spectra-helper -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
