### PR TITLE
Improve network listener attribution

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -191,12 +191,20 @@ func printListeningPorts(listening []netstate.ListeningPort) {
 	// Sort by port for stable output.
 	ports := make([]netstate.ListeningPort, len(listening))
 	copy(ports, listening)
-	sort.Slice(ports, func(i, j int) bool { return ports[i].Port < ports[j].Port })
+	sort.Slice(ports, func(i, j int) bool {
+		if ports[i].Port != ports[j].Port {
+			return ports[i].Port < ports[j].Port
+		}
+		if ports[i].LocalAddr != ports[j].LocalAddr {
+			return ports[i].LocalAddr < ports[j].LocalAddr
+		}
+		return ports[i].PID < ports[j].PID
+	})
 
 	fmt.Println()
 	fmt.Printf("listening ports (%d):\n", len(ports))
 	for _, p := range ports {
-		fmt.Printf("  %s/%d%s%s\n", p.Proto, p.Port, listeningPID(p), listeningApp(p))
+		fmt.Printf("  %s/%d%s%s%s%s\n", p.Proto, p.Port, listeningAddr(p), listeningPID(p), listeningCommand(p), listeningApp(p))
 	}
 }
 
@@ -227,6 +235,20 @@ func listeningPID(p netstate.ListeningPort) string {
 		return ""
 	}
 	return fmt.Sprintf(" pid=%d", p.PID)
+}
+
+func listeningAddr(p netstate.ListeningPort) string {
+	if p.LocalAddr == "" {
+		return ""
+	}
+	return fmt.Sprintf(" addr=%s", p.LocalAddr)
+}
+
+func listeningCommand(p netstate.ListeningPort) string {
+	if p.Command == "" {
+		return ""
+	}
+	return fmt.Sprintf(" cmd=%s", truncate(p.Command, 24))
 }
 
 func listeningApp(p netstate.ListeningPort) string {

--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -163,8 +163,8 @@ NetworkState {
   hosts_overrides []      # only non-default /etc/hosts lines
   vpn_active             # tailscale, cisco anyconnect, openvpn
   vpn_interfaces []
-  listening_ports []{ port, proto, pid, app_path }
-  established_connections_count
+  listening_ports []{ port, proto, local_addr, pid, command, user, app_path }
+  established_connections_count  # TCP ESTABLISHED rows only
   process_throughput []{ pid, command, bytes_in_per_sec, bytes_out_per_sec }
 }
 ```

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -45,7 +45,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | Source | Output | Privilege | Cost | Used by |
 |---|---|---|---|---|
 | `nettop -P -L 2 -x -d -J bytes_in,bytes_out -t external` | per-process network bytes/sec | user (limited) | ~1s sample | `network.process_throughput` |
-| `lsof -i -P -n -sTCP:LISTEN` | current listening TCP sockets | user | one-shot | `network.listening_ports` |
+| `lsof -i -P -n -sTCP:LISTEN` | current listening TCP sockets with bind address, PID, command, and user | user | one-shot | `network.listening_ports` |
 | `lsof -i -P -n` | current TCP/UDP sockets | user | one-shot | `network.connections`, `network.byApp`, established count |
 | `netstat -an` | system-wide TCP/UDP socket state without PID/app attribution | user | low | fallback when `lsof` unavailable |
 | `scutil --proxy` | system proxy config | user | <10ms | `network.proxy_config` |
@@ -55,8 +55,10 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `tcpdump -i <iface>` | raw packet capture | helper | streaming, high | (planned) targeted capture |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
-`nettop`, and `/etc/hosts`. Raw packet capture is reserved for explicit
-future live workflows.
+`nettop`, and `/etc/hosts`. `lsof` is also where current socket owner
+attribution comes from; its visibility is limited to what the invoking user can
+see unless a future helper-backed collector is used. Raw packet capture is
+reserved for explicit future live workflows.
 
 ## Energy and power
 

--- a/docs/inspection/network-endpoints.md
+++ b/docs/inspection/network-endpoints.md
@@ -117,7 +117,7 @@ Related live-network collectors:
 - `internal/netstate/connections.go` — `lsof -i -P -n` socket list with
   `netstat -an` fallback.
 - `internal/netstate/netstate.go` — routes, DNS, proxy config, VPN state,
-  listening ports, and connection counts.
+  listening ports with process attribution, and connection counts.
 
 ## CLI usage
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -296,7 +296,8 @@ spectra jvm jfr stop 4012 --name spectra
 
 Shows unprivileged network state by default, including current routes,
 DNS, VPN state, listening ports, and active per-process throughput from
-`nettop`. `spectra network firewall` asks the privileged helper for
+`nettop`. Listening ports include bind address and process attribution when
+`lsof` exposes it. `spectra network firewall` asks the privileged helper for
 current pf firewall rules.
 
 ### Examples

--- a/internal/netstate/netstate.go
+++ b/internal/netstate/netstate.go
@@ -48,10 +48,13 @@ type HostsEntry struct {
 
 // ListeningPort is one TCP/UDP socket currently bound on the machine.
 type ListeningPort struct {
-	Port    int    `json:"port"`
-	Proto   string `json:"proto"` // "tcp", "udp"
-	PID     int    `json:"pid,omitempty"`
-	AppPath string `json:"app_path,omitempty"`
+	Port      int    `json:"port"`
+	Proto     string `json:"proto"` // "tcp", "udp"
+	LocalAddr string `json:"local_addr,omitempty"`
+	PID       int    `json:"pid,omitempty"`
+	Command   string `json:"command,omitempty"`
+	User      string `json:"user,omitempty"`
+	AppPath   string `json:"app_path,omitempty"`
 }
 
 // Throughput is a per-process network throughput sample from nettop.
@@ -91,7 +94,7 @@ func Collect(run CmdRunner) State {
 		s.VPNInterfaces = parseVPNInterfaces(string(out))
 		s.VPNActive = len(s.VPNInterfaces) > 0
 	}
-	s.EstablishedConnectionsCount = len(collectConnectionRows(run))
+	s.EstablishedConnectionsCount = countEstablishedConnections(collectConnectionRows(run))
 	s.ProcessThroughput = CollectThroughput(run)
 	return s
 }
@@ -104,6 +107,16 @@ func collectConnectionRows(run CmdRunner) []Connection {
 		return parseNetstatConnections(string(out))
 	}
 	return nil
+}
+
+func countEstablishedConnections(conns []Connection) int {
+	count := 0
+	for _, conn := range conns {
+		if conn.Proto == "tcp" && conn.State == "established" {
+			count++
+		}
+	}
+	return count
 }
 
 // CollectThroughput samples per-process external-interface network throughput.
@@ -331,36 +344,70 @@ func parseLSOFListen(out string) []ListeningPort {
 		if len(fields) < 9 {
 			continue
 		}
-		addrField := fields[8]
-		if !strings.HasSuffix(addrField, "(LISTEN)") {
-			// Some lsof versions put (LISTEN) in a separate column.
-			found := false
-			for _, f := range fields {
-				if f == "(LISTEN)" {
-					found = true
-					break
-				}
-			}
-			if !found {
-				continue
-			}
+		nodeIdx := lsofNodeIndex(fields)
+		if nodeIdx < 0 || nodeIdx+1 >= len(fields) {
+			continue
 		}
-		// Address is the field before (LISTEN): "TCP *:8080" or "*:8080"
-		addr := strings.TrimSuffix(addrField, "(LISTEN)")
-		addr = strings.TrimSpace(addr)
-		if idx := strings.LastIndex(addr, ":"); idx >= 0 {
-			portStr := addr[idx+1:]
-			if seen[portStr] {
-				continue
-			}
-			seen[portStr] = true
-			port := parsePort(portStr)
-			if port > 0 {
-				ports = append(ports, ListeningPort{Port: port, Proto: "tcp"})
-			}
+		state := ""
+		if nodeIdx+2 < len(fields) {
+			state = fields[nodeIdx+2]
 		}
+		name := fields[nodeIdx+1]
+		if !isListenState(name, state) {
+			continue
+		}
+		local, port, ok := parseListenAddr(name)
+		if !ok {
+			continue
+		}
+		pid, _ := strconv.Atoi(fields[1])
+		proto := strings.ToLower(fields[nodeIdx])
+		key := proto + "/" + strconv.Itoa(pid) + "/" + local + "/" + strconv.Itoa(port)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ports = append(ports, ListeningPort{
+			Port:      port,
+			Proto:     proto,
+			LocalAddr: local,
+			PID:       pid,
+			Command:   fields[0],
+			User:      fields[2],
+		})
 	}
 	return ports
+}
+
+func lsofNodeIndex(fields []string) int {
+	for i, f := range fields {
+		upper := strings.ToUpper(f)
+		if upper == "TCP" || upper == "UDP" {
+			return i
+		}
+	}
+	return -1
+}
+
+func isListenState(name, state string) bool {
+	return strings.Contains(name, "(LISTEN)") || state == "(LISTEN)"
+}
+
+func parseListenAddr(name string) (string, int, bool) {
+	addr := strings.TrimSpace(strings.TrimSuffix(name, "(LISTEN)"))
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 || idx == len(addr)-1 {
+		return "", 0, false
+	}
+	port := parsePort(addr[idx+1:])
+	if port <= 0 {
+		return "", 0, false
+	}
+	local := strings.TrimSpace(addr[:idx])
+	if local == "" {
+		local = "*"
+	}
+	return local, port, true
 }
 
 func parsePort(s string) int {

--- a/internal/netstate/netstate_test.go
+++ b/internal/netstate/netstate_test.go
@@ -121,12 +121,35 @@ func TestParseLSOFListen(t *testing.T) {
 	if len(ports) != 2 {
 		t.Fatalf("got %d ports, want 2 (8080 and 9090, deduped): %+v", len(ports), ports)
 	}
-	found := map[int]bool{}
+	found := map[int]ListeningPort{}
 	for _, p := range ports {
-		found[p.Port] = true
+		found[p.Port] = p
 	}
-	if !found[8080] || !found[9090] {
+	if _, ok := found[8080]; !ok {
 		t.Errorf("ports = %+v, want 8080 and 9090", ports)
+	}
+	if _, ok := found[9090]; !ok {
+		t.Errorf("ports = %+v, want 8080 and 9090", ports)
+	}
+	slack := found[8080]
+	if slack.PID != 412 || slack.Command != "Slack" || slack.User != "alice" {
+		t.Errorf("8080 attribution = %+v, want Slack pid=412 user=alice", slack)
+	}
+	if slack.LocalAddr != "*" || slack.Proto != "tcp" {
+		t.Errorf("8080 endpoint = %+v, want tcp *:8080", slack)
+	}
+}
+
+func TestParseLSOFListenInlineState(t *testing.T) {
+	out := `COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+node    512 alice 12u IPv6 0x123 0t0 TCP [::1]:9229(LISTEN)
+`
+	ports := parseLSOFListen(out)
+	if len(ports) != 1 {
+		t.Fatalf("ports = %+v, want one inline LISTEN row", ports)
+	}
+	if ports[0].LocalAddr != "[::1]" || ports[0].Port != 9229 || ports[0].PID != 512 {
+		t.Fatalf("inline listen parse = %+v", ports[0])
 	}
 }
 
@@ -274,8 +297,8 @@ func TestCollect(t *testing.T) {
 	if len(s.VPNInterfaces) != 1 || s.VPNInterfaces[0] != "utun3" {
 		t.Errorf("VPNInterfaces = %v, want [utun3]", s.VPNInterfaces)
 	}
-	if s.EstablishedConnectionsCount != 3 {
-		t.Errorf("EstablishedConnectionsCount = %d, want 3", s.EstablishedConnectionsCount)
+	if s.EstablishedConnectionsCount != 1 {
+		t.Errorf("EstablishedConnectionsCount = %d, want 1", s.EstablishedConnectionsCount)
 	}
 	if len(s.ProcessThroughput) != 1 || s.ProcessThroughput[0].PID != 412 {
 		t.Errorf("ProcessThroughput = %+v, want active Slack row", s.ProcessThroughput)
@@ -324,7 +347,7 @@ func TestCollectConnectionsCountFallsBackToNetstat(t *testing.T) {
 		return nil, errors.New("unexpected command")
 	}
 	s := Collect(stub)
-	if s.EstablishedConnectionsCount != 3 {
-		t.Errorf("EstablishedConnectionsCount = %d, want 3", s.EstablishedConnectionsCount)
+	if s.EstablishedConnectionsCount != 1 {
+		t.Errorf("EstablishedConnectionsCount = %d, want 1", s.EstablishedConnectionsCount)
 	}
 }


### PR DESCRIPTION
## Summary

- Add bind address, PID, command, and user metadata to network listening port snapshots.
- Make `established_connections_count` count only TCP `ESTABLISHED` rows.
- Surface listener attribution in `spectra network` output and update the docs to match the NetworkState contract.

## Validation

- `go test ./internal/netstate ./cmd/spectra -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
