### PR TITLE
Guard helper sudo commands

### DIFF
--- a/cmd/spectra/helper.go
+++ b/cmd/spectra/helper.go
@@ -234,12 +234,24 @@ func runHelperStatus(args []string) int {
 }
 
 func sudoRun(name string, args ...string) error {
+	if !sudoCommandAllowed(name) {
+		return fmt.Errorf("sudo command %q is not allowlisted", name)
+	}
 	// #nosec G204 -- sudo is invoked only for the fixed helper management commands.
 	cmd := exec.Command("sudo", append([]string{name}, args...)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	return cmd.Run()
+}
+
+func sudoCommandAllowed(name string) bool {
+	switch name {
+	case "chmod", "chown", "cp", "dseditgroup", "launchctl", "mkdir", "rm":
+		return true
+	default:
+		return false
+	}
 }
 
 // installHelperCmd dispatches install-helper subcommands.

--- a/cmd/spectra/helper_test.go
+++ b/cmd/spectra/helper_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -58,5 +59,23 @@ func TestInstallRootTextFileCopiesTemporaryContent(t *testing.T) {
 	wantCalls := [][]string{{"cp", "/tmp/spectra-helper-test", "/etc/newsyslog.d/spectra-helper.conf"}}
 	if !reflect.DeepEqual(calls, wantCalls) {
 		t.Fatalf("calls = %v, want %v", calls, wantCalls)
+	}
+}
+
+func TestSudoCommandAllowedCoversHelperManagementCommands(t *testing.T) {
+	for _, name := range []string{"chmod", "chown", "cp", "dseditgroup", "launchctl", "mkdir", "rm"} {
+		if !sudoCommandAllowed(name) {
+			t.Fatalf("sudoCommandAllowed(%q) = false", name)
+		}
+	}
+}
+
+func TestSudoRunRejectsNonAllowlistedCommand(t *testing.T) {
+	err := sudoRun("sh", "-c", "echo should-not-run")
+	if err == nil {
+		t.Fatal("sudoRun accepted a non-allowlisted command")
+	}
+	if !strings.Contains(err.Error(), `sudo command "sh" is not allowlisted`) {
+		t.Fatalf("error = %v", err)
 	}
 }

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -139,6 +139,12 @@ attacker-chosen files.
   helper paths (see `internal/bundleid.Valid`).
 - RPC handler dispatch is method-allowlist; unknown methods return
   errors rather than passing through.
+- Subprocess use behind daemon/helper RPC is fixed per method: command
+  names are not accepted from RPC params; PIDs and durations are numeric;
+  `fs_usage` modes and TCC bundle IDs are allowlisted before reaching
+  `os/exec`.
+- Helper installation is the only root `sudo` path, and it rejects command
+  names outside the fixed installer utility allowlist.
 - TCP listen is opt-in. Non-loopback binds require `--allow-remote`,
   which prints an explicit warning that Spectra does not add its own
   authentication layer.
@@ -230,7 +236,7 @@ Things Spectra commits to before v1 release:
       code-signing requirement checks.
 - [x] Fuzz-test the JSON-RPC dispatcher for malformed payloads.
 - [x] Static analysis (`gosec`) runs in CI.
-- [ ] No `os/exec` calls take user-supplied arguments without an
+- [x] No `os/exec` calls take user-supplied arguments without an
       allowlist.
 - [x] No `database/sql` queries take user-supplied strings without
       parameterization (where supported) or strict allowlist


### PR DESCRIPTION
## Summary
- reject helper installer sudo commands outside the fixed utility allowlist
- add tests covering allowed helper commands and non-allowlisted rejection
- close the threat-model os/exec allowlist checklist with audit notes

## Validation
- go test ./cmd/spectra -run 'TestSudo|TestHelper|TestInstallRootTextFile' -count=1
- go test ./internal/helper ./internal/serve ./internal/detect -count=1
- go test ./... -count=1
- go build ./...
- go vet ./...
- golangci-lint run
- gocyclo -over 15 -ignore '_test\.go$' .
- git diff --check
- make docs-validate