### PR TITLE
Add typed connect shortcuts

### DIFF
--- a/cmd/spectra/connect.go
+++ b/cmd/spectra/connect.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,8 +73,12 @@ func runConnect(args []string) int {
 }
 
 func printConnectUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: spectra connect [--timeout 3s] <target> [status|health|jvm|processes|network|toolchains]")
+	fmt.Fprintln(w, "usage: spectra connect [--timeout 3s] <target> [status|host|jvm|processes|network|storage|power|rules]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> inspect <App.app>")
+	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> jvm <pid> | jvm-gc <pid> | jvm-threads <pid> | jvm-heap <pid>")
+	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> sample <pid> [duration] [interval]")
+	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> snapshot [list|create|get|diff|processes|login-items|granted-perms|prune] ...")
+	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> storage <App.app> [more.apps] | network-by-app [App.app ...]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> call <method> [json-params]")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "targets: local, unix:/path/to/sock, /path/to/sock, host:port, host")
@@ -103,7 +108,13 @@ func parseConnectTarget(raw string) (connectTarget, error) {
 }
 
 func parseConnectCall(args []string) (string, json.RawMessage, error) {
-	if len(args) == 0 || args[0] == "status" || args[0] == "health" {
+	if len(args) == 0 {
+		return "health", nil, nil
+	}
+	if args[0] == "status" || args[0] == "health" {
+		if len(args) != 1 {
+			return "", nil, fmt.Errorf("connect %s takes no extra arguments", args[0])
+		}
 		return "health", nil, nil
 	}
 	if method, params, ok, err := parseConnectShortcut(args); ok || err != nil {
@@ -113,28 +124,232 @@ func parseConnectCall(args []string) (string, json.RawMessage, error) {
 }
 
 func parseConnectShortcut(args []string) (string, json.RawMessage, bool, error) {
-	shortcuts := map[string]string{
-		"jvm":        "jvm.list",
-		"process":    "process.list",
-		"processes":  "process.list",
-		"network":    "network.state",
-		"toolchain":  "toolchain.scan",
-		"toolchains": "toolchain.scan",
+	if method, ok := connectPIDShortcuts()[args[0]]; ok {
+		return parseConnectPIDCall(args, method)
 	}
-	if method, ok := shortcuts[args[0]]; ok {
+	if shortcut, ok := connectStringSliceShortcuts()[args[0]]; ok {
+		return parseConnectStringSliceCall(args, shortcut.method, shortcut.paramKey)
+	}
+	if method, ok := connectNoArgShortcuts()[args[0]]; ok {
 		if len(args) != 1 {
 			return "", nil, true, fmt.Errorf("connect %s takes no extra arguments", args[0])
 		}
 		return method, nil, true, nil
 	}
-	if args[0] != "inspect" {
-		return "", nil, false, nil
+	switch args[0] {
+	case "inspect":
+		return parseConnectInspect(args)
+	case "jvm":
+		return parseConnectOptionalPID(args, "jvm.list", "jvm.inspect")
+	case "sample":
+		return parseConnectSample(args)
+	case "storage":
+		if len(args) == 1 {
+			return "storage.system", nil, true, nil
+		}
+		return parseConnectStringSliceCall(args, "storage.byApp", "paths")
+	case "rules":
+		if len(args) == 1 {
+			return "rules.check", nil, true, nil
+		}
+		if len(args) == 2 {
+			return "rules.check", connectParams(map[string]string{"snapshot_id": args[1]}), true, nil
+		}
+		return "", nil, true, fmt.Errorf("connect rules accepts at most one snapshot id")
+	case "snapshot":
+		return parseConnectSnapshot(args)
 	}
+	return "", nil, false, nil
+}
+
+func connectPIDShortcuts() map[string]string {
+	return map[string]string{
+		"jvm-gc":             "jvm.gc_stats",
+		"jvm-heap":           "jvm.heap_histogram",
+		"jvm-heap-histogram": "jvm.heap_histogram",
+		"jvm-thread-dump":    "jvm.thread_dump",
+		"jvm-threads":        "jvm.thread_dump",
+	}
+}
+
+type connectStringSliceShortcut struct {
+	method   string
+	paramKey string
+}
+
+func connectStringSliceShortcuts() map[string]connectStringSliceShortcut {
+	return map[string]connectStringSliceShortcut{
+		"network-apps":   {method: "network.byApp", paramKey: "bundles"},
+		"network-by-app": {method: "network.byApp", paramKey: "bundles"},
+		"process":        {method: "process.list", paramKey: "bundles"},
+		"process-tree":   {method: "process.tree", paramKey: "bundles"},
+		"processes":      {method: "process.list", paramKey: "bundles"},
+		"tree":           {method: "process.tree", paramKey: "bundles"},
+	}
+}
+
+func connectNoArgShortcuts() map[string]string {
+	return map[string]string{
+		"build-tools":         "toolchain.build_tools",
+		"brew":                "toolchain.brew",
+		"cache":               "cache.stats",
+		"cache-stats":         "cache.stats",
+		"connections":         "network.connections",
+		"health":              "health",
+		"host":                "inspect.host",
+		"inspect-host":        "inspect.host",
+		"jdk":                 "jdk.list",
+		"jdk-scan":            "jdk.scan",
+		"jdks":                "jdk.list",
+		"network":             "network.state",
+		"network-connections": "network.connections",
+		"power":               "power.state",
+		"runtimes":            "toolchain.runtimes",
+		"snapshot-create":     "snapshot.create",
+		"snapshot-list":       "snapshot.list",
+		"snapshots":           "snapshot.list",
+		"toolchain":           "toolchain.scan",
+		"toolchains":          "toolchain.scan",
+	}
+}
+
+func parseConnectInspect(args []string) (string, json.RawMessage, bool, error) {
 	if len(args) != 2 {
 		return "", nil, true, fmt.Errorf("connect inspect requires <App.app>")
 	}
-	params, _ := json.Marshal(map[string]string{"path": args[1]})
-	return "inspect.app", json.RawMessage(params), true, nil
+	return "inspect.app", connectParams(map[string]string{"path": args[1]}), true, nil
+}
+
+func parseConnectOptionalPID(args []string, listMethod string, pidMethod string) (string, json.RawMessage, bool, error) {
+	switch len(args) {
+	case 1:
+		return listMethod, nil, true, nil
+	case 2:
+		pid, err := parseConnectPositiveInt(args[1], "pid")
+		if err != nil {
+			return "", nil, true, err
+		}
+		return pidMethod, connectParams(map[string]int{"pid": pid}), true, nil
+	default:
+		return "", nil, true, fmt.Errorf("connect %s accepts at most one pid", args[0])
+	}
+}
+
+func parseConnectPIDCall(args []string, method string) (string, json.RawMessage, bool, error) {
+	if len(args) != 2 {
+		return "", nil, true, fmt.Errorf("connect %s requires <pid>", args[0])
+	}
+	pid, err := parseConnectPositiveInt(args[1], "pid")
+	if err != nil {
+		return "", nil, true, err
+	}
+	return method, connectParams(map[string]int{"pid": pid}), true, nil
+}
+
+func parseConnectSample(args []string) (string, json.RawMessage, bool, error) {
+	if len(args) < 2 || len(args) > 4 {
+		return "", nil, true, fmt.Errorf("connect sample requires <pid> [duration] [interval]")
+	}
+	pid, err := parseConnectPositiveInt(args[1], "pid")
+	if err != nil {
+		return "", nil, true, err
+	}
+	params := map[string]int{"pid": pid}
+	if len(args) >= 3 {
+		duration, err := parseConnectPositiveInt(args[2], "duration")
+		if err != nil {
+			return "", nil, true, err
+		}
+		params["duration"] = duration
+	}
+	if len(args) == 4 {
+		interval, err := parseConnectPositiveInt(args[3], "interval")
+		if err != nil {
+			return "", nil, true, err
+		}
+		params["interval"] = interval
+	}
+	return "process.sample", connectParams(params), true, nil
+}
+
+func parseConnectStringSliceCall(args []string, method string, key string) (string, json.RawMessage, bool, error) {
+	if len(args) == 1 {
+		return method, nil, true, nil
+	}
+	return method, connectParams(map[string][]string{key: args[1:]}), true, nil
+}
+
+func parseConnectSnapshot(args []string) (string, json.RawMessage, bool, error) {
+	if len(args) == 1 {
+		return "snapshot.create", nil, true, nil
+	}
+	switch args[1] {
+	case "create":
+		return connectNoArgSubcommand(args, "snapshot.create")
+	case "list":
+		return connectNoArgSubcommand(args, "snapshot.list")
+	case "get", "show":
+		if len(args) != 3 {
+			return "", nil, true, fmt.Errorf("connect snapshot %s requires <id>", args[1])
+		}
+		return "snapshot.get", connectParams(map[string]string{"ID": args[2]}), true, nil
+	case "diff":
+		if len(args) != 4 {
+			return "", nil, true, fmt.Errorf("connect snapshot diff requires <id-a> <id-b>")
+		}
+		return "snapshot.diff", connectParams(map[string]string{"id_a": args[2], "id_b": args[3]}), true, nil
+	case "processes":
+		return connectSnapshotIDCall(args, "snapshot.processes")
+	case "login-items", "login_items":
+		return connectSnapshotIDCall(args, "snapshot.login_items")
+	case "granted-perms", "granted_perms":
+		return connectSnapshotIDCall(args, "snapshot.granted_perms")
+	case "prune":
+		return parseConnectSnapshotPrune(args)
+	default:
+		return "", nil, true, fmt.Errorf("unknown snapshot subcommand %q", args[1])
+	}
+}
+
+func connectNoArgSubcommand(args []string, method string) (string, json.RawMessage, bool, error) {
+	if len(args) != 2 {
+		return "", nil, true, fmt.Errorf("connect snapshot %s takes no extra arguments", args[1])
+	}
+	return method, nil, true, nil
+}
+
+func connectSnapshotIDCall(args []string, method string) (string, json.RawMessage, bool, error) {
+	if len(args) != 3 {
+		return "", nil, true, fmt.Errorf("connect snapshot %s requires <id>", args[1])
+	}
+	return method, connectParams(map[string]string{"id": args[2]}), true, nil
+}
+
+func parseConnectSnapshotPrune(args []string) (string, json.RawMessage, bool, error) {
+	if len(args) == 2 {
+		return "snapshot.prune", nil, true, nil
+	}
+	if len(args) != 3 {
+		return "", nil, true, fmt.Errorf("connect snapshot prune accepts at most one keep count")
+	}
+	keep, err := parseConnectPositiveInt(args[2], "keep")
+	if err != nil {
+		return "", nil, true, err
+	}
+	return "snapshot.prune", connectParams(map[string]int{"keep": keep}), true, nil
+}
+
+func parseConnectPositiveInt(raw string, name string) (int, error) {
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("invalid %s %q", name, raw)
+	}
+	return value, nil
+}
+
+func connectParams(value any) json.RawMessage {
+	params, _ := json.Marshal(value)
+	return json.RawMessage(params)
 }
 
 func parseConnectGenericCall(args []string) (string, json.RawMessage, error) {

--- a/cmd/spectra/connect_test.go
+++ b/cmd/spectra/connect_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"net"
 	"testing"
@@ -75,18 +76,48 @@ func TestParseConnectCall(t *testing.T) {
 
 func TestParseConnectTypedCalls(t *testing.T) {
 	tests := []struct {
+		name       string
 		args       []string
 		wantMethod string
 		wantParams string
 	}{
-		{args: []string{"jvm"}, wantMethod: "jvm.list"},
-		{args: []string{"processes"}, wantMethod: "process.list"},
-		{args: []string{"network"}, wantMethod: "network.state"},
-		{args: []string{"toolchains"}, wantMethod: "toolchain.scan"},
-		{args: []string{"inspect", "/Applications/Slack.app"}, wantMethod: "inspect.app", wantParams: `{"path":"/Applications/Slack.app"}`},
+		{name: "inspect app", args: []string{"inspect", "/Applications/Slack.app"}, wantMethod: "inspect.app", wantParams: `{"path":"/Applications/Slack.app"}`},
+		{name: "host", args: []string{"host"}, wantMethod: "inspect.host"},
+		{name: "jvm list", args: []string{"jvm"}, wantMethod: "jvm.list"},
+		{name: "jvm inspect", args: []string{"jvm", "4012"}, wantMethod: "jvm.inspect", wantParams: `{"pid":4012}`},
+		{name: "jvm gc", args: []string{"jvm-gc", "4012"}, wantMethod: "jvm.gc_stats", wantParams: `{"pid":4012}`},
+		{name: "jvm threads", args: []string{"jvm-threads", "4012"}, wantMethod: "jvm.thread_dump", wantParams: `{"pid":4012}`},
+		{name: "jvm heap", args: []string{"jvm-heap", "4012"}, wantMethod: "jvm.heap_histogram", wantParams: `{"pid":4012}`},
+		{name: "processes", args: []string{"processes"}, wantMethod: "process.list"},
+		{name: "processes scoped", args: []string{"processes", "/Applications/Slack.app"}, wantMethod: "process.list", wantParams: `{"bundles":["/Applications/Slack.app"]}`},
+		{name: "process tree", args: []string{"process-tree"}, wantMethod: "process.tree"},
+		{name: "sample", args: []string{"sample", "4012", "2", "20"}, wantMethod: "process.sample", wantParams: `{"duration":2,"interval":20,"pid":4012}`},
+		{name: "network", args: []string{"network"}, wantMethod: "network.state"},
+		{name: "connections", args: []string{"connections"}, wantMethod: "network.connections"},
+		{name: "network by app", args: []string{"network-by-app", "/Applications/Slack.app"}, wantMethod: "network.byApp", wantParams: `{"bundles":["/Applications/Slack.app"]}`},
+		{name: "storage system", args: []string{"storage"}, wantMethod: "storage.system"},
+		{name: "storage by app", args: []string{"storage", "/Applications/Slack.app", "/Applications/Cursor.app"}, wantMethod: "storage.byApp", wantParams: `{"paths":["/Applications/Slack.app","/Applications/Cursor.app"]}`},
+		{name: "power", args: []string{"power"}, wantMethod: "power.state"},
+		{name: "rules", args: []string{"rules"}, wantMethod: "rules.check"},
+		{name: "rules snapshot", args: []string{"rules", "snap-1"}, wantMethod: "rules.check", wantParams: `{"snapshot_id":"snap-1"}`},
+		{name: "jdk", args: []string{"jdk"}, wantMethod: "jdk.list"},
+		{name: "brew", args: []string{"brew"}, wantMethod: "toolchain.brew"},
+		{name: "runtimes", args: []string{"runtimes"}, wantMethod: "toolchain.runtimes"},
+		{name: "build tools", args: []string{"build-tools"}, wantMethod: "toolchain.build_tools"},
+		{name: "toolchains", args: []string{"toolchains"}, wantMethod: "toolchain.scan"},
+		{name: "snapshot create", args: []string{"snapshot"}, wantMethod: "snapshot.create"},
+		{name: "snapshot list", args: []string{"snapshot", "list"}, wantMethod: "snapshot.list"},
+		{name: "snapshots alias", args: []string{"snapshots"}, wantMethod: "snapshot.list"},
+		{name: "snapshot get", args: []string{"snapshot", "get", "snap-1"}, wantMethod: "snapshot.get", wantParams: `{"ID":"snap-1"}`},
+		{name: "snapshot diff", args: []string{"snapshot", "diff", "snap-a", "snap-b"}, wantMethod: "snapshot.diff", wantParams: `{"id_a":"snap-a","id_b":"snap-b"}`},
+		{name: "snapshot processes", args: []string{"snapshot", "processes", "snap-1"}, wantMethod: "snapshot.processes", wantParams: `{"id":"snap-1"}`},
+		{name: "snapshot login items", args: []string{"snapshot", "login-items", "snap-1"}, wantMethod: "snapshot.login_items", wantParams: `{"id":"snap-1"}`},
+		{name: "snapshot granted perms", args: []string{"snapshot", "granted-perms", "snap-1"}, wantMethod: "snapshot.granted_perms", wantParams: `{"id":"snap-1"}`},
+		{name: "snapshot prune default", args: []string{"snapshot", "prune"}, wantMethod: "snapshot.prune"},
+		{name: "snapshot prune keep", args: []string{"snapshot", "prune", "25"}, wantMethod: "snapshot.prune", wantParams: `{"keep":25}`},
 	}
 	for _, tt := range tests {
-		t.Run(tt.wantMethod, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			method, params, err := parseConnectCall(tt.args)
 			if err != nil {
 				t.Fatal(err)
@@ -94,8 +125,37 @@ func TestParseConnectTypedCalls(t *testing.T) {
 			if method != tt.wantMethod {
 				t.Fatalf("method = %q, want %q", method, tt.wantMethod)
 			}
-			if tt.wantParams != "" && string(params) != tt.wantParams {
-				t.Fatalf("params = %s, want %s", string(params), tt.wantParams)
+			if tt.wantParams == "" && params != nil {
+				t.Fatalf("params = %s, want nil", string(params))
+			}
+			if tt.wantParams != "" {
+				assertJSONEqual(t, params, tt.wantParams)
+			}
+		})
+	}
+}
+
+func TestParseConnectTypedCallErrors(t *testing.T) {
+	tests := [][]string{
+		{"inspect"},
+		{"jvm", "nope"},
+		{"jvm-gc"},
+		{"jvm-threads", "0"},
+		{"sample", "4012", "0"},
+		{"rules", "snap-1", "extra"},
+		{"snapshot", "get"},
+		{"snapshot", "diff", "snap-a"},
+		{"snapshot", "processes"},
+		{"snapshot", "prune", "-1"},
+		{"snapshot", "unknown"},
+		{"host", "extra"},
+		{"status", "extra"},
+		{"health", "extra"},
+	}
+	for _, args := range tests {
+		t.Run(args[0], func(t *testing.T) {
+			if _, _, err := parseConnectCall(args); err == nil {
+				t.Fatalf("parseConnectCall(%v) succeeded, want error", args)
 			}
 		})
 	}
@@ -125,6 +185,29 @@ func TestCallRPC(t *testing.T) {
 	}
 	if decoded["value"] != "ok" {
 		t.Fatalf("value = %q, want ok", decoded["value"])
+	}
+}
+
+func assertJSONEqual(t *testing.T, got json.RawMessage, want string) {
+	t.Helper()
+	var gotValue any
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("decode got params: %v", err)
+	}
+	var wantValue any
+	if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+		t.Fatalf("decode want params: %v", err)
+	}
+	gotCanonical, err := json.Marshal(gotValue)
+	if err != nil {
+		t.Fatalf("encode got params: %v", err)
+	}
+	wantCanonical, err := json.Marshal(wantValue)
+	if err != nil {
+		t.Fatalf("encode want params: %v", err)
+	}
+	if !bytes.Equal(gotCanonical, wantCanonical) {
+		t.Fatalf("params = %s, want %s", string(got), want)
 	}
 }
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -34,7 +34,7 @@ It can also run a JSON-RPC daemon:
 spectra serve                         # Unix socket at ~/.spectra/sock
 spectra serve --tcp 127.0.0.1:7878    # opt-in TCP listener
 spectra connect 127.0.0.1:7878        # health check
-spectra connect 127.0.0.1:7878 call snapshot.create
+spectra connect 127.0.0.1:7878 snapshot
 ```
 
 ## Daemon-with-clients

--- a/docs/design/remote-portal.md
+++ b/docs/design/remote-portal.md
@@ -30,7 +30,8 @@ Three consequences:
    registers as `work-mac.tailnet-name.ts.net`, and `spectra connect work-mac`
    Just Works with MagicDNS. The current implementation stops one step
    earlier: the daemon can opt into an explicit TCP listener and the
-   client can call JSON-RPC methods with `spectra connect <host> call ...`.
+   client can use typed `spectra connect <host> ...` shortcuts or call
+   JSON-RPC methods directly with `spectra connect <host> call ...`.
 
 ## Authentication
 
@@ -94,8 +95,9 @@ These will get pinned down before the first daemon commit:
    so the same code path serves CLI and daemon.
 2. `spectra serve` over a local Unix socket first. Validates the RPC shape
    without touching networking. **Implemented.**
-3. Add explicit TCP JSON-RPC transport for `spectra connect <host> call`.
-   **Implemented; authentication is still delegated to the network path.**
+3. Add explicit TCP JSON-RPC transport plus typed `spectra connect <host>
+   ...` shortcuts. **Implemented; authentication is still delegated to the
+   network path.**
 4. Add `tsnet` integration. Daemon becomes a tailnet node; client uses
    Tailscale's discovery.
 5. TUI client. Bubble Tea, talks to local-or-remote daemon identically.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,9 +46,8 @@ model, [inspection/](inspection/) for what we extract from each bundle, and
   inspect a teammate's machine over the tailnet without manually exposing a
   TCP listener. See
   [design/remote-portal.md](design/remote-portal.md).
-- **Typed remote commands and fan-out** — ergonomic wrappers around the
-  generic `spectra connect <host> call <method>` escape hatch, plus
-  cross-host aggregation.
+- **Remote fan-out** — typed `spectra connect <host> ...` wrappers exist
+  for common daemon calls; cross-host aggregation is still planned.
 - **TUI client** — Bubble Tea UI against the same local-or-remote daemon
   RPC surface.
 - **Release packaging** — Homebrew formula, prebuilt binaries, signing, and

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -295,11 +295,37 @@ automatic tsnet registration and cross-host fan-out remain future work.
 |---|---|
 | `spectra connect <target>` | Call `health` |
 | `spectra connect <target> status` | Call `health` |
+| `spectra connect <target> host` | Call `inspect.host` |
 | `spectra connect <target> inspect <App.app>` | Call `inspect.app` |
 | `spectra connect <target> jvm` | Call `jvm.list` |
+| `spectra connect <target> jvm <pid>` | Call `jvm.inspect` |
+| `spectra connect <target> jvm-gc <pid>` | Call `jvm.gc_stats` |
+| `spectra connect <target> jvm-threads <pid>` | Call `jvm.thread_dump` |
+| `spectra connect <target> jvm-heap <pid>` | Call `jvm.heap_histogram` |
 | `spectra connect <target> processes` | Call `process.list` |
+| `spectra connect <target> processes <App.app>` | Call `process.list` scoped to bundles |
+| `spectra connect <target> process-tree [App.app ...]` | Call `process.tree` |
+| `spectra connect <target> sample <pid> [duration] [interval]` | Call `process.sample` |
 | `spectra connect <target> network` | Call `network.state` |
+| `spectra connect <target> connections` | Call `network.connections` |
+| `spectra connect <target> network-by-app [App.app ...]` | Call `network.byApp` |
+| `spectra connect <target> storage` | Call `storage.system` |
+| `spectra connect <target> storage <App.app> [more.apps]` | Call `storage.byApp` |
+| `spectra connect <target> power` | Call `power.state` |
+| `spectra connect <target> rules [snapshot-id]` | Call `rules.check` |
+| `spectra connect <target> snapshot` | Call `snapshot.create` |
+| `spectra connect <target> snapshot list` | Call `snapshot.list` |
+| `spectra connect <target> snapshot get <id>` | Call `snapshot.get` |
+| `spectra connect <target> snapshot diff <id-a> <id-b>` | Call `snapshot.diff` |
+| `spectra connect <target> snapshot processes <id>` | Call `snapshot.processes` |
+| `spectra connect <target> snapshot login-items <id>` | Call `snapshot.login_items` |
+| `spectra connect <target> snapshot granted-perms <id>` | Call `snapshot.granted_perms` |
+| `spectra connect <target> snapshot prune [keep]` | Call `snapshot.prune` |
 | `spectra connect <target> toolchains` | Call `toolchain.scan` |
+| `spectra connect <target> jdk` | Call `jdk.list` |
+| `spectra connect <target> brew` | Call `toolchain.brew` |
+| `spectra connect <target> runtimes` | Call `toolchain.runtimes` |
+| `spectra connect <target> build-tools` | Call `toolchain.build_tools` |
 | `spectra connect <target> call <method> [json-params]` | Call an RPC method directly |
 
 ### Examples
@@ -309,11 +335,14 @@ spectra connect local
 spectra connect 127.0.0.1:7878 status
 spectra connect work-mac inspect /Applications/Slack.app
 spectra connect work-mac jvm
+spectra connect work-mac jvm-threads 4012
 spectra connect work-mac processes
 spectra connect work-mac network
+spectra connect work-mac storage /Applications/Slack.app
 spectra connect work-mac toolchains
-spectra connect work-mac call snapshot.create
-spectra connect work-mac call inspect.app '{"path":"/Applications/Slack.app"}'
+spectra connect work-mac snapshot
+spectra connect work-mac snapshot diff snap-before snap-after
+spectra connect work-mac call jvm.heap_dump '{"pid":4012,"confirm_sensitive":true}'
 ```
 
 ## `spectra version`

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -158,7 +158,8 @@ Implemented:
 4. Live process metrics ring buffer and periodic live snapshots.
 5. Local `spectra status` and `spectra metrics` clients.
 6. Privileged helper proxy methods for implemented helper capabilities.
-7. Optional TCP JSON-RPC listener and `spectra connect <target> call`.
+7. Optional TCP JSON-RPC listener, typed `spectra connect <target> ...`
+   shortcuts, and the raw `spectra connect <target> call` escape hatch.
 
 Future:
 

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -37,23 +37,38 @@ generic `call` form:
 
 ```bash
 spectra connect work-mac status
-spectra connect work-mac call inspect.app '{"path":"/Applications/Slack.app"}'
-spectra connect work-mac call jvm.list
-spectra connect work-mac call jvm.thread_dump '{"pid":4012}'
-spectra connect work-mac call snapshot.create
-```
-
-Common typed remote shortcuts are available for frequent read-only calls:
-
-```bash
 spectra connect work-mac inspect /Applications/Slack.app
 spectra connect work-mac jvm
-spectra connect work-mac processes
-spectra connect work-mac network
-spectra connect work-mac toolchains
+spectra connect work-mac jvm-threads 4012
+spectra connect work-mac snapshot
 ```
 
-Use `call` for everything else.
+Typed remote shortcuts cover the common local-debugging workflows:
+
+```bash
+spectra connect work-mac host
+spectra connect work-mac inspect /Applications/Slack.app
+spectra connect work-mac jvm
+spectra connect work-mac jvm-gc 4012
+spectra connect work-mac jvm-heap 4012
+spectra connect work-mac processes
+spectra connect work-mac process-tree /Applications/Slack.app
+spectra connect work-mac network
+spectra connect work-mac connections
+spectra connect work-mac network-by-app /Applications/Slack.app
+spectra connect work-mac storage
+spectra connect work-mac storage /Applications/Slack.app
+spectra connect work-mac power
+spectra connect work-mac rules
+spectra connect work-mac snapshot list
+spectra connect work-mac snapshot diff snap-before snap-after
+spectra connect work-mac toolchains
+spectra connect work-mac jdk
+spectra connect work-mac brew
+```
+
+Use `call` for less common or sensitive methods such as heap dumps and JFR
+artifact writes.
 
 ## Cross-host operations
 
@@ -130,10 +145,10 @@ the full RPC surface.
 ### "Why is my teammate's IDE slow?"
 
 ```bash
-spectra connect alice-laptop call jvm.list
+spectra connect alice-laptop jvm
 # → see all JVMs running, GC stats, heap usage
 
-spectra connect alice-laptop call jvm.thread_dump '{"pid":4012}' > intellij-threads.json
+spectra connect alice-laptop jvm-threads 4012 > intellij-threads.json
 # → captured to local disk for analysis
 ```
 
@@ -166,7 +181,5 @@ remote work:
 
 1. Add tsnet integration so the daemon can join a tailnet without an
    externally managed listener.
-2. Add typed `spectra connect <host> <subcommand>` adapters over the
-   generic JSON-RPC `call` command.
-3. Add host discovery and fan-out commands.
-4. Add TUI support against local-or-remote daemon targets.
+2. Add host discovery and fan-out commands.
+3. Add TUI support against local-or-remote daemon targets.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -60,7 +60,7 @@ recommendations engine.
 ```bash
 spectra serve --tcp 127.0.0.1:7878
 spectra connect 127.0.0.1:7878
-spectra connect 127.0.0.1:7878 call snapshot.create
+spectra connect 127.0.0.1:7878 snapshot
 ```
 
 The daemon always listens on the local Unix socket. TCP is opt-in and is
@@ -75,4 +75,4 @@ limited to loopback unless `--allow-remote` is supplied.
 | What can this app do to my machine? | `spectra -v APP.app` (entitlements + granted) |
 | What hosts does this app talk to? | `spectra -v --network APP.app` |
 | Is anything new on my machine since last week? | `spectra diff baseline pre-incident live` |
-| What's running on my work Mac right now? | `spectra connect work-mac call process.list` |
+| What's running on my work Mac right now? | `spectra connect work-mac processes` |


### PR DESCRIPTION
## Summary
- add typed spectra connect shortcuts for host, JVM, process, network, storage, power, rules, snapshots, and toolchains
- validate shortcut argument parsing, including PIDs and snapshot subcommands
- update remote/CLI docs to prefer typed commands while keeping raw call for uncommon or sensitive RPCs

## Validation
- go build ./...
- go vet ./...
- go test ./... -count=1
- gocyclo -over 15 -ignore '_test\.go$' .
- golangci-lint run --allow-parallel-runners
- make docs-validate
- git diff --check