### PR TITLE
Remove duplicate remote ACL sentence

### DIFF
--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -128,8 +128,6 @@ Tailscale ACLs, or firewall rules to limit access.
 The planned tsnet mode will make Tailscale identity the default
 authorization layer. The Tailscale ACL example for a personal tailnet:
 
-The Tailscale ACL example for a personal tailnet:
-
 ```hujson
 {
   "acls": [


### PR DESCRIPTION
## Summary

- Remove a duplicated introductory sentence before the personal tailnet ACL example in `docs/operations/remote.md`.

## Validation

- `make docs-validate`
