### PR TITLE
Require sensitive artifact confirmation

### DIFF
--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -155,12 +155,10 @@ secrets, then reads the resulting `.hprof` from the blob cache.
 **Mitigation:**
 - Local CLI heap dumps default to `~/.spectra/`, created with user-only
   directory permissions.
-- Daemon RPC exposes `jvm.heap_dump` and `jvm.jfr.*` only to clients
-  that can already reach the daemon. Until consent prompts land, do not
-  expose TCP RPC to peers that should not be allowed to request these
-  operations.
-- Heap-dump consent, sensitive artifact manifests, and remote-serving
-  restrictions are planned hardening items.
+- Daemon RPC requires `confirm_sensitive: true` before `jvm.heap_dump`
+  or `jvm.jfr.dump` writes a sensitive artifact.
+- Sensitive artifact manifests and remote-serving restrictions are
+  planned hardening items.
 - The privileged helper enforces a per-UID request limit so a compromised
   unprivileged daemon cannot hammer root-only commands indefinitely.
 

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -117,7 +117,9 @@ authentication is future work with the remote portal.
 - All RPC calls are read-only by default. State-changing calls
   (`snapshot.create`, `cache.clear`, `issues.acknowledge`,
   `issues.dismiss`, `issues.fix.record`, `snapshot.prune`, JVM heap/JFR
-  capture) are explicit methods.
+  capture) are explicit methods. Sensitive artifact writes
+  (`jvm.heap_dump`, `jvm.jfr.dump`) also require
+  `confirm_sensitive: true` in the request.
 - The daemon is intended to be a low-privilege observer, not a remote
   shell. Method surface is intentionally narrow; arbitrary
   `exec.Command` is not exposed over RPC.

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -110,7 +110,9 @@ For a team tailnet, restrict by tag:
 
 The remote daemon is **read-only by default**. State-changing
 operations (snapshots, heap dumps, JFR recordings) require explicit
-consent on the client side and an audit log entry on the daemon.
+consent on the client side and an audit log entry on the daemon. The
+daemon rejects sensitive artifact writes unless the request includes
+`confirm_sensitive: true`.
 
 The daemon does not expose:
 - Arbitrary file reads outside Spectra-managed paths.

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -645,15 +645,19 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 	// jvm.jfr.dump — dump a running JFR recording. Required: {"pid": <pid>, "dest": "/path/to/out.jfr"}.
 	d.Register("jvm.jfr.dump", func(params json.RawMessage) (any, error) {
 		var p struct {
-			PID  int    `json:"pid"`
-			Name string `json:"name"`
-			Dest string `json:"dest"`
+			PID              int    `json:"pid"`
+			Name             string `json:"name"`
+			Dest             string `json:"dest"`
+			ConfirmSensitive bool   `json:"confirm_sensitive"`
 		}
 		if err := json.Unmarshal(params, &p); err != nil || p.PID == 0 {
 			return nil, fmt.Errorf("jvm.jfr.dump requires {\"pid\": <pid>, \"dest\": \"...\"}")
 		}
 		if p.Dest == "" {
 			return nil, fmt.Errorf("jvm.jfr.dump requires {\"dest\": \"...\"}")
+		}
+		if !p.ConfirmSensitive {
+			return nil, fmt.Errorf("jvm.jfr.dump requires {\"confirm_sensitive\": true} because JFR artifacts may contain sensitive process data")
 		}
 		name := p.Name
 		if name == "" {
@@ -720,11 +724,15 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 	// Required: {"pid": <pid>}. Optional: {"dest": "/path/to/out.hprof"}.
 	jvmHeapDump := func(params json.RawMessage) (any, error) {
 		var p struct {
-			PID  int    `json:"pid"`
-			Dest string `json:"dest"`
+			PID              int    `json:"pid"`
+			Dest             string `json:"dest"`
+			ConfirmSensitive bool   `json:"confirm_sensitive"`
 		}
 		if err := json.Unmarshal(params, &p); err != nil || p.PID == 0 {
 			return nil, fmt.Errorf("jvm.heap_dump requires {\"pid\": <pid>}")
+		}
+		if !p.ConfirmSensitive {
+			return nil, fmt.Errorf("jvm.heap_dump requires {\"confirm_sensitive\": true} because heap dumps may contain secrets and PII")
 		}
 		if p.Dest == "" {
 			p.Dest = fmt.Sprintf("/tmp/spectra-heap-%d.hprof", p.PID)

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -520,6 +520,15 @@ func TestDaemonJVMJFRDumpMissingDest(t *testing.T) {
 	}
 }
 
+func TestDaemonJVMJFRDumpRequiresSensitiveConfirmation(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 137, "jvm.jfr.dump", `{"pid":42,"dest":"/tmp/out.jfr"}`)
+	if resp.Error == nil {
+		t.Error("expected error when confirm_sensitive is missing")
+	}
+}
+
 func TestDaemonJVMJFRDumpUsesDefaultName(t *testing.T) {
 	var gotPID int
 	var gotName, gotDest string
@@ -534,7 +543,7 @@ func TestDaemonJVMJFRDumpUsesDefaultName(t *testing.T) {
 
 	enc, dec, cancel := testDaemon(t)
 	defer cancel()
-	resp := rpcCall(t, enc, dec, 37, "jvm.jfr.dump", `{"pid":42,"dest":"/tmp/out.jfr"}`)
+	resp := rpcCall(t, enc, dec, 37, "jvm.jfr.dump", `{"pid":42,"dest":"/tmp/out.jfr","confirm_sensitive":true}`)
 	if resp.Error != nil {
 		t.Fatalf("jvm.jfr.dump: %v", resp.Error)
 	}
@@ -667,6 +676,15 @@ func TestDaemonJVMHeapDumpRequiresPID(t *testing.T) {
 	resp := rpcCall(t, enc, dec, 52, "jvm.heap_dump", `{}`)
 	if resp.Error == nil {
 		t.Error("expected error when pid=0")
+	}
+}
+
+func TestDaemonJVMHeapDumpRequiresSensitiveConfirmation(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 152, "jvm.heap_dump", `{"pid":42}`)
+	if resp.Error == nil {
+		t.Error("expected error when confirm_sensitive is missing")
 	}
 }
 


### PR DESCRIPTION
## Summary
- require `confirm_sensitive: true` for daemon RPC heap-dump writes
- require the same confirmation for daemon RPC JFR dump writes
- add regression tests for both confirmation gates
- update remote/daemon/threat-model docs to describe the sensitive artifact contract

## Validation
- `go test ./internal/serve -run 'TestDaemonJVM(HeapDump|JFRDump)' -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
