### PR TITLE
Add host reachability probing for spectra hosts

### DIFF
--- a/cmd/spectra/hosts.go
+++ b/cmd/spectra/hosts.go
@@ -8,11 +8,13 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/store"
 )
 
 type hostLister func(context.Context) ([]store.HostRow, error)
+type hostProber func(ctx context.Context, host string) error
 
 func runHosts(args []string) int {
 	dbPath, err := store.DefaultPath()
@@ -26,18 +28,19 @@ func runHosts(args []string) int {
 		return 1
 	}
 	defer db.Close()
-	return runHostsWith(args, os.Stdout, os.Stderr, db.ListHosts)
+	return runHostsWith(args, os.Stdout, os.Stderr, db.ListHosts, probeHost)
 }
 
-func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLister) int {
+func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLister, probe hostProber) int {
 	fs := flag.NewFlagSet("spectra hosts", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON")
+	probeFlag := fs.Bool("probe", false, "Probe each known host and report reachability")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: spectra hosts [--json]")
+		fmt.Fprintln(stderr, "usage: spectra hosts [--json] [--probe]")
 		return 2
 	}
 
@@ -47,9 +50,16 @@ func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLi
 		return 1
 	}
 	if *asJSON {
+		if *probeFlag && probe == nil {
+			return runHostsJSON(stdout, stderr, rows)
+		}
+		if !*probeFlag {
+			return runHostsJSON(stdout, stderr, rows)
+		}
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
-		if err := enc.Encode(rows); err != nil {
+		results := probeHostRows(context.Background(), rows, probe)
+		if err := enc.Encode(results); err != nil {
 			fmt.Fprintf(stderr, "encode hosts: %v\n", err)
 			return 1
 		}
@@ -59,8 +69,76 @@ func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLi
 		fmt.Fprintln(stderr, "no hosts stored - run `spectra snapshot` first")
 		return 0
 	}
+	if *probeFlag {
+		if probe == nil {
+			printHostsTable(stdout, rows)
+			return 0
+		}
+		printHostsProbeTable(stdout, probeHostRows(context.Background(), rows, probe))
+		return 0
+	}
 	printHostsTable(stdout, rows)
 	return 0
+}
+
+func runHostsJSON(stdout io.Writer, stderr io.Writer, rows []store.HostRow) int {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(rows); err != nil {
+		fmt.Fprintf(stderr, "encode hosts: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func probeHostRows(ctx context.Context, rows []store.HostRow, probe hostProber) []hostProbeRow {
+	out := make([]hostProbeRow, 0, len(rows))
+	for _, row := range rows {
+		pr := hostProbeRow{HostRow: row}
+		if row.Hostname == "" {
+			pr.Reachable = false
+			pr.Error = "empty hostname"
+			out = append(out, pr)
+			continue
+		}
+		if err := probe(ctx, row.Hostname); err != nil {
+			pr.Reachable = false
+			pr.Error = err.Error()
+		} else {
+			pr.Reachable = true
+		}
+		out = append(out, pr)
+	}
+	return out
+}
+
+func probeHost(ctx context.Context, rawHost string) error {
+	target, err := parseConnectTarget(rawHost)
+	if err != nil {
+		return err
+	}
+	conn, err := dialConnectTarget(target, 3*time.Second)
+	if err != nil {
+		return fmt.Errorf("connect %q: %w", rawHost, err)
+	}
+	defer conn.Close()
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d, ok := conn.(interface{ SetDeadline(time.Time) error }); ok {
+		_ = d.SetDeadline(time.Now().Add(3 * time.Second))
+	}
+	if _, err := callRPC(conn, "health", nil); err != nil {
+		return fmt.Errorf("health: %w", err)
+	}
+	return nil
+}
+
+type hostProbeRow struct {
+	store.HostRow
+	Reachable bool   `json:"reachable"`
+	Error     string `json:"error,omitempty"`
 }
 
 func printHostsTable(w io.Writer, rows []store.HostRow) {
@@ -74,6 +152,26 @@ func printHostsTable(w io.Writer, rows []store.HostRow) {
 			truncate(osLabel, 18),
 			row.SnapshotCount,
 			row.LastSeen.Format("2006-01-02 15:04:05Z"),
+		)
+	}
+}
+
+func printHostsProbeTable(w io.Writer, rows []hostProbeRow) {
+	fmt.Fprintf(w, "%-28s  %-20s  %-18s  %-7s  %-9s  %s\n", "MACHINE UUID", "HOSTNAME", "OS", "SNAPS", "REACHABLE", "ERROR")
+	fmt.Fprintln(w, strings.Repeat("-", 110))
+	for _, r := range rows {
+		osLabel := strings.TrimSpace(r.OSName + " " + r.OSVersion)
+		reachable := "no"
+		if r.Reachable {
+			reachable = "yes"
+		}
+		fmt.Fprintf(w, "%-28s  %-20s  %-18s  %-7d  %-9s  %s\n",
+			truncate(r.MachineUUID, 28),
+			truncate(r.Hostname, 20),
+			truncate(osLabel, 18),
+			r.SnapshotCount,
+			reachable,
+			r.Error,
 		)
 	}
 }

--- a/cmd/spectra/hosts_test.go
+++ b/cmd/spectra/hosts_test.go
@@ -26,7 +26,7 @@ func TestRunHostsWithTable(t *testing.T) {
 				SnapshotCount: 3,
 			},
 		}, nil
-	})
+	}, nil)
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
 	}
@@ -41,7 +41,7 @@ func TestRunHostsWithJSON(t *testing.T) {
 	var stderr bytes.Buffer
 	code := runHostsWith([]string{"--json"}, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
 		return []store.HostRow{{MachineUUID: "UUID-A", Hostname: "a.local"}}, nil
-	})
+	}, nil)
 	if code != 0 {
 		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
 	}
@@ -59,7 +59,7 @@ func TestRunHostsWithEmptyList(t *testing.T) {
 	var stderr bytes.Buffer
 	code := runHostsWith(nil, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
 		return nil, nil
-	})
+	}, nil)
 	if code != 0 {
 		t.Fatalf("exit code = %d", code)
 	}
@@ -73,11 +73,67 @@ func TestRunHostsWithListError(t *testing.T) {
 	var stderr bytes.Buffer
 	code := runHostsWith(nil, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
 		return nil, errors.New("db unavailable")
-	})
+	}, nil)
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
 	if !strings.Contains(stderr.String(), "db unavailable") {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunHostsWithProbe(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runHostsWith([]string{"--probe"}, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+		return []store.HostRow{
+			{MachineUUID: "UUID-A", Hostname: "work-mac.local", OSName: "macOS", OSVersion: "15.6.1"},
+			{MachineUUID: "UUID-B", Hostname: "deadbox.local", OSName: "macOS", OSVersion: "15.6.1"},
+		}, nil
+	}, func(_ context.Context, host string) error {
+		if host == "work-mac.local" {
+			return nil
+		}
+		return errors.New("timeout")
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "UUID-A") || !strings.Contains(out, "UUID-B") {
+		t.Fatalf("stdout = %q", out)
+	}
+	if !strings.Contains(out, "yes") || !strings.Contains(out, "no") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestRunHostsWithProbeJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runHostsWith([]string{"--probe", "--json"}, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+		return []store.HostRow{
+			{MachineUUID: "UUID-A", Hostname: "work-mac.local", OSName: "macOS", OSVersion: "15.6.1"},
+		}, nil
+	}, func(_ context.Context, host string) error {
+		if host == "work-mac.local" {
+			return nil
+		}
+		return errors.New("timeout")
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+
+	var rows []struct {
+		store.HostRow
+		Reachable bool   `json:"reachable"`
+		Error     string `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || !rows[0].Reachable {
+		t.Fatalf("rows = %+v", rows)
 	}
 }

--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/diff"
@@ -466,8 +467,13 @@ func runSnapshotDiff(args []string) int {
 
 func printDiffUsage() {
 	fmt.Fprintln(os.Stderr, "usage: spectra snapshot diff <id-a> <id-b|live>")
+	fmt.Fprintln(os.Stderr, "   or: spectra diff <host-a> <host-b|live>")
 	fmt.Fprintln(os.Stderr, "   or: spectra diff baseline [name|id] [live|id]")
 }
+
+type remoteSnapshotLoader func(ctx context.Context, host string, snapshotID string) (*snapshot.Snapshot, error)
+
+var loadRemoteSnapshot remoteSnapshotLoader = resolveRemoteSnapshot
 
 func resolveDiffOperands(ctx context.Context, db *store.DB, args []string) (*snapshot.Snapshot, *snapshot.Snapshot, error) {
 	if len(args) > 0 && args[0] == "baseline" {
@@ -478,11 +484,11 @@ func resolveDiffOperands(ctx context.Context, db *store.DB, args []string) (*sna
 		return nil, nil, fmt.Errorf("invalid diff operands")
 	}
 	idA, idB := args[0], args[1]
-	snapA, err := resolveSnapshot(ctx, db, idA)
+	snapA, err := resolveSnapshotWithHostFallback(ctx, db, idA)
 	if err != nil {
 		return nil, nil, fmt.Errorf("snapshot %q: %w", idA, err)
 	}
-	snapB, err := resolveSnapshot(ctx, db, idB)
+	snapB, err := resolveSnapshotWithHostFallback(ctx, db, idB)
 	if err != nil {
 		return nil, nil, fmt.Errorf("snapshot %q: %w", idB, err)
 	}
@@ -523,6 +529,79 @@ func resolveSnapshot(ctx context.Context, db *store.DB, id string) (*snapshot.Sn
 		return &snap, nil
 	}
 	return loadSnapshotFromDB(ctx, db, id)
+}
+
+func resolveSnapshotWithHostFallback(ctx context.Context, db *store.DB, id string) (*snapshot.Snapshot, error) {
+	remoteHost, remoteSnapshot, isRemote, err := parseRemoteDiffOperand(id)
+	if err != nil {
+		return nil, err
+	}
+	if isRemote {
+		return loadRemoteSnapshot(ctx, remoteHost, remoteSnapshot)
+	}
+	if strings.HasPrefix(id, "snap-") || id == "live" || strings.HasPrefix(id, "base-") || id == "" {
+		return resolveSnapshot(ctx, db, id)
+	}
+	snap, err := resolveSnapshot(ctx, db, id)
+	if err == nil {
+		return snap, nil
+	}
+	return loadRemoteSnapshot(ctx, id, "")
+}
+
+func parseRemoteDiffOperand(raw string) (host string, snapshotID string, ok bool, err error) {
+	parts := strings.SplitN(raw, "@", 2)
+	if len(parts) != 2 {
+		return "", "", false, nil
+	}
+	if len(parts[0]) == 0 {
+		return "", "", false, fmt.Errorf("invalid remote snapshot operand %q: empty host", raw)
+	}
+	if len(parts[1]) == 0 {
+		return "", "", false, fmt.Errorf("invalid remote snapshot operand %q: empty snapshot id", raw)
+	}
+	return parts[0], parts[1], true, nil
+}
+
+func resolveRemoteSnapshot(ctx context.Context, host string, snapshotID string) (*snapshot.Snapshot, error) {
+	target, err := parseConnectTarget(host)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := dialConnectTarget(target, 3*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("connect %s: %w", host, err)
+	}
+	defer conn.Close()
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if snapshotID == "" {
+		raw, err := callRPC(conn, "snapshot.list", nil)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot.list: %w", err)
+		}
+		var rows []store.SnapshotRow
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return nil, fmt.Errorf("snapshot.list: %w", err)
+		}
+		if len(rows) == 0 {
+			return nil, fmt.Errorf("host %s has no snapshots", host)
+		}
+		snapshotID = rows[0].ID
+	}
+
+	raw, err := callRPC(conn, "snapshot.get", connectParams(map[string]string{"ID": snapshotID}))
+	if err != nil {
+		return nil, fmt.Errorf("snapshot.get(%q): %w", snapshotID, err)
+	}
+	var snap snapshot.Snapshot
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		return nil, fmt.Errorf("snapshot.get(%q): %w", snapshotID, err)
+	}
+	return &snap, nil
 }
 
 func resolveBaselineSnapshot(ctx context.Context, db *store.DB, ref string) (*snapshot.Snapshot, error) {

--- a/cmd/spectra/snapshot_test.go
+++ b/cmd/spectra/snapshot_test.go
@@ -36,6 +36,151 @@ func TestResolveSnapshotNotFoundReturnsError(t *testing.T) {
 	}
 }
 
+func TestResolveSnapshotWithHostFallbackUsesLocalSnapshot(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	snap := testSnapshot("snap-local", snapshot.KindLive, time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC))
+	saveTestSnapshot(t, db, snap, "")
+
+	got, err := resolveSnapshotWithHostFallback(ctx, db, "snap-local")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.ID != "snap-local" {
+		t.Fatalf("got = %s, want snap-local", got.ID)
+	}
+}
+
+func TestResolveSnapshotWithHostFallbackFallsBackToRemoteSnapshot(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	old := loadRemoteSnapshot
+	t.Cleanup(func() { loadRemoteSnapshot = old })
+	loadRemoteSnapshot = func(context.Context, string, string) (*snapshot.Snapshot, error) {
+		return &snapshot.Snapshot{
+			ID:   "snap-remote",
+			Host: snapshot.HostInfo{Hostname: "remote.lan"},
+		}, nil
+	}
+
+	got, err := resolveSnapshotWithHostFallback(ctx, db, "remote-host")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.ID != "snap-remote" {
+		t.Fatalf("got = %s, want snap-remote", got.ID)
+	}
+}
+
+func TestResolveSnapshotWithHostFallbackFallsBackToLatestRemoteSnapshotForHostOperand(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	gotHost := ""
+	old := loadRemoteSnapshot
+	t.Cleanup(func() { loadRemoteSnapshot = old })
+	loadRemoteSnapshot = func(_ context.Context, host, snapshotID string) (*snapshot.Snapshot, error) {
+		gotHost = host + ":" + snapshotID
+		return &snapshot.Snapshot{
+			ID: "snap-remote-host-latest",
+		}, nil
+	}
+
+	if _, err := resolveSnapshotWithHostFallback(ctx, db, "work-mac"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if gotHost != "work-mac:" {
+		t.Fatalf("host operand forwarded = %q, want %q", gotHost, "work-mac:")
+	}
+}
+
+func TestResolveSnapshotWithHostFallbackUsesExplicitRemoteSnapshotOperand(t *testing.T) {
+	db := tempDB(t)
+	ctx := context.Background()
+	gotHost := ""
+	gotID := ""
+	old := loadRemoteSnapshot
+	t.Cleanup(func() { loadRemoteSnapshot = old })
+	loadRemoteSnapshot = func(_ context.Context, host, snapshotID string) (*snapshot.Snapshot, error) {
+		gotHost = host
+		gotID = snapshotID
+		return &snapshot.Snapshot{ID: snapshotID}, nil
+	}
+
+	got, err := resolveSnapshotWithHostFallback(ctx, db, "work-mac@snap-remote")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if gotHost != "work-mac" {
+		t.Fatalf("host operand = %q, want %q", gotHost, "work-mac")
+	}
+	if gotID != "snap-remote" {
+		t.Fatalf("snapshot operand = %q, want %q", gotID, "snap-remote")
+	}
+	if got.ID != "snap-remote" {
+		t.Fatalf("got = %s, want snap-remote", got.ID)
+	}
+}
+
+func TestParseRemoteDiffOperand(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		wantHost     string
+		wantSnapshot string
+		wantOK       bool
+		wantErr      bool
+	}{
+		{
+			name:     "plain id",
+			raw:      "snap-1",
+			wantOK:   false,
+			wantHost: "",
+		},
+		{
+			name:         "remote operand",
+			raw:          "laptop@snap-remote",
+			wantOK:       true,
+			wantHost:     "laptop",
+			wantSnapshot: "snap-remote",
+		},
+		{
+			name:    "invalid empty host",
+			raw:     "@snap-1",
+			wantOK:  false,
+			wantErr: true,
+		},
+		{
+			name:    "invalid empty snapshot",
+			raw:     "laptop@",
+			wantOK:  false,
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHost, gotSnapshot, gotOK, err := parseRemoteDiffOperand(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if gotHost != tc.wantHost {
+				t.Fatalf("host = %q, want %q", gotHost, tc.wantHost)
+			}
+			if gotSnapshot != tc.wantSnapshot {
+				t.Fatalf("snapshot = %q, want %q", gotSnapshot, tc.wantSnapshot)
+			}
+		})
+	}
+}
+
 func TestSnapshotNameFromArgs(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -178,10 +178,16 @@ by-ui:
 Diffs two stored snapshots. `live` can be used as either side to
 capture an ephemeral current snapshot without storing it.
 
+`snapshot diff` also supports comparing snapshots across hosts when a
+local match is not found: a bare host token resolves to that host's most
+recent stored snapshot.
+
 ### Examples
 
 ```bash
 spectra diff snap-20260504T095749Z-4829 live
+spectra diff workstation work-mac                # latest snapshot on each host
+spectra diff workstation@snap-20260504T095749Z-4829 work-mac@snap-20260503T170201Z-9932
 spectra diff baseline                  # newest baseline against live
 spectra diff baseline pre-incident live
 ```

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -443,12 +443,15 @@ of machines Spectra has seen. `spectra fan` uses this list when
 | Flag | Default | Meaning |
 |---|---:|---|
 | `--json` | false | Emit JSON instead of a table |
+| `--probe` | false | Probe each host with `health` RPC and show reachability |
 
 ### Examples
 
 ```bash
 spectra hosts
 spectra hosts --json
+spectra hosts --probe
+spectra hosts --probe --json
 ```
 
 ## `spectra fan`

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -89,7 +89,8 @@ The client makes parallel RPC calls to each daemon and aggregates
 results locally into one JSON envelope. The remaining intended shape is:
 
 ```bash
-spectra hosts                                # include discovered Spectra daemons
+spectra hosts                                # include discovered Spectra hosts
+spectra hosts --probe                         # report reachable hosts
 spectra fan inspect /Applications/Slack.app  # inspect Slack on every discovered host
 spectra diff laptop work-mac                 # compare two hosts
 ```


### PR DESCRIPTION
## Summary
- Add `spectra hosts --probe` to emit per-host reachability.
- Keep existing table/JSON output unchanged without `--probe`.
- Probe mode reuses `health` RPC for reachability checks.
- Add unit tests covering probe table output and JSON schema.
- Update docs to include `--probe` examples and remote docs note.

## Validation
- go build ./...
- go vet ./...
- go test ./... -count=1
- make docs-validate
