### PR TITLE
Detect WebSocket HTTP upgrades

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -50,7 +50,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `lsof -i -P -n -sTCP:LISTEN` | current listening TCP sockets with bind address, PID, command, and user | user | one-shot | `network.listening_ports` |
 | `lsof -i -P -n` | current TCP/UDP sockets | user | one-shot | `network.connections`, `network.byApp`, established count |
 | `netstat -an` | system-wide TCP/UDP socket state without PID/app attribution | user | low | fallback when `lsof` unavailable |
-| passive HTTP/1 header parser | request/response start line and redacted headers from plaintext HTTP | user/helper depending on capture source | low per header block | `internal/netproto` parser for future plaintext summaries |
+| passive HTTP/1 header parser | request/response start line, redacted headers, and WebSocket upgrade detection from plaintext HTTP | user/helper depending on capture source | low per header block | `internal/netproto` parser for future plaintext summaries |
 | passive DNS parser | query names/types, response flag, response code, truncation, answer count from DNS payloads | user/helper depending on capture source | low per packet | `internal/netproto` parser for future UDP summaries |
 | passive TLS ClientHello parser | SNI, ALPN, TLS versions, ECH-present flag from captured bytes | user/helper depending on capture source | low per record | `internal/netproto` parser for future capture summaries |
 | `scutil --proxy` | system proxy config | user | <10ms | `network.proxy_config` |

--- a/internal/netproto/http.go
+++ b/internal/netproto/http.go
@@ -27,6 +27,7 @@ type HTTPMessage struct {
 	Reason     string       `json:"reason,omitempty"`
 	Version    string       `json:"version,omitempty"`
 	Headers    []HTTPHeader `json:"headers,omitempty"`
+	WebSocket  bool         `json:"websocket,omitempty"`
 	Truncated  bool         `json:"truncated,omitempty"`
 }
 
@@ -65,6 +66,7 @@ func ParseHTTP1Headers(data []byte) (HTTPMessage, error) {
 	if err := sc.Err(); err != nil {
 		return HTTPMessage{}, fmt.Errorf("scan http headers: %w", err)
 	}
+	msg.WebSocket = isWebSocketUpgrade(msg)
 	return msg, nil
 }
 
@@ -121,4 +123,27 @@ func parseHTTPHeader(line string) (HTTPHeader, bool) {
 		header.Redacted = true
 	}
 	return header, header.Name != ""
+}
+
+func isWebSocketUpgrade(msg HTTPMessage) bool {
+	var hasConnectionUpgrade, hasUpgradeWebSocket bool
+	for _, h := range msg.Headers {
+		name := strings.ToLower(h.Name)
+		value := strings.ToLower(h.Value)
+		switch name {
+		case "connection":
+			for _, part := range strings.Split(value, ",") {
+				if strings.TrimSpace(part) == "upgrade" {
+					hasConnectionUpgrade = true
+					break
+				}
+			}
+		case "upgrade":
+			hasUpgradeWebSocket = strings.TrimSpace(value) == "websocket"
+		}
+	}
+	if msg.IsRequest {
+		return hasConnectionUpgrade && hasUpgradeWebSocket
+	}
+	return msg.StatusCode == 101 && hasConnectionUpgrade && hasUpgradeWebSocket
 }

--- a/internal/netproto/http_test.go
+++ b/internal/netproto/http_test.go
@@ -28,7 +28,7 @@ func TestParseHTTP1RequestHeadersRedactsSensitiveValues(t *testing.T) {
 }
 
 func TestParseHTTP1ResponseHeaders(t *testing.T) {
-	raw := []byte("HTTP/1.1 101 Switching Protocols\nUpgrade: websocket\nSet-Cookie: sid=secret\n\nwebsocket bytes")
+	raw := []byte("HTTP/1.1 101 Switching Protocols\nConnection: Upgrade\nUpgrade: websocket\nSet-Cookie: sid=secret\n\nwebsocket bytes")
 
 	msg, err := ParseHTTP1Headers(raw)
 	if err != nil {
@@ -41,8 +41,35 @@ func TestParseHTTP1ResponseHeaders(t *testing.T) {
 	if headers["Upgrade"].Value != "websocket" {
 		t.Fatalf("Upgrade header = %+v", headers["Upgrade"])
 	}
+	if !msg.WebSocket {
+		t.Fatal("WebSocket = false, want true")
+	}
 	if headers["Set-Cookie"].Value != redactedHeaderValue || !headers["Set-Cookie"].Redacted {
 		t.Fatalf("Set-Cookie header = %+v, want redacted", headers["Set-Cookie"])
+	}
+}
+
+func TestParseHTTP1RequestDetectsWebSocketUpgrade(t *testing.T) {
+	raw := []byte("GET /socket HTTP/1.1\r\nHost: example.com\r\nConnection: keep-alive, Upgrade\r\nUpgrade: websocket\r\n\r\n")
+
+	msg, err := ParseHTTP1Headers(raw)
+	if err != nil {
+		t.Fatalf("ParseHTTP1Headers: %v", err)
+	}
+	if !msg.WebSocket {
+		t.Fatal("WebSocket = false, want true")
+	}
+}
+
+func TestParseHTTP1WebSocketRequiresConnectionUpgrade(t *testing.T) {
+	raw := []byte("HTTP/1.1 200 OK\r\nUpgrade: websocket\r\n\r\n")
+
+	msg, err := ParseHTTP1Headers(raw)
+	if err != nil {
+		t.Fatalf("ParseHTTP1Headers: %v", err)
+	}
+	if msg.WebSocket {
+		t.Fatal("WebSocket = true, want false")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add WebSocket upgrade detection to plaintext HTTP/1 metadata parsing.
- Mark request and 101 response handshakes when `Connection: Upgrade` and `Upgrade: websocket` are present.
- Update live data source docs to describe the WebSocket signal.

## Validation

- `go test ./internal/netproto -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
