### PR TITLE
Add stored hosts listing

### DIFF
--- a/cmd/spectra/hosts.go
+++ b/cmd/spectra/hosts.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+type hostLister func(context.Context) ([]store.HostRow, error)
+
+func runHosts(args []string) int {
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+	return runHostsWith(args, os.Stdout, os.Stderr, db.ListHosts)
+}
+
+func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLister) int {
+	fs := flag.NewFlagSet("spectra hosts", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: spectra hosts [--json]")
+		return 2
+	}
+
+	rows, err := list(context.Background())
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rows); err != nil {
+			fmt.Fprintf(stderr, "encode hosts: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(stderr, "no hosts stored - run `spectra snapshot` first")
+		return 0
+	}
+	printHostsTable(stdout, rows)
+	return 0
+}
+
+func printHostsTable(w io.Writer, rows []store.HostRow) {
+	fmt.Fprintf(w, "%-28s  %-20s  %-18s  %-7s  %s\n", "MACHINE UUID", "HOSTNAME", "OS", "SNAPS", "LAST SEEN")
+	fmt.Fprintln(w, strings.Repeat("-", 92))
+	for _, row := range rows {
+		osLabel := strings.TrimSpace(row.OSName + " " + row.OSVersion)
+		fmt.Fprintf(w, "%-28s  %-20s  %-18s  %-7d  %s\n",
+			truncate(row.MachineUUID, 28),
+			truncate(row.Hostname, 20),
+			truncate(osLabel, 18),
+			row.SnapshotCount,
+			row.LastSeen.Format("2006-01-02 15:04:05Z"),
+		)
+	}
+}

--- a/cmd/spectra/hosts_test.go
+++ b/cmd/spectra/hosts_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+func TestRunHostsWithTable(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runHostsWith(nil, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+		return []store.HostRow{
+			{
+				MachineUUID:   "UUID-1234567890",
+				Hostname:      "work-mac.local",
+				OSName:        "macOS",
+				OSVersion:     "15.6.1",
+				LastSeen:      time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC),
+				SnapshotCount: 3,
+			},
+		}, nil
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "UUID-1234567890") || !strings.Contains(out, "work-mac.local") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestRunHostsWithJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runHostsWith([]string{"--json"}, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+		return []store.HostRow{{MachineUUID: "UUID-A", Hostname: "a.local"}}, nil
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	var rows []store.HostRow
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].MachineUUID != "UUID-A" {
+		t.Fatalf("rows = %+v", rows)
+	}
+}
+
+func TestRunHostsWithEmptyList(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runHostsWith(nil, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+		return nil, nil
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if !strings.Contains(stderr.String(), "no hosts stored") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunHostsWithListError(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runHostsWith(nil, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+		return nil, errors.New("db unavailable")
+	})
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "db unavailable") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -49,6 +49,7 @@ func subcommandList() []subcommand {
 		{"serve", "Run the local daemon (Unix socket JSON-RPC server)", runServe},
 		{"connect", "Call a Spectra daemon over Unix socket or TCP JSON-RPC", runConnect},
 		{"fan", "Run one daemon RPC call against multiple targets", runFan},
+		{"hosts", "List hosts known from stored snapshots", runHosts},
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},

--- a/docs/design/remote-portal.md
+++ b/docs/design/remote-portal.md
@@ -108,11 +108,13 @@ These will get pinned down before the first daemon commit:
    network path.**
 4. Add explicit-host `spectra fan --hosts ...` fan-out over the typed
    connect surface. **Implemented.**
-5. Add `tsnet` integration. Daemon becomes a tailnet node; client uses
+5. Add stored `spectra hosts` listing for machines seen through snapshots.
+   **Implemented; live daemon discovery is still planned.**
+6. Add `tsnet` integration. Daemon becomes a tailnet node; client uses
    Tailscale's discovery.
-6. TUI client. Bubble Tea, talks to local-or-remote daemon identically.
-6. Privileged helper as `spectra install-helper` subcommand. Same binary
+7. TUI client. Bubble Tea, talks to local-or-remote daemon identically.
+8. Privileged helper as `spectra install-helper` subcommand. Same binary
    ships the helper; SMAppService-registered LaunchDaemon.
-7. Ring buffer + history for replay (requires SQLite from
+9. Ring buffer + history for replay (requires SQLite from
    [storage.md](storage.md)).
-8. Native GUI after the TUI proves the data model.
+10. Native GUI after the TUI proves the data model.

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,8 +47,9 @@ model, [inspection/](inspection/) for what we extract from each bundle, and
   TCP listener. See
   [design/remote-portal.md](design/remote-portal.md).
 - **Remote fan-out** — `spectra fan --hosts ...` runs one typed remote
-  call across multiple explicit daemon targets; automatic discovery is
-  still planned.
+  call across multiple explicit daemon targets; `spectra hosts` lists
+  locally known hosts from snapshots while automatic discovery is still
+  planned.
 - **TUI client** — Bubble Tea UI against the same local-or-remote daemon
   RPC surface.
 - **Release packaging** — Homebrew formula, prebuilt binaries, signing, and

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -32,6 +32,7 @@ spectra [flags] <App.app>...     # routes to `inspect` (default)
 | `serve` | Run the local Unix-socket JSON-RPC daemon |
 | `connect` | Call a Spectra daemon over Unix socket or TCP JSON-RPC |
 | `fan` | Run one daemon RPC call against multiple explicit targets |
+| `hosts` | List hosts known from stored snapshots |
 | `status` | Check whether the local daemon is running |
 | `metrics` | Show stored process metrics from daemon sampling |
 | `sample` | Collect a user-space CPU sample of a process |
@@ -344,6 +345,23 @@ spectra connect work-mac toolchains
 spectra connect work-mac snapshot
 spectra connect work-mac snapshot diff snap-before snap-after
 spectra connect work-mac call jvm.heap_dump '{"pid":4012,"confirm_sensitive":true}'
+```
+
+## `spectra hosts`
+
+Lists hosts already known to the local SQLite store from persisted
+snapshots. This is not live daemon discovery yet; it is the local record
+of machines Spectra has seen.
+
+| Flag | Default | Meaning |
+|---|---:|---|
+| `--json` | false | Emit JSON instead of a table |
+
+### Examples
+
+```bash
+spectra hosts
+spectra hosts --json
 ```
 
 ## `spectra fan`

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -162,6 +162,7 @@ Implemented:
    shortcuts, and the raw `spectra connect <target> call` escape hatch.
 8. Explicit-host `spectra fan --hosts ...` fan-out over the same remote
    call surface.
+9. `spectra hosts` listing for hosts known from stored snapshots.
 
 Future:
 

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -76,6 +76,7 @@ Explicit-host fan-out is implemented with `spectra fan --hosts`. Host
 discovery is still planned, so callers provide the daemon targets today:
 
 ```bash
+spectra hosts
 spectra fan --hosts work-mac,alice-laptop status
 spectra fan --hosts work-mac,alice-laptop inspect /Applications/Slack.app
 spectra fan --hosts work-mac,alice-laptop jvm
@@ -86,7 +87,7 @@ The client makes parallel RPC calls to each daemon and aggregates
 results locally into one JSON envelope. The remaining intended shape is:
 
 ```bash
-spectra hosts                                # list discovered Spectra daemons
+spectra hosts                                # include discovered Spectra daemons
 spectra fan inspect /Applications/Slack.app  # inspect Slack on every discovered host
 spectra diff laptop work-mac                 # compare two hosts
 ```
@@ -187,6 +188,6 @@ remote work:
 
 1. Add tsnet integration so the daemon can join a tailnet without an
    externally managed listener.
-2. Add host discovery so `spectra fan` can target every discovered daemon
-   without an explicit `--hosts` list.
+2. Add live host discovery so `spectra hosts` includes reachable daemons
+   and `spectra fan` can run without an explicit `--hosts` list.
 3. Add TUI support against local-or-remote daemon targets.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -232,6 +232,22 @@ type SnapshotRow struct {
 	AppCount    int
 }
 
+// HostRow is a summary row from the hosts table.
+type HostRow struct {
+	MachineUUID   string    `json:"machine_uuid"`
+	Hostname      string    `json:"hostname"`
+	OSName        string    `json:"os_name"`
+	OSVersion     string    `json:"os_version"`
+	OSBuild       string    `json:"os_build,omitempty"`
+	CPUBrand      string    `json:"cpu_brand,omitempty"`
+	CPUCores      int       `json:"cpu_cores,omitempty"`
+	RAMBytes      int64     `json:"ram_bytes,omitempty"`
+	Architecture  string    `json:"architecture,omitempty"`
+	FirstSeen     time.Time `json:"first_seen"`
+	LastSeen      time.Time `json:"last_seen"`
+	SnapshotCount int       `json:"snapshot_count"`
+}
+
 // SaveSnapshot persists snap and all its apps. It upserts the host row
 // and inserts the snapshot + apps rows inside a single transaction.
 func (s *DB) SaveSnapshot(ctx context.Context, snap SnapshotInput) error {
@@ -307,6 +323,53 @@ func insertApp(tx *sql.Tx, snapID string, a AppInput) error {
 		a.AppVersion, string(archJSON), string(resultJSON),
 	)
 	return err
+}
+
+// ListHosts returns known hosts ordered by most recent snapshot.
+func (s *DB) ListHosts(ctx context.Context) ([]HostRow, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT h.machine_uuid, h.hostname, h.os_name, h.os_version,
+		       COALESCE(h.os_build, ''), COALESCE(h.cpu_brand, ''),
+		       COALESCE(h.cpu_cores, 0), COALESCE(h.ram_bytes, 0),
+		       COALESCE(h.architecture, ''), h.first_seen, h.last_seen,
+		       COUNT(sn.id)
+		FROM hosts h
+		LEFT JOIN snapshots sn ON sn.machine_uuid = h.machine_uuid
+		GROUP BY h.machine_uuid, h.hostname, h.os_name, h.os_version,
+		         h.os_build, h.cpu_brand, h.cpu_cores, h.ram_bytes,
+		         h.architecture, h.first_seen, h.last_seen
+		ORDER BY h.last_seen DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []HostRow
+	for rows.Next() {
+		var r HostRow
+		var firstSeen string
+		var lastSeen string
+		if err := rows.Scan(
+			&r.MachineUUID,
+			&r.Hostname,
+			&r.OSName,
+			&r.OSVersion,
+			&r.OSBuild,
+			&r.CPUBrand,
+			&r.CPUCores,
+			&r.RAMBytes,
+			&r.Architecture,
+			&firstSeen,
+			&lastSeen,
+			&r.SnapshotCount,
+		); err != nil {
+			return nil, err
+		}
+		r.FirstSeen, _ = time.Parse(time.RFC3339, firstSeen)
+		r.LastSeen, _ = time.Parse(time.RFC3339, lastSeen)
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }
 
 // ListSnapshots returns summary rows ordered newest-first.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -168,6 +168,54 @@ func TestListSnapshotsByMachine(t *testing.T) {
 	}
 }
 
+func TestListHosts(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	older := sampleInput()
+	older.ID = "snap-old"
+	older.MachineUUID = "UUID-OLD"
+	older.Hostname = "old.local"
+	older.TakenAt = time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	if err := db.SaveSnapshot(ctx, older); err != nil {
+		t.Fatal(err)
+	}
+
+	newer := sampleInput()
+	newer.ID = "snap-new"
+	newer.MachineUUID = "UUID-NEW"
+	newer.Hostname = "new.local"
+	newer.TakenAt = time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	if err := db.SaveSnapshot(ctx, newer); err != nil {
+		t.Fatal(err)
+	}
+	newer.ID = "snap-new-2"
+	newer.TakenAt = time.Date(2026, 5, 4, 13, 0, 0, 0, time.UTC)
+	if err := db.SaveSnapshot(ctx, newer); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := db.ListHosts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2", len(rows))
+	}
+	if rows[0].MachineUUID != "UUID-NEW" || rows[0].Hostname != "new.local" {
+		t.Fatalf("rows[0] = %+v", rows[0])
+	}
+	if rows[0].SnapshotCount != 2 {
+		t.Fatalf("snapshot count = %d, want 2", rows[0].SnapshotCount)
+	}
+	if !rows[0].LastSeen.Equal(newer.TakenAt) {
+		t.Fatalf("last seen = %s, want %s", rows[0].LastSeen, newer.TakenAt)
+	}
+	if rows[1].MachineUUID != "UUID-OLD" {
+		t.Fatalf("rows[1] = %+v", rows[1])
+	}
+}
+
 // --- Baseline snapshots (name field) ---
 
 func TestBaselineNameRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `spectra hosts` to list machines known from persisted snapshots
- add store-level `ListHosts` with snapshot counts and first/last seen timestamps
- document stored-host listing separately from future live daemon discovery

## Validation
- go build ./...
- go vet ./...
- go test ./... -count=1
- gocyclo -over 15 -ignore '_test\.go$' .
- golangci-lint run --allow-parallel-runners
- make docs-validate
- git diff --check