### PR TITLE
Populate storage volume filesystem types

### DIFF
--- a/internal/storagestate/storagestate.go
+++ b/internal/storagestate/storagestate.go
@@ -72,6 +72,11 @@ func Collect(opts CollectOptions) State {
 	if out, err := run("df", "-Pk"); err == nil {
 		s.Volumes = parseDF(string(out))
 	}
+	if len(s.Volumes) > 0 {
+		if out, err := run("mount"); err == nil {
+			applyFSTypes(s.Volumes, parseMountFSTypes(string(out)))
+		}
+	}
 	s.UserLibraryBytes = dirBytes(filepath.Join(opts.Home, "Library"))
 	s.AppCachesBytes = dirBytes(filepath.Join(opts.Home, "Library", "Caches"))
 	if len(opts.AppPaths) > 0 {
@@ -111,6 +116,46 @@ func parseDF(out string) []Volume {
 		})
 	}
 	return volumes
+}
+
+func applyFSTypes(volumes []Volume, fsTypes map[string]string) {
+	for i := range volumes {
+		if fsType := fsTypes[volumes[i].MountPoint]; fsType != "" {
+			volumes[i].FSType = fsType
+		}
+	}
+}
+
+func parseMountFSTypes(out string) map[string]string {
+	fsTypes := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		mountPoint, fsType, ok := parseMountLine(line)
+		if ok {
+			fsTypes[mountPoint] = fsType
+		}
+	}
+	return fsTypes
+}
+
+func parseMountLine(line string) (mountPoint string, fsType string, ok bool) {
+	_, rest, ok := strings.Cut(line, " on ")
+	if !ok {
+		return "", "", false
+	}
+	mountPoint, options, ok := strings.Cut(rest, " (")
+	if !ok {
+		return "", "", false
+	}
+	fields := strings.Split(options, ",")
+	if len(fields) == 0 {
+		return "", "", false
+	}
+	fsType = strings.TrimSpace(strings.TrimSuffix(fields[0], ")"))
+	mountPoint = strings.TrimSpace(mountPoint)
+	if mountPoint == "" || fsType == "" {
+		return "", "", false
+	}
+	return mountPoint, fsType, true
 }
 
 // dirBytes returns the total on-disk size of all files under dir using

--- a/internal/storagestate/storagestate_test.go
+++ b/internal/storagestate/storagestate_test.go
@@ -15,6 +15,11 @@ devfs                                  386       386         0   100% /dev
 /dev/disk3s5                     971309944   5312168 444843444     2% /data
 `
 
+const mountOutput = `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+devfs on /dev (devfs, local, nobrowse)
+/dev/disk3s5 on /data (apfs, local, journaled)
+`
+
 func TestParseDF(t *testing.T) {
 	vols := parseDF(dfOutput)
 	// Should include /, /data but skip devfs and /System/Volumes/*
@@ -42,6 +47,29 @@ func TestParseDFBytes(t *testing.T) {
 	// 971309944 * 1024
 	if root.TotalBytes != 971309944*1024 {
 		t.Errorf("TotalBytes = %d, want %d", root.TotalBytes, 971309944*1024)
+	}
+}
+
+func TestParseMountFSTypes(t *testing.T) {
+	got := parseMountFSTypes(mountOutput)
+	if got["/"] != "apfs" {
+		t.Fatalf("root fs type = %q, want apfs", got["/"])
+	}
+	if got["/dev"] != "devfs" {
+		t.Fatalf("/dev fs type = %q, want devfs", got["/dev"])
+	}
+}
+
+func TestApplyFSTypes(t *testing.T) {
+	vols := parseDF(dfOutput)
+	applyFSTypes(vols, parseMountFSTypes(mountOutput))
+	for _, v := range vols {
+		switch v.MountPoint {
+		case "/", "/data":
+			if v.FSType != "apfs" {
+				t.Fatalf("%s fs type = %q, want apfs", v.MountPoint, v.FSType)
+			}
+		}
 	}
 }
 
@@ -114,6 +142,9 @@ func TestCollect(t *testing.T) {
 	os.WriteFile(filepath.Join(cacheDir, "test.dat"), make([]byte, 2048), 0o644)
 
 	stub := func(name string, args ...string) ([]byte, error) {
+		if name == "mount" {
+			return []byte(mountOutput), nil
+		}
 		return []byte(dfOutput), nil
 	}
 
@@ -123,6 +154,9 @@ func TestCollect(t *testing.T) {
 	})
 	if len(s.Volumes) == 0 {
 		t.Error("expected volumes from stubbed df")
+	}
+	if s.Volumes[0].FSType == "" {
+		t.Error("expected fs_type from stubbed mount")
 	}
 	if s.AppCachesBytes == 0 {
 		t.Error("AppCachesBytes should be > 0")


### PR DESCRIPTION
## Summary

- Populate the existing `StorageState.volumes[].fs_type` field from `mount` output.
- Keep `df -Pk` as the source of volume sizing and treat `mount` failures as best-effort.
- Add parser and collector tests for filesystem type enrichment.

## Validation

- `go test ./internal/storagestate -count=1`
- `go build ./...`
- `go vet ./...`
