### PR TITLE
Harden TCC bundle ID SQL allowlist

### DIFF
--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -135,8 +135,8 @@ attacker-chosen files.
 - `Detect()` and friends accept paths only under bundle-validation
   (must be a real `.app`).
 - SQL queries against TCC.db pre-validate the bundle ID against
-  `[a-zA-Z0-9._-]+` allowlist (already implemented; see
-  `validBundleID`).
+  `[a-zA-Z0-9._-]+` allowlist in both the detector and privileged
+  helper paths (see `internal/bundleid.Valid`).
 - RPC handler dispatch is method-allowlist; unknown methods return
   errors rather than passing through.
 - TCP listen is opt-in. Non-loopback binds require `--allow-remote`,
@@ -234,7 +234,7 @@ Things Spectra commits to before v1 release:
 - [x] Static analysis (`gosec`) runs in CI.
 - [ ] No `os/exec` calls take user-supplied arguments without an
       allowlist.
-- [ ] No `database/sql` queries take user-supplied strings without
+- [x] No `database/sql` queries take user-supplied strings without
       parameterization (where supported) or strict allowlist
       (where not, e.g. macOS `sqlite3` CLI).
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -49,7 +49,7 @@ filesystem dependencies on `/Applications`.
 - Network endpoint extraction (regex correctness)
 - Helper / XPC / plugin enumeration
 - Privacy description parsing
-- Bundle ID prefix and SQL safety (`validBundleID`)
+- Bundle ID prefix and SQL safety (`internal/bundleid.Valid`)
 - Wrapper following on small main executables
 - Error path: rejecting non-`.app` paths
 
@@ -59,7 +59,7 @@ filesystem dependencies on `/Applications`.
   CI smoke-tests against `/System/Applications/Calculator.app` and
   `/System/Applications/Chess.app` which exist on every macOS runner.
 - **TCC.db reads** — requires a real SQLite database with an
-  applicable `client` row. The validation gate (`validBundleID`)
+  applicable `client` row. The validation gate (`internal/bundleid.Valid`)
   is unit-tested; the integration is smoke-tested end-to-end.
 
 ## Running tests in CI

--- a/docs/inspection/security.md
+++ b/docs/inspection/security.md
@@ -96,9 +96,10 @@ Service names get the `kTCCService` prefix stripped for display.
 
 macOS's `sqlite3` CLI doesn't accept bind variables on the command
 line, so the bundle ID is interpolated into the query string. Spectra
-guards this with `validBundleID` — an allowlist of `[a-zA-Z0-9._-]+`
-characters that matches the reverse-DNS bundle ID format. Anything
-outside that charset is rejected.
+guards this with `internal/bundleid.Valid` — an allowlist of
+`[a-zA-Z0-9._-]+` characters that matches the reverse-DNS bundle ID
+format. Anything outside that charset is rejected before the detector
+or privileged helper builds the query.
 
 ## Declared vs granted: the gap
 
@@ -138,4 +139,4 @@ until there is a stable declaration key to compare against.
 - `readEntitlements(appPath)` — declared entitlements
 - `readPrivacyDescriptions(appPath)` — `NS*UsageDescription`
 - `scanGrantedPermissions(bundleID)` — TCC reads
-- `validBundleID(s)` — SQL safety gate
+- `internal/bundleid.Valid(s)` — SQL safety gate

--- a/internal/bundleid/bundleid.go
+++ b/internal/bundleid/bundleid.go
@@ -1,0 +1,24 @@
+// Package bundleid validates macOS bundle identifiers used at command and SQL
+// boundaries.
+package bundleid
+
+// Valid returns true if s only contains characters allowed in reverse-DNS
+// bundle identifiers. This is intentionally stricter than CFBundleIdentifier:
+// callers use it as an allowlist before interpolating a bundle ID into sqlite3
+// CLI queries, where bind parameters are not available.
+func Valid(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '-', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/bundleid/bundleid_test.go
+++ b/internal/bundleid/bundleid_test.go
@@ -1,0 +1,19 @@
+package bundleid
+
+import "testing"
+
+func TestValid(t *testing.T) {
+	good := []string{"com.docker.docker", "app.tuple.app", "Test-name_2"}
+	for _, s := range good {
+		if !Valid(s) {
+			t.Errorf("Valid(%q) = false, want true", s)
+		}
+	}
+
+	bad := []string{"", "evil; DROP TABLE", "with space", "x'; --", "quote'in"}
+	for _, s := range bad {
+		if Valid(s) {
+			t.Errorf("Valid(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/kaeawc/spectra/internal/bundleid"
 )
 
 // Result is the diagnosis for one .app bundle.
@@ -1198,20 +1200,7 @@ func scanGrantedPermissions(bundleID string) []string {
 // reverse-DNS bundle identifiers. Used to gate SQL-string interpolation
 // in scanGrantedPermissions where parameter binding isn't available.
 func validBundleID(s string) bool {
-	if s == "" {
-		return false
-	}
-	for _, r := range s {
-		switch {
-		case r >= 'a' && r <= 'z',
-			r >= 'A' && r <= 'Z',
-			r >= '0' && r <= '9',
-			r == '.', r == '-', r == '_':
-		default:
-			return false
-		}
-	}
-	return true
+	return bundleid.Valid(s)
 }
 
 // scanHelpers enumerates sub-bundles inside the .app: helper apps,

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -234,6 +234,49 @@ func TestTCCQueryRequiresBundleID(t *testing.T) {
 	}
 }
 
+func TestTCCQueryRejectsInvalidBundleID(t *testing.T) {
+	d := NewDispatcher()
+	RegisterAll(d, func(string, ...string) ([]byte, error) {
+		return nil, fmt.Errorf("should not be called")
+	})
+
+	req := []byte(`{"jsonrpc":"2.0","id":1,"method":"helper.tcc.system.query","params":{"bundle_id":"x'; --"}}`)
+	resp := d.handle(501, req)
+	if resp.Error == nil {
+		t.Fatal("expected invalid bundle_id error")
+	}
+}
+
+func TestTCCQueryUsesAllowlistedBundleID(t *testing.T) {
+	d := NewDispatcher()
+	var gotName string
+	var gotArgs []string
+	RegisterAll(d, func(name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return []byte("kTCCServiceCamera|2\n"), nil
+	})
+
+	req := []byte(`{"jsonrpc":"2.0","id":1,"method":"helper.tcc.system.query","params":{"bundle_id":"com.example.App-1"}}`)
+	resp := d.handle(501, req)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	if gotName != "sqlite3" {
+		t.Fatalf("command = %q, want sqlite3", gotName)
+	}
+	if len(gotArgs) != 2 {
+		t.Fatalf("args = %v, want db path and query", gotArgs)
+	}
+	if gotArgs[0] != "/Library/Application Support/com.apple.TCC/TCC.db" {
+		t.Errorf("db path = %q", gotArgs[0])
+	}
+	wantQuery := `SELECT service, auth_value FROM access WHERE client="com.example.App-1"`
+	if gotArgs[1] != wantQuery {
+		t.Errorf("query = %q, want %q", gotArgs[1], wantQuery)
+	}
+}
+
 func TestFirewallRulesUsesPFCTL(t *testing.T) {
 	d := NewDispatcher()
 	var gotName string

--- a/internal/helper/methods.go
+++ b/internal/helper/methods.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+
+	"github.com/kaeawc/spectra/internal/bundleid"
 )
 
 // CmdRunner abstracts subprocess calls for testability.
@@ -69,6 +71,9 @@ func RegisterAll(d *Dispatcher, run CmdRunner) {
 		}
 		if err := json.Unmarshal(params, &p); err != nil || p.BundleID == "" {
 			return nil, fmt.Errorf("helper.tcc.system.query requires {\"bundle_id\":\"...\"}")
+		}
+		if !bundleid.Valid(p.BundleID) {
+			return nil, fmt.Errorf("helper.tcc.system.query rejects invalid bundle_id %q", p.BundleID)
 		}
 		const tccDB = "/Library/Application Support/com.apple.TCC/TCC.db"
 		query := fmt.Sprintf(

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/bundleid"
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/diff"
@@ -971,6 +972,9 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		}
 		if err := json.Unmarshal(params, &p); err != nil || p.BundleID == "" {
 			return nil, fmt.Errorf("helper.tcc.system.query requires {\"bundle_id\":\"...\"}")
+		}
+		if !bundleid.Valid(p.BundleID) {
+			return nil, fmt.Errorf("helper.tcc.system.query rejects invalid bundle_id %q", p.BundleID)
 		}
 		result, err := hc.TCCSystemQuery(p.BundleID)
 		if err != nil {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -724,6 +724,15 @@ func TestDaemonHelperTCCRequiresBundleID(t *testing.T) {
 	}
 }
 
+func TestDaemonHelperTCCRejectsInvalidBundleID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 156, "helper.tcc.system.query", `{"bundle_id":"x'; --"}`)
+	if resp.Error == nil {
+		t.Fatal("expected error when bundle_id is invalid")
+	}
+}
+
 func TestDaemonSnapshotProcessesRequiresID(t *testing.T) {
 	enc, dec, cancel := testDaemon(t)
 	defer cancel()


### PR DESCRIPTION
## Summary
- centralize the TCC bundle ID SQL allowlist in `internal/bundleid`
- enforce the same allowlist in the privileged helper and daemon RPC bridge before constructing TCC sqlite3 queries
- update security/testing docs and mark the SQL hardening checklist item complete

## Validation
- `go test ./internal/bundleid ./internal/detect ./internal/helper ./internal/serve -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
