### PR TITLE
Use stored hosts in fan fallback

### DIFF
--- a/cmd/spectra/fan.go
+++ b/cmd/spectra/fan.go
@@ -1,17 +1,23 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kaeawc/spectra/internal/store"
 )
 
 type fanRPCCaller func(target connectTarget, timeout time.Duration, method string, params json.RawMessage) (json.RawMessage, error)
+type fanHostLister func(ctx context.Context) ([]fanTarget, error)
 
 type fanOutput struct {
 	Method  string            `json:"method"`
@@ -28,19 +34,25 @@ type fanTargetOutput struct {
 }
 
 func runFan(args []string) int {
-	return runFanWith(args, os.Stdout, os.Stderr, callFanRPC)
+	return runFanWith(args, os.Stdout, os.Stderr, callFanRPC, discoverFanTargets)
 }
 
-func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPCCaller) int {
+func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPCCaller, discover fanHostLister) int {
 	fs := flag.NewFlagSet("spectra fan", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	timeout := fs.Duration("timeout", 3*time.Second, "Dial/read timeout per target")
-	hosts := fs.String("hosts", "", "Comma-separated daemon targets")
+	hosts := fs.String("hosts", "", "Comma-separated daemon targets; defaults to discovered hosts")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	targets, err := parseFanTargets(*hosts)
+	var targets []fanTarget
+	var err error
+	if strings.TrimSpace(*hosts) == "" {
+		targets, err = discover(context.Background())
+	} else {
+		targets, err = parseFanTargets(*hosts)
+	}
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		printFanUsage(stderr)
@@ -49,6 +61,11 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 	method, params, err := parseConnectCall(fs.Args())
 	if err != nil {
 		fmt.Fprintln(stderr, err)
+		printFanUsage(stderr)
+		return 2
+	}
+	if len(targets) == 0 {
+		fmt.Fprintln(stderr, "fan requires --hosts target[,target...]")
 		printFanUsage(stderr)
 		return 2
 	}
@@ -70,9 +87,9 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 }
 
 func printFanUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: spectra fan --hosts host-a,host-b [status|host|jvm|processes|network|storage|power|rules]")
-	fmt.Fprintln(w, "   or: spectra fan --hosts host-a,host-b inspect <App.app>")
-	fmt.Fprintln(w, "   or: spectra fan --hosts host-a,host-b call <method> [json-params]")
+	fmt.Fprintln(w, "usage: spectra fan [--hosts host-a,host-b] [status|host|jvm|processes|network|storage|power|rules]")
+	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] inspect <App.app>")
+	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] call <method> [json-params]")
 }
 
 func parseFanTargets(raw string) ([]fanTarget, error) {
@@ -92,6 +109,48 @@ func parseFanTargets(raw string) ([]fanTarget, error) {
 	if len(targets) == 0 {
 		return nil, fmt.Errorf("fan requires --hosts target[,target...]")
 	}
+	return targets, nil
+}
+
+func discoverFanTargets(ctx context.Context) ([]fanTarget, error) {
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		return nil, err
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.ListHosts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	targets := make([]fanTarget, 0, len(rows))
+	for _, row := range rows {
+		name := strings.TrimSpace(row.Hostname)
+		if name == "" {
+			continue
+		}
+		target, err := parseConnectTarget(net.JoinHostPort(name, defaultRemotePort))
+		if err != nil {
+			continue
+		}
+		key := target.Address
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, fanTarget{Name: name, Target: target})
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("fan requires --hosts target[,target...]")
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].Name < targets[j].Name
+	})
 	return targets, nil
 }
 

--- a/cmd/spectra/fan_test.go
+++ b/cmd/spectra/fan_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,6 +53,10 @@ func TestRunFanWithTypedShortcut(t *testing.T) {
 			result, _ := json.Marshal(map[string]string{"address": target.Address})
 			return result, nil
 		},
+		func(context.Context) ([]fanTarget, error) {
+			t.Fatal("discover should not be used when --hosts provided")
+			return nil, nil
+		},
 	)
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
@@ -88,6 +93,10 @@ func TestRunFanWithPartialFailure(t *testing.T) {
 			}
 			return json.RawMessage(`{"ok":true}`), nil
 		},
+		func(context.Context) ([]fanTarget, error) {
+			t.Fatal("discover should not be used when --hosts provided")
+			return nil, nil
+		},
 	)
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
@@ -119,11 +128,75 @@ func TestRunFanWithBadShortcut(t *testing.T) {
 			t.Fatal("caller should not run")
 			return nil, nil
 		},
+		func(context.Context) ([]fanTarget, error) {
+			t.Fatal("discover should not be used when --hosts provided")
+			return nil, nil
+		},
 	)
 	if code != 2 {
 		t.Fatalf("exit code = %d, want 2", code)
 	}
 	if !strings.Contains(stderr.String(), "requires <pid>") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunFanWithDiscoveredHosts(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runFanWith(
+		[]string{"host"},
+		&stdout,
+		&stderr,
+		func(target connectTarget, _ time.Duration, _ string, _ json.RawMessage) (json.RawMessage, error) {
+			return json.Marshal(map[string]string{"address": target.Address})
+		},
+		func(_ context.Context) ([]fanTarget, error) {
+			return []fanTarget{
+				{Name: "work-mac", Target: connectTarget{Network: "tcp", Address: "work-mac:7878"}},
+				{Name: "alice-laptop", Target: connectTarget{Network: "tcp", Address: "alice-laptop:7878"}},
+			}, nil
+		},
+	)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+
+	var out fanOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(out.Targets))
+	}
+	targetNames := map[string]bool{}
+	for _, result := range out.Targets {
+		targetNames[result.Target] = result.OK
+	}
+	if !targetNames["work-mac"] || !targetNames["alice-laptop"] {
+		t.Fatalf("targets = %+v", targetNames)
+	}
+}
+
+func TestRunFanWithDiscoveredHostsError(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runFanWith(
+		[]string{"host"},
+		&stdout,
+		&stderr,
+		func(connectTarget, time.Duration, string, json.RawMessage) (json.RawMessage, error) {
+			t.Fatal("caller should not run")
+			return nil, nil
+		},
+		func(context.Context) ([]fanTarget, error) {
+			return nil, nil
+		},
+	)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "requires --hosts") {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
 }

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -218,6 +218,54 @@ spectra baseline list
 spectra baseline drop snap-20260504T095749Z-4829
 ```
 
+## `spectra rules`
+
+Evaluates the recommendations catalog against a live snapshot or a stored
+snapshot. `./spectra.yml` is loaded automatically when present; use
+`--rules-config` to point at a different override file.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--json` | false | Emit JSON findings |
+| `--snapshot` | empty | Evaluate a stored snapshot by ID |
+| `--rules-config` | `./spectra.yml` if present | Rule override file |
+
+Supported `spectra.yml` rule overrides:
+
+```yaml
+rules:
+  disabled:
+    - app-unsigned
+  severity:
+    jvm-eol-version: high
+```
+
+### Examples
+
+```bash
+spectra rules
+spectra rules --json
+spectra rules --snapshot snap-20260504T095749Z-4829
+spectra rules --rules-config team-spectra.yml
+```
+
+## `spectra issues`
+
+Persists recommendation findings as issues and lets users manage their
+lifecycle. `spectra issues check` accepts the same `--snapshot` and
+`--rules-config` flags as `spectra rules`.
+
+### Examples
+
+```bash
+spectra issues check
+spectra issues check --rules-config team-spectra.yml
+spectra issues list --status open
+spectra issues acknowledge issue-123
+spectra issues dismiss issue-123
+spectra issues update --status fixed issue-123
+```
+
 ## `spectra jvm`
 
 Lists or inspects running JVM processes and exposes JDK-tool diagnostics.
@@ -383,7 +431,8 @@ spectra connect work-mac call jvm.heap_dump '{"pid":4012,"confirm_sensitive":tru
 
 Lists hosts already known to the local SQLite store from persisted
 snapshots. This is not live daemon discovery yet; it is the local record
-of machines Spectra has seen.
+of machines Spectra has seen. `spectra fan` uses this list when
+`--hosts` is omitted.
 
 | Flag | Default | Meaning |
 |---|---:|---|
@@ -399,12 +448,12 @@ spectra hosts --json
 ## `spectra fan`
 
 Runs one `spectra connect` call against multiple daemon targets in
-parallel and prints a JSON envelope with one result per target. This is
-explicit-host fan-out; automatic host discovery is still planned.
+parallel and prints a JSON envelope with one result per target. `--hosts`
+is optional; when omitted, fan-out uses hosts from the local store.
 
 | Flag | Default | Meaning |
 |---|---:|---|
-| `--hosts` | required | Comma-separated daemon targets (`local`, `host`, `host:port`, `unix:/path`) |
+| `--hosts` | optional | Comma-separated daemon targets (`local`, `host`, `host:port`, `unix:/path`). Omit to use hosts from local `spectra hosts` data. |
 | `--timeout` | `3s` | Dial/read timeout per target |
 
 The command accepts the same typed shortcuts and raw `call` form as
@@ -419,6 +468,7 @@ spectra fan --hosts work-mac,alice-laptop jvm
 spectra fan --hosts work-mac,alice-laptop jdk
 spectra fan --hosts work-mac,alice-laptop snapshot
 spectra fan --hosts work-mac,alice-laptop call network.connections
+spectra fan inspect /Applications/Slack.app
 ```
 
 ## `spectra version`

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -72,13 +72,15 @@ artifact writes.
 
 ## Cross-host operations
 
-Explicit-host fan-out is implemented with `spectra fan --hosts`. Host
-discovery is still planned, so callers provide the daemon targets today:
+Explicit-host fan-out is implemented with `spectra fan --hosts`.
+When `--hosts` is omitted, `spectra fan` uses discovered/recorded hosts
+from `spectra hosts` (currently local-store-based discovery):
 
 ```bash
 spectra hosts
 spectra fan --hosts work-mac,alice-laptop status
 spectra fan --hosts work-mac,alice-laptop inspect /Applications/Slack.app
+spectra fan inspect /Applications/Slack.app
 spectra fan --hosts work-mac,alice-laptop jvm
 spectra fan --hosts work-mac,alice-laptop network-by-app /Applications/Slack.app
 ```


### PR DESCRIPTION
## Summary
- Allow  to run without  by defaulting to discovered/recorded hosts from the local host store.
- Add a testable host discovery path with DB-backed host loading and reuse existing  conversion.
- Keep explicit  behavior unchanged for deterministic workflows.
- Update CLI and remote docs to describe fallback behavior and remove  as mandatory.

## Validation
- go build ./...
- go vet ./...
- go test ./cmd/spectra -run 'TestRunFanWith|TestParseFanTargets' -count=1