### PR TITLE
Install helper audit log rotation

### DIFF
--- a/cmd/spectra/helper.go
+++ b/cmd/spectra/helper.go
@@ -18,6 +18,10 @@ const helperPlist = "/Library/LaunchDaemons/dev.spectra.helper.plist"
 
 const helperGroup = "_spectra"
 
+const helperLogPath = "/var/log/spectra-helper.log"
+
+const helperNewsyslogConf = "/etc/newsyslog.d/spectra-helper.conf"
+
 // helperPlistContent is the LaunchDaemon plist that starts spectra-helper
 // at boot and keeps it alive.
 const helperPlistContent = `<?xml version="1.0" encoding="UTF-8"?>
@@ -35,9 +39,12 @@ const helperPlistContent = `<?xml version="1.0" encoding="UTF-8"?>
     <key>KeepAlive</key>
     <true/>
     <key>StandardErrorPath</key>
-    <string>/var/log/spectra-helper.log</string>
+    <string>` + helperLogPath + `</string>
 </dict>
 </plist>
+`
+
+const helperNewsyslogContent = helperLogPath + `	root:wheel	640	7	1024	*	J
 `
 
 func runInstallHelper(args []string) int {
@@ -87,17 +94,10 @@ func runInstallHelper(args []string) int {
 			return sudoRun("chmod", "755", helperBinaryDest)
 		}},
 		{"Install LaunchDaemon plist", func() error {
-			// Write plist to a temp file, then sudo-copy it.
-			tmp, err := os.CreateTemp("", "spectra-helper-*.plist")
-			if err != nil {
-				return err
-			}
-			defer os.Remove(tmp.Name())
-			if _, err := tmp.WriteString(helperPlistContent); err != nil {
-				return err
-			}
-			tmp.Close()
-			return sudoRun("cp", tmp.Name(), helperPlist)
+			return installRootTextFile(helperPlist, helperPlistContent, sudoRun, writeTempText)
+		}},
+		{"Install helper log rotation", func() error {
+			return installRootTextFile(helperNewsyslogConf, helperNewsyslogContent, sudoRun, writeTempText)
 		}},
 		{"Load LaunchDaemon", func() error {
 			return sudoRun("launchctl", "load", "-w", helperPlist)
@@ -140,6 +140,39 @@ func helperInstallUser(getenv func(string) string) string {
 	return getenv("USER")
 }
 
+type rootRunner func(name string, args ...string) error
+
+type tempTextWriter func(pattern, content string) (path string, cleanup func(), err error)
+
+func installRootTextFile(dest, content string, run rootRunner, write tempTextWriter) error {
+	tmpPath, cleanup, err := write("spectra-helper-*", content)
+	if err != nil {
+		return err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	return run("cp", tmpPath, dest)
+}
+
+func writeTempText(pattern, content string) (string, func(), error) {
+	tmp, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.Remove(tmp.Name()) }
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return "", nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return tmp.Name(), cleanup, nil
+}
+
 func runUninstallHelper(args []string) int {
 	fs := flag.NewFlagSet("spectra uninstall-helper", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -156,6 +189,9 @@ func runUninstallHelper(args []string) int {
 		}},
 		{"Remove plist", func() error {
 			return sudoRun("rm", "-f", helperPlist)
+		}},
+		{"Remove helper log rotation", func() error {
+			return sudoRun("rm", "-f", helperNewsyslogConf)
 		}},
 		{"Remove binary", func() error {
 			return sudoRun("rm", "-f", helperBinaryDest)

--- a/cmd/spectra/helper_test.go
+++ b/cmd/spectra/helper_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestHelperInstallUserPrefersSudoUser(t *testing.T) {
 	env := map[string]string{"SUDO_USER": "alice", "USER": "root"}
@@ -15,5 +18,45 @@ func TestHelperInstallUserFallsBackToUser(t *testing.T) {
 	got := helperInstallUser(func(key string) string { return env[key] })
 	if got != "bob" {
 		t.Fatalf("helperInstallUser = %q, want bob", got)
+	}
+}
+
+func TestHelperNewsyslogContent(t *testing.T) {
+	want := "/var/log/spectra-helper.log\troot:wheel\t640\t7\t1024\t*\tJ\n"
+	if helperNewsyslogContent != want {
+		t.Fatalf("helperNewsyslogContent = %q, want %q", helperNewsyslogContent, want)
+	}
+}
+
+func TestInstallRootTextFileCopiesTemporaryContent(t *testing.T) {
+	var gotPattern, gotContent string
+	cleaned := false
+	write := func(pattern, content string) (string, func(), error) {
+		gotPattern = pattern
+		gotContent = content
+		return "/tmp/spectra-helper-test", func() { cleaned = true }, nil
+	}
+
+	var calls [][]string
+	run := func(name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}
+
+	if err := installRootTextFile("/etc/newsyslog.d/spectra-helper.conf", helperNewsyslogContent, run, write); err != nil {
+		t.Fatal(err)
+	}
+	if gotPattern != "spectra-helper-*" {
+		t.Fatalf("pattern = %q", gotPattern)
+	}
+	if gotContent != helperNewsyslogContent {
+		t.Fatalf("content = %q", gotContent)
+	}
+	if !cleaned {
+		t.Fatal("temporary file cleanup was not called")
+	}
+	wantCalls := [][]string{{"cp", "/tmp/spectra-helper-test", "/etc/newsyslog.d/spectra-helper.conf"}}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("calls = %v, want %v", calls, wantCalls)
 	}
 }

--- a/docs/design/privileged-helper.md
+++ b/docs/design/privileged-helper.md
@@ -171,8 +171,9 @@ summary without recording request parameters.
 
 Users running with the helper installed can audit what got asked of
 it. The unprivileged daemon never writes to this log directly.
-Rotation is still handled by the host's `/var/log` policy; a dedicated
-Spectra log rotation policy is future hardening work.
+`spectra install-helper` also installs
+`/etc/newsyslog.d/spectra-helper.conf`, which keeps seven compressed
+rotations and rolls the helper audit log after it reaches 1 MiB.
 
 ## Code signing and notarization
 

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -212,8 +212,8 @@ and impersonates the daemon as that tailnet node.
 ## Logging
 
 - Helper stderr is written by launchd to `/var/log/spectra-helper.log`.
-  The helper emits structured per-call JSON audit records there. Dedicated
-  rotation remains planned.
+  The helper emits structured per-call JSON audit records there. The
+  helper installer provisions a dedicated `newsyslog` rotation policy.
 - Daemon lifecycle logs are written as JSONL to
   `~/Library/Logs/Spectra/daemon.jsonl` by default, with `0600`
   permissions. Foreground status lines still go to stderr for interactive


### PR DESCRIPTION
## Summary
- install `/etc/newsyslog.d/spectra-helper.conf` during `spectra install-helper`
- remove that config during helper uninstall
- factor root text-file installation through a fakeable helper and cover the newsyslog config with unit tests
- update helper/threat-model docs now that dedicated audit-log rotation is implemented

## Validation
- `go test ./cmd/spectra -run 'TestHelper|TestInstallRootTextFile' -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
