### PR TITLE
Harden connect target parsing

### DIFF
--- a/cmd/spectra/connect.go
+++ b/cmd/spectra/connect.go
@@ -88,6 +88,10 @@ func printConnectUsage(w io.Writer) {
 }
 
 func parseConnectTarget(raw string) (connectTarget, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return connectTarget{}, fmt.Errorf("empty connect target")
+	}
 	switch {
 	case raw == "local":
 		sock, err := serve.DefaultSockPath()

--- a/cmd/spectra/connect_test.go
+++ b/cmd/spectra/connect_test.go
@@ -35,6 +35,11 @@ func TestParseConnectTarget(t *testing.T) {
 			raw:  "work-mac",
 			want: connectTarget{Network: "tcp", Address: "work-mac:7878"},
 		},
+		{
+			name: "trimmed host default port",
+			raw:  "  work-mac  ",
+			want: connectTarget{Network: "tcp", Address: "work-mac:7878"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -46,6 +51,14 @@ func TestParseConnectTarget(t *testing.T) {
 				t.Fatalf("target = %+v, want %+v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseConnectTargetErrors(t *testing.T) {
+	for _, raw := range []string{"", "   "} {
+		if _, err := parseConnectTarget(raw); err == nil {
+			t.Fatalf("parseConnectTarget(%q) succeeded, want error", raw)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Trim incidental whitespace before parsing `spectra connect` and `spectra fan` targets.
- Return a direct `empty connect target` error for empty or blank targets.
- Add focused parser tests for trimmed hosts and blank target rejection.

## Validation

- `go test ./cmd/spectra -run TestParseConnectTarget -count=1`
- `go build ./...`
- `go vet ./...`
