### PR TITLE
Add nettop process throughput

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -132,6 +132,7 @@ func printNetworkState(s netstate.State) {
 	printProxyState(s.Proxy)
 	printHostsOverrides(s.HostsOverrides)
 	printListeningPorts(s.ListeningPorts)
+	printProcessThroughput(s.ProcessThroughput)
 }
 
 func printNetworkOverview(s netstate.State) {
@@ -148,6 +149,9 @@ func printNetworkOverview(s netstate.State) {
 	}
 	if len(s.DNSServers) > 0 {
 		fmt.Printf("dns:           %s\n", strings.Join(s.DNSServers, ", "))
+	}
+	if len(s.ProcessThroughput) > 0 {
+		fmt.Printf("throughput:    %d active processes\n", len(s.ProcessThroughput))
 	}
 }
 
@@ -193,6 +197,28 @@ func printListeningPorts(listening []netstate.ListeningPort) {
 	fmt.Printf("listening ports (%d):\n", len(ports))
 	for _, p := range ports {
 		fmt.Printf("  %s/%d%s%s\n", p.Proto, p.Port, listeningPID(p), listeningApp(p))
+	}
+}
+
+func printProcessThroughput(rows []netstate.Throughput) {
+	if len(rows) == 0 {
+		return
+	}
+	sorted := append([]netstate.Throughput(nil), rows...)
+	sort.Slice(sorted, func(i, j int) bool {
+		left := sorted[i].BytesInPerSec + sorted[i].BytesOutPerSec
+		right := sorted[j].BytesInPerSec + sorted[j].BytesOutPerSec
+		return left > right
+	})
+	if len(sorted) > 10 {
+		sorted = sorted[:10]
+	}
+
+	fmt.Println()
+	fmt.Printf("network throughput (%d active):\n", len(rows))
+	for _, row := range sorted {
+		fmt.Printf("  pid=%d %-24s in=%d B/s out=%d B/s\n",
+			row.PID, truncate(row.Command, 24), row.BytesInPerSec, row.BytesOutPerSec)
 	}
 }
 

--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -165,6 +165,7 @@ NetworkState {
   vpn_interfaces []
   listening_ports []{ port, proto, pid, app_path }
   established_connections_count
+  process_throughput []{ pid, command, bytes_in_per_sec, bytes_out_per_sec }
 }
 ```
 

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -45,7 +45,7 @@ limiting (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 
 | Source | Output | Privilege | Cost | Used by |
 |---|---|---|---|---|
-| `nettop -P -L 0 -t external` | per-process network bytes/sec | user (limited) | streaming, low | future live throughput counters |
+| `nettop -P -L 2 -x -d -J bytes_in,bytes_out -t external` | per-process network bytes/sec | user (limited) | ~1s sample | `network.process_throughput` |
 | `lsof -i -P -n -sTCP:LISTEN` | current listening TCP sockets | user | one-shot | `network.listening_ports` |
 | `lsof -i -P -n` | current TCP/UDP sockets | user | one-shot | `network.connections`, `network.byApp`, established count |
 | `netstat -an` | system-wide TCP/UDP socket state without PID/app attribution | user | low | fallback when `lsof` unavailable |
@@ -56,8 +56,8 @@ limiting (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `tcpdump -i <iface>` | raw packet capture | helper | streaming, high | (planned) targeted capture |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
-and `/etc/hosts`. `nettop` throughput counters and raw packet capture are
-reserved for explicit future live workflows.
+`nettop`, and `/etc/hosts`. Raw packet capture is reserved for explicit
+future live workflows.
 
 ## Energy and power
 

--- a/docs/inspection/network-endpoints.md
+++ b/docs/inspection/network-endpoints.md
@@ -103,7 +103,7 @@ Useful for:
   `network.connections` / `network.byApp` methods, which are backed by
   `lsof -i -P -n` with a `netstat -an` fallback when `lsof` is unavailable.
   The fallback is system-wide and does not include PID or app attribution.
-  Per-process throughput via `nettop` is still future work.
+  Per-process throughput comes from `nettop` in `network.process_throughput`.
 
 ## Implementation reference
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -237,8 +237,10 @@ spectra jvm jfr stop 4012 --name spectra
 
 ## `spectra network`
 
-Shows unprivileged network state by default. `spectra network firewall`
-asks the privileged helper for current pf firewall rules.
+Shows unprivileged network state by default, including current routes,
+DNS, VPN state, listening ports, and active per-process throughput from
+`nettop`. `spectra network firewall` asks the privileged helper for
+current pf firewall rules.
 
 ### Examples
 

--- a/internal/netstate/netstate.go
+++ b/internal/netstate/netstate.go
@@ -8,8 +8,10 @@ package netstate
 
 import (
 	"bufio"
+	"encoding/csv"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -22,6 +24,7 @@ type State struct {
 	HostsOverrides              []HostsEntry    `json:"hosts_overrides,omitempty"`
 	ListeningPorts              []ListeningPort `json:"listening_ports,omitempty"`
 	EstablishedConnectionsCount int             `json:"established_connections_count,omitempty"`
+	ProcessThroughput           []Throughput    `json:"process_throughput,omitempty"`
 
 	// VPNActive is true when at least one tunnel interface (utun*) is UP with
 	// an assigned address. macOS uses utun interfaces for all VPN types:
@@ -49,6 +52,14 @@ type ListeningPort struct {
 	Proto   string `json:"proto"` // "tcp", "udp"
 	PID     int    `json:"pid,omitempty"`
 	AppPath string `json:"app_path,omitempty"`
+}
+
+// Throughput is a per-process network throughput sample from nettop.
+type Throughput struct {
+	PID            int    `json:"pid"`
+	Command        string `json:"command"`
+	BytesInPerSec  int64  `json:"bytes_in_per_sec"`
+	BytesOutPerSec int64  `json:"bytes_out_per_sec"`
 }
 
 // CmdRunner abstracts shell-out for testability.
@@ -81,6 +92,7 @@ func Collect(run CmdRunner) State {
 		s.VPNActive = len(s.VPNInterfaces) > 0
 	}
 	s.EstablishedConnectionsCount = len(collectConnectionRows(run))
+	s.ProcessThroughput = CollectThroughput(run)
 	return s
 }
 
@@ -92,6 +104,90 @@ func collectConnectionRows(run CmdRunner) []Connection {
 		return parseNetstatConnections(string(out))
 	}
 	return nil
+}
+
+// CollectThroughput samples per-process external-interface network throughput.
+// It asks nettop for two CSV samples in delta mode and uses the final sample;
+// the first sample is cumulative since process start on some macOS releases.
+func CollectThroughput(run CmdRunner) []Throughput {
+	out, err := run("nettop", "-P", "-L", "2", "-x", "-d", "-J", "bytes_in,bytes_out", "-t", "external")
+	if err != nil {
+		return nil
+	}
+	rows := parseNettopThroughput(string(out))
+	active := rows[:0]
+	for _, row := range rows {
+		if row.BytesInPerSec > 0 || row.BytesOutPerSec > 0 {
+			active = append(active, row)
+		}
+	}
+	return active
+}
+
+func parseNettopThroughput(out string) []Throughput {
+	r := csv.NewReader(strings.NewReader(out))
+	r.FieldsPerRecord = -1
+
+	var sample []Throughput
+	var last []Throughput
+	for {
+		record, err := r.Read()
+		if err != nil {
+			break
+		}
+		if len(record) < 3 {
+			continue
+		}
+		if record[0] == "" && record[1] == "bytes_in" && record[2] == "bytes_out" {
+			if sample != nil {
+				last = sample
+			}
+			sample = nil
+			continue
+		}
+		row, ok := parseNettopThroughputRow(record)
+		if ok {
+			sample = append(sample, row)
+		}
+	}
+	if sample != nil {
+		last = sample
+	}
+	return last
+}
+
+func parseNettopThroughputRow(record []string) (Throughput, bool) {
+	command, pid, ok := splitNettopProcess(record[0])
+	if !ok {
+		return Throughput{}, false
+	}
+	bytesIn, err := strconv.ParseInt(strings.TrimSpace(record[1]), 10, 64)
+	if err != nil {
+		return Throughput{}, false
+	}
+	bytesOut, err := strconv.ParseInt(strings.TrimSpace(record[2]), 10, 64)
+	if err != nil {
+		return Throughput{}, false
+	}
+	return Throughput{
+		PID:            pid,
+		Command:        command,
+		BytesInPerSec:  bytesIn,
+		BytesOutPerSec: bytesOut,
+	}, true
+}
+
+func splitNettopProcess(raw string) (string, int, bool) {
+	raw = strings.TrimSpace(raw)
+	idx := strings.LastIndex(raw, ".")
+	if idx <= 0 || idx == len(raw)-1 {
+		return "", 0, false
+	}
+	pid, err := strconv.Atoi(raw[idx+1:])
+	if err != nil || pid <= 0 {
+		return "", 0, false
+	}
+	return raw[:idx], pid, true
 }
 
 // parseRoute extracts interface and gateway from `route -n get default`.

--- a/internal/netstate/netstate_test.go
+++ b/internal/netstate/netstate_test.go
@@ -177,6 +177,55 @@ func TestParseVPNInterfacesEmpty(t *testing.T) {
 	}
 }
 
+const nettopThroughputFixture = `,bytes_in,bytes_out,
+Slack Helper.412,1000,2000,
+Google Chrome H.999,3000,4000,
+,bytes_in,bytes_out,
+Slack Helper.412,7,11,
+Google Chrome H.999,0,0,
+bad-row,1,2,
+`
+
+func TestParseNettopThroughputUsesFinalSample(t *testing.T) {
+	rows := parseNettopThroughput(nettopThroughputFixture)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2: %+v", len(rows), rows)
+	}
+	if rows[0].Command != "Slack Helper" || rows[0].PID != 412 {
+		t.Fatalf("first row identity = %+v", rows[0])
+	}
+	if rows[0].BytesInPerSec != 7 || rows[0].BytesOutPerSec != 11 {
+		t.Fatalf("first row throughput = %+v", rows[0])
+	}
+	if rows[1].Command != "Google Chrome H" || rows[1].PID != 999 {
+		t.Fatalf("second row identity = %+v", rows[1])
+	}
+}
+
+func TestCollectThroughputFiltersInactiveRows(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	stub := func(name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return []byte(nettopThroughputFixture), nil
+	}
+
+	rows := CollectThroughput(stub)
+	if gotName != "nettop" {
+		t.Fatalf("command = %q, want nettop", gotName)
+	}
+	if !hasArg(gotArgs, "-d") || !hasArg(gotArgs, "-P") || !hasArg(gotArgs, "external") {
+		t.Fatalf("nettop args = %v", gotArgs)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("active rows = %d, want 1: %+v", len(rows), rows)
+	}
+	if rows[0].PID != 412 {
+		t.Fatalf("active row = %+v", rows[0])
+	}
+}
+
 func hasArg(args []string, s string) bool {
 	for _, a := range args {
 		if a == s {
@@ -203,6 +252,8 @@ func TestCollect(t *testing.T) {
 			return []byte(lsofFixture), nil
 		case "ifconfig":
 			return []byte(ifconfigWithVPN), nil
+		case "nettop":
+			return []byte(nettopThroughputFixture), nil
 		}
 		return nil, errors.New("unexpected command")
 	}
@@ -225,6 +276,9 @@ func TestCollect(t *testing.T) {
 	}
 	if s.EstablishedConnectionsCount != 3 {
 		t.Errorf("EstablishedConnectionsCount = %d, want 3", s.EstablishedConnectionsCount)
+	}
+	if len(s.ProcessThroughput) != 1 || s.ProcessThroughput[0].PID != 412 {
+		t.Errorf("ProcessThroughput = %+v, want active Slack row", s.ProcessThroughput)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a `nettop`-backed per-process throughput collector to `network.state`
- parse the final delta sample from `nettop -P -L 2 -x -d` and expose active rows as `process_throughput`
- show the top active throughput rows in `spectra network`
- update the live-data, network, CLI, and system-inventory docs now that this item is implemented

## Validation
- `go test ./internal/netstate ./cmd/spectra -run 'TestParseNettop|TestCollectThroughput|TestCollect|TestNetwork' -count=1`
- `go run ./cmd/spectra network --json | jq '.process_throughput[0:3]'`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
