### PR TITLE
Add project-level rules overrides support

### DIFF
--- a/cmd/spectra/issues.go
+++ b/cmd/spectra/issues.go
@@ -161,6 +161,7 @@ func runIssuesCheck(args []string) int {
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit findings JSON")
 	snapID := fs.String("snapshot", "", "Evaluate against a stored snapshot by ID (default: live)")
+	rulesConfig := fs.String("rules-config", "", "Path to spectra.yml rule overrides (default: ./spectra.yml if present)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -183,7 +184,12 @@ func runIssuesCheck(args []string) int {
 		}
 	}
 
-	findings := rules.Evaluate(snap, rules.V1Catalog())
+	catalog, err := loadRuleCatalog(*rulesConfig, os.Stderr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "issues check: %v\n", err)
+		return 1
+	}
+	findings := rules.Evaluate(snap, catalog)
 
 	// Record findings as issues.
 	db, machineUUID, err := openIssuesDB()

--- a/cmd/spectra/rules.go
+++ b/cmd/spectra/rules.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -19,6 +20,7 @@ func runRules(args []string) int {
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
 	snapID := fs.String("snapshot", "", "Evaluate against a stored snapshot by ID (default: take a live snapshot)")
+	rulesConfig := fs.String("rules-config", "", "Path to spectra.yml rule overrides (default: ./spectra.yml if present)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -38,7 +40,12 @@ func runRules(args []string) int {
 		})
 	}
 
-	findings := rules.Evaluate(snap, rules.V1Catalog())
+	catalog, err := loadRuleCatalog(*rulesConfig, os.Stderr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "rules: %v\n", err)
+		return 1
+	}
+	findings := rules.Evaluate(snap, catalog)
 
 	if *asJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -54,6 +61,35 @@ func runRules(args []string) int {
 
 	printFindings(findings)
 	return 0
+}
+
+func loadRuleCatalog(configPath string, stderr io.Writer) ([]rules.Rule, error) {
+	catalog := rules.V1Catalog()
+	path, explicit := resolveRulesConfigPath(configPath)
+	if path == "" {
+		return catalog, nil
+	}
+	overrides, err := rules.LoadOverrides(path)
+	if err != nil {
+		if explicit {
+			return nil, err
+		}
+		if os.IsNotExist(err) {
+			return catalog, nil
+		}
+		return nil, err
+	}
+	for _, warning := range rules.OverrideWarnings(overrides, catalog) {
+		fmt.Fprintf(stderr, "warning: %s\n", warning)
+	}
+	return rules.ApplyOverrides(catalog, overrides), nil
+}
+
+func resolveRulesConfigPath(configPath string) (path string, explicit bool) {
+	if configPath != "" {
+		return configPath, true
+	}
+	return "spectra.yml", false
 }
 
 func loadStoredSnapshot(id string) (*snapshot.Snapshot, error) {

--- a/cmd/spectra/rules_test.go
+++ b/cmd/spectra/rules_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/rules"
+)
+
+func TestLoadRuleCatalogUsesProjectConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "spectra.yml"), []byte(`
+rules:
+  disabled:
+    - app-unsigned
+  severity:
+    jvm-eol-version: high
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	catalog, err := loadRuleCatalog("", &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findRule(catalog, "app-unsigned") != nil {
+		t.Fatal("app-unsigned was not disabled")
+	}
+	rule := findRule(catalog, "jvm-eol-version")
+	if rule == nil {
+		t.Fatal("jvm-eol-version missing")
+	}
+	if rule.Severity != rules.SeverityHigh {
+		t.Fatalf("severity = %q, want high", rule.Severity)
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestLoadRuleCatalogIgnoresMissingDefaultConfig(t *testing.T) {
+	t.Chdir(t.TempDir())
+	catalog, err := loadRuleCatalog("", &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog) != len(rules.V1Catalog()) {
+		t.Fatalf("len(catalog) = %d, want %d", len(catalog), len(rules.V1Catalog()))
+	}
+}
+
+func TestLoadRuleCatalogErrorsOnMissingExplicitConfig(t *testing.T) {
+	_, err := loadRuleCatalog(filepath.Join(t.TempDir(), "missing.yml"), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("loadRuleCatalog succeeded, want missing explicit config error")
+	}
+}
+
+func TestLoadRuleCatalogWarnsOnUnknownRule(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spectra.yml")
+	if err := os.WriteFile(path, []byte(`
+rules:
+  disabled:
+    - no-such-rule
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	if _, err := loadRuleCatalog(path, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if got := stderr.String(); got != "warning: rules override references unknown rule \"no-such-rule\"\n" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func findRule(catalog []rules.Rule, id string) *rules.Rule {
+	for i := range catalog {
+		if catalog[i].ID == id {
+			return &catalog[i]
+		}
+	}
+	return nil
+}

--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -1,9 +1,10 @@
 # Recommendations engine
 
 Spectra has an implemented recommendations engine backed by a built-in Go
-rule catalog, persisted issues, and applied-fix history. The long-term
-architecture still points toward CEL/YAML rules, but today's engine is
-compiled Go code so the catalog can ship without adding a dependency.
+rule catalog, project-local override files, persisted issues, and
+applied-fix history. The long-term architecture still points toward
+CEL/YAML rules, but today's executable rules are compiled Go code so the
+catalog can ship without adding a dependency.
 
 The recommendations engine is what turns Spectra from "DataDog Agent for
 Macs" into something genuinely new: **a persistent issue catalog where
@@ -16,7 +17,9 @@ Entry points:
 spectra rules
 spectra rules --json
 spectra rules --snapshot <snapshot-id>
+spectra rules --rules-config spectra.yml
 spectra issues check
+spectra issues check --rules-config spectra.yml
 spectra issues list [--status open]
 spectra issues acknowledge <issue-id>
 spectra issues dismiss <issue-id>
@@ -49,7 +52,9 @@ type Rule struct {
 `rules.Evaluate(snapshot, rules.V1Catalog())` runs the catalog and returns
 sorted findings. `spectra rules` prints findings without persisting them;
 `spectra issues check` evaluates rules, persists the snapshot when needed,
-and upserts findings into the issue catalog.
+and upserts findings into the issue catalog. Both commands load
+project-local rule overrides from `./spectra.yml` when present, or from
+an explicit `--rules-config` path.
 
 ## Future shape
 
@@ -117,11 +122,28 @@ matching finding.
 
 ## Rule sources
 
-The V1 catalog ships with the binary. Future:
+The V1 catalog ships with the binary. Project-local `spectra.yml`
+overrides are implemented for the built-in catalog:
 
-- **Project-local overrides** — per-team `spectra.yml` extends the catalog.
+```yaml
+rules:
+  disabled:
+    - app-unsigned
+  severity:
+    jvm-eol-version: high
+    library-storage-footprint: low
+```
+
+The supported subset is intentionally small: disable built-in rule IDs and
+override emitted severity (`high`, `medium`, `low`, `info`). Unknown rule
+IDs produce warnings so team configs do not silently drift.
+
+Future:
+
 - **Remote catalogs** — pull from a URL or git repo (e.g.
   `kaeawc/spectra-rules-jvm`).
+- **CEL/YAML rules** — evaluate new declarative rules, not just overrides
+  for built-ins.
 - **AI-generated rules** — at the edge: feed the LLM a structured
   snapshot and let it propose new rules to add to the catalog.
 
@@ -173,5 +195,5 @@ Implemented rules:
   independently; we'll deal with conflicts when we see them.
 - **Multi-host rules** that fire on tailnet-wide patterns (e.g. "this
   team has version drift across machines"). V2.
-- **External CEL/YAML catalogs.** The Go `MatchFn` interface is the point
-  where a future CEL evaluator plugs in.
+- **External CEL/YAML catalogs.** Project-local overrides are implemented,
+  but new externally defined CEL rules remain future work.

--- a/internal/rules/overrides.go
+++ b/internal/rules/overrides.go
@@ -1,0 +1,206 @@
+package rules
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+// Overrides are project-local adjustments loaded from spectra.yml.
+type Overrides struct {
+	Disabled map[string]struct{}
+	Severity map[string]Severity
+}
+
+// Empty reports whether no overrides were configured.
+func (o Overrides) Empty() bool {
+	return len(o.Disabled) == 0 && len(o.Severity) == 0
+}
+
+// LoadOverrides reads a project-local rules config.
+func LoadOverrides(path string) (Overrides, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Overrides{}, err
+	}
+	return ParseOverrides(data)
+}
+
+// ParseOverrides parses the supported spectra.yml rules subset:
+//
+//	rules:
+//	  disabled:
+//	    - app-unsigned
+//	  severity:
+//	    jvm-eol-version: high
+func ParseOverrides(data []byte) (Overrides, error) {
+	out := Overrides{
+		Disabled: map[string]struct{}{},
+		Severity: map[string]Severity{},
+	}
+	var section string
+	var mode string
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for lineNo := 1; scanner.Scan(); lineNo++ {
+		nextSection, nextMode, ok, err := parseOverrideLine(scanner.Text(), lineNo, section, mode, &out)
+		if err != nil {
+			return Overrides{}, err
+		}
+		if !ok {
+			continue
+		}
+		section, mode = nextSection, nextMode
+	}
+	if err := scanner.Err(); err != nil {
+		return Overrides{}, err
+	}
+	return out, nil
+}
+
+func parseOverrideLine(raw string, lineNo int, section string, mode string, out *Overrides) (string, string, bool, error) {
+	line := stripYAMLComment(raw)
+	if strings.TrimSpace(line) == "" {
+		return section, mode, false, nil
+	}
+	indent := leadingSpaces(line)
+	trimmed := strings.TrimSpace(line)
+	if indent == 0 {
+		return parseTopLevelYAMLKey(trimmed), "", true, nil
+	}
+	if section != "rules" {
+		return section, mode, false, nil
+	}
+	if indent == 2 {
+		nextMode := parseRulesMode(trimmed)
+		if nextMode == "" {
+			return "", "", false, fmt.Errorf("line %d: unsupported rules key %q", lineNo, trimmed)
+		}
+		return section, nextMode, true, nil
+	}
+	if err := parseRulesOverrideValue(trimmed, lineNo, mode, out); err != nil {
+		return "", "", false, err
+	}
+	return section, mode, true, nil
+}
+
+func parseRulesOverrideValue(trimmed string, lineNo int, mode string, out *Overrides) error {
+	switch mode {
+	case "disabled":
+		id, ok := strings.CutPrefix(trimmed, "- ")
+		if !ok || strings.TrimSpace(id) == "" {
+			return fmt.Errorf("line %d: disabled rule must be '- <rule-id>'", lineNo)
+		}
+		out.Disabled[strings.TrimSpace(id)] = struct{}{}
+		return nil
+	case "severity":
+		id, rawSeverity, ok := strings.Cut(trimmed, ":")
+		if !ok || strings.TrimSpace(id) == "" || strings.TrimSpace(rawSeverity) == "" {
+			return fmt.Errorf("line %d: severity override must be '<rule-id>: <severity>'", lineNo)
+		}
+		severity, err := parseSeverity(strings.TrimSpace(rawSeverity))
+		if err != nil {
+			return fmt.Errorf("line %d: %w", lineNo, err)
+		}
+		out.Severity[strings.TrimSpace(id)] = severity
+		return nil
+	default:
+		return fmt.Errorf("line %d: unsupported rules override syntax", lineNo)
+	}
+}
+
+// ApplyOverrides returns a catalog with disabled rules removed and severity
+// overrides applied to both the Rule metadata and emitted findings.
+func ApplyOverrides(catalog []Rule, overrides Overrides) []Rule {
+	if overrides.Empty() {
+		return catalog
+	}
+	out := make([]Rule, 0, len(catalog))
+	for _, rule := range catalog {
+		if _, disabled := overrides.Disabled[rule.ID]; disabled {
+			continue
+		}
+		if severity, ok := overrides.Severity[rule.ID]; ok {
+			rule.Severity = severity
+			match := rule.MatchFn
+			rule.MatchFn = func(snap snapshot.Snapshot) []Finding {
+				findings := match(snap)
+				for i := range findings {
+					findings[i].Severity = severity
+				}
+				return findings
+			}
+		}
+		out = append(out, rule)
+	}
+	return out
+}
+
+// OverrideWarnings returns human-readable warnings for override IDs that do
+// not match a rule in catalog.
+func OverrideWarnings(overrides Overrides, catalog []Rule) []string {
+	if overrides.Empty() {
+		return nil
+	}
+	known := make(map[string]struct{}, len(catalog))
+	for _, rule := range catalog {
+		known[rule.ID] = struct{}{}
+	}
+	ids := make(map[string]struct{}, len(overrides.Disabled)+len(overrides.Severity))
+	for id := range overrides.Disabled {
+		ids[id] = struct{}{}
+	}
+	for id := range overrides.Severity {
+		ids[id] = struct{}{}
+	}
+	var warnings []string
+	for id := range ids {
+		if _, ok := known[id]; !ok {
+			warnings = append(warnings, fmt.Sprintf("rules override references unknown rule %q", id))
+		}
+	}
+	sort.Strings(warnings)
+	return warnings
+}
+
+func stripYAMLComment(line string) string {
+	if idx := strings.Index(line, "#"); idx >= 0 {
+		return line[:idx]
+	}
+	return line
+}
+
+func leadingSpaces(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " "))
+}
+
+func parseTopLevelYAMLKey(line string) string {
+	if strings.HasSuffix(line, ":") {
+		return strings.TrimSuffix(line, ":")
+	}
+	return ""
+}
+
+func parseRulesMode(line string) string {
+	switch line {
+	case "disabled:":
+		return "disabled"
+	case "severity:":
+		return "severity"
+	default:
+		return ""
+	}
+}
+
+func parseSeverity(raw string) (Severity, error) {
+	switch Severity(raw) {
+	case SeverityHigh, SeverityMedium, SeverityLow, SeverityInfo:
+		return Severity(raw), nil
+	default:
+		return "", fmt.Errorf("invalid severity %q", raw)
+	}
+}

--- a/internal/rules/overrides_test.go
+++ b/internal/rules/overrides_test.go
@@ -1,0 +1,99 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func TestParseOverrides(t *testing.T) {
+	cfg := []byte(`
+rules:
+  disabled:
+    - app-unsigned
+    - brew-stale-pinned # local exception
+  severity:
+    jvm-eol-version: high
+    library-storage-footprint: low
+`)
+	got, err := ParseOverrides(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got.Disabled["app-unsigned"]; !ok {
+		t.Fatalf("missing disabled app-unsigned: %+v", got.Disabled)
+	}
+	if got.Severity["jvm-eol-version"] != SeverityHigh {
+		t.Fatalf("severity = %q, want high", got.Severity["jvm-eol-version"])
+	}
+	if got.Severity["library-storage-footprint"] != SeverityLow {
+		t.Fatalf("severity = %q, want low", got.Severity["library-storage-footprint"])
+	}
+}
+
+func TestParseOverridesRejectsInvalidSeverity(t *testing.T) {
+	_, err := ParseOverrides([]byte(`
+rules:
+  severity:
+    jvm-eol-version: urgent
+`))
+	if err == nil || !strings.Contains(err.Error(), "invalid severity") {
+		t.Fatalf("err = %v, want invalid severity", err)
+	}
+}
+
+func TestApplyOverrides(t *testing.T) {
+	catalog := []Rule{
+		{
+			ID:       "keep",
+			Severity: SeverityLow,
+			MatchFn: func(snapshot.Snapshot) []Finding {
+				return []Finding{{RuleID: "keep", Severity: SeverityLow}}
+			},
+		},
+		{
+			ID:       "drop",
+			Severity: SeverityHigh,
+			MatchFn: func(snapshot.Snapshot) []Finding {
+				return []Finding{{RuleID: "drop", Severity: SeverityHigh}}
+			},
+		},
+	}
+	got := ApplyOverrides(catalog, Overrides{
+		Disabled: map[string]struct{}{"drop": {}},
+		Severity: map[string]Severity{"keep": SeverityMedium},
+	})
+	if len(got) != 1 || got[0].ID != "keep" {
+		t.Fatalf("catalog = %+v, want only keep", got)
+	}
+	if got[0].Severity != SeverityMedium {
+		t.Fatalf("rule severity = %q, want medium", got[0].Severity)
+	}
+	findings := Evaluate(snapshot.Snapshot{}, got)
+	if len(findings) != 1 || findings[0].Severity != SeverityMedium {
+		t.Fatalf("findings = %+v, want severity medium", findings)
+	}
+}
+
+func TestOverrideWarnings(t *testing.T) {
+	warnings := OverrideWarnings(
+		Overrides{
+			Disabled: map[string]struct{}{"known": {}, "unknown-a": {}},
+			Severity: map[string]Severity{"unknown-b": SeverityHigh},
+		},
+		[]Rule{{ID: "known"}},
+	)
+	want := []string{
+		`rules override references unknown rule "unknown-a"`,
+		`rules override references unknown rule "unknown-b"`,
+	}
+	if len(warnings) != len(want) {
+		t.Fatalf("warnings = %+v, want %+v", warnings, want)
+	}
+	for i := range want {
+		if warnings[i] != want[i] {
+			t.Fatalf("warnings = %+v, want %+v", warnings, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Load optional project-level `spectra.yml` overrides for rule disable-list and severity override.
- Add override parsing and application in the rules engine.
- Wire `spectra rules` and `spectra issues check` to load `./spectra.yml` when present and support explicit `--rules-config`.
- Document supported override shape in recommendation and CLI reference docs.

## Validation
- go build ./...
- go vet ./...
- go test ./internal/rules ./cmd/spectra -run 'Test(ParseOverrides|ApplyOverrides|OverrideWarnings|LoadRuleCatalog|RunRules|RunIssuesCheckWithRules)' -count=1
- gocyclo -over 15 -ignore '_test\.go$' .
- golangci-lint run --allow-parallel-runners
