### PR TITLE
Add user LaunchAgent installer

### DIFF
--- a/cmd/spectra/daemon_install.go
+++ b/cmd/spectra/daemon_install.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"bytes"
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/kaeawc/spectra/internal/fsutil"
+)
+
+const daemonAgentLabel = "dev.spectra.daemon"
+
+type daemonAgentOptions struct {
+	SockPath    string
+	TCPAddr     string
+	AllowRemote bool
+	LogFile     string
+	NoLogFile   bool
+	NoLoad      bool
+}
+
+type daemonAgentDeps struct {
+	executable func() (string, error)
+	homeDir    func() (string, error)
+	uid        func() string
+	mkdirAll   func(string, os.FileMode) error
+	writeFile  func(string, []byte, os.FileMode) error
+	remove     func(string) error
+	run        func(args ...string) error
+	output     func(args ...string) ([]byte, error)
+}
+
+func runInstallDaemonCmd(args []string) int {
+	if len(args) > 0 {
+		switch args[0] {
+		case "uninstall":
+			return runUninstallDaemon(args[1:])
+		case "status":
+			return runDaemonStatus(args[1:])
+		case "print-plist":
+			return runPrintDaemonPlist(args[1:])
+		}
+	}
+	return runInstallDaemon(args)
+}
+
+func runInstallDaemon(args []string) int {
+	opts, ok := parseDaemonAgentOptions("spectra install-daemon", args, os.Stderr)
+	if !ok {
+		return 2
+	}
+	plistPath, err := installDaemonAgent(opts, defaultDaemonAgentDeps())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Fprintf(os.Stdout, "spectra daemon LaunchAgent installed at %s\n", plistPath)
+	if opts.NoLoad {
+		fmt.Fprintln(os.Stdout, "Load skipped; run without --no-load to bootstrap it with launchd.")
+	}
+	return 0
+}
+
+func runPrintDaemonPlist(args []string) int {
+	opts, ok := parseDaemonAgentOptions("spectra install-daemon print-plist", args, os.Stderr)
+	if !ok {
+		return 2
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	paths := daemonAgentPaths(home)
+	fmt.Fprint(os.Stdout, daemonLaunchAgentPlist(exe, opts.serveArgs(), paths.stdoutPath, paths.stderrPath))
+	return 0
+}
+
+func runUninstallDaemon(args []string) int {
+	fs := flag.NewFlagSet("spectra install-daemon uninstall", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: spectra install-daemon uninstall")
+		return 2
+	}
+	plistPath, err := uninstallDaemonAgent(defaultDaemonAgentDeps())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Fprintf(os.Stdout, "spectra daemon LaunchAgent removed from %s\n", plistPath)
+	return 0
+}
+
+func runDaemonStatus(args []string) int {
+	fs := flag.NewFlagSet("spectra install-daemon status", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: spectra install-daemon status")
+		return 2
+	}
+	out, err := daemonAgentStatus(defaultDaemonAgentDeps())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Fprint(os.Stdout, string(out))
+	return 0
+}
+
+func parseDaemonAgentOptions(name string, args []string, stderr io.Writer) (daemonAgentOptions, bool) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	opts := daemonAgentOptions{}
+	fs.StringVar(&opts.SockPath, "sock", "", "Unix socket path passed to spectra serve")
+	fs.StringVar(&opts.TCPAddr, "tcp", "", "Optional TCP listen address passed to spectra serve")
+	fs.BoolVar(&opts.AllowRemote, "allow-remote", false, "Allow non-loopback TCP listen address")
+	fs.StringVar(&opts.LogFile, "log-file", "", "JSONL daemon log path")
+	fs.BoolVar(&opts.NoLogFile, "no-log-file", false, "Disable daemon JSONL log file")
+	fs.BoolVar(&opts.NoLoad, "no-load", false, "Write plist but do not bootstrap with launchd")
+	if err := fs.Parse(args); err != nil {
+		return daemonAgentOptions{}, false
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: spectra install-daemon [--sock path] [--tcp addr] [--allow-remote] [--log-file path|--no-log-file] [--no-load]")
+		return daemonAgentOptions{}, false
+	}
+	if opts.LogFile != "" && opts.NoLogFile {
+		fmt.Fprintln(stderr, "install-daemon: --log-file and --no-log-file are mutually exclusive")
+		return daemonAgentOptions{}, false
+	}
+	if err := validateServeListen(opts.TCPAddr, opts.AllowRemote); err != nil {
+		fmt.Fprintln(stderr, err)
+		return daemonAgentOptions{}, false
+	}
+	return opts, true
+}
+
+func (o daemonAgentOptions) serveArgs() []string {
+	args := []string{"serve"}
+	if o.SockPath != "" {
+		args = append(args, "--sock", o.SockPath)
+	}
+	if o.TCPAddr != "" {
+		args = append(args, "--tcp", o.TCPAddr)
+	}
+	if o.AllowRemote {
+		args = append(args, "--allow-remote")
+	}
+	if o.LogFile != "" {
+		args = append(args, "--log-file", o.LogFile)
+	}
+	if o.NoLogFile {
+		args = append(args, "--no-log-file")
+	}
+	return args
+}
+
+type daemonAgentPathSet struct {
+	launchAgentsDir string
+	logDir          string
+	plistPath       string
+	stdoutPath      string
+	stderrPath      string
+}
+
+func daemonAgentPaths(home string) daemonAgentPathSet {
+	return daemonAgentPathSet{
+		launchAgentsDir: filepath.Join(home, "Library", "LaunchAgents"),
+		logDir:          filepath.Join(home, "Library", "Logs", "Spectra"),
+		plistPath:       filepath.Join(home, "Library", "LaunchAgents", daemonAgentLabel+".plist"),
+		stdoutPath:      filepath.Join(home, "Library", "Logs", "Spectra", "daemon.launchd.out.log"),
+		stderrPath:      filepath.Join(home, "Library", "Logs", "Spectra", "daemon.launchd.err.log"),
+	}
+}
+
+func installDaemonAgent(opts daemonAgentOptions, deps daemonAgentDeps) (string, error) {
+	exe, err := deps.executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve executable: %w", err)
+	}
+	home, err := deps.homeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	paths := daemonAgentPaths(home)
+	if err := deps.mkdirAll(paths.launchAgentsDir, 0o700); err != nil {
+		return "", fmt.Errorf("create LaunchAgents directory: %w", err)
+	}
+	if err := deps.mkdirAll(paths.logDir, 0o700); err != nil {
+		return "", fmt.Errorf("create daemon log directory: %w", err)
+	}
+	plist := daemonLaunchAgentPlist(exe, opts.serveArgs(), paths.stdoutPath, paths.stderrPath)
+	if err := deps.writeFile(paths.plistPath, []byte(plist), 0o644); err != nil {
+		return "", fmt.Errorf("write LaunchAgent plist: %w", err)
+	}
+	if opts.NoLoad {
+		return paths.plistPath, nil
+	}
+	domain := "gui/" + deps.uid()
+	_ = deps.run("bootout", domain, paths.plistPath)
+	if err := deps.run("bootstrap", domain, paths.plistPath); err != nil {
+		return "", fmt.Errorf("launchctl bootstrap: %w", err)
+	}
+	service := domain + "/" + daemonAgentLabel
+	if err := deps.run("enable", service); err != nil {
+		return "", fmt.Errorf("launchctl enable: %w", err)
+	}
+	if err := deps.run("kickstart", "-k", service); err != nil {
+		return "", fmt.Errorf("launchctl kickstart: %w", err)
+	}
+	return paths.plistPath, nil
+}
+
+func uninstallDaemonAgent(deps daemonAgentDeps) (string, error) {
+	home, err := deps.homeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	paths := daemonAgentPaths(home)
+	_ = deps.run("bootout", "gui/"+deps.uid(), paths.plistPath)
+	if err := deps.remove(paths.plistPath); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("remove LaunchAgent plist: %w", err)
+	}
+	return paths.plistPath, nil
+}
+
+func daemonAgentStatus(deps daemonAgentDeps) ([]byte, error) {
+	out, err := deps.output("print", "gui/"+deps.uid()+"/"+daemonAgentLabel)
+	if err != nil {
+		return nil, fmt.Errorf("launchctl print: %w", err)
+	}
+	return out, nil
+}
+
+func defaultDaemonAgentDeps() daemonAgentDeps {
+	return daemonAgentDeps{
+		executable: os.Executable,
+		homeDir:    os.UserHomeDir,
+		uid: func() string {
+			return strconv.Itoa(os.Getuid())
+		},
+		mkdirAll:  os.MkdirAll,
+		writeFile: fsutil.WriteFileAtomic,
+		remove:    os.Remove,
+		run:       runLaunchctl,
+		output:    outputLaunchctl,
+	}
+}
+
+func runLaunchctl(args ...string) error {
+	// #nosec G204 -- command is fixed to launchctl; args are generated by this installer, no shell.
+	cmd := exec.Command("launchctl", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}
+
+func outputLaunchctl(args ...string) ([]byte, error) {
+	// #nosec G204 -- command is fixed to launchctl; args are generated by this installer, no shell.
+	return exec.Command("launchctl", args...).CombinedOutput()
+}
+
+func daemonLaunchAgentPlist(executable string, serveArgs []string, stdoutPath string, stderrPath string) string {
+	args := append([]string{executable}, serveArgs...)
+	var b bytes.Buffer
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	b.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	b.WriteString(`<plist version="1.0">` + "\n")
+	b.WriteString("<dict>\n")
+	writePlistKeyString(&b, "Label", daemonAgentLabel)
+	b.WriteString("    <key>ProgramArguments</key>\n")
+	b.WriteString("    <array>\n")
+	for _, arg := range args {
+		writePlistString(&b, arg)
+	}
+	b.WriteString("    </array>\n")
+	b.WriteString("    <key>RunAtLoad</key>\n")
+	b.WriteString("    <true/>\n")
+	b.WriteString("    <key>KeepAlive</key>\n")
+	b.WriteString("    <true/>\n")
+	writePlistKeyString(&b, "StandardOutPath", stdoutPath)
+	writePlistKeyString(&b, "StandardErrorPath", stderrPath)
+	b.WriteString("</dict>\n")
+	b.WriteString("</plist>\n")
+	return b.String()
+}
+
+func writePlistKeyString(b *bytes.Buffer, key string, value string) {
+	b.WriteString("    <key>")
+	_ = xml.EscapeText(b, []byte(key))
+	b.WriteString("</key>\n")
+	writePlistString(b, value)
+}
+
+func writePlistString(b *bytes.Buffer, value string) {
+	b.WriteString("        <string>")
+	_ = xml.EscapeText(b, []byte(value))
+	b.WriteString("</string>\n")
+}

--- a/cmd/spectra/daemon_install_test.go
+++ b/cmd/spectra/daemon_install_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestDaemonAgentServeArgs(t *testing.T) {
+	opts := daemonAgentOptions{
+		SockPath:    "/tmp/spectra.sock",
+		TCPAddr:     "127.0.0.1:7878",
+		AllowRemote: true,
+		LogFile:     "/tmp/spectra.jsonl",
+	}
+	got := opts.serveArgs()
+	want := []string{
+		"serve",
+		"--sock", "/tmp/spectra.sock",
+		"--tcp", "127.0.0.1:7878",
+		"--allow-remote",
+		"--log-file", "/tmp/spectra.jsonl",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("serveArgs = %v, want %v", got, want)
+	}
+}
+
+func TestDaemonLaunchAgentPlistEscapesArguments(t *testing.T) {
+	plist := daemonLaunchAgentPlist(
+		"/tmp/Spectra & Tool/spectra",
+		[]string{"serve", "--log-file", "/tmp/a&b.jsonl"},
+		"/tmp/out.log",
+		"/tmp/err.log",
+	)
+	for _, want := range []string{
+		"<string>/tmp/Spectra &amp; Tool/spectra</string>",
+		"<string>/tmp/a&amp;b.jsonl</string>",
+		"<key>RunAtLoad</key>",
+		"<key>KeepAlive</key>",
+		"<string>dev.spectra.daemon</string>",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Fatalf("plist missing %q:\n%s", want, plist)
+		}
+	}
+}
+
+func TestInstallDaemonAgentNoLoad(t *testing.T) {
+	fake := newFakeDaemonAgentDeps(t)
+	opts := daemonAgentOptions{NoLoad: true, NoLogFile: true}
+	plistPath, err := installDaemonAgent(opts, fake.deps())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plistPath != filepath.Join(fake.home, "Library", "LaunchAgents", daemonAgentLabel+".plist") {
+		t.Fatalf("plist path = %q", plistPath)
+	}
+	if len(fake.runs) != 0 {
+		t.Fatalf("launchctl calls = %v, want none", fake.runs)
+	}
+	data := string(fake.files[plistPath])
+	if !strings.Contains(data, "<string>/usr/local/bin/spectra</string>") {
+		t.Fatalf("plist = %s", data)
+	}
+	if !strings.Contains(data, "<string>--no-log-file</string>") {
+		t.Fatalf("plist missing --no-log-file:\n%s", data)
+	}
+}
+
+func TestInstallDaemonAgentBootstrapsLaunchd(t *testing.T) {
+	fake := newFakeDaemonAgentDeps(t)
+	plistPath, err := installDaemonAgent(daemonAgentOptions{}, fake.deps())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRuns := [][]string{
+		{"bootout", "gui/501", plistPath},
+		{"bootstrap", "gui/501", plistPath},
+		{"enable", "gui/501/" + daemonAgentLabel},
+		{"kickstart", "-k", "gui/501/" + daemonAgentLabel},
+	}
+	if !equalStringSlices(fake.runs, wantRuns) {
+		t.Fatalf("runs = %v, want %v", fake.runs, wantRuns)
+	}
+}
+
+func TestUninstallDaemonAgent(t *testing.T) {
+	fake := newFakeDaemonAgentDeps(t)
+	plistPath := filepath.Join(fake.home, "Library", "LaunchAgents", daemonAgentLabel+".plist")
+	fake.files[plistPath] = []byte("plist")
+	got, err := uninstallDaemonAgent(fake.deps())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != plistPath {
+		t.Fatalf("plist path = %q", got)
+	}
+	if _, ok := fake.files[plistPath]; ok {
+		t.Fatalf("plist was not removed")
+	}
+	if !equalStringSlices(fake.runs, [][]string{{"bootout", "gui/501", plistPath}}) {
+		t.Fatalf("runs = %v", fake.runs)
+	}
+}
+
+type fakeDaemonAgentDeps struct {
+	home  string
+	files map[string][]byte
+	dirs  []string
+	runs  [][]string
+}
+
+func newFakeDaemonAgentDeps(t *testing.T) *fakeDaemonAgentDeps {
+	t.Helper()
+	return &fakeDaemonAgentDeps{
+		home:  filepath.Join(t.TempDir(), "home"),
+		files: map[string][]byte{},
+	}
+}
+
+func (f *fakeDaemonAgentDeps) deps() daemonAgentDeps {
+	return daemonAgentDeps{
+		executable: func() (string, error) { return "/usr/local/bin/spectra", nil },
+		homeDir:    func() (string, error) { return f.home, nil },
+		uid:        func() string { return "501" },
+		mkdirAll: func(path string, _ os.FileMode) error {
+			f.dirs = append(f.dirs, path)
+			return nil
+		},
+		writeFile: func(path string, data []byte, _ os.FileMode) error {
+			f.files[path] = slices.Clone(data)
+			return nil
+		},
+		remove: func(path string) error {
+			if _, ok := f.files[path]; !ok {
+				return os.ErrNotExist
+			}
+			delete(f.files, path)
+			return nil
+		},
+		run: func(args ...string) error {
+			f.runs = append(f.runs, slices.Clone(args))
+			return nil
+		},
+		output: func(args ...string) ([]byte, error) {
+			if len(args) == 0 {
+				return nil, errors.New("missing launchctl args")
+			}
+			return []byte(strings.Join(args, " ")), nil
+		},
+	}
+}
+
+func equalStringSlices(a [][]string, b [][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !slices.Equal(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -53,6 +53,7 @@ func subcommandList() []subcommand {
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},
+		{"install-daemon", "Install the user LaunchAgent for spectra serve", runInstallDaemonCmd},
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},

--- a/docs/design/distribution.md
+++ b/docs/design/distribution.md
@@ -95,8 +95,14 @@ brew install kaeawc/tap/spectra
 ```
 
 The first Homebrew formula should build the unprivileged CLI and helper
-binary, but should not install or start the helper automatically. Root
-visibility stays behind the same explicit command:
+binary, but should not install or start the helper automatically.
+User-daemon lifecycle is available after install through:
+
+```bash
+spectra install-daemon
+```
+
+Root visibility stays behind the same explicit command:
 
 ```bash
 sudo spectra install-helper

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,13 +52,15 @@ model, [inspection/](inspection/) for what we extract from each bundle, and
   planned.
 - **TUI client** — Bubble Tea UI against the same local-or-remote daemon
   RPC surface.
-- **Release packaging** — Homebrew formula, prebuilt binaries, signing, and
-  notarization.
+- **Release packaging** — the user LaunchAgent installer exists;
+  Homebrew formula, prebuilt binaries, signing, and notarization are
+  still planned.
 
 ## Distribution
 
 Spectra currently installs from source with an optional `sudo` helper
 install for root-only telemetry (system TCC, firewall rules, and
-`powermetrics`). Homebrew and prebuilt binaries are planned. The Mac App
-Store is incompatible with the live-monitoring features. See
+`powermetrics`) and a per-user `spectra install-daemon` LaunchAgent for
+daemon lifecycle. Homebrew and prebuilt binaries are planned. The Mac
+App Store is incompatible with the live-monitoring features. See
 [design/distribution.md](design/distribution.md) for the full analysis.

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -38,6 +38,7 @@ spectra [flags] <App.app>...     # routes to `inspect` (default)
 | `sample` | Collect a user-space CPU sample of a process |
 | `cache` | Manage the local blob cache |
 | `install-helper` | Install the privileged helper daemon |
+| `install-daemon` | Install the user LaunchAgent for `spectra serve` |
 | `version` | Print Spectra version and exit |
 | `help` | Show top-level help |
 
@@ -264,6 +265,9 @@ user's Unix socket at `~/.spectra/sock`.
 | `--sock` | `~/.spectra/sock` | Unix socket path |
 | `--tcp` | empty | Optional TCP listen address, such as `127.0.0.1:7878` |
 | `--allow-remote` | false | Allow `--tcp` to bind a non-loopback address |
+| `--log-file` | `~/Library/Logs/Spectra/daemon.jsonl` | JSONL daemon log path |
+| `--no-log-file` | false | Disable daemon JSONL logging |
+| `--daemon` | false | Start detached and return |
 
 TCP RPC has no Spectra-layer authentication today. Keep it on loopback
 for local use or expose it only through SSH, Tailscale, or firewall
@@ -277,6 +281,34 @@ spectra serve --log-file /tmp/spectra-daemon.jsonl
 spectra serve --no-log-file
 spectra serve --tcp 127.0.0.1:7878
 spectra serve --tcp 100.64.0.5:7878 --allow-remote
+```
+
+## `spectra install-daemon`
+
+Installs a per-user LaunchAgent that runs `spectra serve` through
+launchd. The plist is written to
+`~/Library/LaunchAgents/dev.spectra.daemon.plist`; stdout/stderr from
+launchd go to `~/Library/Logs/Spectra/daemon.launchd.*.log`.
+
+| Form | Description |
+|---|---|
+| `spectra install-daemon [serve flags]` | Write, bootstrap, enable, and kickstart the LaunchAgent |
+| `spectra install-daemon --no-load [serve flags]` | Write the plist without loading it |
+| `spectra install-daemon print-plist [serve flags]` | Print the plist that would be installed |
+| `spectra install-daemon status` | Run `launchctl print` for the agent |
+| `spectra install-daemon uninstall` | Boot out and remove the LaunchAgent plist |
+
+The install and `print-plist` forms accept the serve-listener flags
+`--sock`, `--tcp`, `--allow-remote`, `--log-file`, and `--no-log-file`.
+
+### Examples
+
+```bash
+spectra install-daemon
+spectra install-daemon --tcp 127.0.0.1:7878
+spectra install-daemon print-plist --no-log-file
+spectra install-daemon status
+spectra install-daemon uninstall
 ```
 
 ## `spectra connect`

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -22,12 +22,14 @@ spectra serve --tcp 127.0.0.1:7878
 spectra serve --log-file /tmp/spectra-daemon.jsonl
 spectra serve --no-log-file
 spectra serve --daemon       # start detached and return
+spectra install-daemon       # install and load the per-user LaunchAgent
 ```
 
 By default the CLI runs in the foreground until interrupted. `--daemon`
 starts a detached `spectra serve` child with the same serve flags and
-returns immediately. Launchd-managed agent packaging remains future
-distribution work.
+returns immediately. `spectra install-daemon` writes
+`~/Library/LaunchAgents/dev.spectra.daemon.plist` atomically and uses
+`launchctl bootstrap`/`kickstart` to run the daemon under launchd.
 
 By default, structured daemon lifecycle logs are appended to
 `~/Library/Logs/Spectra/daemon.jsonl` with `0600` permissions. Foreground
@@ -163,10 +165,10 @@ Implemented:
 8. Explicit-host `spectra fan --hosts ...` fan-out over the same remote
    call surface.
 9. `spectra hosts` listing for hosts known from stored snapshots.
+10. Per-user launchd lifecycle through `spectra install-daemon`.
 
 Future:
 
 1. CLI-wide RPC dispatch instead of in-process command execution.
-2. launchd-managed daemon lifecycle.
-3. tsnet listener and Tailscale identity integration.
-4. TUI/GUI clients.
+2. tsnet listener and Tailscale identity integration.
+3. TUI/GUI clients.


### PR DESCRIPTION
## Summary
- add `spectra install-daemon` for per-user LaunchAgent install/status/uninstall/print-plist workflows
- write the LaunchAgent plist atomically and bootstrap it with launchctl using injectable fakes in tests
- update daemon, CLI, distribution, and index docs to mark launchd user lifecycle implemented

## Validation
- go build ./...
- go vet ./...
- go test ./... -count=1
- gocyclo -over 15 -ignore '_test\.go$' .
- golangci-lint run --allow-parallel-runners
- make docs-validate
- git diff --check

Note: targeted `gosec -include=G104,G204 ./cmd/spectra` has pre-existing G104 findings in jvm/sample stdout writes; the new launchd installer file is clean after fixed-command annotations and explicit ignored XML writes.