### PR TITLE
Add HTTP header metadata parser

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -50,6 +50,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `lsof -i -P -n -sTCP:LISTEN` | current listening TCP sockets with bind address, PID, command, and user | user | one-shot | `network.listening_ports` |
 | `lsof -i -P -n` | current TCP/UDP sockets | user | one-shot | `network.connections`, `network.byApp`, established count |
 | `netstat -an` | system-wide TCP/UDP socket state without PID/app attribution | user | low | fallback when `lsof` unavailable |
+| passive HTTP/1 header parser | request/response start line and redacted headers from plaintext HTTP | user/helper depending on capture source | low per header block | `internal/netproto` parser for future plaintext summaries |
 | passive DNS parser | query names/types, response flag, response code, truncation, answer count from DNS payloads | user/helper depending on capture source | low per packet | `internal/netproto` parser for future UDP summaries |
 | passive TLS ClientHello parser | SNI, ALPN, TLS versions, ECH-present flag from captured bytes | user/helper depending on capture source | low per record | `internal/netproto` parser for future capture summaries |
 | `scutil --proxy` | system proxy config | user | <10ms | `network.proxy_config` |
@@ -66,9 +67,10 @@ reserved for explicit future live workflows.
 
 `internal/netproto` contains protocol parsers that future capture collectors can
 use to summarize packet metadata without storing request or response bodies. The
-initial parsers handle DNS messages and TLS ClientHello records. TLS parsing
-exposes SNI and ALPN when the client sends them in cleartext; it cannot decrypt
-HTTPS traffic.
+initial parsers handle plaintext HTTP/1 headers, DNS messages, and TLS
+ClientHello records. HTTP parsing redacts sensitive headers by default. TLS
+parsing exposes SNI and ALPN when the client sends them in cleartext; it cannot
+decrypt HTTPS traffic.
 
 ## Energy and power
 

--- a/internal/netproto/http.go
+++ b/internal/netproto/http.go
@@ -1,0 +1,124 @@
+package netproto
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const redactedHeaderValue = "[redacted]"
+
+var sensitiveHTTPHeaders = map[string]bool{
+	"authorization":       true,
+	"cookie":              true,
+	"proxy-authorization": true,
+	"set-cookie":          true,
+	"x-api-key":           true,
+}
+
+// HTTPMessage is a metadata-only summary of one HTTP/1.x request or response
+// header block. Body bytes are intentionally ignored.
+type HTTPMessage struct {
+	IsRequest  bool         `json:"is_request"`
+	Method     string       `json:"method,omitempty"`
+	Target     string       `json:"target,omitempty"`
+	StatusCode int          `json:"status_code,omitempty"`
+	Reason     string       `json:"reason,omitempty"`
+	Version    string       `json:"version,omitempty"`
+	Headers    []HTTPHeader `json:"headers,omitempty"`
+	Truncated  bool         `json:"truncated,omitempty"`
+}
+
+// HTTPHeader is one parsed HTTP header.
+type HTTPHeader struct {
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	Redacted bool   `json:"redacted,omitempty"`
+}
+
+// ParseHTTP1Headers parses an HTTP/1.x header block. It stops at the first
+// blank line and ignores any body bytes after the header terminator.
+func ParseHTTP1Headers(data []byte) (HTTPMessage, error) {
+	headerBlock, truncated := splitHTTPHeaderBlock(string(data))
+	sc := bufio.NewScanner(strings.NewReader(headerBlock))
+	sc.Buffer(make([]byte, 0, 4096), 256*1024)
+	if !sc.Scan() {
+		return HTTPMessage{}, fmt.Errorf("http header block is empty")
+	}
+	msg, err := parseHTTPStartLine(sc.Text())
+	if err != nil {
+		return HTTPMessage{}, err
+	}
+	msg.Truncated = truncated
+
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" {
+			break
+		}
+		header, ok := parseHTTPHeader(line)
+		if ok {
+			msg.Headers = append(msg.Headers, header)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return HTTPMessage{}, fmt.Errorf("scan http headers: %w", err)
+	}
+	return msg, nil
+}
+
+func splitHTTPHeaderBlock(data string) (string, bool) {
+	if idx := strings.Index(data, "\r\n\r\n"); idx >= 0 {
+		return data[:idx+2], false
+	}
+	if idx := strings.Index(data, "\n\n"); idx >= 0 {
+		return data[:idx+1], false
+	}
+	return data, true
+}
+
+func parseHTTPStartLine(line string) (HTTPMessage, error) {
+	if strings.HasPrefix(line, "HTTP/") {
+		parts := strings.SplitN(line, " ", 3)
+		if len(parts) < 2 {
+			return HTTPMessage{}, fmt.Errorf("malformed http response line")
+		}
+		code, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return HTTPMessage{}, fmt.Errorf("malformed http status code: %w", err)
+		}
+		msg := HTTPMessage{Version: parts[0], StatusCode: code}
+		if len(parts) == 3 {
+			msg.Reason = parts[2]
+		}
+		return msg, nil
+	}
+
+	parts := strings.SplitN(line, " ", 3)
+	if len(parts) != 3 || !strings.HasPrefix(parts[2], "HTTP/") {
+		return HTTPMessage{}, fmt.Errorf("malformed http request line")
+	}
+	return HTTPMessage{
+		IsRequest: true,
+		Method:    parts[0],
+		Target:    parts[1],
+		Version:   parts[2],
+	}, nil
+}
+
+func parseHTTPHeader(line string) (HTTPHeader, bool) {
+	name, value, ok := strings.Cut(line, ":")
+	if !ok {
+		return HTTPHeader{}, false
+	}
+	header := HTTPHeader{
+		Name:  strings.TrimSpace(name),
+		Value: strings.TrimSpace(value),
+	}
+	if sensitiveHTTPHeaders[strings.ToLower(header.Name)] {
+		header.Value = redactedHeaderValue
+		header.Redacted = true
+	}
+	return header, header.Name != ""
+}

--- a/internal/netproto/http_test.go
+++ b/internal/netproto/http_test.go
@@ -1,0 +1,74 @@
+package netproto
+
+import "testing"
+
+func TestParseHTTP1RequestHeadersRedactsSensitiveValues(t *testing.T) {
+	raw := []byte("GET /v1/search?q=spectra HTTP/1.1\r\nHost: api.example.com\r\nAuthorization: Bearer secret\r\nCookie: sid=abc\r\nAccept: application/json\r\n\r\nbody=ignored")
+
+	msg, err := ParseHTTP1Headers(raw)
+	if err != nil {
+		t.Fatalf("ParseHTTP1Headers: %v", err)
+	}
+	if !msg.IsRequest || msg.Method != "GET" || msg.Target != "/v1/search?q=spectra" || msg.Version != "HTTP/1.1" {
+		t.Fatalf("request line = %+v", msg)
+	}
+	if msg.Truncated {
+		t.Fatal("Truncated = true, want false")
+	}
+	headers := headersByName(msg.Headers)
+	if headers["Host"].Value != "api.example.com" || headers["Host"].Redacted {
+		t.Fatalf("Host header = %+v", headers["Host"])
+	}
+	for _, name := range []string{"Authorization", "Cookie"} {
+		h := headers[name]
+		if h.Value != redactedHeaderValue || !h.Redacted {
+			t.Fatalf("%s header = %+v, want redacted", name, h)
+		}
+	}
+}
+
+func TestParseHTTP1ResponseHeaders(t *testing.T) {
+	raw := []byte("HTTP/1.1 101 Switching Protocols\nUpgrade: websocket\nSet-Cookie: sid=secret\n\nwebsocket bytes")
+
+	msg, err := ParseHTTP1Headers(raw)
+	if err != nil {
+		t.Fatalf("ParseHTTP1Headers: %v", err)
+	}
+	if msg.IsRequest || msg.Version != "HTTP/1.1" || msg.StatusCode != 101 || msg.Reason != "Switching Protocols" {
+		t.Fatalf("response line = %+v", msg)
+	}
+	headers := headersByName(msg.Headers)
+	if headers["Upgrade"].Value != "websocket" {
+		t.Fatalf("Upgrade header = %+v", headers["Upgrade"])
+	}
+	if headers["Set-Cookie"].Value != redactedHeaderValue || !headers["Set-Cookie"].Redacted {
+		t.Fatalf("Set-Cookie header = %+v, want redacted", headers["Set-Cookie"])
+	}
+}
+
+func TestParseHTTP1HeadersTruncated(t *testing.T) {
+	msg, err := ParseHTTP1Headers([]byte("POST /upload HTTP/1.1\r\nHost: example.com\r\nContent-Length: 100"))
+	if err != nil {
+		t.Fatalf("ParseHTTP1Headers: %v", err)
+	}
+	if !msg.Truncated {
+		t.Fatal("Truncated = false, want true")
+	}
+}
+
+func TestParseHTTP1HeadersRejectsMalformedStartLine(t *testing.T) {
+	if _, err := ParseHTTP1Headers([]byte("not http\r\nHost: example.com\r\n\r\n")); err == nil {
+		t.Fatal("expected malformed request line error")
+	}
+	if _, err := ParseHTTP1Headers([]byte("HTTP/1.1 nope\r\n\r\n")); err == nil {
+		t.Fatal("expected malformed status code error")
+	}
+}
+
+func headersByName(headers []HTTPHeader) map[string]HTTPHeader {
+	out := make(map[string]HTTPHeader, len(headers))
+	for _, h := range headers {
+		out[h.Name] = h
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Add a metadata-only HTTP/1.x header parser under `internal/netproto`.
- Parse request/response start lines and headers while ignoring body bytes.
- Redact sensitive header values by default, including Authorization, Cookie, Set-Cookie, Proxy-Authorization, and X-Api-Key.

## Validation

- `go test ./internal/netproto -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
