### PR TITLE
Expose app uptime in detection results

### DIFF
--- a/cmd/spectra/inspect.go
+++ b/cmd/spectra/inspect.go
@@ -299,16 +299,12 @@ func loginItemLabel(li detect.LoginItem) string {
 func printRuntimeMeta(r detect.Result) {
 	if len(r.RunningProcesses) > 0 {
 		var totalRSS int
-		var oldest time.Time
 		for _, p := range r.RunningProcesses {
 			totalRSS += p.RSSKiB
-			if !p.StartTime.IsZero() && (oldest.IsZero() || p.StartTime.Before(oldest)) {
-				oldest = p.StartTime
-			}
 		}
 		uptimeStr := ""
-		if !oldest.IsZero() {
-			d := time.Since(oldest).Round(time.Second)
+		if r.AppStartedAt != nil {
+			d := time.Duration(r.AppUptimeSeconds) * time.Second
 			uptimeStr = fmt.Sprintf(", uptime %s", formatDuration(d))
 		}
 		fmt.Printf("    running: %d processes, %s RSS%s\n",

--- a/docs/inspection/running-processes.md
+++ b/docs/inspection/running-processes.md
@@ -22,6 +22,10 @@ For each match Spectra captures:
 - **Command** — bundle-relative path (so `Contents/MacOS/Slack Helper`
   rather than the full `/Applications/Slack.app/...`)
 
+For app-level inspection, Spectra also computes `AppStartedAt` from the
+oldest matching process and `AppUptimeSeconds` from that timestamp to the
+inspection time.
+
 With `spectra process --deep`, Spectra also runs one batched
 `lsof -p <pid1,pid2,...>` call to collect:
 
@@ -33,7 +37,7 @@ With `spectra process --deep`, Spectra also runs one batched
 
 ```
 Claude
-  running: 35 processes, 2.4 GB RSS
+  running: 35 processes, 2.4 GB RSS, uptime 3h42m
 ```
 
 The 35 procs are Chromium's main + helper architecture: one main
@@ -65,7 +69,9 @@ The `RunningProcesses` field on the JSON result holds the full list:
   {"PID": 412, "RSSKiB": 184320, "Command": "Contents/MacOS/Claude"},
   {"PID": 415, "RSSKiB": 92160,  "Command": "Contents/Frameworks/Claude Helper.app/Contents/MacOS/Claude Helper"},
   ...
-]
+],
+"AppStartedAt": "2026-05-06T08:18:00Z",
+"AppUptimeSeconds": 13320
 ```
 
 ## Why this matters
@@ -113,4 +119,3 @@ Full process inventory in `internal/process/`:
 - Switch to `libproc` via cgo (or `process.NewProcess` from
   `gopsutil`) to get richer per-process data without forking the
   initial `ps` inventory.
-- Compute "app uptime" from the oldest matching process's start time.

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -51,6 +51,8 @@ Source of truth: `internal/detect/detect.go`.
 | `Helpers` | *Helpers | Helper apps, XPC services, plugins |
 | `LoginItems` | []LoginItem | Attributed launchd plists |
 | `RunningProcesses` | []ProcessInfo | Currently-running processes for this bundle |
+| `AppStartedAt` | *time.Time | Oldest matching process start time |
+| `AppUptimeSeconds` | int64 | Seconds between inspection time and `AppStartedAt` |
 | `Storage` | *StorageFootprint | Per-`~/Library`-location size sweep |
 | `Dependencies` | *Dependencies | Third-party frameworks, npm packages, jar count |
 | `NetworkEndpoints` | []string | URL hosts (only when `--network` set) |

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -81,6 +81,8 @@ type Result struct {
 	// RunningProcesses lists currently-running processes whose executable
 	// path is inside this app bundle.
 	RunningProcesses []ProcessInfo
+	AppStartedAt     *time.Time `json:",omitempty"` // oldest matching process start time
+	AppUptimeSeconds int64      `json:",omitempty"` // seconds since AppStartedAt at inspection time
 
 	// GrantedPermissions are the privacy permissions actually granted to
 	// this bundle by the user (TCC.db). Distinct from PrivacyDescriptions
@@ -165,6 +167,7 @@ type NativeModule struct {
 // Options controls optional, more expensive sub-detections.
 type Options struct {
 	ScanNetwork bool // scan binary + app.asar for embedded URL hosts
+	Now         func() time.Time
 }
 
 // Detect inspects the bundle at appPath and returns a Result.
@@ -222,12 +225,20 @@ func DetectWith(appPath string, opts Options) (Result, error) {
 	r.Helpers = scanHelpers(appPath)
 	r.LoginItems = scanLoginItems(appPath, r.BundleID)
 	r.RunningProcesses = scanRunningProcesses(appPath)
+	r.AppStartedAt, r.AppUptimeSeconds = appUptime(r.RunningProcesses, detectNow(opts))
 	r.GrantedPermissions = scanGrantedPermissions(r.BundleID)
 	r.GatekeeperStatus = readGatekeeperStatus(appPath)
 	if opts.ScanNetwork {
 		r.NetworkEndpoints = scanNetworkEndpoints(appPath, exe)
 	}
 	return r, nil
+}
+
+func detectNow(opts Options) time.Time {
+	if opts.Now != nil {
+		return opts.Now()
+	}
+	return time.Now()
 }
 
 // populateMetadata fills the metadata fields on Result. Each piece is
@@ -1477,7 +1488,7 @@ func scanRunningProcesses(appPath string) []ProcessInfo {
 		}
 
 		lstartStr := strings.Join(fields[2:7], " ")
-		startTime, _ := time.Parse(lstartLayout, lstartStr)
+		startTime := parseLstart(lstartStr)
 
 		procs = append(procs, ProcessInfo{
 			PID:       pid,
@@ -1487,6 +1498,32 @@ func scanRunningProcesses(appPath string) []ProcessInfo {
 		})
 	}
 	return procs
+}
+
+func parseLstart(s string) time.Time {
+	t, _ := time.ParseInLocation(lstartLayout, s, time.Local)
+	return t
+}
+
+func appUptime(procs []ProcessInfo, now time.Time) (*time.Time, int64) {
+	var oldest time.Time
+	for _, p := range procs {
+		if p.StartTime.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || p.StartTime.Before(oldest) {
+			oldest = p.StartTime
+		}
+	}
+	if oldest.IsZero() {
+		return nil, 0
+	}
+	seconds := int64(now.Sub(oldest).Seconds())
+	if seconds < 0 {
+		seconds = 0
+	}
+	started := oldest
+	return &started, seconds
 }
 
 // readPrivacyDescriptions returns the NS*UsageDescription keys declared

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -428,6 +428,47 @@ func TestNativeModuleRiskHintsFromPackageName(t *testing.T) {
 	}
 }
 
+func TestAppUptimeUsesOldestProcessStart(t *testing.T) {
+	newer := time.Date(2026, 5, 6, 11, 30, 0, 0, time.UTC)
+	older := time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	started, seconds := appUptime([]ProcessInfo{
+		{PID: 10, StartTime: newer},
+		{PID: 11, StartTime: older},
+	}, now)
+	if started == nil || !started.Equal(older) {
+		t.Fatalf("started = %v, want %v", started, older)
+	}
+	if seconds != 7200 {
+		t.Fatalf("seconds = %d, want 7200", seconds)
+	}
+}
+
+func TestAppUptimeIgnoresMissingStartTimes(t *testing.T) {
+	started, seconds := appUptime([]ProcessInfo{{PID: 10}}, time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC))
+	if started != nil {
+		t.Fatalf("started = %v, want nil", started)
+	}
+	if seconds != 0 {
+		t.Fatalf("seconds = %d, want 0", seconds)
+	}
+}
+
+func TestParseLstartUsesLocalTimeZone(t *testing.T) {
+	oldLocal := time.Local
+	loc := time.FixedZone("Spectra/Test", -5*60*60)
+	time.Local = loc
+	t.Cleanup(func() { time.Local = oldLocal })
+
+	got := parseLstart("Wed May  6 12:34:56 2026")
+	if got.Location() != loc {
+		t.Fatalf("location = %v, want %v", got.Location(), loc)
+	}
+	if got.Hour() != 12 || got.Minute() != 34 || got.Second() != 56 {
+		t.Fatalf("parsed time = %v", got)
+	}
+}
+
 func hasHint(hints []string, want string) bool {
 	for _, hint := range hints {
 		if hint == want {


### PR DESCRIPTION
## Summary
- add AppStartedAt and AppUptimeSeconds to detection results based on the oldest matching app process
- use the structured uptime fields in table output instead of recomputing there
- parse ps lstart values in the local timezone and document the JSON/schema behavior

## Validation
- go test ./internal/detect -run 'TestAppUptime|TestParseLstart' -count=1
- go test ./... -count=1
- go build ./...
- go vet ./...
- golangci-lint run --allow-parallel-runners
- gocyclo -over 15 -ignore '_test\.go$' .
- git diff --check
- make docs-validate