### PR TITLE
Flag native module risk patterns

### DIFF
--- a/cmd/spectra/inspect.go
+++ b/cmd/spectra/inspect.go
@@ -147,6 +147,9 @@ func printTable(rs []detect.Result, verbose bool) {
 					for _, h := range m.Hints {
 						fmt.Printf("           %s\n", h)
 					}
+					for _, h := range m.RiskHints {
+						fmt.Printf("           risk: %s\n", h)
+					}
 				}
 			}
 		}

--- a/docs/detection/native-modules.md
+++ b/docs/detection/native-modules.md
@@ -26,6 +26,20 @@ Known high-signal packages also add capability hints. Examples:
 | `@serialport/bindings-cpp` | uses serial devices |
 | `usb` / `node-hid` | uses USB or HID devices |
 
+Security-sensitive packages also populate `RiskHints`, separate from the
+general capability `Hints`, so reviewers can filter for modules that may
+touch credentials, input, devices, shells, or privacy-permission state.
+
+| Package | Risk hint |
+|---|---|
+| `keytar` / `node-keytar` | credential store access |
+| `iohook` / `uiohook-napi` | global input monitoring |
+| `robotjs` | synthetic input control |
+| `node-pty` | shell or terminal process control |
+| `fsevents` | filesystem activity monitoring |
+| `@serialport/bindings-cpp`, `usb`, `node-hid` | external device access |
+| `node-mac-permissions` | privacy permission probing |
+
 Then language classification runs in order:
 
 1. **Rust signal #1 — Cargo target path.** If the link map contains
@@ -110,5 +124,5 @@ useful classification than "Electron."
 
 ## Future ideas
 
-- Cross-reference with Electron's known security-sensitive modules to
-  flag risk patterns.
+- Expand `RiskHints` as more Electron native modules show repeatable
+  security-sensitive patterns in real apps.

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -67,6 +67,7 @@ type NativeModule struct {
     PackageVersion string   // npm package version when package.json is present
     Language       string   // Rust, Swift, C++, unknown
     Hints          []string // additional context (linked frameworks, etc.)
+    RiskHints      []string // security-sensitive capability patterns to review
 }
 ```
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -159,6 +159,7 @@ type NativeModule struct {
 	PackageVersion string // npm package version when package.json is present
 	Language       string // Rust, Swift, C++, unknown
 	Hints          []string
+	RiskHints      []string // security-sensitive capability patterns to review
 }
 
 // Options controls optional, more expensive sub-detections.
@@ -966,6 +967,7 @@ func classifyNativeModule(absPath, relPath string) NativeModule {
 	m := NativeModule{Name: filepath.Base(absPath), Path: relPath, Language: "C++"}
 	readNativeModulePackage(absPath, &m)
 	appendNativeModuleCapabilityHints(&m)
+	appendNativeModuleRiskHints(&m)
 	libs := otoolL(absPath)
 	joined := strings.Join(libs, "\n")
 
@@ -1038,6 +1040,27 @@ func appendNativeModuleCapabilityHints(m *NativeModule) {
 		return
 	}
 	m.Hints = append(m.Hints, nativeModuleCapabilityHints[strings.ToLower(m.PackageName)]...)
+}
+
+var nativeModuleRiskHints = map[string][]string{
+	"@serialport/bindings-cpp": {"external device access"},
+	"fsevents":                 {"filesystem activity monitoring"},
+	"iohook":                   {"global input monitoring"},
+	"keytar":                   {"credential store access"},
+	"node-hid":                 {"external device access"},
+	"node-keytar":              {"credential store access"},
+	"node-mac-permissions":     {"privacy permission probing"},
+	"node-pty":                 {"shell or terminal process control"},
+	"robotjs":                  {"synthetic input control"},
+	"uiohook-napi":             {"global input monitoring"},
+	"usb":                      {"external device access"},
+}
+
+func appendNativeModuleRiskHints(m *NativeModule) {
+	if m.PackageName == "" {
+		return
+	}
+	m.RiskHints = append(m.RiskHints, nativeModuleRiskHints[strings.ToLower(m.PackageName)]...)
 }
 
 func readNativeModulePackage(absPath string, m *NativeModule) {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -401,6 +401,31 @@ func TestNativeModuleCapabilityHintsFromPackageName(t *testing.T) {
 	if !hasHint(m.Hints, "uses macOS Keychain") {
 		t.Fatalf("hints = %v, want macOS Keychain hint", m.Hints)
 	}
+	if !hasHint(m.RiskHints, "credential store access") {
+		t.Fatalf("risk hints = %v, want credential store access", m.RiskHints)
+	}
+}
+
+func TestNativeModuleRiskHintsFromPackageName(t *testing.T) {
+	app := makeBundle(t, "FakeInputHookNativeModule")
+	root := filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/uiohook-napi")
+	mod := filepath.Join(root, "prebuilds/darwin-arm64/uiohook.node")
+	if err := os.MkdirAll(filepath.Dir(mod), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mod, []byte("native addon"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "package.json"), []byte(`{"name":"uiohook-napi","version":"1.5.4"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := classifyNativeModule(mod, "Contents/Resources/app.asar.unpacked/node_modules/uiohook-napi/prebuilds/darwin-arm64/uiohook.node")
+	if !hasHint(m.Hints, "can observe global input events") {
+		t.Fatalf("hints = %v, want input capability hint", m.Hints)
+	}
+	if !hasHint(m.RiskHints, "global input monitoring") {
+		t.Fatalf("risk hints = %v, want global input monitoring", m.RiskHints)
+	}
 }
 
 func hasHint(hints []string, want string) bool {


### PR DESCRIPTION
## Summary
- add NativeModule.RiskHints for security-sensitive native package patterns
- flag credential-store, global-input, synthetic-input, shell/terminal, filesystem, external-device, and privacy-permission patterns
- show risk hints in verbose native-module output and document the schema/docs behavior

## Validation
- go test ./internal/detect -run 'TestNativeModuleCapabilityHints|TestNativeModuleRiskHints' -count=1
- go test ./... -count=1
- go build ./...
- go vet ./...
- golangci-lint run --allow-parallel-runners
- gocyclo -over 15 -ignore '_test\.go$' .
- git diff --check
- make docs-validate