### PR TITLE
Add explicit remote fanout

### DIFF
--- a/cmd/spectra/fan.go
+++ b/cmd/spectra/fan.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type fanRPCCaller func(target connectTarget, timeout time.Duration, method string, params json.RawMessage) (json.RawMessage, error)
+
+type fanOutput struct {
+	Method  string            `json:"method"`
+	Targets []fanTargetOutput `json:"targets"`
+}
+
+type fanTargetOutput struct {
+	Target  string          `json:"target"`
+	Network string          `json:"network"`
+	Address string          `json:"address"`
+	OK      bool            `json:"ok"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   string          `json:"error,omitempty"`
+}
+
+func runFan(args []string) int {
+	return runFanWith(args, os.Stdout, os.Stderr, callFanRPC)
+}
+
+func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPCCaller) int {
+	fs := flag.NewFlagSet("spectra fan", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	timeout := fs.Duration("timeout", 3*time.Second, "Dial/read timeout per target")
+	hosts := fs.String("hosts", "", "Comma-separated daemon targets")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	targets, err := parseFanTargets(*hosts)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		printFanUsage(stderr)
+		return 2
+	}
+	method, params, err := parseConnectCall(fs.Args())
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		printFanUsage(stderr)
+		return 2
+	}
+
+	results := fanCallTargets(targets, *timeout, method, params, caller)
+	out := fanOutput{Method: method, Targets: results}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintf(stderr, "encode fan response: %v\n", err)
+		return 1
+	}
+	for _, result := range results {
+		if !result.OK {
+			return 1
+		}
+	}
+	return 0
+}
+
+func printFanUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: spectra fan --hosts host-a,host-b [status|host|jvm|processes|network|storage|power|rules]")
+	fmt.Fprintln(w, "   or: spectra fan --hosts host-a,host-b inspect <App.app>")
+	fmt.Fprintln(w, "   or: spectra fan --hosts host-a,host-b call <method> [json-params]")
+}
+
+func parseFanTargets(raw string) ([]fanTarget, error) {
+	parts := strings.Split(raw, ",")
+	targets := make([]fanTarget, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			continue
+		}
+		target, err := parseConnectTarget(name)
+		if err != nil {
+			return nil, fmt.Errorf("parse fan target %q: %w", name, err)
+		}
+		targets = append(targets, fanTarget{Name: name, Target: target})
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("fan requires --hosts target[,target...]")
+	}
+	return targets, nil
+}
+
+type fanTarget struct {
+	Name   string
+	Target connectTarget
+}
+
+func fanCallTargets(targets []fanTarget, timeout time.Duration, method string, params json.RawMessage, caller fanRPCCaller) []fanTargetOutput {
+	results := make([]fanTargetOutput, len(targets))
+	var wg sync.WaitGroup
+	wg.Add(len(targets))
+	for i, target := range targets {
+		go func(i int, target fanTarget) {
+			defer wg.Done()
+			result, err := caller(target.Target, timeout, method, params)
+			results[i] = fanTargetOutput{
+				Target:  target.Name,
+				Network: target.Target.Network,
+				Address: target.Target.Address,
+				OK:      err == nil,
+				Result:  result,
+			}
+			if err != nil {
+				results[i].Error = err.Error()
+			}
+		}(i, target)
+	}
+	wg.Wait()
+	return results
+}
+
+func callFanRPC(target connectTarget, timeout time.Duration, method string, params json.RawMessage) (json.RawMessage, error) {
+	conn, err := dialConnectTarget(target, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("connect %s: %w", target.Address, err)
+	}
+	defer conn.Close()
+
+	if d, ok := conn.(interface{ SetDeadline(time.Time) error }); ok {
+		_ = d.SetDeadline(time.Now().Add(timeout))
+	}
+	return callRPC(conn, method, params)
+}

--- a/cmd/spectra/fan_test.go
+++ b/cmd/spectra/fan_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseFanTargets(t *testing.T) {
+	targets, err := parseFanTargets("work-mac, 127.0.0.1:9000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(targets))
+	}
+	if targets[0].Name != "work-mac" || targets[0].Target.Address != "work-mac:7878" {
+		t.Fatalf("target[0] = %+v", targets[0])
+	}
+	if targets[1].Name != "127.0.0.1:9000" || targets[1].Target.Address != "127.0.0.1:9000" {
+		t.Fatalf("target[1] = %+v", targets[1])
+	}
+}
+
+func TestParseFanTargetsRejectsEmptyList(t *testing.T) {
+	if _, err := parseFanTargets(" , "); err == nil {
+		t.Fatal("parseFanTargets succeeded, want error")
+	}
+}
+
+func TestRunFanWithTypedShortcut(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runFanWith(
+		[]string{"--hosts", "mac-a,mac-b", "jvm"},
+		&stdout,
+		&stderr,
+		func(target connectTarget, timeout time.Duration, method string, params json.RawMessage) (json.RawMessage, error) {
+			if timeout != 3*time.Second {
+				return nil, fmt.Errorf("timeout = %s, want 3s", timeout)
+			}
+			if method != "jvm.list" {
+				return nil, fmt.Errorf("method = %q, want jvm.list", method)
+			}
+			if params != nil {
+				return nil, fmt.Errorf("params = %s, want nil", string(params))
+			}
+			result, _ := json.Marshal(map[string]string{"address": target.Address})
+			return result, nil
+		},
+	)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+
+	var out fanOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Method != "jvm.list" {
+		t.Fatalf("method = %q, want jvm.list", out.Method)
+	}
+	if len(out.Targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(out.Targets))
+	}
+	if out.Targets[0].Target != "mac-a" || !out.Targets[0].OK {
+		t.Fatalf("target[0] = %+v", out.Targets[0])
+	}
+	if out.Targets[1].Address != "mac-b:7878" || !out.Targets[1].OK {
+		t.Fatalf("target[1] = %+v", out.Targets[1])
+	}
+}
+
+func TestRunFanWithPartialFailure(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runFanWith(
+		[]string{"--hosts", "mac-a,mac-b", "host"},
+		&stdout,
+		&stderr,
+		func(target connectTarget, _ time.Duration, _ string, _ json.RawMessage) (json.RawMessage, error) {
+			if strings.HasPrefix(target.Address, "mac-b:") {
+				return nil, errors.New("dial refused")
+			}
+			return json.RawMessage(`{"ok":true}`), nil
+		},
+	)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+
+	var out fanOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(out.Targets))
+	}
+	if !out.Targets[0].OK {
+		t.Fatalf("target[0] = %+v", out.Targets[0])
+	}
+	if out.Targets[1].OK || out.Targets[1].Error != "dial refused" {
+		t.Fatalf("target[1] = %+v", out.Targets[1])
+	}
+}
+
+func TestRunFanWithBadShortcut(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runFanWith(
+		[]string{"--hosts", "mac-a", "jvm-gc"},
+		&stdout,
+		&stderr,
+		func(connectTarget, time.Duration, string, json.RawMessage) (json.RawMessage, error) {
+			t.Fatal("caller should not run")
+			return nil, nil
+		},
+	)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "requires <pid>") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -48,6 +48,7 @@ func subcommandList() []subcommand {
 		{"baseline", "Manage baseline snapshots (list, drop)", runSnapshotBaseline},
 		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},
 		{"connect", "Call a Spectra daemon over Unix socket or TCP JSON-RPC", runConnect},
+		{"fan", "Run one daemon RPC call against multiple targets", runFan},
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},

--- a/docs/design/remote-portal.md
+++ b/docs/design/remote-portal.md
@@ -48,11 +48,19 @@ V1 will be Tailscale-ACL-only.
 
 ## The killer feature: cross-host correlation
 
-Once each Mac is a tailnet node running the daemon, queries fan out:
+Once each Mac is running the daemon, queries can fan out. Explicit-host
+fan-out is implemented today; tailnet discovery is the planned next step:
+
+```bash
+spectra fan --hosts laptop,work-mac inspect /Applications/Slack.app
+# both daemons inspect Slack and return one JSON envelope
+```
+
+The intended discovered-host workflow remains:
 
 ```bash
 spectra list --all-hosts
-# tailnet roundtrip: every Mac running spectra reports its app inventory
+# every Mac running spectra reports its app inventory
 # aggregated and grouped, with version drift highlighted
 ```
 
@@ -98,9 +106,11 @@ These will get pinned down before the first daemon commit:
 3. Add explicit TCP JSON-RPC transport plus typed `spectra connect <host>
    ...` shortcuts. **Implemented; authentication is still delegated to the
    network path.**
-4. Add `tsnet` integration. Daemon becomes a tailnet node; client uses
+4. Add explicit-host `spectra fan --hosts ...` fan-out over the typed
+   connect surface. **Implemented.**
+5. Add `tsnet` integration. Daemon becomes a tailnet node; client uses
    Tailscale's discovery.
-5. TUI client. Bubble Tea, talks to local-or-remote daemon identically.
+6. TUI client. Bubble Tea, talks to local-or-remote daemon identically.
 6. Privileged helper as `spectra install-helper` subcommand. Same binary
    ships the helper; SMAppService-registered LaunchDaemon.
 7. Ring buffer + history for replay (requires SQLite from

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,8 +46,9 @@ model, [inspection/](inspection/) for what we extract from each bundle, and
   inspect a teammate's machine over the tailnet without manually exposing a
   TCP listener. See
   [design/remote-portal.md](design/remote-portal.md).
-- **Remote fan-out** — typed `spectra connect <host> ...` wrappers exist
-  for common daemon calls; cross-host aggregation is still planned.
+- **Remote fan-out** — `spectra fan --hosts ...` runs one typed remote
+  call across multiple explicit daemon targets; automatic discovery is
+  still planned.
 - **TUI client** — Bubble Tea UI against the same local-or-remote daemon
   RPC surface.
 - **Release packaging** — Homebrew formula, prebuilt binaries, signing, and

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -31,6 +31,7 @@ spectra [flags] <App.app>...     # routes to `inspect` (default)
 | `process` | List running processes sorted by memory |
 | `serve` | Run the local Unix-socket JSON-RPC daemon |
 | `connect` | Call a Spectra daemon over Unix socket or TCP JSON-RPC |
+| `fan` | Run one daemon RPC call against multiple explicit targets |
 | `status` | Check whether the local daemon is running |
 | `metrics` | Show stored process metrics from daemon sampling |
 | `sample` | Collect a user-space CPU sample of a process |
@@ -281,7 +282,7 @@ spectra serve --tcp 100.64.0.5:7878 --allow-remote
 
 Calls a running daemon using the same JSON-RPC protocol as the local
 Unix-socket client. This is the implemented remote transport today;
-automatic tsnet registration and cross-host fan-out remain future work.
+automatic tsnet registration and host discovery remain future work.
 
 | Target | Meaning |
 |---|---|
@@ -343,6 +344,31 @@ spectra connect work-mac toolchains
 spectra connect work-mac snapshot
 spectra connect work-mac snapshot diff snap-before snap-after
 spectra connect work-mac call jvm.heap_dump '{"pid":4012,"confirm_sensitive":true}'
+```
+
+## `spectra fan`
+
+Runs one `spectra connect` call against multiple daemon targets in
+parallel and prints a JSON envelope with one result per target. This is
+explicit-host fan-out; automatic host discovery is still planned.
+
+| Flag | Default | Meaning |
+|---|---:|---|
+| `--hosts` | required | Comma-separated daemon targets (`local`, `host`, `host:port`, `unix:/path`) |
+| `--timeout` | `3s` | Dial/read timeout per target |
+
+The command accepts the same typed shortcuts and raw `call` form as
+`spectra connect`.
+
+### Examples
+
+```bash
+spectra fan --hosts work-mac,alice-laptop status
+spectra fan --hosts work-mac,alice-laptop inspect /Applications/Slack.app
+spectra fan --hosts work-mac,alice-laptop jvm
+spectra fan --hosts work-mac,alice-laptop jdk
+spectra fan --hosts work-mac,alice-laptop snapshot
+spectra fan --hosts work-mac,alice-laptop call network.connections
 ```
 
 ## `spectra version`

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -160,6 +160,8 @@ Implemented:
 6. Privileged helper proxy methods for implemented helper capabilities.
 7. Optional TCP JSON-RPC listener, typed `spectra connect <target> ...`
    shortcuts, and the raw `spectra connect <target> call` escape hatch.
+8. Explicit-host `spectra fan --hosts ...` fan-out over the same remote
+   call surface.
 
 Future:
 

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -72,17 +72,24 @@ artifact writes.
 
 ## Cross-host operations
 
-Cross-host fan-out is still planned. The intended shape is:
+Explicit-host fan-out is implemented with `spectra fan --hosts`. Host
+discovery is still planned, so callers provide the daemon targets today:
 
 ```bash
-spectra hosts                                # list discovered Spectra daemons
-spectra fan inspect /Applications/Slack.app  # inspect Slack on every host
-spectra fan jvm                              # JVM snapshot from every host
-spectra diff laptop work-mac                 # compare two hosts
+spectra fan --hosts work-mac,alice-laptop status
+spectra fan --hosts work-mac,alice-laptop inspect /Applications/Slack.app
+spectra fan --hosts work-mac,alice-laptop jvm
+spectra fan --hosts work-mac,alice-laptop network-by-app /Applications/Slack.app
 ```
 
 The client makes parallel RPC calls to each daemon and aggregates
-results locally.
+results locally into one JSON envelope. The remaining intended shape is:
+
+```bash
+spectra hosts                                # list discovered Spectra daemons
+spectra fan inspect /Applications/Slack.app  # inspect Slack on every discovered host
+spectra diff laptop work-mac                 # compare two hosts
+```
 
 ## TUI mode
 
@@ -155,9 +162,8 @@ spectra connect alice-laptop jvm-threads 4012 > intellij-threads.json
 ### "Are we on the same JDK?"
 
 ```bash
-spectra fan jdk list
-# → tabulates installed JDKs across all hosts in the tailnet,
-#   highlights drift
+spectra fan --hosts alice-laptop,bob-laptop jdk
+# → returns one JDK inventory per host for drift comparison
 ```
 
 ### "What does this app do that mine doesn't?"
@@ -171,7 +177,7 @@ spectra diff me work-mac --filter app=Slack
 ### "Snapshot the whole team's machines as a baseline"
 
 ```bash
-spectra fan snapshot create --name pre-incident
+spectra fan --hosts alice-laptop,bob-laptop snapshot
 ```
 
 ## Implementation order
@@ -181,5 +187,6 @@ remote work:
 
 1. Add tsnet integration so the daemon can join a tailnet without an
    externally managed listener.
-2. Add host discovery and fan-out commands.
+2. Add host discovery so `spectra fan` can target every discovered daemon
+   without an explicit `--hosts` list.
 3. Add TUI support against local-or-remote daemon targets.


### PR DESCRIPTION
## Summary
- add `spectra fan --hosts ...` to run one typed connect/RPC call against multiple daemon targets in parallel
- return a JSON envelope with per-target success, result, or error so partial failures are visible
- document explicit-host fan-out while leaving tsnet host discovery as the next remote component

## Validation
- go build ./...
- go vet ./...
- go test ./... -count=1
- gocyclo -over 15 -ignore '_test\.go$' .
- golangci-lint run --allow-parallel-runners
- make docs-validate
- git diff --check