### PR TITLE
Add native module capability hints

### DIFF
--- a/docs/detection/native-modules.md
+++ b/docs/detection/native-modules.md
@@ -15,6 +15,17 @@ For each `.node` file, Spectra first walks up to the owning
 surfaced alongside the module filename so output can distinguish
 `pty.node` from `node-pty@x.y.z`.
 
+Known high-signal packages also add capability hints. Examples:
+
+| Package | Hint |
+|---|---|
+| `keytar` / `node-keytar` | uses macOS Keychain |
+| `node-mac-notifier` | uses Notification Center |
+| `node-pty` | uses pseudoterminals |
+| `fsevents` | watches filesystem events |
+| `@serialport/bindings-cpp` | uses serial devices |
+| `usb` / `node-hid` | uses USB or HID devices |
+
 Then language classification runs in order:
 
 1. **Rust signal #1 — Cargo target path.** If the link map contains
@@ -99,8 +110,5 @@ useful classification than "Electron."
 
 ## Future ideas
 
-- Detect specific high-signal modules by name (e.g. `node-keytar` →
-  "uses macOS Keychain"; `node-mac-notifier` → "uses Notification Center")
-  and surface that as a capability hint.
 - Cross-reference with Electron's known security-sensitive modules to
   flag risk patterns.

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -965,6 +965,7 @@ func nativeModuleRoots(appPath string) []string {
 func classifyNativeModule(absPath, relPath string) NativeModule {
 	m := NativeModule{Name: filepath.Base(absPath), Path: relPath, Language: "C++"}
 	readNativeModulePackage(absPath, &m)
+	appendNativeModuleCapabilityHints(&m)
 	libs := otoolL(absPath)
 	joined := strings.Join(libs, "\n")
 
@@ -1014,6 +1015,29 @@ func classifyNativeModule(absPath, relPath string) NativeModule {
 		m.Hints = append(m.Hints, "links libc++")
 	}
 	return m
+}
+
+var nativeModuleCapabilityHints = map[string][]string{
+	"@serialport/bindings-cpp": {"uses serial devices"},
+	"better-sqlite3":           {"uses local SQLite native binding"},
+	"fsevents":                 {"watches filesystem events"},
+	"iohook":                   {"can observe global input events"},
+	"keytar":                   {"uses macOS Keychain"},
+	"node-hid":                 {"uses HID devices"},
+	"node-keytar":              {"uses macOS Keychain"},
+	"node-mac-notifier":        {"uses Notification Center"},
+	"node-pty":                 {"uses pseudoterminals"},
+	"robotjs":                  {"can synthesize keyboard/mouse input"},
+	"sqlite3":                  {"uses local SQLite native binding"},
+	"uiohook-napi":             {"can observe global input events"},
+	"usb":                      {"uses USB devices"},
+}
+
+func appendNativeModuleCapabilityHints(m *NativeModule) {
+	if m.PackageName == "" {
+		return
+	}
+	m.Hints = append(m.Hints, nativeModuleCapabilityHints[strings.ToLower(m.PackageName)]...)
 }
 
 func readNativeModulePackage(absPath string, m *NativeModule) {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -384,6 +384,34 @@ func TestNativeModulePackageRootHandlesScopedPackages(t *testing.T) {
 	}
 }
 
+func TestNativeModuleCapabilityHintsFromPackageName(t *testing.T) {
+	app := makeBundle(t, "FakeKeytarNativeModule")
+	root := filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/keytar")
+	mod := filepath.Join(root, "build/Release/keytar.node")
+	if err := os.MkdirAll(filepath.Dir(mod), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mod, []byte("native addon"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "package.json"), []byte(`{"name":"keytar","version":"7.9.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := classifyNativeModule(mod, "Contents/Resources/app.asar.unpacked/node_modules/keytar/build/Release/keytar.node")
+	if !hasHint(m.Hints, "uses macOS Keychain") {
+		t.Fatalf("hints = %v, want macOS Keychain hint", m.Hints)
+	}
+}
+
+func hasHint(hints []string, want string) bool {
+	for _, hint := range hints {
+		if hint == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestNativeModuleRootsOnlyExistingElectronPayloads(t *testing.T) {
 	app := makeBundle(t, "FakeNativeRoots")
 	if roots := nativeModuleRoots(app); len(roots) != 0 {


### PR DESCRIPTION
## Summary
- add capability hints for high-signal native npm packages such as keytar, node-mac-notifier, node-pty, fsevents, serialport, USB/HID, and input hook modules
- attach hints during native module classification after package.json metadata is read
- document the package-to-capability mapping and remove the implemented future item

## Validation
- go test ./internal/detect -run 'TestNativeModuleCapabilityHints|TestElectronNativeModules|TestNativeModulePackageRoot' -count=1
- go test ./... -count=1
- go build ./...
- go vet ./...
- golangci-lint run --allow-parallel-runners
- gocyclo -over 15 -ignore '_test\.go$' .
- git diff --check
- make docs-validate