### PR TITLE
Add TLS ClientHello metadata parser

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -48,6 +48,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `lsof -i -P -n -sTCP:LISTEN` | current listening TCP sockets with bind address, PID, command, and user | user | one-shot | `network.listening_ports` |
 | `lsof -i -P -n` | current TCP/UDP sockets | user | one-shot | `network.connections`, `network.byApp`, established count |
 | `netstat -an` | system-wide TCP/UDP socket state without PID/app attribution | user | low | fallback when `lsof` unavailable |
+| passive TLS ClientHello parser | SNI, ALPN, TLS versions, ECH-present flag from captured bytes | user/helper depending on capture source | low per record | `internal/netproto` parser for future capture summaries |
 | `scutil --proxy` | system proxy config | user | <10ms | `network.proxy_config` |
 | `scutil --dns` | DNS resolver config | user | <10ms | `network.dns_servers` |
 | `route -n get default` | default route + interface | user | <10ms | `network.default_route_*` |
@@ -59,6 +60,11 @@ The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
 attribution comes from; its visibility is limited to what the invoking user can
 see unless a future helper-backed collector is used. Raw packet capture is
 reserved for explicit future live workflows.
+
+`internal/netproto` contains protocol parsers that future capture collectors can
+use to summarize packet metadata without storing request or response bodies. The
+first parser handles TLS ClientHello records, which exposes SNI and ALPN when
+the client sends them in cleartext; it cannot decrypt HTTPS traffic.
 
 ## Energy and power
 

--- a/internal/netproto/tls.go
+++ b/internal/netproto/tls.go
@@ -1,0 +1,204 @@
+// Package netproto contains small protocol parsers used by network
+// inspection. Parsers in this package summarize metadata only; they do not
+// decrypt or retain payload bodies.
+package netproto
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	tlsRecordHandshake = 22
+	tlsHandshakeClient = 1
+
+	tlsExtServerName     = 0
+	tlsExtALPN           = 16
+	tlsExtSupportedVers  = 43
+	tlsExtEncryptedHello = 0xfe0d
+)
+
+// TLSClientHello is the passive metadata Spectra can extract from a TLS
+// ClientHello. SNI may be empty when the client omitted it or when ECH hides it.
+type TLSClientHello struct {
+	SNI               string   `json:"sni,omitempty"`
+	ALPN              []string `json:"alpn,omitempty"`
+	LegacyVersion     string   `json:"legacy_version,omitempty"`
+	SupportedVersions []string `json:"supported_versions,omitempty"`
+	ECHPresent        bool     `json:"ech_present,omitempty"`
+}
+
+// ParseTLSClientHello parses one TLS record containing a ClientHello.
+func ParseTLSClientHello(record []byte) (TLSClientHello, error) {
+	if len(record) < 5 {
+		return TLSClientHello{}, fmt.Errorf("tls record too short")
+	}
+	if record[0] != tlsRecordHandshake {
+		return TLSClientHello{}, fmt.Errorf("tls record is not a handshake")
+	}
+	recordLen := int(binary.BigEndian.Uint16(record[3:5]))
+	if recordLen <= 0 || len(record[5:]) < recordLen {
+		return TLSClientHello{}, fmt.Errorf("tls record length exceeds buffer")
+	}
+	body := record[5 : 5+recordLen]
+	if len(body) < 4 || body[0] != tlsHandshakeClient {
+		return TLSClientHello{}, fmt.Errorf("tls handshake is not a client hello")
+	}
+	helloLen := int(body[1])<<16 | int(body[2])<<8 | int(body[3])
+	if helloLen <= 0 || len(body[4:]) < helloLen {
+		return TLSClientHello{}, fmt.Errorf("client hello length exceeds record")
+	}
+	return parseClientHello(body[4 : 4+helloLen])
+}
+
+func parseClientHello(hello []byte) (TLSClientHello, error) {
+	if len(hello) < 34 {
+		return TLSClientHello{}, fmt.Errorf("client hello too short")
+	}
+	out := TLSClientHello{LegacyVersion: tlsVersion(hello[0], hello[1])}
+	pos := 34 // legacy_version + random
+
+	sessionLen, ok := readUint8(hello, &pos)
+	if !ok || !skip(hello, &pos, int(sessionLen)) {
+		return TLSClientHello{}, fmt.Errorf("client hello session id exceeds buffer")
+	}
+	cipherLen, ok := readUint16(hello, &pos)
+	if !ok || cipherLen%2 != 0 || !skip(hello, &pos, int(cipherLen)) {
+		return TLSClientHello{}, fmt.Errorf("client hello cipher suites exceed buffer")
+	}
+	compressionLen, ok := readUint8(hello, &pos)
+	if !ok || !skip(hello, &pos, int(compressionLen)) {
+		return TLSClientHello{}, fmt.Errorf("client hello compression methods exceed buffer")
+	}
+	if pos == len(hello) {
+		return out, nil
+	}
+	extensionsLen, ok := readUint16(hello, &pos)
+	if !ok || len(hello[pos:]) < int(extensionsLen) {
+		return TLSClientHello{}, fmt.Errorf("client hello extensions exceed buffer")
+	}
+	parseTLSExtensions(hello[pos:pos+int(extensionsLen)], &out)
+	return out, nil
+}
+
+func parseTLSExtensions(exts []byte, hello *TLSClientHello) {
+	for pos := 0; pos+4 <= len(exts); {
+		extType := binary.BigEndian.Uint16(exts[pos : pos+2])
+		extLen := int(binary.BigEndian.Uint16(exts[pos+2 : pos+4]))
+		pos += 4
+		if len(exts[pos:]) < extLen {
+			return
+		}
+		data := exts[pos : pos+extLen]
+		pos += extLen
+
+		switch extType {
+		case tlsExtServerName:
+			if sni := parseServerName(data); sni != "" {
+				hello.SNI = sni
+			}
+		case tlsExtALPN:
+			hello.ALPN = parseALPN(data)
+		case tlsExtSupportedVers:
+			hello.SupportedVersions = parseSupportedVersions(data)
+		case tlsExtEncryptedHello:
+			hello.ECHPresent = true
+		}
+	}
+}
+
+func parseServerName(data []byte) string {
+	if len(data) < 2 {
+		return ""
+	}
+	listLen := int(binary.BigEndian.Uint16(data[:2]))
+	if len(data[2:]) < listLen {
+		return ""
+	}
+	for pos := 2; pos+3 <= 2+listLen; {
+		nameType := data[pos]
+		nameLen := int(binary.BigEndian.Uint16(data[pos+1 : pos+3]))
+		pos += 3
+		if len(data[pos:]) < nameLen {
+			return ""
+		}
+		if nameType == 0 {
+			return string(data[pos : pos+nameLen])
+		}
+		pos += nameLen
+	}
+	return ""
+}
+
+func parseALPN(data []byte) []string {
+	if len(data) < 2 {
+		return nil
+	}
+	listLen := int(binary.BigEndian.Uint16(data[:2]))
+	if len(data[2:]) < listLen {
+		return nil
+	}
+	var protocols []string
+	for pos := 2; pos < 2+listLen; {
+		nameLen := int(data[pos])
+		pos++
+		if nameLen == 0 || len(data[pos:]) < nameLen {
+			return protocols
+		}
+		protocols = append(protocols, string(data[pos:pos+nameLen]))
+		pos += nameLen
+	}
+	return protocols
+}
+
+func parseSupportedVersions(data []byte) []string {
+	if len(data) < 1 {
+		return nil
+	}
+	listLen := int(data[0])
+	if listLen%2 != 0 || len(data[1:]) < listLen {
+		return nil
+	}
+	versions := make([]string, 0, listLen/2)
+	for pos := 1; pos < 1+listLen; pos += 2 {
+		versions = append(versions, tlsVersion(data[pos], data[pos+1]))
+	}
+	return versions
+}
+
+func readUint8(data []byte, pos *int) (uint8, bool) {
+	if *pos >= len(data) {
+		return 0, false
+	}
+	v := data[*pos]
+	*pos += 1
+	return v, true
+}
+
+func readUint16(data []byte, pos *int) (uint16, bool) {
+	if len(data[*pos:]) < 2 {
+		return 0, false
+	}
+	v := binary.BigEndian.Uint16(data[*pos : *pos+2])
+	*pos += 2
+	return v, true
+}
+
+func skip(data []byte, pos *int, n int) bool {
+	if n < 0 || len(data[*pos:]) < n {
+		return false
+	}
+	*pos += n
+	return true
+}
+
+func tlsVersion(major, minor byte) string {
+	switch {
+	case major == 3 && minor == 0:
+		return "SSL 3.0"
+	case major == 3 && minor >= 1 && minor <= 4:
+		return fmt.Sprintf("TLS 1.%d", minor-1)
+	default:
+		return fmt.Sprintf("0x%02x%02x", major, minor)
+	}
+}

--- a/internal/netproto/tls_test.go
+++ b/internal/netproto/tls_test.go
@@ -1,0 +1,146 @@
+package netproto
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestParseTLSClientHelloMetadata(t *testing.T) {
+	record := makeClientHello(t,
+		extension(0, serverName("api.example.com")),
+		extension(16, alpn("h2", "http/1.1")),
+		extension(43, []byte{4, 0x03, 0x04, 0x03, 0x03}),
+		extension(0xfe0d, []byte{0, 1, 2, 3}),
+	)
+
+	hello, err := ParseTLSClientHello(record)
+	if err != nil {
+		t.Fatalf("ParseTLSClientHello: %v", err)
+	}
+	if hello.SNI != "api.example.com" {
+		t.Fatalf("SNI = %q, want api.example.com", hello.SNI)
+	}
+	if hello.LegacyVersion != "TLS 1.2" {
+		t.Fatalf("LegacyVersion = %q, want TLS 1.2", hello.LegacyVersion)
+	}
+	if !hello.ECHPresent {
+		t.Fatal("ECHPresent = false, want true")
+	}
+	wantALPN := []string{"h2", "http/1.1"}
+	if !sameStrings(hello.ALPN, wantALPN) {
+		t.Fatalf("ALPN = %v, want %v", hello.ALPN, wantALPN)
+	}
+	wantVersions := []string{"TLS 1.3", "TLS 1.2"}
+	if !sameStrings(hello.SupportedVersions, wantVersions) {
+		t.Fatalf("SupportedVersions = %v, want %v", hello.SupportedVersions, wantVersions)
+	}
+}
+
+func TestParseTLSClientHelloNoExtensions(t *testing.T) {
+	hello, err := ParseTLSClientHello(makeClientHello(t))
+	if err != nil {
+		t.Fatalf("ParseTLSClientHello: %v", err)
+	}
+	if hello.SNI != "" || len(hello.ALPN) != 0 || len(hello.SupportedVersions) != 0 || hello.ECHPresent {
+		t.Fatalf("unexpected extension metadata: %+v", hello)
+	}
+}
+
+func TestParseTLSClientHelloRejectsInvalidRecord(t *testing.T) {
+	if _, err := ParseTLSClientHello([]byte{23, 3, 3, 0, 0}); err == nil {
+		t.Fatal("expected error for non-handshake record")
+	}
+	truncated := makeClientHello(t, extension(0, serverName("example.com")))
+	truncated = truncated[:len(truncated)-2]
+	if _, err := ParseTLSClientHello(truncated); err == nil {
+		t.Fatal("expected error for truncated record")
+	}
+}
+
+func makeClientHello(t *testing.T, exts ...[]byte) []byte {
+	t.Helper()
+	var hello bytes.Buffer
+	hello.Write([]byte{0x03, 0x03})          // legacy_version
+	hello.Write(bytes.Repeat([]byte{1}, 32)) // random
+	hello.WriteByte(0)                       // session_id length
+	writeUint16(&hello, 2)                   // cipher_suites length
+	hello.Write([]byte{0x13, 0x01})          // TLS_AES_128_GCM_SHA256
+	hello.WriteByte(1)                       // compression_methods length
+	hello.WriteByte(0)                       // null compression
+	if len(exts) > 0 {
+		var all bytes.Buffer
+		for _, ext := range exts {
+			all.Write(ext)
+		}
+		writeUint16(&hello, all.Len())
+		hello.Write(all.Bytes())
+	}
+
+	var handshake bytes.Buffer
+	handshake.WriteByte(tlsHandshakeClient)
+	writeUint24(&handshake, hello.Len())
+	handshake.Write(hello.Bytes())
+
+	var record bytes.Buffer
+	record.Write([]byte{tlsRecordHandshake, 0x03, 0x03})
+	writeUint16(&record, handshake.Len())
+	record.Write(handshake.Bytes())
+	return record.Bytes()
+}
+
+func extension(extType uint16, data []byte) []byte {
+	var b bytes.Buffer
+	writeUint16(&b, int(extType))
+	writeUint16(&b, len(data))
+	b.Write(data)
+	return b.Bytes()
+}
+
+func serverName(host string) []byte {
+	var names bytes.Buffer
+	names.WriteByte(0)
+	writeUint16(&names, len(host))
+	names.WriteString(host)
+
+	var data bytes.Buffer
+	writeUint16(&data, names.Len())
+	data.Write(names.Bytes())
+	return data.Bytes()
+}
+
+func alpn(protocols ...string) []byte {
+	var list bytes.Buffer
+	for _, proto := range protocols {
+		list.WriteByte(byte(len(proto)))
+		list.WriteString(proto)
+	}
+	var data bytes.Buffer
+	writeUint16(&data, list.Len())
+	data.Write(list.Bytes())
+	return data.Bytes()
+}
+
+func writeUint16(b *bytes.Buffer, n int) {
+	var tmp [2]byte
+	binary.BigEndian.PutUint16(tmp[:], uint16(n))
+	b.Write(tmp[:])
+}
+
+func writeUint24(b *bytes.Buffer, n int) {
+	b.WriteByte(byte(n >> 16))
+	b.WriteByte(byte(n >> 8))
+	b.WriteByte(byte(n))
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- Add `internal/netproto` with a metadata-only TLS ClientHello parser.
- Extract SNI, ALPN, legacy TLS version, supported versions, and ECH presence from captured ClientHello records.
- Document the parser as future capture-summary infrastructure that does not decrypt HTTPS or retain request/response bodies.

## Validation

- `go test ./internal/netproto -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
