### PR TITLE
Add tcpdump capture argument builder

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -58,6 +58,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `route -n get default` | default route + interface | user | <10ms | `network.default_route_*` |
 | `pfctl -s rules` | firewall rules | helper | one-shot | `helper.firewall.rules`, `spectra network firewall` |
 | `tcpdump -i <iface>` | raw packet capture | helper | streaming, high | (planned) targeted capture |
+| `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for planned targeted capture |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
 `nettop`, and `/etc/hosts`. `lsof` is also where current socket owner

--- a/internal/netcap/tcpdump.go
+++ b/internal/netcap/tcpdump.go
@@ -1,0 +1,123 @@
+// Package netcap contains capture plumbing shared by future helper-backed
+// packet capture workflows.
+package netcap
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultDuration = 30 * time.Second
+	MaxDuration     = time.Minute
+	DefaultSnapLen  = 262144
+)
+
+// Options describes one bounded tcpdump capture.
+type Options struct {
+	Interface string
+	Output    string
+	Duration  time.Duration
+	SnapLen   int
+	Host      string
+	Port      int
+	Proto     string
+}
+
+// BuildTCPDumpArgs validates Options and returns argv for tcpdump. Duration is
+// validated here but enforced by the caller's process context.
+func BuildTCPDumpArgs(opts Options) ([]string, error) {
+	if opts.Interface == "" {
+		return nil, fmt.Errorf("capture interface is required")
+	}
+	if !validToken(opts.Interface) {
+		return nil, fmt.Errorf("invalid capture interface %q", opts.Interface)
+	}
+	if opts.Output == "" {
+		return nil, fmt.Errorf("capture output path is required")
+	}
+	duration := opts.Duration
+	if duration == 0 {
+		duration = DefaultDuration
+	}
+	if duration <= 0 || duration > MaxDuration {
+		return nil, fmt.Errorf("capture duration must be >0 and <= %s", MaxDuration)
+	}
+	snapLen := opts.SnapLen
+	if snapLen == 0 {
+		snapLen = DefaultSnapLen
+	}
+	if snapLen < 96 || snapLen > DefaultSnapLen {
+		return nil, fmt.Errorf("capture snap length must be between 96 and %d", DefaultSnapLen)
+	}
+	filter, err := bpfFilterArgs(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		"-i", opts.Interface,
+		"-n",
+		"-s", strconv.Itoa(snapLen),
+		"-w", opts.Output,
+	}
+	if len(filter) > 0 {
+		args = append(args, filter...)
+	}
+	return args, nil
+}
+
+func bpfFilterArgs(opts Options) ([]string, error) {
+	var parts []string
+	if opts.Proto != "" {
+		proto := strings.ToLower(opts.Proto)
+		switch proto {
+		case "tcp", "udp":
+			parts = append(parts, proto)
+		default:
+			return nil, fmt.Errorf("invalid capture protocol %q", opts.Proto)
+		}
+	}
+	if opts.Host != "" {
+		if !validHost(opts.Host) {
+			return nil, fmt.Errorf("invalid capture host %q", opts.Host)
+		}
+		parts = appendBPFAnd(parts, "host", opts.Host)
+	}
+	if opts.Port > 0 {
+		if opts.Port > 65535 {
+			return nil, fmt.Errorf("invalid capture port %d", opts.Port)
+		}
+		parts = appendBPFAnd(parts, "port", strconv.Itoa(opts.Port))
+	}
+	return parts, nil
+}
+
+func appendBPFAnd(parts []string, next ...string) []string {
+	if len(parts) > 0 {
+		parts = append(parts, "and")
+	}
+	return append(parts, next...)
+}
+
+func validToken(s string) bool {
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validHost(s string) bool {
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '.' || r == ':' {
+			continue
+		}
+		return false
+	}
+	return s != ""
+}

--- a/internal/netcap/tcpdump_test.go
+++ b/internal/netcap/tcpdump_test.go
@@ -1,0 +1,58 @@
+package netcap
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBuildTCPDumpArgsDefaults(t *testing.T) {
+	args, err := BuildTCPDumpArgs(Options{
+		Interface: "en0",
+		Output:    "/tmp/spectra.pcap",
+	})
+	if err != nil {
+		t.Fatalf("BuildTCPDumpArgs: %v", err)
+	}
+	want := []string{"-i", "en0", "-n", "-s", "262144", "-w", "/tmp/spectra.pcap"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+}
+
+func TestBuildTCPDumpArgsWithFilter(t *testing.T) {
+	args, err := BuildTCPDumpArgs(Options{
+		Interface: "utun3",
+		Output:    "/tmp/spectra.pcap",
+		Duration:  5 * time.Second,
+		SnapLen:   4096,
+		Proto:     "TCP",
+		Host:      "api.example.com",
+		Port:      443,
+	})
+	if err != nil {
+		t.Fatalf("BuildTCPDumpArgs: %v", err)
+	}
+	want := []string{"-i", "utun3", "-n", "-s", "4096", "-w", "/tmp/spectra.pcap", "tcp", "and", "host", "api.example.com", "and", "port", "443"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+}
+
+func TestBuildTCPDumpArgsRejectsInvalidOptions(t *testing.T) {
+	tests := []Options{
+		{Output: "/tmp/out.pcap"},
+		{Interface: "en0;rm", Output: "/tmp/out.pcap"},
+		{Interface: "en0"},
+		{Interface: "en0", Output: "/tmp/out.pcap", Duration: MaxDuration + time.Millisecond},
+		{Interface: "en0", Output: "/tmp/out.pcap", SnapLen: 64},
+		{Interface: "en0", Output: "/tmp/out.pcap", Proto: "icmp"},
+		{Interface: "en0", Output: "/tmp/out.pcap", Host: "example.com or port 22"},
+		{Interface: "en0", Output: "/tmp/out.pcap", Port: 70000},
+	}
+	for _, tt := range tests {
+		if _, err := BuildTCPDumpArgs(tt); err == nil {
+			t.Fatalf("BuildTCPDumpArgs(%+v) succeeded, want error", tt)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/netcap` tcpdump argument builder for planned bounded packet capture.
- Validate interface, output, duration, snap length, protocol, host, and port before constructing argv.
- Return tcpdump BPF filters as separate argv tokens and cover unsafe input rejection in unit tests.

## Validation

- `go test ./internal/netcap -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
