### PR TITLE
Add helper fs_usage traces

### DIFF
--- a/cmd/spectra-helper/main.go
+++ b/cmd/spectra-helper/main.go
@@ -4,6 +4,7 @@
 //
 //   - System TCC.db queries
 //   - powermetrics samples
+//   - fs_usage traces for a specific PID
 //   - Full process tree (including system daemons)
 //
 // The socket is /var/run/spectra-helper.sock (0660 root:_spectra).

--- a/docs/design/distribution.md
+++ b/docs/design/distribution.md
@@ -34,7 +34,7 @@ sudo ./spectra install-helper
 | System TCC.db | ✗ | ✓ via helper | ✓ via helper | ✓ via helper |
 | `lsof -i`, `nettop` | ✗ | ✓ | ✓ | ✓ |
 | `powermetrics`, system TCC, pf rules | ✗ | ✓ via helper | ✓ via helper | ✓ via helper |
-| `fs_usage` | ✗ | planned helper method | planned helper method | planned helper method |
+| bounded `fs_usage` traces | ✗ | ✓ via helper | ✓ via helper | ✓ via helper |
 | Listen on TCP / Unix socket | ✗ | ✓ | ✓ | ✓ |
 | Embed `tsnet` (Tailscale) | ✗ | ✓ | ✓ | ✓ |
 | Install LaunchDaemon | ✗ | ✓ via `sudo spectra install-helper` | ✓ via opt-in command | planned signed helper |
@@ -105,8 +105,8 @@ sudo spectra install-helper
 ## Why an optional sudo helper
 
 The capabilities that need root (`powermetrics`, system TCC.db, pf
-firewall rules, and future `fs_usage`) require a separately installed
-privileged helper. The user grants this once, explicitly:
+firewall rules, and bounded `fs_usage` traces) require a separately
+installed privileged helper. The user grants this once, explicitly:
 
 ```bash
 sudo spectra install-helper

--- a/docs/design/privileged-helper.md
+++ b/docs/design/privileged-helper.md
@@ -67,13 +67,16 @@ The helper's RPC surface is intentionally narrow. It listens on
 | `helper.tcc.system.query(bundleID)` | Query system TCC.db for granted services |
 | `helper.powermetrics.sample(duration)` | One-shot powermetrics output |
 | `helper.firewall.rules()` | Current pf firewall rules |
+| `helper.fs_usage.start(pid, mode, duration)` | Start a bounded root `fs_usage` trace for one PID |
+| `helper.fs_usage.stop(handle)` | Stop a trace and return captured output |
 | `helper.process.tree()` | Process tree including processes the user can't see (e.g. system daemons) |
 | `helper.health()` | Liveness + version |
 
-Planned but not implemented yet:
-
-- `helper.fs_usage.start(filter)`
-- `helper.fs_usage.stop(handle)`
+`helper.fs_usage.start` requires a numeric PID and an allowlisted mode
+(`filesys`, `pathname`, `exec`, `diskio`, or `network`). It defaults to
+`filesys`, caps trace duration at 60 seconds, and never accepts an
+arbitrary command string or file path. Handles are removed when stopped
+or when the bounded trace reaches its duration limit.
 
 Notably absent:
 
@@ -152,7 +155,7 @@ internal/
     dispatcher.go         # method dispatch
     framing.go            # length-prefixed JSON-RPC framing
     peeruid_darwin.go     # getpeereid
-    methods.go            # TCC, powermetrics, process tree
+    methods.go            # TCC, powermetrics, fs_usage, process tree
   helperclient/           # used by the unprivileged daemon
     client.go
     fallback.go           # graceful "no helper installed" path

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -31,15 +31,14 @@ eliminate more fork cost and add richer per-process detail.
 |---|---|---|---|---|
 | `lsof -p <pid[,pid...]>` | open files + sockets per process | user (own); helper for others | ~50-100ms batched | `process.open_fds`, `process.listening_ports`, `process.outbound_connections` |
 | `lsof -i -P -n` | system-wide network connections | user (limited); helper for full | ~100ms | network connections collector |
-| `fs_usage -w -f filesys` | live file system trace | helper-only | streaming | `fs_usage` collector via helper |
-| `fs_usage -e <pid>` | per-process file activity | helper-only | streaming | targeted file-activity capture |
+| `fs_usage -w -f <mode> <pid>` | bounded live trace for one process | helper-only | streaming, capped | `helper.fs_usage.start` / `helper.fs_usage.stop` |
 | `iostat 1` | per-volume IOPS and throughput | user | streaming, low | volume IO ring buffer |
 | `du -sk` | directory disk usage | user | seconds for large trees | not used; we walk + `Stat_t.Blocks` instead |
 
 `fs_usage` is the killer: per-process, syscall-level filesystem
-events. But it requires root and produces a high-volume stream;
-exposing it through the helper requires careful filtering and rate
-limiting (see [../design/privileged-helper.md](../design/privileged-helper.md)).
+events. It requires root and produces a high-volume stream, so Spectra
+only exposes bounded helper traces for a specific PID and allowlisted
+mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 
 ## Network state
 

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -56,7 +56,8 @@ JSON-RPC 2.0 methods, organized by concern:
 - **Live state** — `process.live`, `process.history`, `process.list`,
   `process.tree`, `process.sample`
 - **Helper** — `helper.health`, `helper.powermetrics.sample`,
-  `helper.tcc.system.query`, `helper.firewall.rules`
+  `helper.tcc.system.query`, `helper.firewall.rules`,
+  `helper.fs_usage.start`, `helper.fs_usage.stop`
 - **JVM** — `jvm.list`, `jvm.inspect`, `jvm.threadDump`, `jvm.heapDump`,
   `jvm.heapHistogram`, `jvm.gcStats`, `jvm.jfr.start`, `jvm.jfr.stop`,
   `jvm.jfr.dump`, `jvm.jfr.summary`
@@ -71,7 +72,8 @@ JSON-RPC 2.0 methods, organized by concern:
   `issues.fix.list`
 - **Cache** — `cache.stats`, `cache.clear`
 - **Helper proxy** — `helper.health`, `helper.powermetrics.sample`,
-  `helper.tcc.system.query`, `helper.firewall.rules`
+  `helper.tcc.system.query`, `helper.firewall.rules`,
+  `helper.fs_usage.start`, `helper.fs_usage.stop`
 
 Snake-case and camel-case aliases exist for selected older JVM methods
 (`jvm.thread_dump` / `jvm.threadDump`, etc.).
@@ -98,7 +100,7 @@ that loop to keep the tick cheap.
 For root-only data, the unprivileged daemon can proxy to a separately
 installed privileged helper over a local Unix socket. Implemented helper
 proxy methods cover health, system TCC query, and one-shot `powermetrics`
-sampling, plus pf firewall rule reads. `fs_usage` remains future work. See
+sampling, pf firewall rule reads, and bounded `fs_usage` traces. See
 [../design/distribution.md](../design/distribution.md).
 
 The remote client never talks to the helper directly — the daemon

--- a/internal/helper/fsusage.go
+++ b/internal/helper/fsusage.go
@@ -1,0 +1,184 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultFSUsageDuration = 30 * time.Second
+	maxFSUsageDuration     = time.Minute
+	fsUsageStopTimeout     = 3 * time.Second
+)
+
+type fsUsageStarter func(ctx context.Context, stdout, stderr io.Writer, name string, args ...string) (fsUsageProcess, error)
+
+type fsUsageProcess interface {
+	Wait() error
+}
+
+type fsUsageManager struct {
+	mu       sync.Mutex
+	next     atomic.Uint64
+	starter  fsUsageStarter
+	sessions map[string]*fsUsageSession
+}
+
+type fsUsageSession struct {
+	cancel context.CancelFunc
+	done   chan error
+	buf    lockedBuffer
+}
+
+type fsUsageStartParams struct {
+	PID        int    `json:"pid"`
+	Mode       string `json:"mode"`
+	DurationMS int    `json:"duration_ms"`
+}
+
+type fsUsageStopParams struct {
+	Handle string `json:"handle"`
+}
+
+func newFSUsageManager(starter fsUsageStarter) *fsUsageManager {
+	if starter == nil {
+		starter = startFSUsageProcess
+	}
+	return &fsUsageManager{starter: starter, sessions: make(map[string]*fsUsageSession)}
+}
+
+func (m *fsUsageManager) start(p fsUsageStartParams) (map[string]any, error) {
+	if p.PID <= 0 {
+		return nil, fmt.Errorf("helper.fs_usage.start requires {\"pid\": <pid>}")
+	}
+	mode := p.Mode
+	if mode == "" {
+		mode = "filesys"
+	}
+	if !validFSUsageMode(mode) {
+		return nil, fmt.Errorf("helper.fs_usage.start rejects invalid mode %q", mode)
+	}
+	duration := defaultFSUsageDuration
+	if p.DurationMS > 0 {
+		duration = time.Duration(p.DurationMS) * time.Millisecond
+	}
+	if duration <= 0 || duration > maxFSUsageDuration {
+		return nil, fmt.Errorf("helper.fs_usage.start requires duration_ms <= %d", maxFSUsageDuration.Milliseconds())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	sess := &fsUsageSession{cancel: cancel, done: make(chan error, 1)}
+	handle := fmt.Sprintf("fsu-%d", m.next.Add(1))
+	args := []string{"-w", "-f", mode, strconv.Itoa(p.PID)}
+	proc, err := m.starter(ctx, &sess.buf, &sess.buf, "fs_usage", args...)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("fs_usage start: %w", err)
+	}
+	m.mu.Lock()
+	m.sessions[handle] = sess
+	m.mu.Unlock()
+	go func() {
+		sess.done <- proc.Wait()
+		if ctx.Err() == context.DeadlineExceeded {
+			m.forget(handle)
+		}
+	}()
+
+	return map[string]any{
+		"handle":      handle,
+		"pid":         p.PID,
+		"mode":        mode,
+		"duration_ms": duration.Milliseconds(),
+	}, nil
+}
+
+func (m *fsUsageManager) stop(p fsUsageStopParams) (map[string]any, error) {
+	if p.Handle == "" {
+		return nil, fmt.Errorf("helper.fs_usage.stop requires {\"handle\": \"...\"}")
+	}
+	m.mu.Lock()
+	sess, ok := m.sessions[p.Handle]
+	if ok {
+		delete(m.sessions, p.Handle)
+	}
+	m.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("helper.fs_usage.stop unknown handle %q", p.Handle)
+	}
+
+	sess.cancel()
+	timedOut := false
+	select {
+	case <-sess.done:
+	case <-time.After(fsUsageStopTimeout):
+		timedOut = true
+	}
+	result := map[string]any{
+		"handle":     p.Handle,
+		"raw_output": sess.buf.String(),
+		"stopped":    true,
+	}
+	if timedOut {
+		result["wait_error"] = "timeout waiting for fs_usage to stop"
+	}
+	return result, nil
+}
+
+func (m *fsUsageManager) forget(handle string) {
+	m.mu.Lock()
+	delete(m.sessions, handle)
+	m.mu.Unlock()
+}
+
+func validFSUsageMode(mode string) bool {
+	switch mode {
+	case "network", "filesys", "pathname", "exec", "diskio":
+		return true
+	default:
+		return false
+	}
+}
+
+type execFSUsageProcess struct {
+	cmd *exec.Cmd
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	return len(p), nil
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.buf)
+}
+
+func startFSUsageProcess(ctx context.Context, stdout, stderr io.Writer, name string, args ...string) (fsUsageProcess, error) {
+	// #nosec G204 -- helper fs_usage runs a fixed binary with allowlisted flags and numeric PID.
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &execFSUsageProcess{cmd: cmd}, nil
+}
+
+func (p *execFSUsageProcess) Wait() error {
+	return p.cmd.Wait()
+}

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -2,8 +2,10 @@ package helper
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"path/filepath"
 	"testing"
@@ -301,5 +303,90 @@ func TestFirewallRulesUsesPFCTL(t *testing.T) {
 	}
 	if m["raw_rules"] != "block drop all\npass out all\n" {
 		t.Errorf("raw_rules = %q", m["raw_rules"])
+	}
+}
+
+type fakeFSUsageProcess struct {
+	ctx context.Context
+}
+
+func (p fakeFSUsageProcess) Wait() error {
+	<-p.ctx.Done()
+	return p.ctx.Err()
+}
+
+func TestFSUsageStartRejectsInvalidParams(t *testing.T) {
+	d := NewDispatcher()
+	called := false
+	registerAll(d, nil, func(context.Context, io.Writer, io.Writer, string, ...string) (fsUsageProcess, error) {
+		called = true
+		return nil, fmt.Errorf("should not be called")
+	})
+
+	req := []byte(`{"jsonrpc":"2.0","id":1,"method":"helper.fs_usage.start","params":{"mode":"filesys"}}`)
+	resp := d.handle(501, req)
+	if resp.Error == nil {
+		t.Fatal("expected missing pid error")
+	}
+	if called {
+		t.Fatal("fs_usage starter should not be called")
+	}
+
+	req = []byte(`{"jsonrpc":"2.0","id":2,"method":"helper.fs_usage.start","params":{"pid":42,"mode":"bad"}}`)
+	resp = d.handle(501, req)
+	if resp.Error == nil {
+		t.Fatal("expected invalid mode error")
+	}
+	if called {
+		t.Fatal("fs_usage starter should not be called")
+	}
+}
+
+func TestFSUsageStartStop(t *testing.T) {
+	d := NewDispatcher()
+	var gotName string
+	var gotArgs []string
+	registerAll(d, nil, func(ctx context.Context, stdout, _ io.Writer, name string, args ...string) (fsUsageProcess, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		_, _ = io.WriteString(stdout, "open /tmp/example\n")
+		return fakeFSUsageProcess{ctx: ctx}, nil
+	})
+
+	startReq := []byte(`{"jsonrpc":"2.0","id":1,"method":"helper.fs_usage.start","params":{"pid":42,"mode":"pathname","duration_ms":1000}}`)
+	startResp := d.handle(501, startReq)
+	if startResp.Error != nil {
+		t.Fatalf("start error: %+v", startResp.Error)
+	}
+	if gotName != "fs_usage" {
+		t.Fatalf("command = %q, want fs_usage", gotName)
+	}
+	wantArgs := []string{"-w", "-f", "pathname", "42"}
+	if fmt.Sprint(gotArgs) != fmt.Sprint(wantArgs) {
+		t.Fatalf("args = %v, want %v", gotArgs, wantArgs)
+	}
+	startResult, ok := startResp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("start result type %T, want map", startResp.Result)
+	}
+	handle, _ := startResult["handle"].(string)
+	if handle == "" {
+		t.Fatalf("handle = %q", handle)
+	}
+
+	stopReq := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":2,"method":"helper.fs_usage.stop","params":{"handle":%q}}`, handle))
+	stopResp := d.handle(501, stopReq)
+	if stopResp.Error != nil {
+		t.Fatalf("stop error: %+v", stopResp.Error)
+	}
+	stopResult, ok := stopResp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("stop result type %T, want map", stopResp.Result)
+	}
+	if stopResult["raw_output"] != "open /tmp/example\n" {
+		t.Fatalf("raw_output = %q", stopResult["raw_output"])
+	}
+	if stopResult["stopped"] != true {
+		t.Fatalf("stopped = %v, want true", stopResult["stopped"])
 	}
 }

--- a/internal/helper/methods.go
+++ b/internal/helper/methods.go
@@ -19,9 +19,14 @@ func defaultRunner(name string, args ...string) ([]byte, error) {
 // RegisterAll registers all helper methods on d using the provided runner.
 // run may be nil (uses the real commands).
 func RegisterAll(d *Dispatcher, run CmdRunner) {
+	registerAll(d, run, nil)
+}
+
+func registerAll(d *Dispatcher, run CmdRunner, fsUsageStarter fsUsageStarter) {
 	if run == nil {
 		run = defaultRunner
 	}
+	fsUsage := newFSUsageManager(fsUsageStarter)
 
 	d.Register("helper.health", func(_ uint32, _ json.RawMessage) (any, error) {
 		return map[string]any{"ok": true, "helper": true}, nil
@@ -63,6 +68,22 @@ func RegisterAll(d *Dispatcher, run CmdRunner) {
 			return nil, fmt.Errorf("pfctl rules: %w", err)
 		}
 		return map[string]any{"raw_rules": string(out)}, nil
+	})
+
+	d.Register("helper.fs_usage.start", func(_ uint32, params json.RawMessage) (any, error) {
+		var p fsUsageStartParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, fmt.Errorf("helper.fs_usage.start invalid params: %w", err)
+		}
+		return fsUsage.start(p)
+	})
+
+	d.Register("helper.fs_usage.stop", func(_ uint32, params json.RawMessage) (any, error) {
+		var p fsUsageStopParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, fmt.Errorf("helper.fs_usage.stop invalid params: %w", err)
+		}
+		return fsUsage.stop(p)
 	})
 
 	d.Register("helper.tcc.system.query", func(_ uint32, params json.RawMessage) (any, error) {

--- a/internal/helperclient/client.go
+++ b/internal/helperclient/client.go
@@ -144,3 +144,27 @@ func (c *Client) FirewallRules() (map[string]any, error) {
 	var m map[string]any
 	return m, json.Unmarshal(raw, &m)
 }
+
+// FSUsageStart starts a bounded fs_usage trace for pid using an allowlisted mode.
+func (c *Client) FSUsageStart(pid int, mode string, durationMS int) (map[string]any, error) {
+	raw, err := c.call("helper.fs_usage.start", map[string]any{
+		"pid":         pid,
+		"mode":        mode,
+		"duration_ms": durationMS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	return m, json.Unmarshal(raw, &m)
+}
+
+// FSUsageStop stops a running fs_usage trace and returns its captured output.
+func (c *Client) FSUsageStop(handle string) (map[string]any, error) {
+	raw, err := c.call("helper.fs_usage.stop", map[string]any{"handle": handle})
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	return m, json.Unmarshal(raw, &m)
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -974,6 +974,42 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		return result, nil
 	})
 
+	d.Register("helper.fs_usage.start", func(params json.RawMessage) (any, error) {
+		var p struct {
+			PID        int    `json:"pid"`
+			Mode       string `json:"mode"`
+			DurationMS int    `json:"duration_ms"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.PID <= 0 {
+			return nil, fmt.Errorf("helper.fs_usage.start requires {\"pid\": <pid>}")
+		}
+		result, err := hc.FSUsageStart(p.PID, p.Mode, p.DurationMS)
+		if err != nil {
+			if helperclient.IsUnavailable(err) {
+				return nil, fmt.Errorf("privileged helper not running; install with: sudo spectra install-helper")
+			}
+			return nil, err
+		}
+		return result, nil
+	})
+
+	d.Register("helper.fs_usage.stop", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Handle string `json:"handle"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.Handle == "" {
+			return nil, fmt.Errorf("helper.fs_usage.stop requires {\"handle\": \"...\"}")
+		}
+		result, err := hc.FSUsageStop(p.Handle)
+		if err != nil {
+			if helperclient.IsUnavailable(err) {
+				return nil, fmt.Errorf("privileged helper not running; install with: sudo spectra install-helper")
+			}
+			return nil, err
+		}
+		return result, nil
+	})
+
 	d.Register("helper.tcc.system.query", func(params json.RawMessage) (any, error) {
 		var p struct {
 			BundleID string `json:"bundle_id"`

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -733,6 +733,24 @@ func TestDaemonHelperFirewallRulesRequiresHelper(t *testing.T) {
 	}
 }
 
+func TestDaemonHelperFSUsageStartRequiresPID(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 156, "helper.fs_usage.start", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when pid missing")
+	}
+}
+
+func TestDaemonHelperFSUsageStopRequiresHandle(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 157, "helper.fs_usage.stop", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when handle missing")
+	}
+}
+
 func TestDaemonHelperTCCRequiresBundleID(t *testing.T) {
 	enc, dec, cancel := testDaemon(t)
 	defer cancel()


### PR DESCRIPTION
## Summary
- add bounded `helper.fs_usage.start` / `helper.fs_usage.stop` methods with required PID, allowlisted mode, and max duration
- proxy those methods through daemon RPC and helperclient
- add fake-backed helper tests plus daemon validation tests
- update helper, daemon, distribution, and live data-source docs now that bounded fs_usage traces are implemented

## Validation
- `go test ./internal/helper ./internal/helperclient ./internal/serve ./cmd/spectra-helper -run 'TestFSUsage|TestDaemonHelperFSUsage|TestHelper' -count=1`
- `go test ./internal/helper -race -run 'TestFSUsage|TestDispatcher' -count=1`
- `go test ./... -count=1`
- `go build ./... && go vet ./...`
- `make docs-validate`
- `golangci-lint run`
- `gocyclo -over 15 -ignore '_test\\.go$' .`
- `git diff --check`
