### PR TITLE
Add detached serve mode

### DIFF
--- a/cmd/spectra/detach_darwin.go
+++ b/cmd/spectra/detach_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package main
+
+import "syscall"
+
+func detachedSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/cmd/spectra/detach_other.go
+++ b/cmd/spectra/detach_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package main
+
+import "syscall"
+
+func detachedSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}

--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 	"time"
@@ -25,12 +26,21 @@ func runServe(args []string) int {
 	allowRemote := fs.Bool("allow-remote", false, "Allow --tcp to bind a non-loopback address")
 	logFile := fs.String("log-file", "", "JSONL daemon log path (default: ~/Library/Logs/Spectra/daemon.jsonl)")
 	noLogFile := fs.Bool("no-log-file", false, "Disable the daemon JSONL log file")
+	daemon := fs.Bool("daemon", false, "Start spectra serve in the background and return")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *tcpAddr != "" && !*allowRemote && !isLoopbackListenAddr(*tcpAddr) {
-		fmt.Fprintln(os.Stderr, "spectra serve: --tcp is limited to loopback unless --allow-remote is set")
+	if err := validateServeListen(*tcpAddr, *allowRemote); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		return 2
+	}
+	if *daemon {
+		if err := startDetachedServeFunc(serveChildArgs(args)); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Fprintln(os.Stderr, "spectra serve: started in background")
+		return 0
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -80,6 +90,50 @@ func runServe(args []string) int {
 		return 1
 	}
 	return 0
+}
+
+func validateServeListen(tcpAddr string, allowRemote bool) error {
+	if tcpAddr != "" && !allowRemote && !isLoopbackListenAddr(tcpAddr) {
+		return fmt.Errorf("spectra serve: --tcp is limited to loopback unless --allow-remote is set")
+	}
+	return nil
+}
+
+var startDetachedServeFunc = startDetachedServe
+
+func serveChildArgs(args []string) []string {
+	child := []string{"serve"}
+	for _, arg := range args {
+		switch arg {
+		case "--daemon", "-daemon", "--daemon=true", "-daemon=true":
+			continue
+		default:
+			child = append(child, arg)
+		}
+	}
+	return child
+}
+
+func startDetachedServe(args []string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable: %w", err)
+	}
+	null, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", os.DevNull, err)
+	}
+	defer null.Close()
+	// #nosec G204 -- restarts this executable with parsed serve flags, no shell.
+	cmd := exec.Command(exe, args...)
+	cmd.Stdin = null
+	cmd.Stdout = null
+	cmd.Stderr = null
+	cmd.SysProcAttr = detachedSysProcAttr()
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start detached spectra serve: %w", err)
+	}
+	return nil
 }
 
 func openDaemonLogger(path string, disabled bool) (logger.Logger, func(), string, error) {

--- a/cmd/spectra/serve_test.go
+++ b/cmd/spectra/serve_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -34,5 +35,32 @@ func TestOpenDaemonLoggerCreatesFile(t *testing.T) {
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestServeChildArgsDropsDaemonFlag(t *testing.T) {
+	got := serveChildArgs([]string{"--daemon", "--sock", "/tmp/spectra.sock", "--no-log-file"})
+	want := []string{"serve", "--sock", "/tmp/spectra.sock", "--no-log-file"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("serveChildArgs = %v, want %v", got, want)
+	}
+}
+
+func TestRunServeDaemonStartsDetached(t *testing.T) {
+	old := startDetachedServeFunc
+	t.Cleanup(func() { startDetachedServeFunc = old })
+	var got []string
+	startDetachedServeFunc = func(args []string) error {
+		got = append([]string(nil), args...)
+		return nil
+	}
+
+	code := runServe([]string{"--daemon", "--sock", "/tmp/spectra.sock", "--no-log-file"})
+	if code != 0 {
+		t.Fatalf("runServe code = %d, want 0", code)
+	}
+	want := []string{"serve", "--sock", "/tmp/spectra.sock", "--no-log-file"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("detached args = %v, want %v", got, want)
 	}
 }

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -21,10 +21,13 @@ spectra serve --sock /tmp/spectra.sock
 spectra serve --tcp 127.0.0.1:7878
 spectra serve --log-file /tmp/spectra-daemon.jsonl
 spectra serve --no-log-file
+spectra serve --daemon       # start detached and return
 ```
 
-The current CLI runs in the foreground until interrupted. A launchd-managed
-agent or detached `--daemon` mode is still future packaging work.
+By default the CLI runs in the foreground until interrupted. `--daemon`
+starts a detached `spectra serve` child with the same serve flags and
+returns immediately. Launchd-managed agent packaging remains future
+distribution work.
 
 By default, structured daemon lifecycle logs are appended to
 `~/Library/Logs/Spectra/daemon.jsonl` with `0600` permissions. Foreground
@@ -160,6 +163,6 @@ Implemented:
 Future:
 
 1. CLI-wide RPC dispatch instead of in-process command execution.
-2. launchd or detached daemon lifecycle.
+2. launchd-managed daemon lifecycle.
 3. tsnet listener and Tailscale identity integration.
 4. TUI/GUI clients.


### PR DESCRIPTION
## Summary
- add spectra serve --daemon to spawn a detached serve child and return
- scrub the daemon flag from child args and detach stdio/session on Darwin
- update daemon lifecycle docs and add fake-backed CLI tests

## Validation
- go test ./cmd/spectra -run 'TestServeChildArgs|TestRunServeDaemon|TestOpenDaemonLogger' -count=1
- go test ./... -count=1
- go build ./...
- go vet ./...
- golangci-lint run --allow-parallel-runners
- gocyclo -over 15 -ignore '_test\.go$' .
- git diff --check
- make docs-validate