### PR TITLE
spectra: add optional tailscale peer merge for fan discover

### DIFF
--- a/cmd/spectra/fan.go
+++ b/cmd/spectra/fan.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
 	"sync"
@@ -17,7 +18,7 @@ import (
 )
 
 type fanRPCCaller func(target connectTarget, timeout time.Duration, method string, params json.RawMessage) (json.RawMessage, error)
-type fanHostLister func(ctx context.Context, probeUnreachable bool) ([]fanTarget, error)
+type fanHostLister func(ctx context.Context, probeUnreachable bool, discover bool) ([]fanTarget, error)
 type fanTargetProber func(ctx context.Context, target connectTarget, timeout time.Duration) error
 
 type fanOutput struct {
@@ -44,6 +45,7 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 	timeout := fs.Duration("timeout", 3*time.Second, "Dial/read timeout per target")
 	hosts := fs.String("hosts", "", "Comma-separated daemon targets; defaults to discovered hosts")
 	probe := fs.Bool("probe", false, "When discovering hosts, skip entries that fail a health check")
+	discoverHosts := fs.Bool("discover", false, "Include tailscale peers from tailscale status --json")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -51,7 +53,7 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 	var targets []fanTarget
 	var err error
 	if strings.TrimSpace(*hosts) == "" {
-		targets, err = discover(context.Background(), *probe)
+		targets, err = discover(context.Background(), *probe, *discoverHosts)
 	} else {
 		targets, err = parseFanTargets(*hosts)
 	}
@@ -89,7 +91,7 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 }
 
 func printFanUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: spectra fan [--hosts host-a,host-b] [--probe] [status|host|jvm|processes|network|storage|power|rules]")
+	fmt.Fprintln(w, "usage: spectra fan [--hosts host-a,host-b] [--probe] [--discover] [status|host|jvm|processes|network|storage|power|rules]")
 	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] inspect <App.app>")
 	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] call <method> [json-params]")
 }
@@ -115,8 +117,9 @@ func parseFanTargets(raw string) ([]fanTarget, error) {
 }
 
 var fanProbeTarget fanTargetProber = probeFanTarget
+var fanDiscoverPeers func() ([]string, error) = discoverTailscalePeers
 
-func discoverFanTargets(ctx context.Context, probeUnreachable bool) ([]fanTarget, error) {
+func discoverFanTargets(ctx context.Context, probeUnreachable bool, discover bool) ([]fanTarget, error) {
 	dbPath, err := store.DefaultPath()
 	if err != nil {
 		return nil, err
@@ -149,6 +152,28 @@ func discoverFanTargets(ctx context.Context, probeUnreachable bool) ([]fanTarget
 		seen[key] = struct{}{}
 		targets = append(targets, fanTarget{Name: name, Target: target})
 	}
+	if discover {
+		discovered, err := fanDiscoverPeers()
+		if err != nil && len(targets) == 0 {
+			return nil, fmt.Errorf("discover remote hosts: %w", err)
+		}
+		for _, host := range discovered {
+			name := strings.TrimSpace(host)
+			if name == "" {
+				continue
+			}
+			target, err := parseConnectTarget(net.JoinHostPort(name, defaultRemotePort))
+			if err != nil {
+				continue
+			}
+			key := target.Address
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			targets = append(targets, fanTarget{Name: name, Target: target})
+		}
+	}
 	if probeUnreachable {
 		filtered := make([]fanTarget, 0, len(targets))
 		for _, target := range targets {
@@ -166,6 +191,54 @@ func discoverFanTargets(ctx context.Context, probeUnreachable bool) ([]fanTarget
 		return targets[i].Name < targets[j].Name
 	})
 	return targets, nil
+}
+
+func discoverTailscalePeers() ([]string, error) {
+	raw, err := runTailscaleStatus()
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Peers map[string]struct {
+			HostName string `json:"HostName"`
+			DNSName  string `json:"DNSName"`
+		} `json:"Peers"`
+		Peer map[string]struct {
+			HostName string `json:"HostName"`
+			DNSName  string `json:"DNSName"`
+		} `json:"Peer"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, err
+	}
+	out := make(map[string]struct{}, len(payload.Peers)+len(payload.Peer))
+	addFanPeer := func(p struct {
+		HostName string `json:"HostName"`
+		DNSName  string `json:"DNSName"`
+	}) {
+		switch {
+		case p.DNSName != "":
+			out[p.DNSName] = struct{}{}
+		case p.HostName != "":
+			out[p.HostName] = struct{}{}
+		}
+	}
+	for _, peer := range payload.Peers {
+		addFanPeer(peer)
+	}
+	for _, peer := range payload.Peer {
+		addFanPeer(peer)
+	}
+	hosts := make([]string, 0, len(out))
+	for host := range out {
+		hosts = append(hosts, host)
+	}
+	sort.Strings(hosts)
+	return hosts, nil
+}
+
+var runTailscaleStatus = func() ([]byte, error) {
+	return exec.Command("tailscale", "status", "--json").Output()
 }
 
 func probeFanTarget(ctx context.Context, target connectTarget, timeout time.Duration) error {

--- a/cmd/spectra/fan_test.go
+++ b/cmd/spectra/fan_test.go
@@ -56,7 +56,7 @@ func TestRunFanWithTypedShortcut(t *testing.T) {
 			result, _ := json.Marshal(map[string]string{"address": target.Address})
 			return result, nil
 		},
-		func(context.Context, bool) ([]fanTarget, error) {
+		func(context.Context, bool, bool) ([]fanTarget, error) {
 			t.Fatal("discover should not be used when --hosts provided")
 			return nil, nil
 		},
@@ -96,7 +96,7 @@ func TestRunFanWithPartialFailure(t *testing.T) {
 			}
 			return json.RawMessage(`{"ok":true}`), nil
 		},
-		func(context.Context, bool) ([]fanTarget, error) {
+		func(context.Context, bool, bool) ([]fanTarget, error) {
 			t.Fatal("discover should not be used when --hosts provided")
 			return nil, nil
 		},
@@ -131,7 +131,7 @@ func TestRunFanWithBadShortcut(t *testing.T) {
 			t.Fatal("caller should not run")
 			return nil, nil
 		},
-		func(context.Context, bool) ([]fanTarget, error) {
+		func(context.Context, bool, bool) ([]fanTarget, error) {
 			t.Fatal("discover should not be used when --hosts provided")
 			return nil, nil
 		},
@@ -162,7 +162,7 @@ func TestRunFanWithDiscoveredHosts(t *testing.T) {
 		func(target connectTarget, _ time.Duration, _ string, _ json.RawMessage) (json.RawMessage, error) {
 			return json.Marshal(map[string]string{"address": target.Address})
 		},
-		func(_ context.Context, probe bool) ([]fanTarget, error) {
+		func(_ context.Context, probe bool, discover bool) ([]fanTarget, error) {
 			if probe {
 				t.Fatal("discover should not probe unless --probe is set")
 			}
@@ -217,7 +217,10 @@ func TestRunFanWithDiscoveredHostsProbe(t *testing.T) {
 		func(target connectTarget, _ time.Duration, _ string, _ json.RawMessage) (json.RawMessage, error) {
 			return json.Marshal(map[string]string{"address": target.Address})
 		},
-		func(_ context.Context, probe bool) ([]fanTarget, error) {
+		func(_ context.Context, probe bool, discover bool) ([]fanTarget, error) {
+			if discover {
+				t.Fatal("discover should not receive --discover")
+			}
 			if !probe {
 				t.Fatal("discover should receive --probe")
 			}
@@ -294,7 +297,7 @@ func TestDiscoverFanTargetsWithProbeFiltersUnreachable(t *testing.T) {
 	}
 	t.Cleanup(func() { fanProbeTarget = origProbeTarget })
 
-	targets, err := discoverFanTargets(ctx, true)
+	targets, err := discoverFanTargets(ctx, true, false)
 	if err != nil {
 		t.Fatalf("discoverFanTargets = %v", err)
 	}
@@ -309,6 +312,212 @@ func TestDiscoverFanTargetsWithProbeFiltersUnreachable(t *testing.T) {
 	}
 }
 
+func TestRunFanWithDiscoverFanout(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	var gotDiscover bool
+	code := runFanWith(
+		[]string{"--discover", "host"},
+		&stdout,
+		&stderr,
+		func(target connectTarget, _ time.Duration, _ string, _ json.RawMessage) (json.RawMessage, error) {
+			return json.Marshal(map[string]string{"address": target.Address})
+		},
+		func(_ context.Context, probe bool, discover bool) ([]fanTarget, error) {
+			gotDiscover = discover
+			if probe {
+				t.Fatal("discover should not receive --probe")
+			}
+			if !discover {
+				t.Fatal("discover should receive --discover")
+			}
+			return []fanTarget{
+				{Name: "work-mac", Target: connectTarget{Network: "tcp", Address: "work-mac:7878"}},
+				{Name: "alice-laptop", Target: connectTarget{Network: "tcp", Address: "alice-laptop:7878"}},
+			}, nil
+		},
+	)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	if !gotDiscover {
+		t.Fatalf("discover flag was not passed")
+	}
+
+	var out fanOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(out.Targets))
+	}
+}
+
+func TestDiscoverFanTargetsWithDiscoveredPeers(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := filepath.Join(home, ".spectra", "spectra.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	takenAt := time.Date(2026, time.May, 5, 12, 0, 0, 0, time.UTC)
+	if err := db.SaveSnapshot(ctx, store.SnapshotInput{
+		ID:          "snap-work-mac",
+		MachineUUID: "uuid-work-mac",
+		TakenAt:     takenAt,
+		Kind:        "live",
+		Hostname:    "work-mac",
+		OSName:      "macOS",
+		OSVersion:   "15.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	origDiscoverPeers := fanDiscoverPeers
+	fanDiscoverPeers = func() ([]string, error) {
+		return []string{"work-mac", "alice-laptop"}, nil
+	}
+	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
+
+	targets, err := discoverFanTargets(ctx, false, true)
+	if err != nil {
+		t.Fatalf("discoverFanTargets = %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(targets))
+	}
+	if targets[0].Name != "alice-laptop" || targets[0].Target.Address != "alice-laptop:7878" {
+		t.Fatalf("targets[0] = %+v", targets[0])
+	}
+	if targets[1].Name != "work-mac" || targets[1].Target.Address != "work-mac:7878" {
+		t.Fatalf("targets[1] = %+v", targets[1])
+	}
+}
+
+func TestDiscoverFanTargetsWithDiscoveryFallbackToPeers(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origDiscoverPeers := fanDiscoverPeers
+	fanDiscoverPeers = func() ([]string, error) {
+		return []string{"remote-laptop", "remote-laptop"}, nil
+	}
+	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
+
+	targets, err := discoverFanTargets(ctx, false, true)
+	if err != nil {
+		t.Fatalf("discoverFanTargets = %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("len(targets) = %d, want 1", len(targets))
+	}
+	if targets[0].Name != "remote-laptop" || targets[0].Target.Address != "remote-laptop:7878" {
+		t.Fatalf("targets[0] = %+v", targets[0])
+	}
+}
+
+func TestDiscoverFanTargetsDiscoveryErrorWithDbFallback(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := filepath.Join(home, ".spectra", "spectra.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	takenAt := time.Date(2026, time.May, 5, 12, 0, 0, 0, time.UTC)
+	if err := db.SaveSnapshot(ctx, store.SnapshotInput{
+		ID:          "snap-work-mac",
+		MachineUUID: "uuid-work-mac",
+		TakenAt:     takenAt,
+		Kind:        "live",
+		Hostname:    "work-mac",
+		OSName:      "macOS",
+		OSVersion:   "15.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	origDiscoverPeers := fanDiscoverPeers
+	fanDiscoverPeers = func() ([]string, error) {
+		return nil, errors.New("tailscale unavailable")
+	}
+	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
+
+	targets, err := discoverFanTargets(ctx, false, true)
+	if err != nil {
+		t.Fatalf("discoverFanTargets = %v", err)
+	}
+	if len(targets) != 1 || targets[0].Name != "work-mac" {
+		t.Fatalf("targets = %+v", targets)
+	}
+}
+
+func TestDiscoverFanTargetsDiscoveryErrorWithoutDb(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origDiscoverPeers := fanDiscoverPeers
+	fanDiscoverPeers = func() ([]string, error) {
+		return nil, errors.New("tailscale unavailable")
+	}
+	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
+
+	_, err := discoverFanTargets(ctx, false, true)
+	if err == nil {
+		t.Fatal("discoverFanTargets succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "discover remote hosts") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestDiscoverTailscalePeersFromStatusJSON(t *testing.T) {
+	origRunTailscaleStatus := runTailscaleStatus
+	runTailscaleStatus = func() ([]byte, error) {
+		body := map[string]any{
+			"Peers": map[string]map[string]string{
+				"foo": {"DNSName": "foo.tailnet.example"},
+				"bar": {"HostName": "bar-laptop"},
+				"dup": {"DNSName": "foo.tailnet.example"},
+			},
+			"Peer": map[string]map[string]string{
+				"legacy": {"DNSName": "legacy.tailnet.example"},
+			},
+		}
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return raw, nil
+	}
+	t.Cleanup(func() { runTailscaleStatus = origRunTailscaleStatus })
+
+	peers, err := discoverTailscalePeers()
+	if err != nil {
+		t.Fatalf("discoverTailscalePeers = %v", err)
+	}
+	if len(peers) != 3 {
+		t.Fatalf("len(peers) = %d, want 3", len(peers))
+	}
+	expected := []string{"bar-laptop", "foo.tailnet.example", "legacy.tailnet.example"}
+	for i, peer := range peers {
+		if peer != expected[i] {
+			t.Fatalf("peers[%d] = %q, want %q", i, peer, expected[i])
+		}
+	}
+}
+
 func TestRunFanWithDiscoveredHostsError(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -320,7 +529,7 @@ func TestRunFanWithDiscoveredHostsError(t *testing.T) {
 			t.Fatal("caller should not run")
 			return nil, nil
 		},
-		func(context.Context, bool) ([]fanTarget, error) {
+		func(context.Context, bool, bool) ([]fanTarget, error) {
 			return nil, nil
 		},
 	)

--- a/cmd/spectra/hosts.go
+++ b/cmd/spectra/hosts.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/kaeawc/spectra/internal/store"
 )
 
-type hostLister func(context.Context) ([]store.HostRow, error)
+type hostLister func(context.Context, bool) ([]store.HostRow, error)
 type hostProber func(ctx context.Context, host string) error
 
 func runHosts(args []string) int {
@@ -28,7 +29,9 @@ func runHosts(args []string) int {
 		return 1
 	}
 	defer db.Close()
-	return runHostsWith(args, os.Stdout, os.Stderr, db.ListHosts, probeHost)
+	return runHostsWith(args, os.Stdout, os.Stderr, func(ctx context.Context, discover bool) ([]store.HostRow, error) {
+		return listHostRows(ctx, db, discover)
+	}, probeHost)
 }
 
 func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLister, probe hostProber) int {
@@ -36,15 +39,16 @@ func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLi
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON")
 	probeFlag := fs.Bool("probe", false, "Probe each known host and report reachability")
+	discoverFlag := fs.Bool("discover", false, "Merge tailscale peer discovery from `tailscale status --json`")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: spectra hosts [--json] [--probe]")
+		fmt.Fprintln(stderr, "usage: spectra hosts [--json] [--probe] [--discover]")
 		return 2
 	}
 
-	rows, err := list(context.Background())
+	rows, err := list(context.Background(), *discoverFlag)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -139,6 +143,53 @@ type hostProbeRow struct {
 	store.HostRow
 	Reachable bool   `json:"reachable"`
 	Error     string `json:"error,omitempty"`
+}
+
+var discoverHostRowsNow = time.Now
+
+func listHostRows(ctx context.Context, db *store.DB, discover bool) ([]store.HostRow, error) {
+	rows, err := db.ListHosts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	out := make([]store.HostRow, 0, len(rows))
+	for _, row := range rows {
+		name := strings.TrimSpace(row.Hostname)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, row)
+	}
+	if discover {
+		discovered, err := fanDiscoverPeers()
+		if err != nil && len(rows) == 0 {
+			return nil, fmt.Errorf("discover remote hosts: %w", err)
+		}
+		for _, host := range discovered {
+			name := strings.TrimSpace(host)
+			if name == "" {
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			out = append(out, store.HostRow{
+				MachineUUID: name,
+				Hostname:    name,
+				LastSeen:    discoverHostRowsNow().UTC(),
+			})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Hostname < out[j].Hostname
+	})
+	return out, nil
 }
 
 func printHostsTable(w io.Writer, rows []store.HostRow) {

--- a/cmd/spectra/hosts_test.go
+++ b/cmd/spectra/hosts_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ import (
 func TestRunHostsWithTable(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith(nil, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+	code := runHostsWith(nil, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
 		return []store.HostRow{
 			{
 				MachineUUID:   "UUID-1234567890",
@@ -39,7 +40,7 @@ func TestRunHostsWithTable(t *testing.T) {
 func TestRunHostsWithJSON(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith([]string{"--json"}, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+	code := runHostsWith([]string{"--json"}, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
 		return []store.HostRow{{MachineUUID: "UUID-A", Hostname: "a.local"}}, nil
 	}, nil)
 	if code != 0 {
@@ -57,7 +58,7 @@ func TestRunHostsWithJSON(t *testing.T) {
 func TestRunHostsWithEmptyList(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith(nil, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+	code := runHostsWith(nil, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
 		return nil, nil
 	}, nil)
 	if code != 0 {
@@ -71,7 +72,7 @@ func TestRunHostsWithEmptyList(t *testing.T) {
 func TestRunHostsWithListError(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith(nil, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+	code := runHostsWith(nil, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
 		return nil, errors.New("db unavailable")
 	}, nil)
 	if code != 1 {
@@ -85,7 +86,7 @@ func TestRunHostsWithListError(t *testing.T) {
 func TestRunHostsWithProbe(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith([]string{"--probe"}, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+	code := runHostsWith([]string{"--probe"}, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
 		return []store.HostRow{
 			{MachineUUID: "UUID-A", Hostname: "work-mac.local", OSName: "macOS", OSVersion: "15.6.1"},
 			{MachineUUID: "UUID-B", Hostname: "deadbox.local", OSName: "macOS", OSVersion: "15.6.1"},
@@ -111,7 +112,7 @@ func TestRunHostsWithProbe(t *testing.T) {
 func TestRunHostsWithProbeJSON(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith([]string{"--probe", "--json"}, &stdout, &stderr, func(context.Context) ([]store.HostRow, error) {
+	code := runHostsWith([]string{"--probe", "--json"}, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
 		return []store.HostRow{
 			{MachineUUID: "UUID-A", Hostname: "work-mac.local", OSName: "macOS", OSVersion: "15.6.1"},
 		}, nil
@@ -135,5 +136,142 @@ func TestRunHostsWithProbeJSON(t *testing.T) {
 	}
 	if len(rows) != 1 || !rows[0].Reachable {
 		t.Fatalf("rows = %+v", rows)
+	}
+}
+
+func TestRunHostsWithDiscover(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runHostsWith([]string{"--discover"}, &stdout, &stderr, func(_ context.Context, discover bool) ([]store.HostRow, error) {
+		if !discover {
+			t.Fatal("discover flag was not passed")
+		}
+		return []store.HostRow{
+			{MachineUUID: "UUID-A", Hostname: "work-mac.local", OSName: "macOS", OSVersion: "15.6.1"},
+		}, nil
+	}, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "work-mac.local") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestListHostRowsWithDiscoveredPeers(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := filepath.Join(home, ".spectra", "spectra.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	takenAt := time.Date(2026, time.May, 5, 12, 0, 0, 0, time.UTC)
+	if err := db.SaveSnapshot(ctx, store.SnapshotInput{
+		ID:          "snap-work-mac",
+		MachineUUID: "uuid-work-mac",
+		TakenAt:     takenAt,
+		Kind:        "live",
+		Hostname:    "work-mac",
+		OSName:      "macOS",
+		OSVersion:   "15.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	origDiscoverPeers := fanDiscoverPeers
+	fanDiscoverPeers = func() ([]string, error) {
+		return []string{"work-mac", "alice-laptop"}, nil
+	}
+	origNow := discoverHostRowsNow
+	discoverHostRowsNow = func() time.Time { return time.Date(2026, time.May, 5, 13, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() {
+		fanDiscoverPeers = origDiscoverPeers
+		discoverHostRowsNow = origNow
+	})
+
+	rows, err := listHostRows(ctx, db, true)
+	if err != nil {
+		t.Fatalf("listHostRows = %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2", len(rows))
+	}
+	if rows[0].Hostname != "alice-laptop" || rows[0].MachineUUID != "alice-laptop" {
+		t.Fatalf("rows[0] = %+v", rows[0])
+	}
+	if rows[1].Hostname != "work-mac" || rows[1].MachineUUID != "uuid-work-mac" {
+		t.Fatalf("rows[1] = %+v", rows[1])
+	}
+}
+
+func TestListHostRowsDiscoveryErrorFallback(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := filepath.Join(home, ".spectra", "spectra.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	takenAt := time.Date(2026, time.May, 5, 12, 0, 0, 0, time.UTC)
+	if err := db.SaveSnapshot(ctx, store.SnapshotInput{
+		ID:          "snap-work-mac",
+		MachineUUID: "uuid-work-mac",
+		TakenAt:     takenAt,
+		Kind:        "live",
+		Hostname:    "work-mac",
+		OSName:      "macOS",
+		OSVersion:   "15.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	origDiscoverPeers := fanDiscoverPeers
+	fanDiscoverPeers = func() ([]string, error) {
+		return nil, errors.New("tailscale unavailable")
+	}
+	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
+
+	rows, err := listHostRows(ctx, db, true)
+	if err != nil {
+		t.Fatalf("listHostRows = %v", err)
+	}
+	if len(rows) != 1 || rows[0].Hostname != "work-mac" {
+		t.Fatalf("rows = %+v", rows)
+	}
+}
+
+func TestListHostRowsDiscoveryErrorWithoutDb(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := filepath.Join(home, ".spectra", "spectra.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	origDiscoverPeers := fanDiscoverPeers
+	fanDiscoverPeers = func() ([]string, error) {
+		return nil, errors.New("tailscale unavailable")
+	}
+	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
+
+	_, err = listHostRows(ctx, db, true)
+	if err == nil {
+		t.Fatal("listHostRows succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "discover remote hosts") {
+		t.Fatalf("err = %v", err)
 	}
 }

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -478,6 +478,7 @@ of machines Spectra has seen. `spectra fan` uses this list when
 |---|---:|---|
 | `--json` | false | Emit JSON instead of a table |
 | `--probe` | false | Probe each host with `health` RPC and show reachability |
+| `--discover` | false | Merge tailscale peers from `tailscale status --json` into host list |
 
 ### Examples
 
@@ -486,7 +487,8 @@ spectra hosts
 spectra hosts --json
 spectra hosts --probe
 spectra hosts --probe --json
-```
+spectra hosts --discover
+``` 
 
 ## `spectra fan`
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -404,6 +404,7 @@ automatic tsnet registration and host discovery remain future work.
 | `spectra connect <target> storage <App.app> [more.apps]` | Call `storage.byApp` |
 | `spectra connect <target> power` | Call `power.state` |
 | `spectra connect <target> rules [snapshot-id]` | Call `rules.check` |
+| `spectra connect <target> issues check [snapshot-id]` | Call `issues.check` |
 | `spectra connect <target> issues <machine-id> [status]` | Call `issues.list` |
 | `spectra connect <target> issues list <machine-id> [status]` | Call `issues.list` |
 | `spectra connect <target> issues update <issue-id> <status>` | Call `issues.update` |
@@ -458,6 +459,8 @@ spectra connect work-mac jvm-heap-dump 4012 /tmp/heap.hprof
 spectra connect work-mac processes
 spectra connect work-mac network
 spectra connect work-mac storage /Applications/Slack.app
+spectra connect work-mac issues check
+spectra connect work-mac issues check snap-1
 spectra connect work-mac toolchains
 spectra connect work-mac snapshot
 spectra connect work-mac snapshot diff snap-before snap-after
@@ -494,6 +497,8 @@ is optional; when omitted, fan-out uses hosts from the local store.
 | Flag | Default | Meaning |
 |---|---:|---|
 | `--hosts` | optional | Comma-separated daemon targets (`local`, `host`, `host:port`, `unix:/path`). Omit to use hosts from local `spectra hosts` data. |
+| `--probe` | false | Probe each target with `health` RPC and skip unreachable hosts when true. |
+| `--discover` | false | Include tailscale peers from `tailscale status --json` and merge with local-known hosts. |
 | `--timeout` | `3s` | Dial/read timeout per target |
 
 The command accepts the same typed shortcuts and raw `call` form as
@@ -509,6 +514,8 @@ spectra fan --hosts work-mac,alice-laptop jdk
 spectra fan --hosts work-mac,alice-laptop snapshot
 spectra fan --hosts work-mac,alice-laptop call network.connections
 spectra fan inspect /Applications/Slack.app
+spectra fan --discover status
+spectra fan --discover --probe inspect /Applications/Slack.app
 ```
 
 ## `spectra version`

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -93,6 +93,7 @@ fully managed tsnet fan-out:
 
 ```bash
 spectra hosts
+spectra hosts --discover
 spectra fan --hosts work-mac,alice-laptop status
 spectra fan --hosts work-mac,alice-laptop inspect /Applications/Slack.app
 spectra fan inspect /Applications/Slack.app

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -62,6 +62,7 @@ spectra connect work-mac storage
 spectra connect work-mac storage /Applications/Slack.app
 spectra connect work-mac power
 spectra connect work-mac rules
+spectra connect work-mac issues check
 spectra connect work-mac cache
 spectra connect work-mac cache clear detect
 spectra connect work-mac issues local-machine
@@ -82,9 +83,13 @@ Use `call` for less common methods such as direct JDK calls.
 
 ## Cross-host operations
 
-Explicit-host fan-out is implemented with `spectra fan --hosts`.
-When `--hosts` is omitted, `spectra fan` uses discovered/recorded hosts
-from `spectra hosts` (currently local-store-based discovery):
+Cross-host fan-out is implemented with `spectra fan --hosts`.
+When `--hosts` is omitted, `spectra fan` can merge:
+- hosts from local `spectra hosts` data (`~/.spectra/spectra.db`), and
+- optional tailscale peers (`spectra fan --discover`) from `tailscale status --json`.
+
+This currently supports a manual discovery opt-in path while we migrate toward
+fully managed tsnet fan-out:
 
 ```bash
 spectra hosts
@@ -93,6 +98,7 @@ spectra fan --hosts work-mac,alice-laptop inspect /Applications/Slack.app
 spectra fan inspect /Applications/Slack.app
 spectra fan --hosts work-mac,alice-laptop jvm
 spectra fan --hosts work-mac,alice-laptop network-by-app /Applications/Slack.app
+spectra fan --discover status
 ```
 
 The client makes parallel RPC calls to each daemon and aggregates
@@ -201,6 +207,6 @@ remote work:
 
 1. Add tsnet integration so the daemon can join a tailnet without an
    externally managed listener.
-2. Add live host discovery so `spectra hosts` includes reachable daemons
+2. Add managed tsnet host discovery so `spectra hosts` includes reachable daemons
    and `spectra fan` can run without an explicit `--hosts` list.
 3. Add TUI support against local-or-remote daemon targets.


### PR DESCRIPTION
## What changed
- Add  flag to  to include tailscale peers from .
- Merge discovered peers with store hosts and dedupe.
- Add fallback behavior: discovery errors are tolerated when local hosts exist, but fail when discovery is the only source.
- Add unit tests for CLI behavior, store/peer merge, and tailscale JSON parsing.
- Update CLI/remote docs for the new discovery flow.

## Validation
- gofmt
- go test ./cmd/spectra
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate