### PR TITLE
Improve process inspection replay

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -75,7 +75,7 @@ required only for root-grade visibility.
   pure work; a daemon caches it and serves repeat inspections in
   microseconds.
 - **Live state needs continuity.** A ring buffer of recent CPU/RSS/network
-  samples enables "what was this process doing five minutes ago" without
+  samples enables "what was this process doing 30 minutes ago" without
   the user having had Spectra running at the time.
 - **The recommendations engine and issue tracker need persistence.** Both
   imply a single owner of the SQLite database — that's the daemon.

--- a/docs/design/storage.md
+++ b/docs/design/storage.md
@@ -104,7 +104,7 @@ queued / completed / failed / bytes. Borrowed from
 ## Tier 3: In-memory ring buffer
 
 Live data (CPU%, RSS, network bytes/sec, GC ticks) at ~1Hz is too dense
-to write straight to SQLite. The collector keeps the most recent 5
+to write straight to SQLite. The collector keeps the most recent 30
 minutes per process in RAM, then aggregates to 1-minute rows when
 flushing. Per-second resolution is reachable for "what just happened"
 queries but doesn't bloat persistent storage.

--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -65,6 +65,8 @@ ProcessInfo {
   pid, ppid
   uid, user
   command, full_command_line
+  bsd_name                  # proc_pidinfo on Darwin when visible
+  executable_path           # proc_pidpath on Darwin when visible
   cpu_pct                  # over the last sample interval
   rss_kib, vsize_kib
   thread_count             # proc_pidinfo on Darwin when visible

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -13,17 +13,19 @@ fork cost twice.
 | Source | Output | Privilege | Cost | Used by |
 |---|---|---|---|---|
 | `ps -axwwo pid,ppid,pcpu,rss,vsz,uid,user,lstart,command` | full process table | user | ~30ms / call | `process.CollectAll`, snapshots, daemon ring buffer |
-| `proc_pidinfo(PROC_PIDTASKINFO)` | per-process thread count | user | microseconds / process | `process.CollectAll`, snapshots |
-| `libproc` (cgo) | richer per-process: fd count, region info | user | ~per-process | future replacement for `ps` |
+| `proc_pidinfo(PROC_PIDTASKALLINFO)` + `proc_pidpath` | per-process thread count, BSD name, executable path | user | microseconds / process | `process.CollectAll`, snapshots |
+| `libproc` (cgo) | richer per-process: fd count, region info | user | ~per-process | future expansion |
 | `top -l 1 -n 10 -o power -stats pid,power,command` | flat per-process energy attribution | user | ~200ms | `power.energy_top_users` |
 | `sample <pid> 1` | one-second user-space sample, kernel sample optional | user (own procs); root (others) | ~1s + binding cost | `spectra sample` |
 
-`ps` is what we use today for snapshots, `spectra process`, and the
-daemon's ~1Hz metrics sampler. `--deep` process scans add one batched
-`lsof -p pid1,pid2,...` call to populate open file descriptor counts,
-listening ports, and outbound remote addresses. The natural upgrade path
-is expanding the direct `libproc` / `proc_pidinfo` coverage, which would
-eliminate more fork cost and add richer per-process detail.
+`ps` is still the base inventory source for snapshots, `spectra process`,
+and the daemon's ~1Hz metrics sampler. Darwin builds enrich those rows
+with direct libproc calls for fields that are cheap and structured.
+`--deep` process scans add one batched `lsof -p pid1,pid2,...` call to
+populate open file descriptor counts, listening ports, and outbound
+remote addresses. The natural upgrade path is expanding the direct
+`libproc` / `proc_pidinfo` coverage, which would eliminate more fork cost
+and add richer per-process detail.
 
 ## File and disk activity
 

--- a/docs/inspection/running-processes.md
+++ b/docs/inspection/running-processes.md
@@ -10,7 +10,11 @@ otherwise static inspection.
 `ps -axwwo pid=,ppid=,pcpu=,rss=,vsz=,uid=,user=,lstart=,command=`
 for the full process subcommand. Equals signs suppress the column
 headers; `axww` gets every process with full unwrapped command lines.
-A process is attributed to the app when its executable path starts
+For full process inventory, Darwin builds with cgo enrich those rows with
+`libproc` calls (`proc_pidinfo(PROC_PIDTASKALLINFO)` and `proc_pidpath`)
+to collect thread counts, BSD process names, and executable paths without
+extra forks. In that collector, a process is attributed to the app when
+its libproc executable path, falling back to its command line, starts
 with `<app-path>/`.
 
 For each match Spectra captures:
@@ -21,6 +25,8 @@ For each match Spectra captures:
 - **Start time** — parsed from `lstart`
 - **Command** — bundle-relative path (so `Contents/MacOS/Slack Helper`
   rather than the full `/Applications/Slack.app/...`)
+- **Executable path** — direct `proc_pidpath` value when visible
+- **BSD name** — direct `p_comm` value when visible
 
 For app-level inspection, Spectra also computes `AppStartedAt` from the
 oldest matching process and `AppUptimeSeconds` from that timestamp to the
@@ -95,7 +101,7 @@ The `RunningProcesses` field on the JSON result holds the full list:
   but trends require the daemon metrics ring buffer.
 - **Thread counts are best effort.** macOS `ps` does not expose
   Linux-style `nlwp`/`thcount` fields on this host, so Spectra fills
-  `thread_count` with `proc_pidinfo(PROC_PIDTASKINFO)` on Darwin when
+  `thread_count` with `proc_pidinfo(PROC_PIDTASKALLINFO)` on Darwin when
   the process is visible to the current user. Processes that cannot be
   queried keep `thread_count: 0`.
 
@@ -109,13 +115,14 @@ Per-app attribution in `internal/detect/detect.go`:
 
 Full process inventory in `internal/process/`:
 - `CollectAll(ctx, opts)` — parses `ps` rows, including `pcpu`
-- `collectThreadCounts(procs)` — Darwin `proc_pidinfo` enrichment for
-  per-process thread counts
+- `collectProcessDetails(procs)` — Darwin `libproc` enrichment for
+  thread counts, BSD process names, and executable paths
 - `enrichDeep(procs, run)` — one batched `lsof -p` call for FD and
   socket detail when `--deep` is set
 
 ## Future ideas
 
-- Switch to `libproc` via cgo (or `process.NewProcess` from
-  `gopsutil`) to get richer per-process data without forking the
-  initial `ps` inventory.
+- Continue moving fields from forked tools to `libproc`, especially
+  descriptor metadata that can reduce `lsof` dependence for process-only
+  views. Socket peer attribution still needs either richer direct socket
+  inspection or the privileged helper path.

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -92,7 +92,7 @@ LRU today.
 ## Live data ring buffer
 
 Process-level metrics (CPU%, RSS, virtual size) are sampled at ~1Hz into
-an in-memory ring buffer. The last 5 minutes per process are kept in RAM
+an in-memory ring buffer. The last 30 minutes per process are kept in RAM
 and flushed as 1-minute aggregates to SQLite. `spectra metrics` reads the
 stored rows; the `process.live` RPC returns recent in-memory samples.
 

--- a/internal/metrics/ring.go
+++ b/internal/metrics/ring.go
@@ -1,7 +1,7 @@
 // Package metrics implements the live data ring buffer described in
 // docs/operations/daemon.md and docs/design/storage.md (Tier 3).
 //
-// Process-level metrics are sampled at ~1Hz. The last 5 minutes per
+// Process-level metrics are sampled at ~1Hz. The last 30 minutes per
 // process are kept in RAM as a circular buffer. When the buffer wraps
 // or the daemon requests a flush, samples are aggregated to 1-minute
 // rows and written to SQLite.
@@ -12,8 +12,11 @@ import (
 	"time"
 )
 
-// maxSamples is 5 minutes at 1Hz.
-const maxSamples = 300
+// DefaultRetainWindow is the in-memory per-process replay window.
+const DefaultRetainWindow = 30 * time.Minute
+
+// maxSamples is DefaultRetainWindow at 1Hz.
+const maxSamples = int(DefaultRetainWindow / time.Second)
 
 // Sample is one point-in-time observation of a single process.
 type Sample struct {

--- a/internal/netstate/connections.go
+++ b/internal/netstate/connections.go
@@ -3,6 +3,8 @@ package netstate
 import (
 	"strconv"
 	"strings"
+
+	"github.com/kaeawc/spectra/internal/process"
 )
 
 // Connection is one active TCP or UDP socket from `lsof -i -P -n`.
@@ -13,6 +15,12 @@ type Connection struct {
 	LocalAddr  string `json:"local_addr"`
 	RemoteAddr string `json:"remote_addr,omitempty"` // empty for unconnected UDP
 	State      string `json:"state,omitempty"`       // "established", "close_wait", etc.
+}
+
+// AttributedConnection is a socket row joined to an app bundle path.
+type AttributedConnection struct {
+	Connection
+	AppPath string `json:"app_path,omitempty"`
 }
 
 // CollectConnections returns all active (non-LISTEN) TCP and UDP sockets.
@@ -27,6 +35,27 @@ func CollectConnections(run CmdRunner) []Connection {
 		return nil
 	}
 	return parseNetstatConnections(string(out))
+}
+
+// GroupConnectionsByApp joins active connections to process app attribution by
+// PID. Unattributed connections are grouped under the empty string key.
+func GroupConnectionsByApp(conns []Connection, procs []process.Info) map[string][]AttributedConnection {
+	pidApp := make(map[int]string, len(procs))
+	for _, p := range procs {
+		if p.PID > 0 && p.AppPath != "" {
+			pidApp[p.PID] = p.AppPath
+		}
+	}
+
+	grouped := make(map[string][]AttributedConnection)
+	for _, c := range conns {
+		app := pidApp[c.PID]
+		grouped[app] = append(grouped[app], AttributedConnection{
+			Connection: c,
+			AppPath:    app,
+		})
+	}
+	return grouped
 }
 
 // parseLSOFConnections extracts active connections from `lsof -i -P -n` output.

--- a/internal/netstate/connections_test.go
+++ b/internal/netstate/connections_test.go
@@ -3,6 +3,8 @@ package netstate
 import (
 	"errors"
 	"testing"
+
+	"github.com/kaeawc/spectra/internal/process"
 )
 
 // lsof -i -P -n output fixture (header + representative rows).
@@ -129,5 +131,41 @@ func TestCollectConnectionsSuccess(t *testing.T) {
 	conns := CollectConnections(run)
 	if len(conns) != 3 {
 		t.Errorf("CollectConnections: got %d, want 3", len(conns))
+	}
+}
+
+func TestGroupConnectionsByApp(t *testing.T) {
+	conns := []Connection{
+		{PID: 412, Command: "Slack", Proto: "tcp", RemoteAddr: "52.1.2.3:443"},
+		{PID: 789, Command: "firefox", Proto: "udp", RemoteAddr: "8.8.8.8:53"},
+		{PID: 999, Command: "netbiosd", Proto: "udp", LocalAddr: "*:138"},
+	}
+	procs := []process.Info{
+		{PID: 412, AppPath: "/Applications/Slack.app"},
+		{PID: 789, AppPath: "/Applications/Firefox.app"},
+	}
+
+	grouped := GroupConnectionsByApp(conns, procs)
+	if len(grouped["/Applications/Slack.app"]) != 1 {
+		t.Fatalf("Slack group = %+v, want one connection", grouped["/Applications/Slack.app"])
+	}
+	if grouped["/Applications/Slack.app"][0].AppPath != "/Applications/Slack.app" {
+		t.Fatalf("Slack AppPath = %q", grouped["/Applications/Slack.app"][0].AppPath)
+	}
+	if len(grouped["/Applications/Firefox.app"]) != 1 {
+		t.Fatalf("Firefox group = %+v, want one connection", grouped["/Applications/Firefox.app"])
+	}
+	if len(grouped[""]) != 1 {
+		t.Fatalf("unattributed group = %+v, want one connection", grouped[""])
+	}
+	if grouped[""][0].AppPath != "" {
+		t.Fatalf("unattributed AppPath = %q, want empty", grouped[""][0].AppPath)
+	}
+}
+
+func TestGroupConnectionsByAppEmptyInputs(t *testing.T) {
+	grouped := GroupConnectionsByApp(nil, nil)
+	if len(grouped) != 0 {
+		t.Fatalf("GroupConnectionsByApp(nil, nil) = %+v, want empty map", grouped)
 	}
 }

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -21,7 +21,9 @@ type Info struct {
 	PPID            int       `json:"ppid"`
 	UID             int       `json:"uid"`
 	User            string    `json:"user,omitempty"`
-	Command         string    `json:"command"`           // short (comm) — just the exe name
+	Command         string    `json:"command"`            // short (comm) — just the exe name
+	BSDName         string    `json:"bsd_name,omitempty"` // p_comm from libproc when available
+	ExecutablePath  string    `json:"executable_path,omitempty"`
 	FullCommandLine string    `json:"full_command_line"` // full argv[0...] string
 	RSSKiB          int64     `json:"rss_kib"`
 	VSizeKiB        int64     `json:"vsize_kib"`
@@ -54,8 +56,21 @@ type CollectOptions struct {
 	// CmdRunner overrides exec.Command for testing.
 	CmdRunner func(name string, args ...string) ([]byte, error)
 
+	// DetailCollector overrides the platform process-detail collector for
+	// testing. On Darwin this is backed by libproc/proc_pidinfo.
+	DetailCollector func([]Info) map[int]Details
+
 	// ThreadCounter overrides the platform thread-count collector for testing.
+	// Deprecated: use DetailCollector for new tests.
 	ThreadCounter func([]Info) map[int]int
+}
+
+// Details contains direct per-process metadata collected without spawning
+// extra tools where the platform exposes it.
+type Details struct {
+	ThreadCount    int
+	BSDName        string
+	ExecutablePath string
 }
 
 // CollectAll returns all running processes. Any parse errors for individual
@@ -74,6 +89,7 @@ func CollectAll(_ context.Context, opts CollectOptions) []Info {
 		return nil
 	}
 	procs := parsePS(string(out))
+	applyProcessDetails(procs, opts.DetailCollector)
 	applyThreadCounts(procs, opts.ThreadCounter)
 	if len(opts.BundlePaths) > 0 {
 		attributeBundles(procs, opts.BundlePaths)
@@ -84,12 +100,34 @@ func CollectAll(_ context.Context, opts CollectOptions) []Info {
 	return procs
 }
 
+func applyProcessDetails(procs []Info, collector func([]Info) map[int]Details) {
+	if len(procs) == 0 {
+		return
+	}
+	if collector == nil {
+		collector = collectProcessDetails
+	}
+	details := collector(procs)
+	for i := range procs {
+		d := details[procs[i].PID]
+		if d.ThreadCount > 0 {
+			procs[i].ThreadCount = d.ThreadCount
+		}
+		if d.BSDName != "" {
+			procs[i].BSDName = d.BSDName
+		}
+		if d.ExecutablePath != "" {
+			procs[i].ExecutablePath = d.ExecutablePath
+		}
+	}
+}
+
 func applyThreadCounts(procs []Info, counter func([]Info) map[int]int) {
 	if len(procs) == 0 {
 		return
 	}
 	if counter == nil {
-		counter = collectThreadCounts
+		return
 	}
 	counts := counter(procs)
 	for i := range procs {
@@ -145,7 +183,7 @@ func parseRow(line string) Info {
 	// fields[6] = user; fields[7:12] = lstart (5 tokens); fields[12:] = command
 	lstartStr := strings.Join(fields[7:12], " ")
 	var startTime time.Time
-	if t, err := time.Parse(lstartLayout, lstartStr); err == nil {
+	if t, err := time.ParseInLocation(lstartLayout, lstartStr, time.Local); err == nil {
 		startTime = t
 	}
 	full := strings.Join(fields[12:], " ")
@@ -167,7 +205,11 @@ func parseRow(line string) Info {
 // For absolute paths, it returns the last path component minus any flags.
 // "/Applications/Slack.app/Contents/MacOS/Slack --args" → "Slack"
 func shortName(cmd string) string {
-	exe := strings.Fields(cmd)[0] // strip flags
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return ""
+	}
+	exe := fields[0] // strip flags
 	if idx := strings.LastIndex(exe, "/"); idx >= 0 {
 		return exe[idx+1:]
 	}
@@ -175,18 +217,31 @@ func shortName(cmd string) string {
 }
 
 // attributeBundles sets AppPath for each process whose full command line
-// starts with one of the bundle paths. O(N*M) but both N and M are small
-// enough that a simple loop is fine.
+// or executable path starts with one of the bundle paths. O(N*M) but both N
+// and M are small enough that a simple loop is fine.
 func attributeBundles(procs []Info, bundles []string) {
 	for i := range procs {
-		cmd := procs[i].FullCommandLine
 		for _, b := range bundles {
-			if strings.HasPrefix(cmd, b) {
+			if processBelongsToBundle(procs[i], b) {
 				procs[i].AppPath = b
 				break
 			}
 		}
 	}
+}
+
+func processBelongsToBundle(p Info, bundle string) bool {
+	if pathInsideBundle(p.ExecutablePath, bundle) {
+		return true
+	}
+	return strings.HasPrefix(p.FullCommandLine, bundle)
+}
+
+func pathInsideBundle(path, bundle string) bool {
+	if path == "" || bundle == "" {
+		return false
+	}
+	return path == bundle || strings.HasPrefix(path, strings.TrimRight(bundle, "/")+"/")
 }
 
 // GroupByApp returns processes grouped by AppPath. Processes with no

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 // fakePS returns a CmdRunner that feeds canned ps output.
@@ -87,6 +88,9 @@ func TestParsePSStartTime(t *testing.T) {
 	if slack.StartTime.Year() != 2026 {
 		t.Errorf("StartTime year = %d, want 2026", slack.StartTime.Year())
 	}
+	if slack.StartTime.Location() != time.Local {
+		t.Errorf("StartTime location = %v, want time.Local", slack.StartTime.Location())
+	}
 }
 
 func TestCollectAll(t *testing.T) {
@@ -122,6 +126,35 @@ func TestCollectAllAppliesThreadCounts(t *testing.T) {
 	}
 }
 
+func TestCollectAllAppliesProcessDetails(t *testing.T) {
+	opts := CollectOptions{
+		CmdRunner: fakePS(psFixture),
+		DetailCollector: func(procs []Info) map[int]Details {
+			if len(procs) != 4 {
+				t.Fatalf("detail collector saw %d procs, want 4", len(procs))
+			}
+			return map[int]Details{
+				412: {
+					ThreadCount:    13,
+					BSDName:        "Slack",
+					ExecutablePath: "/Applications/Slack.app/Contents/MacOS/Slack",
+				},
+			}
+		},
+	}
+	procs := CollectAll(context.Background(), opts)
+	slack := procs[1]
+	if slack.ThreadCount != 13 {
+		t.Errorf("ThreadCount = %d, want 13", slack.ThreadCount)
+	}
+	if slack.BSDName != "Slack" {
+		t.Errorf("BSDName = %q, want Slack", slack.BSDName)
+	}
+	if slack.ExecutablePath != "/Applications/Slack.app/Contents/MacOS/Slack" {
+		t.Errorf("ExecutablePath = %q", slack.ExecutablePath)
+	}
+}
+
 func TestCollectAllPSError(t *testing.T) {
 	opts := CollectOptions{
 		CmdRunner: func(name string, args ...string) ([]byte, error) {
@@ -131,6 +164,25 @@ func TestCollectAllPSError(t *testing.T) {
 	procs := CollectAll(context.Background(), opts)
 	if len(procs) != 0 {
 		t.Errorf("expected nil on ps error, got %d procs", len(procs))
+	}
+}
+
+func TestBundleAttributionUsesExecutablePath(t *testing.T) {
+	opts := CollectOptions{
+		CmdRunner:   fakePS("700 1 0.0 1024 2048 501 alice Sat May  2 23:00:00 2026 Helper --flag\n"),
+		BundlePaths: []string{"/Applications/Foo Bar.app"},
+		DetailCollector: func([]Info) map[int]Details {
+			return map[int]Details{
+				700: {ExecutablePath: "/Applications/Foo Bar.app/Contents/MacOS/Helper"},
+			}
+		},
+	}
+	procs := CollectAll(context.Background(), opts)
+	if len(procs) != 1 {
+		t.Fatalf("CollectAll = %d procs, want 1", len(procs))
+	}
+	if procs[0].AppPath != "/Applications/Foo Bar.app" {
+		t.Errorf("AppPath = %q, want /Applications/Foo Bar.app", procs[0].AppPath)
 	}
 }
 

--- a/internal/process/thread_darwin.go
+++ b/internal/process/thread_darwin.go
@@ -10,17 +10,42 @@ import "C"
 import "unsafe"
 
 func collectThreadCounts(procs []Info) map[int]int {
-	counts := make(map[int]int, len(procs))
+	details := collectProcessDetails(procs)
+	counts := make(map[int]int, len(details))
+	for pid, d := range details {
+		if d.ThreadCount > 0 {
+			counts[pid] = d.ThreadCount
+		}
+	}
+	return counts
+}
+
+func collectProcessDetails(procs []Info) map[int]Details {
+	details := make(map[int]Details, len(procs))
 	for _, p := range procs {
 		if p.PID <= 0 {
 			continue
 		}
-		var taskInfo C.struct_proc_taskinfo
-		size := C.int(unsafe.Sizeof(taskInfo))
-		n := C.proc_pidinfo(C.int(p.PID), C.PROC_PIDTASKINFO, 0, unsafe.Pointer(&taskInfo), size)
-		if n == size && taskInfo.pti_threadnum > 0 {
-			counts[p.PID] = int(taskInfo.pti_threadnum)
+
+		d := Details{}
+		var taskAllInfo C.struct_proc_taskallinfo
+		taskAllInfoSize := C.int(unsafe.Sizeof(taskAllInfo))
+		n := C.proc_pidinfo(C.int(p.PID), C.PROC_PIDTASKALLINFO, 0, unsafe.Pointer(&taskAllInfo), taskAllInfoSize)
+		if n == taskAllInfoSize {
+			if taskAllInfo.ptinfo.pti_threadnum > 0 {
+				d.ThreadCount = int(taskAllInfo.ptinfo.pti_threadnum)
+			}
+			d.BSDName = C.GoString(&taskAllInfo.pbsd.pbi_name[0])
+		}
+
+		var pathBuf [C.PROC_PIDPATHINFO_MAXSIZE]C.char
+		if n := C.proc_pidpath(C.int(p.PID), unsafe.Pointer(&pathBuf[0]), C.uint32_t(len(pathBuf))); n > 0 {
+			d.ExecutablePath = C.GoString(&pathBuf[0])
+		}
+
+		if d.ThreadCount > 0 || d.BSDName != "" || d.ExecutablePath != "" {
+			details[p.PID] = d
 		}
 	}
-	return counts
+	return details
 }

--- a/internal/process/thread_stub.go
+++ b/internal/process/thread_stub.go
@@ -5,3 +5,7 @@ package process
 func collectThreadCounts(_ []Info) map[int]int {
 	return nil
 }
+
+func collectProcessDetails(_ []Info) map[int]Details {
+	return nil
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -188,7 +188,7 @@ func flushMetricsLoop(ctx context.Context, c *metrics.Collector, db *store.DB) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			aggs := c.FlushAggregates(5 * time.Minute)
+			aggs := c.FlushAggregates(metrics.DefaultRetainWindow)
 			if len(aggs) == 0 {
 				continue
 			}
@@ -877,26 +877,7 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		procs := process.CollectAll(context.Background(), process.CollectOptions{
 			BundlePaths: p.Bundles,
 		})
-
-		// Build PID → AppPath map.
-		pidApp := make(map[int]string, len(procs))
-		for _, pr := range procs {
-			if pr.AppPath != "" {
-				pidApp[pr.PID] = pr.AppPath
-			}
-		}
-
-		// Group connections by AppPath ("" for unattributed).
-		type connWithApp struct {
-			netstate.Connection
-			AppPath string `json:"app_path,omitempty"`
-		}
-		grouped := make(map[string][]connWithApp)
-		for _, c := range conns {
-			app := pidApp[c.PID]
-			grouped[app] = append(grouped[app], connWithApp{Connection: c, AppPath: app})
-		}
-		return grouped, nil
+		return netstate.GroupConnectionsByApp(conns, procs), nil
 	})
 
 	// process.list — snapshot of all running processes via ps.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -667,7 +667,8 @@ func boolInt(b bool) int {
 }
 
 // SaveProcessMetrics persists a batch of 1-minute aggregates from the ring
-// buffer. Uses INSERT OR IGNORE so duplicate (pid, minute_at) rows are skipped.
+// buffer. Rows are upserted because each flush may include a more complete
+// aggregate for a minute that was already partially written.
 func (s *DB) SaveProcessMetrics(ctx context.Context, aggs []ProcessMetricRow) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -676,9 +677,15 @@ func (s *DB) SaveProcessMetrics(ctx context.Context, aggs []ProcessMetricRow) er
 	defer tx.Rollback() //nolint:errcheck
 	for _, a := range aggs {
 		_, err := tx.ExecContext(ctx, `
-			INSERT OR IGNORE INTO process_metrics
+			INSERT INTO process_metrics
 			    (pid, minute_at, avg_rss_kib, max_rss_kib, avg_cpu_pct, max_cpu_pct, sample_count)
-			VALUES (?,?,?,?,?,?,?)`,
+			VALUES (?,?,?,?,?,?,?)
+			ON CONFLICT(pid, minute_at) DO UPDATE SET
+			    avg_rss_kib=excluded.avg_rss_kib,
+			    max_rss_kib=excluded.max_rss_kib,
+			    avg_cpu_pct=excluded.avg_cpu_pct,
+			    max_cpu_pct=excluded.max_cpu_pct,
+			    sample_count=excluded.sample_count`,
 			a.PID, a.MinuteAt.UTC().Format(time.RFC3339),
 			a.AvgRSSKiB, a.MaxRSSKiB,
 			a.AvgCPUPct, a.MaxCPUPct,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -567,6 +567,64 @@ func TestProcessesFromSnapshot(t *testing.T) {
 	}
 }
 
+func TestSaveAndGetProcessMetrics(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	minute := time.Date(2026, 5, 6, 15, 4, 0, 0, time.UTC)
+
+	rows := []ProcessMetricRow{
+		{PID: 412, MinuteAt: minute, AvgRSSKiB: 1000, MaxRSSKiB: 1200, AvgCPUPct: 1.5, MaxCPUPct: 2.0, SampleCount: 30},
+		{PID: 412, MinuteAt: minute.Add(time.Minute), AvgRSSKiB: 2000, MaxRSSKiB: 2400, AvgCPUPct: 2.5, MaxCPUPct: 3.0, SampleCount: 60},
+	}
+	if err := db.SaveProcessMetrics(ctx, rows); err != nil {
+		t.Fatalf("SaveProcessMetrics: %v", err)
+	}
+
+	got, err := db.GetProcessMetrics(ctx, 412, 10)
+	if err != nil {
+		t.Fatalf("GetProcessMetrics: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if !got[0].MinuteAt.Equal(minute.Add(time.Minute)) {
+		t.Fatalf("newest row first = %v, want %v", got[0].MinuteAt, minute.Add(time.Minute))
+	}
+	if got[0].SampleCount != 60 || got[0].MaxRSSKiB != 2400 {
+		t.Fatalf("newest row = %+v", got[0])
+	}
+}
+
+func TestSaveProcessMetricsUpsertsDuplicateMinute(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	minute := time.Date(2026, 5, 6, 15, 4, 0, 0, time.UTC)
+
+	first := []ProcessMetricRow{
+		{PID: 412, MinuteAt: minute, AvgRSSKiB: 1000, MaxRSSKiB: 1200, AvgCPUPct: 1.5, MaxCPUPct: 2.0, SampleCount: 30},
+	}
+	second := []ProcessMetricRow{
+		{PID: 412, MinuteAt: minute, AvgRSSKiB: 1500, MaxRSSKiB: 2200, AvgCPUPct: 2.5, MaxCPUPct: 4.0, SampleCount: 60},
+	}
+	if err := db.SaveProcessMetrics(ctx, first); err != nil {
+		t.Fatalf("first SaveProcessMetrics: %v", err)
+	}
+	if err := db.SaveProcessMetrics(ctx, second); err != nil {
+		t.Fatalf("second SaveProcessMetrics: %v", err)
+	}
+
+	got, err := db.GetProcessMetrics(ctx, 412, 10)
+	if err != nil {
+		t.Fatalf("GetProcessMetrics: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].AvgRSSKiB != 1500 || got[0].MaxRSSKiB != 2200 || got[0].AvgCPUPct != 2.5 || got[0].MaxCPUPct != 4.0 || got[0].SampleCount != 60 {
+		t.Fatalf("upserted row = %+v, want second aggregate", got[0])
+	}
+}
+
 func TestSaveAndGetLoginItems(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- enrich process snapshots with Darwin libproc details for BSD names, executable paths, and thread counts
- move network connection app grouping into netstate with unit coverage
- make process metric history safer with duplicate-minute upserts and a 30-minute replay window
- update docs for the current process/network inspection path and replay behavior

## Validation
- go build ./...
- go vet ./...
- go test ./... -count=1
- make docs-validate
- go run ./cmd/spectra process --top 1 --json