### PR TITLE
Add JSON-RPC fuzz coverage

### DIFF
--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -143,8 +143,8 @@ attacker-chosen files.
   which prints an explicit warning that Spectra does not add its own
   authentication layer.
 
-**Residual risk:** A bug in input validation. Mitigated by
-fuzz-testing the RPC layer (planned) and keeping the surface
+**Residual risk:** A bug in input validation. Mitigated by native Go fuzz
+coverage for RPC request handling (`FuzzHandle`) and keeping the surface
 intentionally narrow.
 
 ### T3: Heap-dump exfiltration
@@ -230,7 +230,7 @@ Things Spectra commits to before v1 release:
 - [x] Helper install path provisions `_spectra` and sets socket group
       ownership, or moves to `SMAppService` / `SMJobBless` with
       code-signing requirement checks.
-- [ ] Fuzz-test the JSON-RPC dispatcher for malformed payloads.
+- [x] Fuzz-test the JSON-RPC dispatcher for malformed payloads.
 - [x] Static analysis (`gosec`) runs in CI.
 - [ ] No `os/exec` calls take user-supplied arguments without an
       allowlist.

--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -101,3 +101,38 @@ func TestServeOverUnixSocket(t *testing.T) {
 		t.Errorf("result = %v, want pong", resp.Result)
 	}
 }
+
+func FuzzHandle(f *testing.F) {
+	seeds := [][]byte{
+		[]byte(`{"jsonrpc":"2.0","id":1,"method":"echo","params":{"value":"ok"}}`),
+		[]byte(`{"jsonrpc":"2.0","id":1,"method":"missing"}`),
+		[]byte(`{"jsonrpc":"2.0","id":1}`),
+		[]byte(`{bad json`),
+		[]byte(""),
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	d := NewDispatcher()
+	d.Register("echo", func(params json.RawMessage) (any, error) {
+		var v any
+		if len(params) > 0 {
+			_ = json.Unmarshal(params, &v)
+		}
+		return v, nil
+	})
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		resp := d.handle(raw)
+		if resp.JSONRPC != "2.0" {
+			t.Fatalf("JSONRPC = %q, want 2.0 for raw %q", resp.JSONRPC, string(raw))
+		}
+		if resp.Error != nil && resp.Result != nil {
+			t.Fatalf("response has both result and error: %+v", resp)
+		}
+		if _, err := json.Marshal(resp); err != nil {
+			t.Fatalf("response is not JSON-serializable: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add native Go fuzz coverage for JSON-RPC request handling
- seed valid, invalid, missing-method, unknown-method, malformed, and empty requests
- update the threat-model residual-risk and hardening checklist now that RPC fuzzing exists

## Validation
- `go test ./internal/rpc -run Test -count=1`
- `go test ./internal/rpc -run '^$' -fuzz FuzzHandle -fuzztime=5s`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
