### PR TITLE
Add JVM GC pressure rule

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -150,6 +150,7 @@ Implemented rules:
 
 - `jvm-eol-version`
 - `jvm-heap-vs-system`
+- `jvm-gc-pressure`
 - `jdk-major-version-drift`
 - `java-home-mismatch`
 - `library-storage-footprint`

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -3,10 +3,11 @@
 Spectra implements the JDK shell-tool layer of JVM inspection today:
 running-process discovery, structured per-PID metadata, thread dumps,
 heap histograms, heap dumps, one-shot GC stats, and JFR start/dump/stop.
-It also parses `jfr summary` output into structured event counts and
-attributes running JVMs back to the installed-JDK inventory when
-`java.home` matches a discovered JDK path. The in-process Java agent layer
-remains future work.
+The JVM snapshot includes one-shot `jstat -gc` counters for each running
+JVM when `jstat` is available. It also parses `jfr summary` output into
+structured event counts and attributes running JVMs back to the
+installed-JDK inventory when `java.home` matches a discovered JDK path.
+The in-process Java agent layer remains future work.
 
 Spectra is intended to **supplant VisualVM** for the day-to-day
 "what's this Java process doing" question. JVM inspection is a
@@ -168,12 +169,14 @@ Implemented:
 2. `jps`-based running-JVM discovery.
 3. `jcmd`-based system properties, command-line parsing, VM flags,
    thread count, thread dump, class histogram, heap dump, and JFR control.
-4. `jstat -gc` one-shot GC counter parsing.
+4. `jstat -gc` one-shot GC counter parsing and snapshot attachment.
 5. CLI and daemon RPC surfaces for the implemented collectors.
 6. Path-based attribution from each running JVM's `java.home` to the
    installed-JDK inventory.
 7. `jfr summary` parsing for structured recording metadata and event
    counts.
+8. JVM GC-pressure recommendations from old-generation occupancy and
+   full-GC counters.
 
 Future:
 

--- a/internal/jvm/collect.go
+++ b/internal/jvm/collect.go
@@ -88,6 +88,9 @@ func collectOne(_ context.Context, pid int, main string, run CmdRunner, jdks []t
 
 	info.VMFlags, info.VMArgs = collectCommandLine(pid, run)
 	info.ThreadCount = collectThreadCount(pid, run)
+	if gc, err := CollectGCStats(pid, run); err == nil {
+		info.GC = gc
+	}
 	attributeJDK(&info, jdks)
 
 	return info

--- a/internal/jvm/jvm_test.go
+++ b/internal/jvm/jvm_test.go
@@ -305,6 +305,10 @@ java_command: com.example.Server
 "GC Thread" #2
 `), nil
 			}
+		case "jstat":
+			return []byte(`S0C S1C S0U S1U EC EU OC OU MC MU CCSC CCSU YGC YGCT FGC FGCT GCT
+0.0 0.0 0.0 0.0 40960.0 20480.0 204800.0 4096.0 61440.0 59900.3 8064.0 7678.7 5 0.078 0 0.000 0.078
+`), nil
 		}
 		return nil, fmt.Errorf("unexpected: %s %v", name, args)
 	}
@@ -334,6 +338,9 @@ java_command: com.example.Server
 	}
 	if info.SysProps["java.home"] != "/usr/lib/jvm/temurin-21" {
 		t.Errorf("java.home = %q", info.SysProps["java.home"])
+	}
+	if info.GC == nil || info.GC.YGC != 5 {
+		t.Fatalf("GC = %#v, want YGC=5", info.GC)
 	}
 }
 

--- a/internal/jvm/types.go
+++ b/internal/jvm/types.go
@@ -21,6 +21,7 @@ type Info struct {
 	VMArgs       string            `json:"vm_args,omitempty"`  // from jcmd VM.command_line
 	VMFlags      string            `json:"vm_flags,omitempty"` // JVM flags (XX: flags)
 	ThreadCount  int               `json:"thread_count,omitempty"`
+	GC           *GCStats          `json:"gc,omitempty"`        // one-shot jstat -gc counters
 	SysProps     map[string]string `json:"sys_props,omitempty"` // selected system properties
 }
 

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
@@ -17,6 +18,7 @@ func V1Catalog() []Rule {
 	return []Rule{
 		ruleJVMEOLVersion(),
 		ruleJVMHeapVsSystemRAM(),
+		ruleJVMGCPressure(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),
 		ruleStorageFootprint(),
@@ -106,6 +108,51 @@ func ruleJVMHeapVsSystemRAM() Rule {
 			return findings
 		},
 	}
+}
+
+// ruleJVMGCPressure fires when a one-shot jstat snapshot suggests the JVM is
+// under memory pressure: old generation is nearly full or full GC has already
+// consumed meaningful wall time.
+func ruleJVMGCPressure() Rule {
+	return Rule{
+		ID:       "jvm-gc-pressure",
+		Severity: SeverityMedium,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, j := range s.JVMs {
+				if j.GC == nil {
+					continue
+				}
+				if pct := oldGenUsedPct(j.GC); pct >= 90 {
+					findings = append(findings, Finding{
+						RuleID:   "jvm-gc-pressure",
+						Severity: SeverityMedium,
+						Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
+						Message:  fmt.Sprintf("Old generation is %.0f%% full; allocation pressure may trigger frequent full GC.", pct),
+						Fix:      "Inspect heap histogram/JFR allocation events and reduce live-set size or adjust heap sizing.",
+					})
+					continue
+				}
+				if j.GC.FGC >= 5 && j.GC.FGCT >= 1 {
+					findings = append(findings, Finding{
+						RuleID:   "jvm-gc-pressure",
+						Severity: SeverityMedium,
+						Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
+						Message:  fmt.Sprintf("%d full GCs have consumed %.1fs; check for old-gen pressure or promotion failures.", j.GC.FGC, j.GC.FGCT),
+						Fix:      "Capture a JFR recording or heap histogram to identify allocation hot spots and retained objects.",
+					})
+				}
+			}
+			return findings
+		},
+	}
+}
+
+func oldGenUsedPct(stats *jvm.GCStats) float64 {
+	if stats == nil || stats.OC <= 0 {
+		return 0
+	}
+	return stats.OU * 100 / stats.OC
 }
 
 // ruleJDKMajorVersionDrift fires when more than one installed JDK shares

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -119,6 +119,46 @@ func TestJVMHeapVsSystemNoFire(t *testing.T) {
 	}
 }
 
+// --- jvm-gc-pressure ---
+
+func TestJVMGCPressureFiresForOldGenOccupancy(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{
+		{PID: 10, MainClass: "hot.App", GC: &jvm.GCStats{OC: 1000, OU: 925}},
+		{PID: 11, MainClass: "ok.App", GC: &jvm.GCStats{OC: 1000, OU: 500}},
+	}
+	findings := ruleJVMGCPressure().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 GC pressure finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].RuleID != "jvm-gc-pressure" {
+		t.Fatalf("rule ID = %q", findings[0].RuleID)
+	}
+}
+
+func TestJVMGCPressureFiresForFullGCTime(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{PID: 10, MainClass: "fullgc.App", GC: &jvm.GCStats{FGC: 7, FGCT: 1.8}}}
+	findings := ruleJVMGCPressure().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 GC pressure finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityMedium {
+		t.Fatalf("severity = %q, want medium", findings[0].Severity)
+	}
+}
+
+func TestJVMGCPressureNoFire(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{
+		{PID: 10, GC: &jvm.GCStats{OC: 1000, OU: 700, FGC: 4, FGCT: 0.9}},
+		{PID: 11},
+	}
+	if findings := ruleJVMGCPressure().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("expected no GC pressure findings, got %v", findings)
+	}
+}
+
 // --- jdk-major-version-drift ---
 
 func TestJDKDriftFires(t *testing.T) {


### PR DESCRIPTION
## Summary
- attach one-shot jstat -gc counters to JVM process snapshots when available
- add a built-in jvm-gc-pressure recommendation for old-generation occupancy and full-GC pressure
- update JVM and recommendations docs to reflect GC snapshot attachment and the new V1 rule

## Validation
- go test ./internal/jvm -run 'TestCollectAllSingleProcess|TestCollectGCStats|TestParseGCStats' -count=1
- go test ./internal/rules -run 'TestJVMGCPressure|TestV1Catalog' -count=1
- go test ./... -count=1
- go build ./...
- go vet ./...
- golangci-lint run --allow-parallel-runners
- gocyclo -over 15 -ignore '_test\.go$' .
- git diff --check
- make docs-validate