### PR TITLE
Refresh helper capability docs

### DIFF
--- a/docs/design/distribution.md
+++ b/docs/design/distribution.md
@@ -33,7 +33,8 @@ sudo ./spectra install-helper
 | Per-user TCC.db | ✗ | ✓ | ✓ | ✓ |
 | System TCC.db | ✗ | ✓ via helper | ✓ via helper | ✓ via helper |
 | `lsof -i`, `nettop` | ✗ | ✓ | ✓ | ✓ |
-| `fs_usage`, `powermetrics`, `pmset` | ✗ | ✓ via helper | ✓ via helper | ✓ via helper |
+| `powermetrics`, system TCC, pf rules | ✗ | ✓ via helper | ✓ via helper | ✓ via helper |
+| `fs_usage` | ✗ | planned helper method | planned helper method | planned helper method |
 | Listen on TCP / Unix socket | ✗ | ✓ | ✓ | ✓ |
 | Embed `tsnet` (Tailscale) | ✗ | ✓ | ✓ | ✓ |
 | Install LaunchDaemon | ✗ | ✓ via `sudo spectra install-helper` | ✓ via opt-in command | planned signed helper |
@@ -103,9 +104,9 @@ sudo spectra install-helper
 
 ## Why an optional sudo helper
 
-The capabilities that need root (`fs_usage`, `powermetrics`, system
-TCC.db) require a separately installed privileged helper. The user grants
-this once, explicitly:
+The capabilities that need root (`powermetrics`, system TCC.db, pf
+firewall rules, and future `fs_usage`) require a separately installed
+privileged helper. The user grants this once, explicitly:
 
 ```bash
 sudo spectra install-helper

--- a/docs/design/privileged-helper.md
+++ b/docs/design/privileged-helper.md
@@ -66,6 +66,7 @@ The helper's RPC surface is intentionally narrow. It listens on
 |---|---|
 | `helper.tcc.system.query(bundleID)` | Query system TCC.db for granted services |
 | `helper.powermetrics.sample(duration)` | One-shot powermetrics output |
+| `helper.firewall.rules()` | Current pf firewall rules |
 | `helper.process.tree()` | Process tree including processes the user can't see (e.g. system daemons) |
 | `helper.health()` | Liveness + version |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,8 +56,8 @@ model, [inspection/](inspection/) for what we extract from each bundle, and
 
 ## Distribution
 
-Spectra currently installs from source. Homebrew and prebuilt binaries are
-planned, with an optional `sudo` step that installs a privileged helper for
-root-only telemetry (Full Disk Access, `fs_usage`, `powermetrics`). The Mac
-App Store is incompatible with the live-monitoring features. See
+Spectra currently installs from source with an optional `sudo` helper
+install for root-only telemetry (system TCC, firewall rules, and
+`powermetrics`). Homebrew and prebuilt binaries are planned. The Mac App
+Store is incompatible with the live-monitoring features. See
 [design/distribution.md](design/distribution.md) for the full analysis.

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -71,7 +71,7 @@ JSON-RPC 2.0 methods, organized by concern:
   `issues.fix.list`
 - **Cache** — `cache.stats`, `cache.clear`
 - **Helper proxy** — `helper.health`, `helper.powermetrics.sample`,
-  `helper.tcc.system.query`
+  `helper.tcc.system.query`, `helper.firewall.rules`
 
 Snake-case and camel-case aliases exist for selected older JVM methods
 (`jvm.thread_dump` / `jvm.threadDump`, etc.).
@@ -98,7 +98,7 @@ that loop to keep the tick cheap.
 For root-only data, the unprivileged daemon can proxy to a separately
 installed privileged helper over a local Unix socket. Implemented helper
 proxy methods cover health, system TCC query, and one-shot `powermetrics`
-sampling. `fs_usage` remains future work. See
+sampling, plus pf firewall rule reads. `fs_usage` remains future work. See
 [../design/distribution.md](../design/distribution.md).
 
 The remote client never talks to the helper directly — the daemon


### PR DESCRIPTION
## Summary
- update the product index to describe the implemented source-install helper path
- list `helper.firewall.rules` in the privileged-helper and daemon RPC docs
- clarify distribution docs so implemented helper capabilities are separated from future `fs_usage`

## Validation
- `make docs-validate`
- `git diff --check`
