### PR TITLE
Add cross-host snapshot diff fallback

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/diff"
@@ -466,8 +467,13 @@ func runSnapshotDiff(args []string) int {
 
 func printDiffUsage() {
 	fmt.Fprintln(os.Stderr, "usage: spectra snapshot diff <id-a> <id-b|live>")
+	fmt.Fprintln(os.Stderr, "   or: spectra diff <host-a> <host-b|live>")
 	fmt.Fprintln(os.Stderr, "   or: spectra diff baseline [name|id] [live|id]")
 }
+
+type remoteSnapshotLoader func(ctx context.Context, host string, snapshotID string) (*snapshot.Snapshot, error)
+
+var loadRemoteSnapshot remoteSnapshotLoader = resolveRemoteSnapshot
 
 func resolveDiffOperands(ctx context.Context, db *store.DB, args []string) (*snapshot.Snapshot, *snapshot.Snapshot, error) {
 	if len(args) > 0 && args[0] == "baseline" {
@@ -478,11 +484,11 @@ func resolveDiffOperands(ctx context.Context, db *store.DB, args []string) (*sna
 		return nil, nil, fmt.Errorf("invalid diff operands")
 	}
 	idA, idB := args[0], args[1]
-	snapA, err := resolveSnapshot(ctx, db, idA)
+	snapA, err := resolveSnapshotWithHostFallback(ctx, db, idA)
 	if err != nil {
 		return nil, nil, fmt.Errorf("snapshot %q: %w", idA, err)
 	}
-	snapB, err := resolveSnapshot(ctx, db, idB)
+	snapB, err := resolveSnapshotWithHostFallback(ctx, db, idB)
 	if err != nil {
 		return nil, nil, fmt.Errorf("snapshot %q: %w", idB, err)
 	}
@@ -523,6 +529,79 @@ func resolveSnapshot(ctx context.Context, db *store.DB, id string) (*snapshot.Sn
 		return &snap, nil
 	}
 	return loadSnapshotFromDB(ctx, db, id)
+}
+
+func resolveSnapshotWithHostFallback(ctx context.Context, db *store.DB, id string) (*snapshot.Snapshot, error) {
+	remoteHost, remoteSnapshot, isRemote, err := parseRemoteDiffOperand(id)
+	if err != nil {
+		return nil, err
+	}
+	if isRemote {
+		return loadRemoteSnapshot(ctx, remoteHost, remoteSnapshot)
+	}
+	if strings.HasPrefix(id, "snap-") || id == "live" || strings.HasPrefix(id, "base-") || id == "" {
+		return resolveSnapshot(ctx, db, id)
+	}
+	snap, err := resolveSnapshot(ctx, db, id)
+	if err == nil {
+		return snap, nil
+	}
+	return loadRemoteSnapshot(ctx, id, "")
+}
+
+func parseRemoteDiffOperand(raw string) (host string, snapshotID string, ok bool, err error) {
+	parts := strings.SplitN(raw, "@", 2)
+	if len(parts) != 2 {
+		return "", "", false, nil
+	}
+	if len(parts[0]) == 0 {
+		return "", "", false, fmt.Errorf("invalid remote snapshot operand %q: empty host", raw)
+	}
+	if len(parts[1]) == 0 {
+		return "", "", false, fmt.Errorf("invalid remote snapshot operand %q: empty snapshot id", raw)
+	}
+	return parts[0], parts[1], true, nil
+}
+
+func resolveRemoteSnapshot(ctx context.Context, host string, snapshotID string) (*snapshot.Snapshot, error) {
+	target, err := parseConnectTarget(host)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := dialConnectTarget(target, 3*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("connect %s: %w", host, err)
+	}
+	defer conn.Close()
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if snapshotID == "" {
+		raw, err := callRPC(conn, "snapshot.list", nil)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot.list: %w", err)
+		}
+		var rows []store.SnapshotRow
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return nil, fmt.Errorf("snapshot.list: %w", err)
+		}
+		if len(rows) == 0 {
+			return nil, fmt.Errorf("host %s has no snapshots", host)
+		}
+		snapshotID = rows[0].ID
+	}
+
+	raw, err := callRPC(conn, "snapshot.get", connectParams(map[string]string{"ID": snapshotID}))
+	if err != nil {
+		return nil, fmt.Errorf("snapshot.get(%q): %w", snapshotID, err)
+	}
+	var snap snapshot.Snapshot
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		return nil, fmt.Errorf("snapshot.get(%q): %w", snapshotID, err)
+	}
+	return &snap, nil
 }
 
 func resolveBaselineSnapshot(ctx context.Context, db *store.DB, ref string) (*snapshot.Snapshot, error) {

--- a/cmd/spectra/snapshot_test.go
+++ b/cmd/spectra/snapshot_test.go
@@ -36,6 +36,151 @@ func TestResolveSnapshotNotFoundReturnsError(t *testing.T) {
 	}
 }
 
+func TestResolveSnapshotWithHostFallbackUsesLocalSnapshot(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	snap := testSnapshot("snap-local", snapshot.KindLive, time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC))
+	saveTestSnapshot(t, db, snap, "")
+
+	got, err := resolveSnapshotWithHostFallback(ctx, db, "snap-local")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.ID != "snap-local" {
+		t.Fatalf("got = %s, want snap-local", got.ID)
+	}
+}
+
+func TestResolveSnapshotWithHostFallbackFallsBackToRemoteSnapshot(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	old := loadRemoteSnapshot
+	t.Cleanup(func() { loadRemoteSnapshot = old })
+	loadRemoteSnapshot = func(context.Context, string, string) (*snapshot.Snapshot, error) {
+		return &snapshot.Snapshot{
+			ID:   "snap-remote",
+			Host: snapshot.HostInfo{Hostname: "remote.lan"},
+		}, nil
+	}
+
+	got, err := resolveSnapshotWithHostFallback(ctx, db, "remote-host")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.ID != "snap-remote" {
+		t.Fatalf("got = %s, want snap-remote", got.ID)
+	}
+}
+
+func TestResolveSnapshotWithHostFallbackFallsBackToLatestRemoteSnapshotForHostOperand(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	gotHost := ""
+	old := loadRemoteSnapshot
+	t.Cleanup(func() { loadRemoteSnapshot = old })
+	loadRemoteSnapshot = func(_ context.Context, host, snapshotID string) (*snapshot.Snapshot, error) {
+		gotHost = host + ":" + snapshotID
+		return &snapshot.Snapshot{
+			ID: "snap-remote-host-latest",
+		}, nil
+	}
+
+	if _, err := resolveSnapshotWithHostFallback(ctx, db, "work-mac"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if gotHost != "work-mac:" {
+		t.Fatalf("host operand forwarded = %q, want %q", gotHost, "work-mac:")
+	}
+}
+
+func TestResolveSnapshotWithHostFallbackUsesExplicitRemoteSnapshotOperand(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	gotHost := ""
+	gotID := ""
+	old := loadRemoteSnapshot
+	t.Cleanup(func() { loadRemoteSnapshot = old })
+	loadRemoteSnapshot = func(_ context.Context, host, snapshotID string) (*snapshot.Snapshot, error) {
+		gotHost = host
+		gotID = snapshotID
+		return &snapshot.Snapshot{ID: snapshotID}, nil
+	}
+
+	got, err := resolveSnapshotWithHostFallback(ctx, db, "work-mac@snap-remote")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if gotHost != "work-mac" {
+		t.Fatalf("host operand = %q, want %q", gotHost, "work-mac")
+	}
+	if gotID != "snap-remote" {
+		t.Fatalf("snapshot operand = %q, want %q", gotID, "snap-remote")
+	}
+	if got.ID != "snap-remote" {
+		t.Fatalf("got = %s, want snap-remote", got.ID)
+	}
+}
+
+func TestParseRemoteDiffOperand(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		wantHost     string
+		wantSnapshot string
+		wantOK       bool
+		wantErr      bool
+	}{
+		{
+			name:     "plain id",
+			raw:      "snap-1",
+			wantOK:   false,
+			wantHost: "",
+		},
+		{
+			name:         "remote operand",
+			raw:          "laptop@snap-remote",
+			wantOK:       true,
+			wantHost:     "laptop",
+			wantSnapshot: "snap-remote",
+		},
+		{
+			name:    "invalid empty host",
+			raw:     "@snap-1",
+			wantOK:  false,
+			wantErr: true,
+		},
+		{
+			name:    "invalid empty snapshot",
+			raw:     "laptop@",
+			wantOK:  false,
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHost, gotSnapshot, gotOK, err := parseRemoteDiffOperand(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if gotHost != tc.wantHost {
+				t.Fatalf("host = %q, want %q", gotHost, tc.wantHost)
+			}
+			if gotSnapshot != tc.wantSnapshot {
+				t.Fatalf("snapshot = %q, want %q", gotSnapshot, tc.wantSnapshot)
+			}
+		})
+	}
+}
+
 func TestSnapshotNameFromArgs(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -178,10 +178,16 @@ by-ui:
 Diffs two stored snapshots. `live` can be used as either side to
 capture an ephemeral current snapshot without storing it.
 
+`snapshot diff` also supports comparing snapshots across hosts when a
+local match is not found: a bare host token resolves to that host's most
+recent stored snapshot.
+
 ### Examples
 
 ```bash
 spectra diff snap-20260504T095749Z-4829 live
+spectra diff workstation work-mac                # latest snapshot on each host
+spectra diff workstation@snap-20260504T095749Z-4829 work-mac@snap-20260503T170201Z-9932
 spectra diff baseline                  # newest baseline against live
 spectra diff baseline pre-incident live
 ```


### PR DESCRIPTION
## Summary
- Add cross-host snapshot diff fallback for `spectra diff`/`snapshot diff`.
- Add explicit remote operand form `host@snapshot-id` plus local fallback to `host` latest snapshot.
- Add unit tests for fallback parsing and remote operand handling.
- Document host-based diff examples.

## Validation
- go build ./...
- go vet ./...
- go test ./... -count=1
- make docs-validate
