### PR TITLE
Surface native module package versions

### DIFF
--- a/cmd/spectra/inspect.go
+++ b/cmd/spectra/inspect.go
@@ -142,7 +142,7 @@ func printTable(rs []detect.Result, verbose bool) {
 		if len(r.NativeModules) > 0 {
 			fmt.Printf("    native modules:\n")
 			for _, m := range r.NativeModules {
-				fmt.Printf("      [%s] %s\n", m.Language, m.Name)
+				fmt.Printf("      [%s] %s\n", m.Language, nativeModuleLabel(m))
 				if verbose {
 					for _, h := range m.Hints {
 						fmt.Printf("           %s\n", h)
@@ -151,6 +151,16 @@ func printTable(rs []detect.Result, verbose bool) {
 			}
 		}
 	}
+}
+
+func nativeModuleLabel(m detect.NativeModule) string {
+	if m.PackageName == "" {
+		return m.Name
+	}
+	if m.PackageVersion == "" {
+		return fmt.Sprintf("%s (%s)", m.Name, m.PackageName)
+	}
+	return fmt.Sprintf("%s (%s@%s)", m.Name, m.PackageName, m.PackageVersion)
 }
 
 func printMeta(r detect.Result) {

--- a/cmd/spectra/main_test.go
+++ b/cmd/spectra/main_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/detect"
+)
 
 func TestSubcommandListIncludesList(t *testing.T) {
 	for _, sc := range subcommandList() {
@@ -39,5 +43,16 @@ func TestListInspectArgsPrependsAll(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("arg %d = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestNativeModuleLabelIncludesPackageVersion(t *testing.T) {
+	got := nativeModuleLabel(detect.NativeModule{
+		Name:           "addon.node",
+		PackageName:    "@scope/pkg",
+		PackageVersion: "1.2.3",
+	})
+	if got != "addon.node (@scope/pkg@1.2.3)" {
+		t.Fatalf("nativeModuleLabel = %q", got)
 	}
 }

--- a/docs/detection/native-modules.md
+++ b/docs/detection/native-modules.md
@@ -9,7 +9,13 @@ Rust/Swift code.
 
 ## Classification rules
 
-Per `.node` file, in order:
+For each `.node` file, Spectra first walks up to the owning
+`node_modules` package, including scoped packages, and reads
+`package.json` when present. `PackageName` and `PackageVersion` are
+surfaced alongside the module filename so output can distinguish
+`pty.node` from `node-pty@x.y.z`.
+
+Then language classification runs in order:
 
 1. **Rust signal #1 — Cargo target path.** If the link map contains
    `/target/.../-apple-darwin/release/` or `.../debug/`, classify as
@@ -93,8 +99,6 @@ useful classification than "Electron."
 
 ## Future ideas
 
-- Surface module versions by reading the package's `package.json` if
-  present in the unpacked tree.
 - Detect specific high-signal modules by name (e.g. `node-keytar` →
   "uses macOS Keychain"; `node-mac-notifier` → "uses Notification Center")
   and surface that as a capability hint.

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -61,10 +61,12 @@ Source of truth: `internal/detect/detect.go`.
 
 ```go
 type NativeModule struct {
-    Name     string   // e.g. "computer_use.node"
-    Path     string   // bundle-relative
-    Language string   // Rust, Swift, C++, unknown
-    Hints    []string // additional context (linked frameworks, etc.)
+    Name           string   // e.g. "computer_use.node"
+    Path           string   // bundle-relative
+    PackageName    string   // npm package name when package.json is present
+    PackageVersion string   // npm package version when package.json is present
+    Language       string   // Rust, Swift, C++, unknown
+    Hints          []string // additional context (linked frameworks, etc.)
 }
 ```
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -153,10 +153,12 @@ type StorageFootprint struct {
 // app.asar.unpacked tree. The Language field is the best-guess source
 // language inferred from link map and binary content.
 type NativeModule struct {
-	Name     string // basename, e.g. "computer_use.node"
-	Path     string // bundle-relative path
-	Language string // Rust, Swift, C++, unknown
-	Hints    []string
+	Name           string // basename, e.g. "computer_use.node"
+	Path           string // bundle-relative path
+	PackageName    string // npm package name when package.json is present
+	PackageVersion string // npm package version when package.json is present
+	Language       string // Rust, Swift, C++, unknown
+	Hints          []string
 }
 
 // Options controls optional, more expensive sub-detections.
@@ -962,6 +964,7 @@ func nativeModuleRoots(appPath string) []string {
 // rust-strings scanning, then C++.
 func classifyNativeModule(absPath, relPath string) NativeModule {
 	m := NativeModule{Name: filepath.Base(absPath), Path: relPath, Language: "C++"}
+	readNativeModulePackage(absPath, &m)
 	libs := otoolL(absPath)
 	joined := strings.Join(libs, "\n")
 
@@ -1011,6 +1014,48 @@ func classifyNativeModule(absPath, relPath string) NativeModule {
 		m.Hints = append(m.Hints, "links libc++")
 	}
 	return m
+}
+
+func readNativeModulePackage(absPath string, m *NativeModule) {
+	root := nativeModulePackageRoot(absPath)
+	if root == "" {
+		return
+	}
+	data, err := os.ReadFile(filepath.Join(root, "package.json"))
+	if err != nil {
+		return
+	}
+	var pkg struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return
+	}
+	m.PackageName = pkg.Name
+	m.PackageVersion = pkg.Version
+}
+
+func nativeModulePackageRoot(absPath string) string {
+	parts := strings.Split(filepath.Clean(absPath), string(os.PathSeparator))
+	for i := len(parts) - 1; i >= 0; i-- {
+		if parts[i] != "node_modules" || i+1 >= len(parts) {
+			continue
+		}
+		end := i + 2
+		if strings.HasPrefix(parts[i+1], "@") {
+			if i+2 >= len(parts) {
+				return ""
+			}
+			end = i + 3
+		}
+		root := filepath.Join(parts[:end]...)
+		if filepath.IsAbs(absPath) && !filepath.IsAbs(root) {
+			root = string(os.PathSeparator) + root
+		}
+		return root
+	}
+	return ""
 }
 
 func nativeModuleSidecars(absPath string, libs []string, m *NativeModule) []string {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -321,6 +321,9 @@ func TestElectronNativeModulesScannedFromAsarUnpackedAndAppDir(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(rustModule), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/custom/package.json"), []byte(`{"name":"custom-native","version":"1.2.3"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	body := strings.Repeat("rustc/library/core/src/panicking.rs core::panicking\n", 60)
 	if err := os.WriteFile(rustModule, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
@@ -348,11 +351,36 @@ func TestElectronNativeModulesScannedFromAsarUnpackedAndAppDir(t *testing.T) {
 	if r.NativeModules[0].Language != "Rust" {
 		t.Errorf("custom module language = %q, want Rust; hints=%v", r.NativeModules[0].Language, r.NativeModules[0].Hints)
 	}
+	if r.NativeModules[0].PackageName != "custom-native" || r.NativeModules[0].PackageVersion != "1.2.3" {
+		t.Errorf("custom module package = %q@%q, want custom-native@1.2.3", r.NativeModules[0].PackageName, r.NativeModules[0].PackageVersion)
+	}
 	if r.NativeModules[1].Path != "Contents/Resources/app/node_modules/plain/build/Release/plain.node" {
 		t.Errorf("second module path = %q", r.NativeModules[1].Path)
 	}
 	if r.NativeModules[1].Language != "C++" {
 		t.Errorf("plain module language = %q, want C++", r.NativeModules[1].Language)
+	}
+}
+
+func TestNativeModulePackageRootHandlesScopedPackages(t *testing.T) {
+	app := makeBundle(t, "FakeScopedNativeModule")
+	root := filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/@scope/pkg")
+	mod := filepath.Join(root, "prebuilds/darwin-arm64/addon.node")
+	if err := os.MkdirAll(filepath.Dir(mod), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mod, []byte("native addon"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "package.json"), []byte(`{"name":"@scope/pkg","version":"4.5.6"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := nativeModulePackageRoot(mod); got != root {
+		t.Fatalf("nativeModulePackageRoot = %q, want %q", got, root)
+	}
+	m := classifyNativeModule(mod, "Contents/Resources/app.asar.unpacked/node_modules/@scope/pkg/prebuilds/darwin-arm64/addon.node")
+	if m.PackageName != "@scope/pkg" || m.PackageVersion != "4.5.6" {
+		t.Fatalf("module package = %q@%q, want @scope/pkg@4.5.6", m.PackageName, m.PackageVersion)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add native module package name/version metadata from owning npm package.json
- handle scoped package roots under node_modules
- show package identity in native-module table output and update schema/docs

## Validation
- go test ./internal/detect -run 'TestElectronNativeModules|TestNativeModulePackageRoot' -count=1
- go test ./cmd/spectra -run TestNativeModuleLabelIncludesPackageVersion -count=1
- go test ./... -count=1
- go build ./...
- go vet ./...
- golangci-lint run
- gocyclo -over 15 -ignore '_test\.go$' .
- git diff --check
- make docs-validate