### PR TITLE
Add helper bounded network capture

### DIFF
--- a/docs/design/privileged-helper.md
+++ b/docs/design/privileged-helper.md
@@ -69,6 +69,8 @@ The helper's RPC surface is intentionally narrow. It listens on
 | `helper.firewall.rules()` | Current pf firewall rules |
 | `helper.fs_usage.start(pid, mode, duration)` | Start a bounded root `fs_usage` trace for one PID |
 | `helper.fs_usage.stop(handle)` | Stop a trace and return captured output |
+| `helper.net_capture.start(interface, duration, filters)` | Start a bounded root `tcpdump` capture with validated filters |
+| `helper.net_capture.stop(handle)` | Stop a capture and return capture path + size metadata |
 | `helper.process.tree()` | Process tree including processes the user can't see (e.g. system daemons) |
 | `helper.health()` | Liveness + version |
 
@@ -77,6 +79,15 @@ The helper's RPC surface is intentionally narrow. It listens on
 `filesys`, caps trace duration at 60 seconds, and never accepts an
 arbitrary command string or file path. Handles are removed when stopped
 or when the bounded trace reaches its duration limit.
+
+`helper.net_capture.start` requires an interface name and accepts only
+structured duration, snap length, host, port, and TCP/UDP protocol
+filters. The helper generates output paths under a per-caller-UID
+directory in `/var/tmp/spectra-netcap`, chowns that directory and the
+completed pcap to the caller, and never accepts a caller-supplied output
+path. This keeps the method from becoming a root arbitrary-file writer.
+Captures are capped at 60 seconds. `helper.net_capture.stop` returns the
+generated path and file size, not packet contents.
 
 Notably absent:
 

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -57,8 +57,8 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `scutil --dns` | DNS resolver config | user | <10ms | `network.dns_servers` |
 | `route -n get default` | default route + interface | user | <10ms | `network.default_route_*` |
 | `pfctl -s rules` | firewall rules | helper | one-shot | `helper.firewall.rules`, `spectra network firewall` |
-| `tcpdump -i <iface>` | raw packet capture | helper | streaming, high | (planned) targeted capture |
-| `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for planned targeted capture |
+| `tcpdump -i <iface>` | raw packet capture to helper-generated pcap path | helper | streaming, high | `helper.net_capture.start` / `helper.net_capture.stop` |
+| `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
 `nettop`, and `/etc/hosts`. `lsof` is also where current socket owner

--- a/internal/helper/methods.go
+++ b/internal/helper/methods.go
@@ -27,6 +27,7 @@ func registerAll(d *Dispatcher, run CmdRunner, fsUsageStarter fsUsageStarter) {
 		run = defaultRunner
 	}
 	fsUsage := newFSUsageManager(fsUsageStarter)
+	netCapture := newNetCaptureManager(nil, "")
 
 	d.Register("helper.health", func(_ uint32, _ json.RawMessage) (any, error) {
 		return map[string]any{"ok": true, "helper": true}, nil
@@ -84,6 +85,22 @@ func registerAll(d *Dispatcher, run CmdRunner, fsUsageStarter fsUsageStarter) {
 			return nil, fmt.Errorf("helper.fs_usage.stop invalid params: %w", err)
 		}
 		return fsUsage.stop(p)
+	})
+
+	d.Register("helper.net_capture.start", func(uid uint32, params json.RawMessage) (any, error) {
+		var p netCaptureStartParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, fmt.Errorf("helper.net_capture.start invalid params: %w", err)
+		}
+		return netCapture.start(uid, p)
+	})
+
+	d.Register("helper.net_capture.stop", func(_ uint32, params json.RawMessage) (any, error) {
+		var p netCaptureStopParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, fmt.Errorf("helper.net_capture.stop invalid params: %w", err)
+		}
+		return netCapture.stop(p)
 	})
 
 	d.Register("helper.tcc.system.query", func(_ uint32, params json.RawMessage) (any, error) {

--- a/internal/helper/net_capture.go
+++ b/internal/helper/net_capture.go
@@ -1,0 +1,213 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/netcap"
+)
+
+const (
+	defaultNetCaptureDir = "/var/tmp/spectra-netcap"
+	netCaptureStopWait   = 3 * time.Second
+)
+
+type netCaptureStarter func(ctx context.Context, stdout, stderr io.Writer, name string, args ...string) (netCaptureProcess, error)
+
+type netCaptureProcess interface {
+	Wait() error
+}
+
+type netCaptureManager struct {
+	mu       sync.Mutex
+	next     atomic.Uint64
+	starter  netCaptureStarter
+	baseDir  string
+	sessions map[string]*netCaptureSession
+}
+
+type netCaptureSession struct {
+	cancel context.CancelFunc
+	done   chan error
+	output string
+	uid    uint32
+	buf    lockedBuffer
+}
+
+type netCaptureStartParams struct {
+	Interface  string `json:"interface"`
+	DurationMS int    `json:"duration_ms"`
+	SnapLen    int    `json:"snap_len"`
+	Host       string `json:"host"`
+	Port       int    `json:"port"`
+	Proto      string `json:"proto"`
+}
+
+type netCaptureStopParams struct {
+	Handle string `json:"handle"`
+}
+
+func newNetCaptureManager(starter netCaptureStarter, baseDir string) *netCaptureManager {
+	if starter == nil {
+		starter = startNetCaptureProcess
+	}
+	if baseDir == "" {
+		baseDir = defaultNetCaptureDir
+	}
+	return &netCaptureManager{starter: starter, baseDir: baseDir, sessions: make(map[string]*netCaptureSession)}
+}
+
+func (m *netCaptureManager) start(uid uint32, p netCaptureStartParams) (map[string]any, error) {
+	duration := time.Duration(p.DurationMS) * time.Millisecond
+	if duration == 0 {
+		duration = netcap.DefaultDuration
+	}
+	handle := fmt.Sprintf("netcap-%d", m.next.Add(1))
+	outputDir := filepath.Join(m.baseDir, fmt.Sprint(uid))
+	output := filepath.Join(outputDir, handle+".pcap")
+	opts := netcap.Options{
+		Interface: p.Interface,
+		Output:    output,
+		Duration:  duration,
+		SnapLen:   p.SnapLen,
+		Host:      p.Host,
+		Port:      p.Port,
+		Proto:     p.Proto,
+	}
+	args, err := netcap.BuildTCPDumpArgs(opts)
+	if err != nil {
+		return nil, fmt.Errorf("helper.net_capture.start: %w", err)
+	}
+	if err := ensureCaptureDir(outputDir, uid); err != nil {
+		return nil, fmt.Errorf("create capture dir: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	sess := &netCaptureSession{cancel: cancel, done: make(chan error, 1), output: output, uid: uid}
+	proc, err := m.starter(ctx, &sess.buf, &sess.buf, "tcpdump", args...)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("tcpdump start: %w", err)
+	}
+	m.mu.Lock()
+	m.sessions[handle] = sess
+	m.mu.Unlock()
+	go func() {
+		sess.done <- proc.Wait()
+		if ctx.Err() == context.DeadlineExceeded {
+			m.forget(handle)
+		}
+	}()
+
+	return map[string]any{
+		"handle":      handle,
+		"output_path": output,
+		"duration_ms": duration.Milliseconds(),
+		"interface":   p.Interface,
+	}, nil
+}
+
+func (m *netCaptureManager) stop(p netCaptureStopParams) (map[string]any, error) {
+	if p.Handle == "" {
+		return nil, fmt.Errorf("helper.net_capture.stop requires {\"handle\": \"...\"}")
+	}
+	m.mu.Lock()
+	sess, ok := m.sessions[p.Handle]
+	if ok {
+		delete(m.sessions, p.Handle)
+	}
+	m.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("helper.net_capture.stop unknown handle %q", p.Handle)
+	}
+
+	sess.cancel()
+	waitErr := waitNetCapture(sess.done)
+	ownerErr := makeCaptureReadableByOwner(sess.output, sess.uid)
+	info, statErr := os.Stat(sess.output)
+	size := int64(0)
+	if statErr == nil {
+		size = info.Size()
+	}
+	result := map[string]any{
+		"handle":      p.Handle,
+		"output_path": sess.output,
+		"stopped":     true,
+		"size_bytes":  size,
+	}
+	if waitErr != "" {
+		result["wait_error"] = waitErr
+	}
+	if statErr != nil && !os.IsNotExist(statErr) {
+		result["stat_error"] = statErr.Error()
+	}
+	if ownerErr != nil && !os.IsNotExist(ownerErr) {
+		result["owner_error"] = ownerErr.Error()
+	}
+	return result, nil
+}
+
+func ensureCaptureDir(path string, uid uint32) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	if os.Geteuid() == 0 || int(uid) != os.Getuid() {
+		if err := os.Chown(path, int(uid), -1); err != nil {
+			return err
+		}
+	}
+	return os.Chmod(path, 0o700)
+}
+
+func makeCaptureReadableByOwner(path string, uid uint32) error {
+	if os.Geteuid() == 0 || int(uid) != os.Getuid() {
+		if err := os.Chown(path, int(uid), -1); err != nil {
+			return err
+		}
+	}
+	return os.Chmod(path, 0o600)
+}
+
+func waitNetCapture(done <-chan error) string {
+	select {
+	case err := <-done:
+		if err != nil {
+			return err.Error()
+		}
+	case <-time.After(netCaptureStopWait):
+		return "timeout waiting for tcpdump to stop"
+	}
+	return ""
+}
+
+func (m *netCaptureManager) forget(handle string) {
+	m.mu.Lock()
+	delete(m.sessions, handle)
+	m.mu.Unlock()
+}
+
+type execNetCaptureProcess struct {
+	cmd *exec.Cmd
+}
+
+func startNetCaptureProcess(ctx context.Context, stdout, stderr io.Writer, name string, args ...string) (netCaptureProcess, error) {
+	// #nosec G204 -- tcpdump is invoked by the helper with validated structured args only.
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &execNetCaptureProcess{cmd: cmd}, nil
+}
+
+func (p *execNetCaptureProcess) Wait() error {
+	return p.cmd.Wait()
+}

--- a/internal/helper/net_capture_test.go
+++ b/internal/helper/net_capture_test.go
@@ -1,0 +1,109 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type fakeNetCaptureProcess struct {
+	done chan error
+}
+
+func (p *fakeNetCaptureProcess) Wait() error {
+	return <-p.done
+}
+
+func TestNetCaptureStartBuildsBoundedTCPDump(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	proc := &fakeNetCaptureProcess{done: make(chan error, 1)}
+	baseDir := t.TempDir()
+	uid := uint32(os.Getuid())
+	m := newNetCaptureManager(func(_ context.Context, _, _ io.Writer, name string, args ...string) (netCaptureProcess, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return proc, nil
+	}, baseDir)
+
+	res, err := m.start(uid, netCaptureStartParams{
+		Interface:  "en0",
+		DurationMS: 5000,
+		SnapLen:    4096,
+		Proto:      "tcp",
+		Host:       "api.example.com",
+		Port:       443,
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if gotName != "tcpdump" {
+		t.Fatalf("command = %q, want tcpdump", gotName)
+	}
+	output := filepath.Join(baseDir, fmt.Sprint(uid), "netcap-1.pcap")
+	wantArgs := []string{"-i", "en0", "-n", "-s", "4096", "-w", output, "tcp", "and", "host", "api.example.com", "and", "port", "443"}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("args = %v, want %v", gotArgs, wantArgs)
+	}
+	if res["handle"] != "netcap-1" || res["output_path"] != output {
+		t.Fatalf("result = %+v", res)
+	}
+
+	proc.done <- nil
+}
+
+func TestNetCaptureStopReturnsOutputSize(t *testing.T) {
+	proc := &fakeNetCaptureProcess{done: make(chan error, 1)}
+	baseDir := t.TempDir()
+	m := newNetCaptureManager(func(_ context.Context, _, _ io.Writer, _ string, _ ...string) (netCaptureProcess, error) {
+		return proc, nil
+	}, baseDir)
+
+	res, err := m.start(uint32(os.Getuid()), netCaptureStartParams{Interface: "en0", DurationMS: 5000})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	output := res["output_path"].(string)
+	if err := os.WriteFile(output, []byte("pcap"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	proc.done <- nil
+
+	stop, err := m.stop(netCaptureStopParams{Handle: "netcap-1"})
+	if err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if stop["size_bytes"] != int64(4) {
+		t.Fatalf("stop = %+v, want size 4", stop)
+	}
+}
+
+func TestNetCaptureRejectsUnsafeParams(t *testing.T) {
+	called := false
+	m := newNetCaptureManager(func(context.Context, io.Writer, io.Writer, string, ...string) (netCaptureProcess, error) {
+		called = true
+		return nil, nil
+	}, t.TempDir())
+
+	if _, err := m.start(501, netCaptureStartParams{
+		Interface:  "en0;rm",
+		DurationMS: int((time.Minute + time.Millisecond).Milliseconds()),
+	}); err == nil {
+		t.Fatal("expected invalid params error")
+	}
+	if called {
+		t.Fatal("starter was called for invalid params")
+	}
+}
+
+func TestNetCaptureStopUnknownHandle(t *testing.T) {
+	m := newNetCaptureManager(nil, t.TempDir())
+	if _, err := m.stop(netCaptureStopParams{Handle: "missing"}); err == nil {
+		t.Fatal("expected unknown handle error")
+	}
+}

--- a/internal/helperclient/client.go
+++ b/internal/helperclient/client.go
@@ -168,3 +168,30 @@ func (c *Client) FSUsageStop(handle string) (map[string]any, error) {
 	var m map[string]any
 	return m, json.Unmarshal(raw, &m)
 }
+
+// NetCaptureStart starts a bounded helper tcpdump capture.
+func (c *Client) NetCaptureStart(iface string, durationMS, snapLen int, proto, host string, port int) (map[string]any, error) {
+	raw, err := c.call("helper.net_capture.start", map[string]any{
+		"interface":   iface,
+		"duration_ms": durationMS,
+		"snap_len":    snapLen,
+		"proto":       proto,
+		"host":        host,
+		"port":        port,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	return m, json.Unmarshal(raw, &m)
+}
+
+// NetCaptureStop stops a running helper tcpdump capture.
+func (c *Client) NetCaptureStop(handle string) (map[string]any, error) {
+	raw, err := c.call("helper.net_capture.stop", map[string]any{"handle": handle})
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	return m, json.Unmarshal(raw, &m)
+}


### PR DESCRIPTION
## Summary

- Add helper-backed bounded `tcpdump` capture start/stop methods.
- Keep output paths helper-generated under per-caller UID directories in `/var/tmp/spectra-netcap`.
- Chown completed pcap files to the caller and return path/size metadata, not packet contents.
- Add helperclient wrappers and document the narrow helper API.

## Validation

- `go test ./internal/helper ./internal/helperclient ./internal/netcap -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
