### PR TITLE
Add DNS message metadata parser

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -50,6 +50,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `lsof -i -P -n -sTCP:LISTEN` | current listening TCP sockets with bind address, PID, command, and user | user | one-shot | `network.listening_ports` |
 | `lsof -i -P -n` | current TCP/UDP sockets | user | one-shot | `network.connections`, `network.byApp`, established count |
 | `netstat -an` | system-wide TCP/UDP socket state without PID/app attribution | user | low | fallback when `lsof` unavailable |
+| passive DNS parser | query names/types, response flag, response code, truncation, answer count from DNS payloads | user/helper depending on capture source | low per packet | `internal/netproto` parser for future UDP summaries |
 | passive TLS ClientHello parser | SNI, ALPN, TLS versions, ECH-present flag from captured bytes | user/helper depending on capture source | low per record | `internal/netproto` parser for future capture summaries |
 | `scutil --proxy` | system proxy config | user | <10ms | `network.proxy_config` |
 | `scutil --dns` | DNS resolver config | user | <10ms | `network.dns_servers` |
@@ -65,8 +66,9 @@ reserved for explicit future live workflows.
 
 `internal/netproto` contains protocol parsers that future capture collectors can
 use to summarize packet metadata without storing request or response bodies. The
-first parser handles TLS ClientHello records, which exposes SNI and ALPN when
-the client sends them in cleartext; it cannot decrypt HTTPS traffic.
+initial parsers handle DNS messages and TLS ClientHello records. TLS parsing
+exposes SNI and ALPN when the client sends them in cleartext; it cannot decrypt
+HTTPS traffic.
 
 ## Energy and power
 

--- a/internal/netproto/dns.go
+++ b/internal/netproto/dns.go
@@ -1,0 +1,142 @@
+package netproto
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+const dnsHeaderLen = 12
+
+// DNSMessage is a compact summary of one DNS datagram.
+type DNSMessage struct {
+	ID        uint16        `json:"id"`
+	Response  bool          `json:"response"`
+	OpCode    int           `json:"op_code,omitempty"`
+	RCode     int           `json:"rcode,omitempty"`
+	Truncated bool          `json:"truncated,omitempty"`
+	Questions []DNSQuestion `json:"questions,omitempty"`
+	Answers   int           `json:"answers,omitempty"`
+}
+
+// DNSQuestion identifies one DNS question.
+type DNSQuestion struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Class string `json:"class"`
+}
+
+// ParseDNSMessage parses DNS message metadata from a UDP or TCP DNS payload.
+// For TCP DNS, pass the DNS message without the two-byte length prefix.
+func ParseDNSMessage(packet []byte) (DNSMessage, error) {
+	if len(packet) < dnsHeaderLen {
+		return DNSMessage{}, fmt.Errorf("dns message too short")
+	}
+	flags := binary.BigEndian.Uint16(packet[2:4])
+	qdCount := int(binary.BigEndian.Uint16(packet[4:6]))
+	anCount := int(binary.BigEndian.Uint16(packet[6:8]))
+	msg := DNSMessage{
+		ID:        binary.BigEndian.Uint16(packet[:2]),
+		Response:  flags&0x8000 != 0,
+		OpCode:    int((flags >> 11) & 0x0f),
+		RCode:     int(flags & 0x0f),
+		Truncated: flags&0x0200 != 0,
+		Answers:   anCount,
+	}
+
+	pos := dnsHeaderLen
+	for i := 0; i < qdCount; i++ {
+		name, next, err := parseDNSName(packet, pos, 0)
+		if err != nil {
+			return DNSMessage{}, err
+		}
+		pos = next
+		if len(packet[pos:]) < 4 {
+			return DNSMessage{}, fmt.Errorf("dns question exceeds buffer")
+		}
+		qType := binary.BigEndian.Uint16(packet[pos : pos+2])
+		qClass := binary.BigEndian.Uint16(packet[pos+2 : pos+4])
+		pos += 4
+		msg.Questions = append(msg.Questions, DNSQuestion{
+			Name:  name,
+			Type:  dnsType(qType),
+			Class: dnsClass(qClass),
+		})
+	}
+	return msg, nil
+}
+
+func parseDNSName(packet []byte, pos, depth int) (string, int, error) {
+	if depth > 8 {
+		return "", 0, fmt.Errorf("dns name compression loop")
+	}
+	var labels []string
+	next := pos
+	for {
+		if next >= len(packet) {
+			return "", 0, fmt.Errorf("dns name exceeds buffer")
+		}
+		l := packet[next]
+		next++
+		switch {
+		case l == 0:
+			if len(labels) == 0 {
+				return ".", next, nil
+			}
+			return strings.Join(labels, "."), next, nil
+		case l&0xc0 == 0xc0:
+			if next >= len(packet) {
+				return "", 0, fmt.Errorf("dns compression pointer exceeds buffer")
+			}
+			ptr := int(l&0x3f)<<8 | int(packet[next])
+			next++
+			name, _, err := parseDNSName(packet, ptr, depth+1)
+			if err != nil {
+				return "", 0, err
+			}
+			labels = append(labels, name)
+			return strings.Join(labels, "."), next, nil
+		case l&0xc0 != 0:
+			return "", 0, fmt.Errorf("unsupported dns label type")
+		default:
+			labelLen := int(l)
+			if labelLen == 0 || len(packet[next:]) < labelLen {
+				return "", 0, fmt.Errorf("dns label exceeds buffer")
+			}
+			labels = append(labels, string(packet[next:next+labelLen]))
+			next += labelLen
+		}
+	}
+}
+
+func dnsType(t uint16) string {
+	switch t {
+	case 1:
+		return "A"
+	case 2:
+		return "NS"
+	case 5:
+		return "CNAME"
+	case 15:
+		return "MX"
+	case 16:
+		return "TXT"
+	case 28:
+		return "AAAA"
+	case 33:
+		return "SRV"
+	case 65:
+		return "HTTPS"
+	default:
+		return fmt.Sprintf("TYPE%d", t)
+	}
+}
+
+func dnsClass(c uint16) string {
+	switch c {
+	case 1:
+		return "IN"
+	default:
+		return fmt.Sprintf("CLASS%d", c)
+	}
+}

--- a/internal/netproto/dns_test.go
+++ b/internal/netproto/dns_test.go
@@ -1,0 +1,125 @@
+package netproto
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestParseDNSQuery(t *testing.T) {
+	packet := makeDNSQuery(t, 0x1234, "api.example.com", 1)
+
+	msg, err := ParseDNSMessage(packet)
+	if err != nil {
+		t.Fatalf("ParseDNSMessage: %v", err)
+	}
+	if msg.ID != 0x1234 || msg.Response || msg.OpCode != 0 || msg.RCode != 0 {
+		t.Fatalf("header = %+v", msg)
+	}
+	if len(msg.Questions) != 1 {
+		t.Fatalf("questions = %d, want 1", len(msg.Questions))
+	}
+	q := msg.Questions[0]
+	if q.Name != "api.example.com" || q.Type != "A" || q.Class != "IN" {
+		t.Fatalf("question = %+v", q)
+	}
+}
+
+func TestParseDNSResponseWithCompressedQuestion(t *testing.T) {
+	packet := makeDNSResponseWithCompressedQuestion(t)
+
+	msg, err := ParseDNSMessage(packet)
+	if err != nil {
+		t.Fatalf("ParseDNSMessage: %v", err)
+	}
+	if !msg.Response || msg.RCode != 3 || !msg.Truncated || msg.Answers != 2 {
+		t.Fatalf("response header = %+v", msg)
+	}
+	if len(msg.Questions) != 2 {
+		t.Fatalf("questions = %+v", msg.Questions)
+	}
+	if msg.Questions[0].Name != "example.com" || msg.Questions[1].Name != "www.example.com" {
+		t.Fatalf("question names = %+v", msg.Questions)
+	}
+	if msg.Questions[1].Type != "HTTPS" {
+		t.Fatalf("question type = %q, want HTTPS", msg.Questions[1].Type)
+	}
+}
+
+func TestParseDNSRejectsMalformedPackets(t *testing.T) {
+	if _, err := ParseDNSMessage([]byte{1, 2, 3}); err == nil {
+		t.Fatal("expected short packet error")
+	}
+
+	truncated := makeDNSQuery(t, 1, "example.com", 1)
+	truncated = truncated[:len(truncated)-2]
+	if _, err := ParseDNSMessage(truncated); err == nil {
+		t.Fatal("expected truncated question error")
+	}
+
+	loop := makeDNSQuery(t, 1, "example.com", 1)
+	loop[12] = 0xc0
+	loop[13] = 12
+	if _, err := ParseDNSMessage(loop); err == nil {
+		t.Fatal("expected compression loop error")
+	}
+}
+
+func makeDNSQuery(t *testing.T, id uint16, name string, qType uint16) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	write16(&b, id)
+	write16(&b, 0x0100) // recursion desired
+	write16(&b, 1)      // qdcount
+	write16(&b, 0)      // ancount
+	write16(&b, 0)      // nscount
+	write16(&b, 0)      // arcount
+	writeDNSName(t, &b, name)
+	write16(&b, qType)
+	write16(&b, 1)
+	return b.Bytes()
+}
+
+func makeDNSResponseWithCompressedQuestion(t *testing.T) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	write16(&b, 0x9999)
+	write16(&b, 0x8383) // response, truncated, rcode=3
+	write16(&b, 2)
+	write16(&b, 2)
+	write16(&b, 0)
+	write16(&b, 0)
+	writeDNSName(t, &b, "example.com")
+	write16(&b, 1)
+	write16(&b, 1)
+	b.WriteByte(3)
+	b.WriteString("www")
+	b.Write([]byte{0xc0, 12}) // pointer to example.com above
+	write16(&b, 65)
+	write16(&b, 1)
+	return b.Bytes()
+}
+
+func writeDNSName(t *testing.T, b *bytes.Buffer, name string) {
+	t.Helper()
+	start := 0
+	for i := 0; i <= len(name); i++ {
+		if i != len(name) && name[i] != '.' {
+			continue
+		}
+		label := name[start:i]
+		if len(label) > 63 {
+			t.Fatalf("label too long: %q", label)
+		}
+		b.WriteByte(byte(len(label)))
+		b.WriteString(label)
+		start = i + 1
+	}
+	b.WriteByte(0)
+}
+
+func write16(b *bytes.Buffer, n uint16) {
+	var tmp [2]byte
+	binary.BigEndian.PutUint16(tmp[:], n)
+	b.Write(tmp[:])
+}


### PR DESCRIPTION
## Summary

- Add a metadata-only DNS message parser under `internal/netproto`.
- Extract message ID, query/response flag, opcode, rcode, truncation, answer count, and DNS question names/types/classes.
- Cover normal queries, compressed names, malformed packets, and compression loop protection in unit tests.

## Validation

- `go test ./internal/netproto -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
