### PR TITLE
spectra connect: add cache clear shortcut

### DIFF
--- a/cmd/spectra/connect.go
+++ b/cmd/spectra/connect.go
@@ -77,6 +77,7 @@ func printConnectUsage(w io.Writer) {
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> inspect <App.app>")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> jvm <pid> | jvm-gc <pid> | jvm-threads <pid> | jvm-heap <pid>")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> metrics [pid] [limit]")
+	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> cache [stats|clear [kind]]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> sample <pid> [duration] [interval]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> snapshot [list|create|get|diff|processes|login-items|granted-perms|prune] ...")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> storage <App.app> [more.apps] | network-by-app [App.app ...]")
@@ -125,6 +126,9 @@ func parseConnectCall(args []string) (string, json.RawMessage, error) {
 }
 
 func parseConnectShortcut(args []string) (string, json.RawMessage, bool, error) {
+	if args[0] == "cache" {
+		return parseConnectCache(args)
+	}
 	if method, ok := connectPIDShortcuts()[args[0]]; ok {
 		return parseConnectPIDCall(args, method)
 	}
@@ -163,6 +167,26 @@ func parseConnectShortcut(args []string) (string, json.RawMessage, bool, error) 
 		return parseConnectSnapshot(args)
 	}
 	return "", nil, false, nil
+}
+
+func parseConnectCache(args []string) (string, json.RawMessage, bool, error) {
+	if len(args) == 1 {
+		return "cache.stats", nil, true, nil
+	}
+	if len(args) == 2 {
+		switch args[1] {
+		case "stats":
+			return "cache.stats", nil, true, nil
+		case "clear":
+			return "cache.clear", nil, true, nil
+		default:
+			return "", nil, true, fmt.Errorf("connect cache supports `stats` and `clear`")
+		}
+	}
+	if len(args) == 3 {
+		return "cache.clear", connectParams(map[string]string{"kind": args[2]}), true, nil
+	}
+	return "", nil, true, fmt.Errorf("connect cache clear accepts at most one kind")
 }
 
 func parseConnectMetrics(args []string) (string, json.RawMessage, bool, error) {
@@ -220,7 +244,6 @@ func connectNoArgShortcuts() map[string]string {
 	return map[string]string{
 		"build-tools":         "toolchain.build_tools",
 		"brew":                "toolchain.brew",
-		"cache":               "cache.stats",
 		"cache-stats":         "cache.stats",
 		"connections":         "network.connections",
 		"health":              "health",

--- a/cmd/spectra/connect_test.go
+++ b/cmd/spectra/connect_test.go
@@ -118,6 +118,10 @@ func TestParseConnectTypedCalls(t *testing.T) {
 		{name: "snapshot granted perms", args: []string{"snapshot", "granted-perms", "snap-1"}, wantMethod: "snapshot.granted_perms", wantParams: `{"id":"snap-1"}`},
 		{name: "snapshot prune default", args: []string{"snapshot", "prune"}, wantMethod: "snapshot.prune"},
 		{name: "snapshot prune keep", args: []string{"snapshot", "prune", "25"}, wantMethod: "snapshot.prune", wantParams: `{"keep":25}`},
+		{name: "cache", args: []string{"cache"}, wantMethod: "cache.stats"},
+		{name: "cache stats", args: []string{"cache", "stats"}, wantMethod: "cache.stats"},
+		{name: "cache clear", args: []string{"cache", "clear"}, wantMethod: "cache.clear"},
+		{name: "cache clear kind", args: []string{"cache", "clear", "detect"}, wantMethod: "cache.clear", wantParams: `{"kind":"detect"}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -157,6 +161,8 @@ func TestParseConnectTypedCallErrors(t *testing.T) {
 		{"host", "extra"},
 		{"status", "extra"},
 		{"health", "extra"},
+		{"cache", "clear", "too", "many"},
+		{"cache", "weird"},
 	}
 	for _, args := range tests {
 		t.Run(args[0], func(t *testing.T) {

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -416,6 +416,9 @@ automatic tsnet registration and host discovery remain future work.
 | `spectra connect <target> brew` | Call `toolchain.brew` |
 | `spectra connect <target> runtimes` | Call `toolchain.runtimes` |
 | `spectra connect <target> build-tools` | Call `toolchain.build_tools` |
+| `spectra connect <target> cache` | Call `cache.stats` |
+| `spectra connect <target> cache stats` | Call `cache.stats` |
+| `spectra connect <target> cache clear [kind]` | Call `cache.clear` |
 | `spectra connect <target> call <method> [json-params]` | Call an RPC method directly |
 
 ### Examples
@@ -428,6 +431,8 @@ spectra connect work-mac jvm
 spectra connect work-mac jvm-threads 4012
 spectra connect work-mac metrics
 spectra connect work-mac metrics 4012 120
+spectra connect work-mac cache
+spectra connect work-mac cache clear detect
 spectra connect work-mac processes
 spectra connect work-mac network
 spectra connect work-mac storage /Applications/Slack.app

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -62,6 +62,8 @@ spectra connect work-mac storage
 spectra connect work-mac storage /Applications/Slack.app
 spectra connect work-mac power
 spectra connect work-mac rules
+spectra connect work-mac cache
+spectra connect work-mac cache clear detect
 spectra connect work-mac snapshot list
 spectra connect work-mac snapshot diff snap-before snap-after
 spectra connect work-mac toolchains


### PR DESCRIPTION
## Summary
- Add remote `spectra connect cache` typed shortcuts.
- `cache` now resolves to `cache.stats`.
- `cache stats` also resolves to `cache.stats`.
- `cache clear` resolves to `cache.clear` with optional kind: `cache clear <kind>`.
- Add parser tests for success/error forms.
- Document cache shortcuts in CLI and remote operation docs.

## Validation
- `go test ./cmd/spectra -run TestParseConnect -count=1`
- `go test ./... -count=1`
- `go build ./...`
- `go vet ./...`
- `make docs-validate`
