### PR TITLE
[codex] Harden tsnet daemon integration

### DIFF
--- a/cmd/spectra/daemon_install.go
+++ b/cmd/spectra/daemon_install.go
@@ -18,18 +18,20 @@ import (
 const daemonAgentLabel = "dev.spectra.daemon"
 
 type daemonAgentOptions struct {
-	SockPath       string
-	TCPAddr        string
-	AllowRemote    bool
-	TsnetEnabled   bool
-	TsnetAddr      string
-	TsnetHostname  string
-	TsnetStateDir  string
-	TsnetEphemeral bool
-	TsnetTags      string
-	LogFile        string
-	NoLogFile      bool
-	NoLoad         bool
+	SockPath         string
+	TCPAddr          string
+	AllowRemote      bool
+	TsnetEnabled     bool
+	TsnetAddr        string
+	TsnetHostname    string
+	TsnetStateDir    string
+	TsnetEphemeral   bool
+	TsnetTags        string
+	TsnetAllowLogins string
+	TsnetAllowNodes  string
+	LogFile          string
+	NoLogFile        bool
+	NoLoad           bool
 }
 
 type daemonAgentDeps struct {
@@ -145,6 +147,8 @@ func parseDaemonAgentOptions(name string, args []string, stderr io.Writer) (daem
 	fs.StringVar(&opts.TsnetStateDir, "tsnet-state-dir", "", "tsnet state directory passed to spectra serve")
 	fs.BoolVar(&opts.TsnetEphemeral, "tsnet-ephemeral", false, "Register the tsnet node as ephemeral")
 	fs.StringVar(&opts.TsnetTags, "tsnet-tags", "", "Comma-separated Tailscale tags to advertise")
+	fs.StringVar(&opts.TsnetAllowLogins, "tsnet-allow-logins", "", "Comma-separated Tailscale login names allowed to connect")
+	fs.StringVar(&opts.TsnetAllowNodes, "tsnet-allow-nodes", "", "Comma-separated Tailscale node names allowed to connect")
 	fs.StringVar(&opts.LogFile, "log-file", "", "JSONL daemon log path")
 	fs.BoolVar(&opts.NoLogFile, "no-log-file", false, "Disable daemon JSONL log file")
 	fs.BoolVar(&opts.NoLoad, "no-load", false, "Write plist but do not bootstrap with launchd")
@@ -152,7 +156,7 @@ func parseDaemonAgentOptions(name string, args []string, stderr io.Writer) (daem
 		return daemonAgentOptions{}, false
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: spectra install-daemon [--sock path] [--tcp addr] [--allow-remote] [--tsnet] [--tsnet-hostname name] [--log-file path|--no-log-file] [--no-load]")
+		fmt.Fprintln(stderr, "usage: spectra install-daemon [--sock path] [--tcp addr] [--allow-remote] [--tsnet] [--tsnet-hostname name] [--tsnet-allow-logins users] [--tsnet-allow-nodes nodes] [--log-file path|--no-log-file] [--no-load]")
 		return daemonAgentOptions{}, false
 	}
 	if opts.LogFile != "" && opts.NoLogFile {
@@ -194,6 +198,12 @@ func (o daemonAgentOptions) serveArgs() []string {
 	}
 	if o.TsnetTags != "" {
 		args = append(args, "--tsnet-tags", o.TsnetTags)
+	}
+	if o.TsnetAllowLogins != "" {
+		args = append(args, "--tsnet-allow-logins", o.TsnetAllowLogins)
+	}
+	if o.TsnetAllowNodes != "" {
+		args = append(args, "--tsnet-allow-nodes", o.TsnetAllowNodes)
 	}
 	if o.LogFile != "" {
 		args = append(args, "--log-file", o.LogFile)

--- a/cmd/spectra/daemon_install_test.go
+++ b/cmd/spectra/daemon_install_test.go
@@ -11,16 +11,18 @@ import (
 
 func TestDaemonAgentServeArgs(t *testing.T) {
 	opts := daemonAgentOptions{
-		SockPath:       "/tmp/spectra.sock",
-		TCPAddr:        "127.0.0.1:7878",
-		AllowRemote:    true,
-		TsnetEnabled:   true,
-		TsnetAddr:      ":7879",
-		TsnetHostname:  "work-mac",
-		TsnetStateDir:  "/tmp/spectra-tsnet",
-		TsnetEphemeral: true,
-		TsnetTags:      "tag:engineer,tag:spectra",
-		LogFile:        "/tmp/spectra.jsonl",
+		SockPath:         "/tmp/spectra.sock",
+		TCPAddr:          "127.0.0.1:7878",
+		AllowRemote:      true,
+		TsnetEnabled:     true,
+		TsnetAddr:        ":7879",
+		TsnetHostname:    "work-mac",
+		TsnetStateDir:    "/tmp/spectra-tsnet",
+		TsnetEphemeral:   true,
+		TsnetTags:        "tag:engineer,tag:spectra",
+		TsnetAllowLogins: "alice@example.com,bob@example.com",
+		TsnetAllowNodes:  "alice-mac,bob-mac.tailnet.ts.net.",
+		LogFile:          "/tmp/spectra.jsonl",
 	}
 	got := opts.serveArgs()
 	want := []string{
@@ -34,6 +36,8 @@ func TestDaemonAgentServeArgs(t *testing.T) {
 		"--tsnet-state-dir", "/tmp/spectra-tsnet",
 		"--tsnet-ephemeral",
 		"--tsnet-tags", "tag:engineer,tag:spectra",
+		"--tsnet-allow-logins", "alice@example.com,bob@example.com",
+		"--tsnet-allow-nodes", "alice-mac,bob-mac.tailnet.ts.net.",
 		"--log-file", "/tmp/spectra.jsonl",
 	}
 	if !slices.Equal(got, want) {

--- a/cmd/spectra/fan.go
+++ b/cmd/spectra/fan.go
@@ -18,7 +18,7 @@ import (
 )
 
 type fanRPCCaller func(target connectTarget, timeout time.Duration, method string, params json.RawMessage) (json.RawMessage, error)
-type fanHostLister func(ctx context.Context, probeUnreachable bool, discover bool) ([]fanTarget, error)
+type fanHostLister func(ctx context.Context, probeUnreachable bool, discover bool, discoverDaemons bool) ([]fanTarget, error)
 type fanTargetProber func(ctx context.Context, target connectTarget, timeout time.Duration) error
 
 type fanOutput struct {
@@ -46,6 +46,7 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 	hosts := fs.String("hosts", "", "Comma-separated daemon targets; defaults to discovered hosts")
 	probe := fs.Bool("probe", false, "When discovering hosts, skip entries that fail a health check")
 	discoverHosts := fs.Bool("discover", false, "Include tailscale peers from tailscale status --json")
+	discoverDaemons := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from Tailscale peers")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -53,7 +54,7 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 	var targets []fanTarget
 	var err error
 	if strings.TrimSpace(*hosts) == "" {
-		targets, err = discover(context.Background(), *probe, *discoverHosts)
+		targets, err = discover(context.Background(), *probe, *discoverHosts, *discoverDaemons)
 	} else {
 		targets, err = parseFanTargets(*hosts)
 	}
@@ -91,7 +92,7 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 }
 
 func printFanUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: spectra fan [--hosts host-a,host-b] [--probe] [--discover] [status|host|jvm|processes|network|storage|power|rules]")
+	fmt.Fprintln(w, "usage: spectra fan [--hosts host-a,host-b] [--probe] [--discover|--discover-daemons] [status|host|jvm|processes|network|storage|power|rules]")
 	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] inspect <App.app>")
 	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] call <method> [json-params]")
 }
@@ -119,7 +120,7 @@ func parseFanTargets(raw string) ([]fanTarget, error) {
 var fanProbeTarget fanTargetProber = probeFanTarget
 var fanDiscoverPeers func() ([]string, error) = discoverTailscalePeers
 
-func discoverFanTargets(ctx context.Context, probeUnreachable bool, discover bool) ([]fanTarget, error) {
+func discoverFanTargets(ctx context.Context, probeUnreachable bool, discover bool, discoverDaemons bool) ([]fanTarget, error) {
 	dbPath, err := store.DefaultPath()
 	if err != nil {
 		return nil, err
@@ -152,7 +153,7 @@ func discoverFanTargets(ctx context.Context, probeUnreachable bool, discover boo
 		seen[key] = struct{}{}
 		targets = append(targets, fanTarget{Name: name, Target: target})
 	}
-	if discover {
+	if discover || discoverDaemons {
 		discovered, err := fanDiscoverPeers()
 		if err != nil && len(targets) == 0 {
 			return nil, fmt.Errorf("discover remote hosts: %w", err)
@@ -169,6 +170,11 @@ func discoverFanTargets(ctx context.Context, probeUnreachable bool, discover boo
 			key := target.Address
 			if _, ok := seen[key]; ok {
 				continue
+			}
+			if discoverDaemons {
+				if err := fanProbeTarget(ctx, target, 3*time.Second); err != nil {
+					continue
+				}
 			}
 			seen[key] = struct{}{}
 			targets = append(targets, fanTarget{Name: name, Target: target})

--- a/cmd/spectra/fan_test.go
+++ b/cmd/spectra/fan_test.go
@@ -56,7 +56,7 @@ func TestRunFanWithTypedShortcut(t *testing.T) {
 			result, _ := json.Marshal(map[string]string{"address": target.Address})
 			return result, nil
 		},
-		func(context.Context, bool, bool) ([]fanTarget, error) {
+		func(context.Context, bool, bool, bool) ([]fanTarget, error) {
 			t.Fatal("discover should not be used when --hosts provided")
 			return nil, nil
 		},
@@ -96,7 +96,7 @@ func TestRunFanWithPartialFailure(t *testing.T) {
 			}
 			return json.RawMessage(`{"ok":true}`), nil
 		},
-		func(context.Context, bool, bool) ([]fanTarget, error) {
+		func(context.Context, bool, bool, bool) ([]fanTarget, error) {
 			t.Fatal("discover should not be used when --hosts provided")
 			return nil, nil
 		},
@@ -131,7 +131,7 @@ func TestRunFanWithBadShortcut(t *testing.T) {
 			t.Fatal("caller should not run")
 			return nil, nil
 		},
-		func(context.Context, bool, bool) ([]fanTarget, error) {
+		func(context.Context, bool, bool, bool) ([]fanTarget, error) {
 			t.Fatal("discover should not be used when --hosts provided")
 			return nil, nil
 		},
@@ -162,9 +162,12 @@ func TestRunFanWithDiscoveredHosts(t *testing.T) {
 		func(target connectTarget, _ time.Duration, _ string, _ json.RawMessage) (json.RawMessage, error) {
 			return json.Marshal(map[string]string{"address": target.Address})
 		},
-		func(_ context.Context, probe bool, discover bool) ([]fanTarget, error) {
+		func(_ context.Context, probe bool, discover bool, discoverDaemons bool) ([]fanTarget, error) {
 			if probe {
 				t.Fatal("discover should not probe unless --probe is set")
+			}
+			if discoverDaemons {
+				t.Fatal("discover should not receive --discover-daemons")
 			}
 			return []fanTarget{
 				{Name: "work-mac", Target: connectTarget{Network: "tcp", Address: "work-mac:7878"}},
@@ -217,9 +220,12 @@ func TestRunFanWithDiscoveredHostsProbe(t *testing.T) {
 		func(target connectTarget, _ time.Duration, _ string, _ json.RawMessage) (json.RawMessage, error) {
 			return json.Marshal(map[string]string{"address": target.Address})
 		},
-		func(_ context.Context, probe bool, discover bool) ([]fanTarget, error) {
+		func(_ context.Context, probe bool, discover bool, discoverDaemons bool) ([]fanTarget, error) {
 			if discover {
 				t.Fatal("discover should not receive --discover")
+			}
+			if discoverDaemons {
+				t.Fatal("discover should not receive --discover-daemons")
 			}
 			if !probe {
 				t.Fatal("discover should receive --probe")
@@ -297,7 +303,7 @@ func TestDiscoverFanTargetsWithProbeFiltersUnreachable(t *testing.T) {
 	}
 	t.Cleanup(func() { fanProbeTarget = origProbeTarget })
 
-	targets, err := discoverFanTargets(ctx, true, false)
+	targets, err := discoverFanTargets(ctx, true, false, false)
 	if err != nil {
 		t.Fatalf("discoverFanTargets = %v", err)
 	}
@@ -323,10 +329,13 @@ func TestRunFanWithDiscoverFanout(t *testing.T) {
 		func(target connectTarget, _ time.Duration, _ string, _ json.RawMessage) (json.RawMessage, error) {
 			return json.Marshal(map[string]string{"address": target.Address})
 		},
-		func(_ context.Context, probe bool, discover bool) ([]fanTarget, error) {
+		func(_ context.Context, probe bool, discover bool, discoverDaemons bool) ([]fanTarget, error) {
 			gotDiscover = discover
 			if probe {
 				t.Fatal("discover should not receive --probe")
+			}
+			if discoverDaemons {
+				t.Fatal("discover should not receive --discover-daemons")
 			}
 			if !discover {
 				t.Fatal("discover should receive --discover")
@@ -350,6 +359,42 @@ func TestRunFanWithDiscoverFanout(t *testing.T) {
 	}
 	if len(out.Targets) != 2 {
 		t.Fatalf("len(targets) = %d, want 2", len(out.Targets))
+	}
+}
+
+func TestRunFanWithDiscoverDaemons(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	var gotDiscoverDaemons bool
+	code := runFanWith(
+		[]string{"--discover-daemons", "host"},
+		&stdout,
+		&stderr,
+		func(target connectTarget, _ time.Duration, _ string, _ json.RawMessage) (json.RawMessage, error) {
+			return json.Marshal(map[string]string{"address": target.Address})
+		},
+		func(_ context.Context, probe bool, discover bool, discoverDaemons bool) ([]fanTarget, error) {
+			if probe || discover {
+				t.Fatalf("probe=%t discover=%t, want false false", probe, discover)
+			}
+			gotDiscoverDaemons = discoverDaemons
+			return []fanTarget{
+				{Name: "work-mac", Target: connectTarget{Network: "tcp", Address: "work-mac:7878"}},
+			}, nil
+		},
+	)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	if !gotDiscoverDaemons {
+		t.Fatal("discover-daemons flag was not passed")
+	}
+	var out fanOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Targets) != 1 || out.Targets[0].Target != "work-mac" {
+		t.Fatalf("targets = %+v", out.Targets)
 	}
 }
 
@@ -384,7 +429,7 @@ func TestDiscoverFanTargetsWithDiscoveredPeers(t *testing.T) {
 	}
 	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
 
-	targets, err := discoverFanTargets(ctx, false, true)
+	targets, err := discoverFanTargets(ctx, false, true, false)
 	if err != nil {
 		t.Fatalf("discoverFanTargets = %v", err)
 	}
@@ -399,6 +444,39 @@ func TestDiscoverFanTargetsWithDiscoveredPeers(t *testing.T) {
 	}
 }
 
+func TestDiscoverFanTargetsWithDiscoveredDaemons(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origDiscoverPeers := fanDiscoverPeers
+	fanDiscoverPeers = func() ([]string, error) {
+		return []string{"work-mac", "deadbox", "work-mac"}, nil
+	}
+	origProbeTarget := fanProbeTarget
+	fanProbeTarget = func(_ context.Context, target connectTarget, _ time.Duration) error {
+		if target.Address == "work-mac:7878" {
+			return nil
+		}
+		return errors.New("unreachable")
+	}
+	t.Cleanup(func() {
+		fanDiscoverPeers = origDiscoverPeers
+		fanProbeTarget = origProbeTarget
+	})
+
+	targets, err := discoverFanTargets(ctx, false, false, true)
+	if err != nil {
+		t.Fatalf("discoverFanTargets = %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("len(targets) = %d, want 1", len(targets))
+	}
+	if targets[0].Name != "work-mac" || targets[0].Target.Address != "work-mac:7878" {
+		t.Fatalf("target = %+v", targets[0])
+	}
+}
+
 func TestDiscoverFanTargetsWithDiscoveryFallbackToPeers(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()
@@ -410,7 +488,7 @@ func TestDiscoverFanTargetsWithDiscoveryFallbackToPeers(t *testing.T) {
 	}
 	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
 
-	targets, err := discoverFanTargets(ctx, false, true)
+	targets, err := discoverFanTargets(ctx, false, true, false)
 	if err != nil {
 		t.Fatalf("discoverFanTargets = %v", err)
 	}
@@ -453,7 +531,7 @@ func TestDiscoverFanTargetsDiscoveryErrorWithDbFallback(t *testing.T) {
 	}
 	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
 
-	targets, err := discoverFanTargets(ctx, false, true)
+	targets, err := discoverFanTargets(ctx, false, true, false)
 	if err != nil {
 		t.Fatalf("discoverFanTargets = %v", err)
 	}
@@ -473,7 +551,7 @@ func TestDiscoverFanTargetsDiscoveryErrorWithoutDb(t *testing.T) {
 	}
 	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
 
-	_, err := discoverFanTargets(ctx, false, true)
+	_, err := discoverFanTargets(ctx, false, true, false)
 	if err == nil {
 		t.Fatal("discoverFanTargets succeeded, want error")
 	}
@@ -529,7 +607,7 @@ func TestRunFanWithDiscoveredHostsError(t *testing.T) {
 			t.Fatal("caller should not run")
 			return nil, nil
 		},
-		func(context.Context, bool, bool) ([]fanTarget, error) {
+		func(context.Context, bool, bool, bool) ([]fanTarget, error) {
 			return nil, nil
 		},
 	)

--- a/cmd/spectra/hosts.go
+++ b/cmd/spectra/hosts.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kaeawc/spectra/internal/store"
 )
 
-type hostLister func(context.Context, bool) ([]store.HostRow, error)
+type hostLister func(context.Context, bool, bool) ([]store.HostRow, error)
 type hostProber func(ctx context.Context, host string) error
 
 func runHosts(args []string) int {
@@ -29,8 +29,8 @@ func runHosts(args []string) int {
 		return 1
 	}
 	defer db.Close()
-	return runHostsWith(args, os.Stdout, os.Stderr, func(ctx context.Context, discover bool) ([]store.HostRow, error) {
-		return listHostRows(ctx, db, discover)
+	return runHostsWith(args, os.Stdout, os.Stderr, func(ctx context.Context, discover bool, discoverDaemons bool) ([]store.HostRow, error) {
+		return listHostRows(ctx, db, discover, discoverDaemons)
 	}, probeHost)
 }
 
@@ -40,15 +40,16 @@ func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLi
 	asJSON := fs.Bool("json", false, "Emit JSON")
 	probeFlag := fs.Bool("probe", false, "Probe each known host and report reachability")
 	discoverFlag := fs.Bool("discover", false, "Merge tailscale peer discovery from `tailscale status --json`")
+	discoverDaemonsFlag := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from Tailscale peers")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: spectra hosts [--json] [--probe] [--discover]")
+		fmt.Fprintln(stderr, "usage: spectra hosts [--json] [--probe] [--discover|--discover-daemons]")
 		return 2
 	}
 
-	rows, err := list(context.Background(), *discoverFlag)
+	rows, err := list(context.Background(), *discoverFlag, *discoverDaemonsFlag)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -146,8 +147,9 @@ type hostProbeRow struct {
 }
 
 var discoverHostRowsNow = time.Now
+var discoverHostProbe hostProber = probeHost
 
-func listHostRows(ctx context.Context, db *store.DB, discover bool) ([]store.HostRow, error) {
+func listHostRows(ctx context.Context, db *store.DB, discover bool, discoverDaemons bool) ([]store.HostRow, error) {
 	rows, err := db.ListHosts(ctx)
 	if err != nil {
 		return nil, err
@@ -165,7 +167,7 @@ func listHostRows(ctx context.Context, db *store.DB, discover bool) ([]store.Hos
 		seen[name] = struct{}{}
 		out = append(out, row)
 	}
-	if discover {
+	if discover || discoverDaemons {
 		discovered, err := fanDiscoverPeers()
 		if err != nil && len(rows) == 0 {
 			return nil, fmt.Errorf("discover remote hosts: %w", err)
@@ -177,6 +179,11 @@ func listHostRows(ctx context.Context, db *store.DB, discover bool) ([]store.Hos
 			}
 			if _, ok := seen[name]; ok {
 				continue
+			}
+			if discoverDaemons {
+				if err := discoverHostProbe(ctx, name); err != nil {
+					continue
+				}
 			}
 			seen[name] = struct{}{}
 			out = append(out, store.HostRow{

--- a/cmd/spectra/hosts_test.go
+++ b/cmd/spectra/hosts_test.go
@@ -16,7 +16,7 @@ import (
 func TestRunHostsWithTable(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith(nil, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
+	code := runHostsWith(nil, &stdout, &stderr, func(context.Context, bool, bool) ([]store.HostRow, error) {
 		return []store.HostRow{
 			{
 				MachineUUID:   "UUID-1234567890",
@@ -40,7 +40,7 @@ func TestRunHostsWithTable(t *testing.T) {
 func TestRunHostsWithJSON(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith([]string{"--json"}, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
+	code := runHostsWith([]string{"--json"}, &stdout, &stderr, func(context.Context, bool, bool) ([]store.HostRow, error) {
 		return []store.HostRow{{MachineUUID: "UUID-A", Hostname: "a.local"}}, nil
 	}, nil)
 	if code != 0 {
@@ -58,7 +58,7 @@ func TestRunHostsWithJSON(t *testing.T) {
 func TestRunHostsWithEmptyList(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith(nil, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
+	code := runHostsWith(nil, &stdout, &stderr, func(context.Context, bool, bool) ([]store.HostRow, error) {
 		return nil, nil
 	}, nil)
 	if code != 0 {
@@ -72,7 +72,7 @@ func TestRunHostsWithEmptyList(t *testing.T) {
 func TestRunHostsWithListError(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith(nil, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
+	code := runHostsWith(nil, &stdout, &stderr, func(context.Context, bool, bool) ([]store.HostRow, error) {
 		return nil, errors.New("db unavailable")
 	}, nil)
 	if code != 1 {
@@ -86,7 +86,7 @@ func TestRunHostsWithListError(t *testing.T) {
 func TestRunHostsWithProbe(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith([]string{"--probe"}, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
+	code := runHostsWith([]string{"--probe"}, &stdout, &stderr, func(context.Context, bool, bool) ([]store.HostRow, error) {
 		return []store.HostRow{
 			{MachineUUID: "UUID-A", Hostname: "work-mac.local", OSName: "macOS", OSVersion: "15.6.1"},
 			{MachineUUID: "UUID-B", Hostname: "deadbox.local", OSName: "macOS", OSVersion: "15.6.1"},
@@ -112,7 +112,7 @@ func TestRunHostsWithProbe(t *testing.T) {
 func TestRunHostsWithProbeJSON(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith([]string{"--probe", "--json"}, &stdout, &stderr, func(context.Context, bool) ([]store.HostRow, error) {
+	code := runHostsWith([]string{"--probe", "--json"}, &stdout, &stderr, func(context.Context, bool, bool) ([]store.HostRow, error) {
 		return []store.HostRow{
 			{MachineUUID: "UUID-A", Hostname: "work-mac.local", OSName: "macOS", OSVersion: "15.6.1"},
 		}, nil
@@ -142,9 +142,34 @@ func TestRunHostsWithProbeJSON(t *testing.T) {
 func TestRunHostsWithDiscover(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := runHostsWith([]string{"--discover"}, &stdout, &stderr, func(_ context.Context, discover bool) ([]store.HostRow, error) {
+	code := runHostsWith([]string{"--discover"}, &stdout, &stderr, func(_ context.Context, discover bool, discoverDaemons bool) ([]store.HostRow, error) {
 		if !discover {
 			t.Fatal("discover flag was not passed")
+		}
+		if discoverDaemons {
+			t.Fatal("discover-daemons flag should not be passed")
+		}
+		return []store.HostRow{
+			{MachineUUID: "UUID-A", Hostname: "work-mac.local", OSName: "macOS", OSVersion: "15.6.1"},
+		}, nil
+	}, nil)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "work-mac.local") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRunHostsWithDiscoverDaemons(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runHostsWith([]string{"--discover-daemons"}, &stdout, &stderr, func(_ context.Context, discover bool, discoverDaemons bool) ([]store.HostRow, error) {
+		if discover {
+			t.Fatal("discover flag should not be passed")
+		}
+		if !discoverDaemons {
+			t.Fatal("discover-daemons flag was not passed")
 		}
 		return []store.HostRow{
 			{MachineUUID: "UUID-A", Hostname: "work-mac.local", OSName: "macOS", OSVersion: "15.6.1"},
@@ -194,7 +219,7 @@ func TestListHostRowsWithDiscoveredPeers(t *testing.T) {
 		discoverHostRowsNow = origNow
 	})
 
-	rows, err := listHostRows(ctx, db, true)
+	rows, err := listHostRows(ctx, db, true, false)
 	if err != nil {
 		t.Fatalf("listHostRows = %v", err)
 	}
@@ -206,6 +231,46 @@ func TestListHostRowsWithDiscoveredPeers(t *testing.T) {
 	}
 	if rows[1].Hostname != "work-mac" || rows[1].MachineUUID != "uuid-work-mac" {
 		t.Fatalf("rows[1] = %+v", rows[1])
+	}
+}
+
+func TestListHostRowsWithDiscoveredDaemons(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dbPath := filepath.Join(home, ".spectra", "spectra.db")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	origDiscoverPeers := fanDiscoverPeers
+	fanDiscoverPeers = func() ([]string, error) {
+		return []string{"work-mac", "deadbox", "work-mac"}, nil
+	}
+	origProbe := discoverHostProbe
+	discoverHostProbe = func(_ context.Context, host string) error {
+		if host == "work-mac" {
+			return nil
+		}
+		return errors.New("unreachable")
+	}
+	t.Cleanup(func() {
+		fanDiscoverPeers = origDiscoverPeers
+		discoverHostProbe = origProbe
+	})
+
+	rows, err := listHostRows(ctx, db, false, true)
+	if err != nil {
+		t.Fatalf("listHostRows = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if rows[0].Hostname != "work-mac" || rows[0].MachineUUID != "work-mac" {
+		t.Fatalf("row = %+v", rows[0])
 	}
 }
 
@@ -240,7 +305,7 @@ func TestListHostRowsDiscoveryErrorFallback(t *testing.T) {
 	}
 	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
 
-	rows, err := listHostRows(ctx, db, true)
+	rows, err := listHostRows(ctx, db, true, false)
 	if err != nil {
 		t.Fatalf("listHostRows = %v", err)
 	}
@@ -267,7 +332,7 @@ func TestListHostRowsDiscoveryErrorWithoutDb(t *testing.T) {
 	}
 	t.Cleanup(func() { fanDiscoverPeers = origDiscoverPeers })
 
-	_, err = listHostRows(ctx, db, true)
+	_, err = listHostRows(ctx, db, true, false)
 	if err == nil {
 		t.Fatal("listHostRows succeeded, want error")
 	}

--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -30,6 +30,8 @@ func runServe(args []string) int {
 	tsnetStateDir := fs.String("tsnet-state-dir", "", "tsnet state directory (default: ~/.spectra/tsnet)")
 	tsnetEphemeral := fs.Bool("tsnet-ephemeral", false, "Register the tsnet node as ephemeral")
 	tsnetTags := fs.String("tsnet-tags", "", "Comma-separated Tailscale tags to advertise, such as tag:engineer")
+	tsnetAllowLogins := fs.String("tsnet-allow-logins", "", "Comma-separated Tailscale login names allowed to connect")
+	tsnetAllowNodes := fs.String("tsnet-allow-nodes", "", "Comma-separated Tailscale node names allowed to connect")
 	logFile := fs.String("log-file", "", "JSONL daemon log path (default: ~/Library/Logs/Spectra/daemon.jsonl)")
 	noLogFile := fs.Bool("no-log-file", false, "Disable the daemon JSONL log file")
 	daemon := fs.Bool("daemon", false, "Start spectra serve in the background and return")
@@ -90,17 +92,19 @@ func runServe(args []string) int {
 		detectStore = cacheStores.Detect
 	}
 	if err := serve.Run(ctx, serve.Options{
-		SockPath:       sock,
-		TCPAddr:        *tcpAddr,
-		TsnetEnabled:   *tsnetEnabled,
-		TsnetAddr:      *tsnetAddr,
-		TsnetHostname:  *tsnetHostname,
-		TsnetStateDir:  *tsnetStateDir,
-		TsnetEphemeral: *tsnetEphemeral,
-		TsnetTags:      splitCommaList(*tsnetTags),
-		SpectraVersion: version,
-		DetectStore:    detectStore,
-		Logger:         daemonLog,
+		SockPath:         sock,
+		TCPAddr:          *tcpAddr,
+		TsnetEnabled:     *tsnetEnabled,
+		TsnetAddr:        *tsnetAddr,
+		TsnetHostname:    *tsnetHostname,
+		TsnetStateDir:    *tsnetStateDir,
+		TsnetEphemeral:   *tsnetEphemeral,
+		TsnetTags:        splitCommaList(*tsnetTags),
+		TsnetAllowLogins: splitCommaList(*tsnetAllowLogins),
+		TsnetAllowNodes:  splitCommaList(*tsnetAllowNodes),
+		SpectraVersion:   version,
+		DetectStore:      detectStore,
+		Logger:           daemonLog,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -331,6 +331,8 @@ user's Unix socket at `~/.spectra/sock`.
 | `--tsnet-state-dir` | `~/.spectra/tsnet` | tsnet state directory |
 | `--tsnet-ephemeral` | false | Register the tsnet node as ephemeral |
 | `--tsnet-tags` | empty | Comma-separated Tailscale tags to advertise |
+| `--tsnet-allow-logins` | empty | Comma-separated Tailscale login names allowed to connect |
+| `--tsnet-allow-nodes` | empty | Comma-separated Tailscale node names allowed to connect |
 | `--log-file` | `~/Library/Logs/Spectra/daemon.jsonl` | JSONL daemon log path |
 | `--no-log-file` | false | Disable daemon JSONL logging |
 | `--daemon` | false | Start detached and return |
@@ -339,7 +341,9 @@ TCP RPC has no Spectra-layer authentication today. Keep it on loopback
 for local use or expose it only through SSH, Tailscale, or firewall
 controls you trust. `--tsnet` uses Tailscale identity and ACLs; first-run
 enrollment uses existing tsnet state, `TS_AUTHKEY`, or a login URL written
-to the daemon log or stderr.
+to the daemon log or stderr. `--tsnet-allow-logins` and
+`--tsnet-allow-nodes` add an optional Spectra-side allowlist on top of
+Tailscale ACLs.
 
 ### Examples
 
@@ -351,6 +355,7 @@ spectra serve --tcp 127.0.0.1:7878
 spectra serve --tcp 100.64.0.5:7878 --allow-remote
 spectra serve --tsnet --tsnet-hostname work-mac
 spectra serve --tsnet --tsnet-hostname work-mac --tsnet-tags tag:engineer
+spectra serve --tsnet --tsnet-allow-logins alice@example.com,bob@example.com
 ```
 
 ## `spectra install-daemon`
@@ -371,7 +376,8 @@ launchd go to `~/Library/Logs/Spectra/daemon.launchd.*.log`.
 The install and `print-plist` forms accept the serve-listener flags
 `--sock`, `--tcp`, `--allow-remote`, `--tsnet`, `--tsnet-addr`,
 `--tsnet-hostname`, `--tsnet-state-dir`, `--tsnet-ephemeral`,
-`--tsnet-tags`, `--log-file`, and `--no-log-file`.
+`--tsnet-tags`, `--tsnet-allow-logins`, `--tsnet-allow-nodes`,
+`--log-file`, and `--no-log-file`.
 
 ### Examples
 
@@ -498,6 +504,7 @@ of machines Spectra has seen. `spectra fan` uses this list when
 | `--json` | false | Emit JSON instead of a table |
 | `--probe` | false | Probe each host with `health` RPC and show reachability |
 | `--discover` | false | Merge tailscale peers from `tailscale status --json` into host list |
+| `--discover-daemons` | false | Discover Tailscale peers running reachable Spectra daemons |
 
 ### Examples
 
@@ -507,6 +514,7 @@ spectra hosts --json
 spectra hosts --probe
 spectra hosts --probe --json
 spectra hosts --discover
+spectra hosts --discover-daemons
 ``` 
 
 ## `spectra fan`
@@ -520,6 +528,7 @@ is optional; when omitted, fan-out uses hosts from the local store.
 | `--hosts` | optional | Comma-separated daemon targets (`local`, `host`, `host:port`, `unix:/path`). Omit to use hosts from local `spectra hosts` data. |
 | `--probe` | false | Probe each target with `health` RPC and skip unreachable hosts when true. |
 | `--discover` | false | Include tailscale peers from `tailscale status --json` and merge with local-known hosts. |
+| `--discover-daemons` | false | Discover Tailscale peers running reachable Spectra daemons and merge with local-known hosts. |
 | `--timeout` | `3s` | Dial/read timeout per target |
 
 The command accepts the same typed shortcuts and raw `call` form as
@@ -536,6 +545,7 @@ spectra fan --hosts work-mac,alice-laptop snapshot
 spectra fan --hosts work-mac,alice-laptop call network.connections
 spectra fan inspect /Applications/Slack.app
 spectra fan --discover status
+spectra fan --discover-daemons status
 spectra fan --discover --probe inspect /Applications/Slack.app
 ```
 

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -59,6 +59,12 @@ Tailscale login URL to the daemon log or stderr. `--tsnet-hostname`
 controls the MagicDNS name, and `--tsnet-tags` advertises comma-separated
 tags for ACL-managed tailnets.
 
+By default, any peer allowed by Tailscale ACLs can connect to the tsnet
+listener. Add `--tsnet-allow-logins` or `--tsnet-allow-nodes` to enforce a
+Spectra-side allowlist using Tailscale `WhoIs` identity. Login names and node
+names are exact matches after case normalization; node names may include or
+omit the trailing dot returned by Tailscale.
+
 ## RPC surface
 
 JSON-RPC 2.0 methods, organized by concern:
@@ -125,8 +131,9 @@ mediates and applies its own access control.
 
 Current local mode relies on Unix socket filesystem permissions. TCP mode
 relies on the network path that exposes it. `tsnet` mode relies on
-Tailscale identity and ACLs. Spectra-layer remote tokens remain future
-work with the remote portal.
+Tailscale identity and ACLs, with optional `WhoIs`-based allowlists for
+login names and node names. Spectra-layer remote tokens remain future work
+with the remote portal.
 
 ## Security posture
 
@@ -147,8 +154,10 @@ work with the remote portal.
 ## Health
 
 Each daemon exposes a JSON-RPC `health` method returning
-`{ ok: true, version: ... }` on the Unix socket and any opted-in TCP
-listener. Used by:
+`{ ok: true, version: ... }` on the Unix socket and any opted-in TCP or
+tsnet listener. When `--tsnet` is enabled, the result also includes a
+`tsnet` object with the managed node hostname, listen address, and current
+Tailscale IPs when assigned. Used by:
 
 - `spectra status` — local health check.
 - `spectra connect <target>` — Unix or TCP health check.
@@ -158,9 +167,10 @@ listener. Used by:
 
 The daemon writes JSONL records for listener startup, storage readiness,
 serving start, and shutdown/error events. These records include socket paths,
-TCP listen addresses, database path, version, and listener count. They do not
-include heap-dump contents, JFR contents, process command-line arguments, or
-RPC payloads.
+TCP listen addresses, database path, version, and listener count. For tsnet
+connections, the daemon also logs Tailscale `WhoIs` identity metadata for the
+connecting peer when available. Logs do not include heap-dump contents, JFR
+contents, process command-line arguments, or RPC payloads.
 
 ## Implementation order
 
@@ -184,5 +194,4 @@ Implemented:
 Future:
 
 1. CLI-wide RPC dispatch instead of in-process command execution.
-2. Managed tsnet host discovery.
-3. TUI/GUI clients.
+2. TUI/GUI clients.

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -39,6 +39,14 @@ Tailscale login URL to its log or stderr. Once enrolled, peers allowed by
 Tailscale ACLs can connect through the MagicDNS name and the same
 `spectra connect` commands.
 
+To narrow access inside an already-permitted tailnet, add a Spectra-side
+allowlist:
+
+```bash
+spectra serve --tsnet --tsnet-allow-logins alice@example.com,bob@example.com
+spectra serve --tsnet --tsnet-allow-nodes alice-mac.tailnet.ts.net
+```
+
 ## What you can do
 
 Any RPC method the daemon exposes is available remotely through the
@@ -97,8 +105,10 @@ When `--hosts` is omitted, `spectra fan` can merge:
 - hosts from local `spectra hosts` data (`~/.spectra/spectra.db`), and
 - optional tailscale peers (`spectra fan --discover`) from `tailscale status --json`.
 
-This currently supports a manual discovery opt-in path while we migrate toward
-fully managed tsnet fan-out:
+This supports both raw Tailscale peer merge and managed Spectra daemon
+discovery. Use `--discover` to include all Tailscale peers from
+`tailscale status --json`; use `--discover-daemons` to probe those peers and
+keep only reachable Spectra daemons:
 
 ```bash
 spectra hosts
@@ -109,15 +119,16 @@ spectra fan inspect /Applications/Slack.app
 spectra fan --hosts work-mac,alice-laptop jvm
 spectra fan --hosts work-mac,alice-laptop network-by-app /Applications/Slack.app
 spectra fan --discover status
+spectra fan --discover-daemons status
 ```
 
 The client makes parallel RPC calls to each daemon and aggregates
 results locally into one JSON envelope. The remaining intended shape is:
 
 ```bash
-spectra hosts                                # include discovered Spectra hosts
-spectra hosts --probe                         # report reachable hosts
-spectra fan inspect /Applications/Slack.app  # inspect Slack on every discovered host
+spectra hosts --discover-daemons             # include reachable Spectra daemons
+spectra hosts --probe                        # report reachable hosts
+spectra fan --discover-daemons inspect /Applications/Slack.app
 spectra diff laptop work-mac                 # compare two hosts
 ```
 
@@ -222,9 +233,7 @@ spectra fan --hosts alice-laptop,bob-laptop snapshot
 
 ## Implementation order
 
-The local daemon, explicit TCP transport, and embedded tsnet listener are
-implemented. Remaining remote work:
+The local daemon, explicit TCP transport, embedded tsnet listener, and
+managed Tailscale daemon discovery are implemented. Remaining remote work:
 
-1. Add managed tsnet host discovery so `spectra hosts` includes reachable daemons
-   and `spectra fan` can run without an explicit `--hosts` list.
-2. Add TUI support against local-or-remote daemon targets.
+1. Add TUI support against local-or-remote daemon targets.

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -34,7 +34,6 @@ import (
 	"github.com/kaeawc/spectra/internal/store"
 	"github.com/kaeawc/spectra/internal/sysinfo"
 	"github.com/kaeawc/spectra/internal/toolchain"
-	"tailscale.com/tsnet"
 )
 
 var (
@@ -55,19 +54,22 @@ func DefaultSockPath() (string, error) {
 
 // Options configures the daemon.
 type Options struct {
-	SockPath       string
-	TCPAddr        string
-	TsnetEnabled   bool
-	TsnetAddr      string
-	TsnetHostname  string
-	TsnetStateDir  string
-	TsnetEphemeral bool
-	TsnetTags      []string
-	SpectraVersion string
-	DBPath         string              // empty = store.DefaultPath()
-	CacheRegistry  *cache.Registry     // nil = cache.Default
-	DetectStore    *cache.ShardedStore // nil = no detect caching
-	Logger         logger.Logger       // nil = discard
+	SockPath         string
+	TCPAddr          string
+	TsnetEnabled     bool
+	TsnetAddr        string
+	TsnetHostname    string
+	TsnetStateDir    string
+	TsnetEphemeral   bool
+	TsnetTags        []string
+	TsnetAllowLogins []string
+	TsnetAllowNodes  []string
+	TsnetFactory     TsnetFactory
+	SpectraVersion   string
+	DBPath           string              // empty = store.DefaultPath()
+	CacheRegistry    *cache.Registry     // nil = cache.Default
+	DetectStore      *cache.ShardedStore // nil = no detect caching
+	Logger           logger.Logger       // nil = discard
 }
 
 const DefaultTsnetAddr = ":7878"
@@ -105,7 +107,8 @@ func Run(ctx context.Context, opts Options) error {
 	log.Info("daemon unix listener ready", "socket", sockPath)
 
 	listeners := []net.Listener{ln}
-	var ts *tsnet.Server
+	var ts TsnetNode
+	var tsnetStatus *TsnetStatus
 	if opts.TCPAddr != "" {
 		tcpLn, err := net.Listen("tcp", opts.TCPAddr)
 		if err != nil {
@@ -117,13 +120,14 @@ func Run(ctx context.Context, opts Options) error {
 		log.Warn("daemon tcp listener ready", "address", opts.TCPAddr)
 	}
 	if opts.TsnetEnabled {
-		tsLn, tsServer, err := listenTsnet(opts, log)
+		tsLn, tsServer, status, err := listenTsnet(opts, log)
 		if err != nil {
 			closeListeners(listeners)
 			os.Remove(sockPath)
 			return err
 		}
 		ts = tsServer
+		tsnetStatus = status
 		listeners = append(listeners, tsLn)
 	}
 	defer os.Remove(sockPath)
@@ -163,7 +167,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, opts.SpectraVersion, db, collector, cacheReg, opts.DetectStore)
+	registerHandlers(d, opts.SpectraVersion, db, collector, cacheReg, opts.DetectStore, tsnetStatus, ts)
 	log.Info("daemon serving", "version", opts.SpectraVersion, "listeners", len(listeners))
 
 	// Close the listener when ctx is cancelled to unblock Accept.
@@ -201,20 +205,20 @@ func DefaultTsnetHostname() string {
 	return "spectra"
 }
 
-func listenTsnet(opts Options, log logger.Logger) (net.Listener, *tsnet.Server, error) {
+func listenTsnet(opts Options, log logger.Logger) (net.Listener, TsnetNode, *TsnetStatus, error) {
 	stateDir := opts.TsnetStateDir
 	if stateDir == "" {
 		var err error
 		stateDir, err = DefaultTsnetStateDir()
 		if err != nil {
-			return nil, nil, fmt.Errorf("serve: resolve tsnet state dir: %w", err)
+			return nil, nil, nil, fmt.Errorf("serve: resolve tsnet state dir: %w", err)
 		}
 	}
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		return nil, nil, fmt.Errorf("serve: mkdir tsnet state dir: %w", err)
+		return nil, nil, nil, fmt.Errorf("serve: mkdir tsnet state dir: %w", err)
 	}
 	if err := os.Chmod(stateDir, 0o700); err != nil {
-		return nil, nil, fmt.Errorf("serve: chmod tsnet state dir %s: %w", stateDir, err)
+		return nil, nil, nil, fmt.Errorf("serve: chmod tsnet state dir %s: %w", stateDir, err)
 	}
 	addr := opts.TsnetAddr
 	if addr == "" {
@@ -226,25 +230,49 @@ func listenTsnet(opts Options, log logger.Logger) (net.Listener, *tsnet.Server, 
 	}
 	hostname = sanitizeTsnetHostname(hostname)
 	if hostname == "" {
-		return nil, nil, fmt.Errorf("serve: invalid empty tsnet hostname")
+		return nil, nil, nil, fmt.Errorf("serve: invalid empty tsnet hostname")
 	}
-	s := &tsnet.Server{
-		Dir:           stateDir,
-		Hostname:      hostname,
-		Ephemeral:     opts.TsnetEphemeral,
-		AdvertiseTags: opts.TsnetTags,
+	factory := opts.TsnetFactory
+	if factory == nil {
+		factory = NewTsnetServer
+	}
+	cfg := TsnetConfig{
+		StateDir:    stateDir,
+		Hostname:    hostname,
+		Ephemeral:   opts.TsnetEphemeral,
+		Tags:        opts.TsnetTags,
+		AllowLogins: opts.TsnetAllowLogins,
+		AllowNodes:  opts.TsnetAllowNodes,
 	}
 	if opts.Logger != nil {
-		s.UserLogf = func(format string, args ...any) {
+		cfg.UserLogf = func(format string, args ...any) {
 			log.Info("daemon tsnet status", "message", fmt.Sprintf(format, args...))
 		}
 	}
+	s := factory(cfg)
 	ln, err := s.Listen("tcp", addr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("serve: listen tsnet %s: %w", addr, err)
+		_ = s.Close()
+		return nil, nil, nil, fmt.Errorf("serve: listen tsnet %s: %w", addr, err)
+	}
+	if opts.Logger != nil || len(opts.TsnetAllowLogins) > 0 || len(opts.TsnetAllowNodes) > 0 {
+		ln = &tsnetIdentityListener{
+			Listener: ln,
+			node:     s,
+			log:      log,
+			policy: tsnetPolicy{
+				AllowedLogins: opts.TsnetAllowLogins,
+				AllowedNodes:  opts.TsnetAllowNodes,
+			},
+		}
+	}
+	status := &TsnetStatus{
+		Enabled:    true,
+		Hostname:   hostname,
+		ListenAddr: addr,
 	}
 	log.Info("daemon tsnet listener ready", "hostname", hostname, "address", addr, "state_dir", stateDir)
-	return ln, s, nil
+	return ln, s, status, nil
 }
 
 func sanitizeTsnetHostname(host string) string {
@@ -364,9 +392,23 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB) {
 // registerHandlers wires all JSON-RPC methods into d.
 //
 //gocyclo:ignore
-func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, cacheReg *cache.Registry, detectStore *cache.ShardedStore) {
+func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, cacheReg *cache.Registry, detectStore *cache.ShardedStore, tsnetStatus *TsnetStatus, tsnetNode TsnetNode) {
 	d.Register("health", func(_ json.RawMessage) (any, error) {
-		return map[string]any{"ok": true, "version": version}, nil
+		result := map[string]any{"ok": true, "version": version}
+		if tsnetStatus != nil {
+			status := *tsnetStatus
+			if tsnetNode != nil {
+				ip4, ip6 := tsnetNode.TailscaleIPs()
+				if ip4.IsValid() {
+					status.IPv4 = ip4.String()
+				}
+				if ip6.IsValid() {
+					status.IPv6 = ip6.String()
+				}
+			}
+			result["tsnet"] = status
+		}
+		return result, nil
 	})
 
 	d.Register("snapshot.list", func(_ json.RawMessage) (any, error) {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -3,10 +3,14 @@ package serve
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -72,7 +76,7 @@ func testDaemonWithDB(t *testing.T) (*json.Encoder, *json.Decoder, *store.DB, co
 		collectToolchains = origCollectToolchains
 		collectJDKs = origCollectJDKs
 	})
-	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default, nil)
+	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default, nil, nil, nil)
 
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -171,6 +175,257 @@ func TestRunLogsLifecycle(t *testing.T) {
 	}
 }
 
+func TestRunTsnetUsesFactoryAndServesRPC(t *testing.T) {
+	dir, err := os.MkdirTemp("", "sp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	sockPath := filepath.Join(dir, "s.sock")
+	dbPath := filepath.Join(dir, "t.db")
+	stateDir := filepath.Join(dir, "tsnet")
+	fake := newFakeTsnetFactory(t)
+	logs := logger.NewCapture(slog.LevelInfo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, Options{
+			SockPath:         sockPath,
+			DBPath:           dbPath,
+			TsnetEnabled:     true,
+			TsnetAddr:        ":7879",
+			TsnetHostname:    "Work Mac.local",
+			TsnetStateDir:    stateDir,
+			TsnetEphemeral:   true,
+			TsnetTags:        []string{"tag:engineer", "tag:spectra"},
+			TsnetAllowLogins: []string{"alice@example.com"},
+			TsnetAllowNodes:  []string{"alice-mac.tailnet.ts.net"},
+			TsnetFactory:     fake.newNode,
+			SpectraVersion:   "test-version",
+			CacheRegistry:    cache.Default,
+			Logger:           logs,
+		})
+	}()
+
+	addr := fake.waitAddr(t)
+	conn, err := rpc.DialNetwork("tcp", addr)
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := json.NewEncoder(conn).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "health",
+	}); err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	var resp rpc.Response
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		cancel()
+		t.Fatalf("unexpected RPC error: %+v", resp.Error)
+	}
+	var health struct {
+		OK      bool   `json:"ok"`
+		Version string `json:"version"`
+		Tsnet   struct {
+			Enabled    bool   `json:"enabled"`
+			Hostname   string `json:"hostname"`
+			ListenAddr string `json:"listen_addr"`
+			IPv4       string `json:"ipv4"`
+			IPv6       string `json:"ipv6"`
+		} `json:"tsnet"`
+	}
+	raw, err := json.Marshal(resp.Result)
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &health); err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	if !health.Tsnet.Enabled || health.Tsnet.Hostname != "work-mac" || health.Tsnet.ListenAddr != ":7879" {
+		cancel()
+		t.Fatalf("health tsnet = %+v", health.Tsnet)
+	}
+	if health.Tsnet.IPv4 != "100.64.0.10" || health.Tsnet.IPv6 != "fd7a:115c:a1e0::10" {
+		cancel()
+		t.Fatalf("health tsnet IPs = %s %s", health.Tsnet.IPv4, health.Tsnet.IPv6)
+	}
+	fake.waitWhoIs(t)
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not stop after context cancellation")
+	}
+
+	cfg := fake.config()
+	if cfg.StateDir != stateDir {
+		t.Fatalf("state dir = %q, want %q", cfg.StateDir, stateDir)
+	}
+	if cfg.Hostname != "work-mac" {
+		t.Fatalf("hostname = %q, want work-mac", cfg.Hostname)
+	}
+	if !cfg.Ephemeral {
+		t.Fatal("ephemeral = false, want true")
+	}
+	if !slices.Equal(cfg.Tags, []string{"tag:engineer", "tag:spectra"}) {
+		t.Fatalf("tags = %v", cfg.Tags)
+	}
+	if !slices.Equal(cfg.AllowLogins, []string{"alice@example.com"}) {
+		t.Fatalf("allow logins = %v", cfg.AllowLogins)
+	}
+	if !slices.Equal(cfg.AllowNodes, []string{"alice-mac.tailnet.ts.net"}) {
+		t.Fatalf("allow nodes = %v", cfg.AllowNodes)
+	}
+	if cfg.UserLogf == nil {
+		t.Fatal("UserLogf is nil")
+	}
+	if !fake.closed() {
+		t.Fatal("fake tsnet node was not closed")
+	}
+	waitForLog(t, logs, "daemon tsnet peer connected")
+	if got := fake.whoIsRemoteAddr(); got == "" {
+		t.Fatal("WhoIs was not called with a remote address")
+	}
+	info, err := os.Stat(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("state dir mode = %o, want 700", got)
+	}
+}
+
+func TestTsnetPolicyAllowsLoginOrNode(t *testing.T) {
+	policy := tsnetPolicy{
+		AllowedLogins: []string{"alice@example.com"},
+		AllowedNodes:  []string{"work-mac.tailnet.ts.net"},
+	}
+	tests := []struct {
+		name string
+		peer *TsnetPeer
+		want bool
+	}{
+		{
+			name: "login match",
+			peer: &TsnetPeer{LoginName: "Alice@Example.com", NodeName: "other.tailnet.ts.net."},
+			want: true,
+		},
+		{
+			name: "node match",
+			peer: &TsnetPeer{LoginName: "bob@example.com", NodeName: "work-mac.tailnet.ts.net."},
+			want: true,
+		},
+		{
+			name: "no match",
+			peer: &TsnetPeer{LoginName: "bob@example.com", NodeName: "other.tailnet.ts.net."},
+			want: false,
+		},
+		{
+			name: "nil peer",
+			peer: nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := policy.Allows(tt.peer); got != tt.want {
+				t.Fatalf("Allows = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTsnetIdentityListenerRejectsDisallowedPeer(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	logs := logger.NewCapture(slog.LevelInfo)
+	fake := newFakeTsnetFactory(t)
+	fake.peer = TsnetPeer{
+		LoginName:   "bob@example.com",
+		DisplayName: "Bob Example",
+		NodeName:    "bob-mac.tailnet.ts.net.",
+	}
+	wrapped := &tsnetIdentityListener{
+		Listener: ln,
+		node:     fake.newNode(TsnetConfig{}),
+		log:      logs,
+		policy:   tsnetPolicy{AllowedLogins: []string{"alice@example.com"}},
+	}
+	errCh := make(chan error, 1)
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		conn, err := wrapped.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		connCh <- conn
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.Close()
+	fake.waitWhoIs(t)
+	_ = ln.Close()
+
+	select {
+	case conn := <-connCh:
+		conn.Close()
+		t.Fatal("disallowed peer was accepted")
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Accept did not return after listener close")
+	}
+	waitForLog(t, logs, "daemon tsnet peer rejected")
+}
+
+func TestListenTsnetClosesNodeOnListenError(t *testing.T) {
+	dir := t.TempDir()
+	wantErr := errors.New("listen failed")
+	fake := newFakeTsnetFactory(t)
+	fake.listenErr = wantErr
+
+	ln, node, status, err := listenTsnet(Options{
+		TsnetAddr:     ":7879",
+		TsnetHostname: "work-mac",
+		TsnetStateDir: dir,
+		TsnetFactory:  fake.newNode,
+	}, logger.Discard())
+	if err == nil {
+		t.Fatal("listenTsnet err = nil, want error")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("listenTsnet err = %v, want %v", err, wantErr)
+	}
+	if ln != nil || node != nil || status != nil {
+		t.Fatalf("listenTsnet returned values on error: %v %v %v", ln, node, status)
+	}
+	if !fake.closed() {
+		t.Fatal("fake tsnet node was not closed after Listen error")
+	}
+}
+
 func TestSanitizeTsnetHostname(t *testing.T) {
 	tests := map[string]string{
 		"Work Mac.local": "work-mac",
@@ -185,6 +440,131 @@ func TestSanitizeTsnetHostname(t *testing.T) {
 	}
 }
 
+type fakeTsnetFactory struct {
+	t *testing.T
+
+	mu          sync.Mutex
+	ready       chan struct{}
+	whois       chan struct{}
+	cfg         TsnetConfig
+	ln          net.Listener
+	listenErr   error
+	closeCalled bool
+	whoisCalled bool
+	remoteAddr  string
+	peer        TsnetPeer
+}
+
+func newFakeTsnetFactory(t *testing.T) *fakeTsnetFactory {
+	t.Helper()
+	return &fakeTsnetFactory{
+		t:     t,
+		ready: make(chan struct{}),
+		whois: make(chan struct{}),
+		peer: TsnetPeer{
+			LoginName:   "alice@example.com",
+			DisplayName: "Alice Example",
+			NodeName:    "alice-mac.tailnet.ts.net.",
+		},
+	}
+}
+
+func (f *fakeTsnetFactory) newNode(cfg TsnetConfig) TsnetNode {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cfg = cfg
+	return (*fakeTsnetNode)(f)
+}
+
+func (f *fakeTsnetFactory) config() TsnetConfig {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.cfg
+}
+
+func (f *fakeTsnetFactory) waitAddr(t *testing.T) string {
+	t.Helper()
+	select {
+	case <-f.ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fake tsnet listener was not created")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ln == nil {
+		t.Fatal("fake tsnet listener was not created")
+	}
+	return f.ln.Addr().String()
+}
+
+func (f *fakeTsnetFactory) closed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closeCalled
+}
+
+func (f *fakeTsnetFactory) waitWhoIs(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.whois:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fake tsnet WhoIs was not called")
+	}
+}
+
+func (f *fakeTsnetFactory) whoIsRemoteAddr() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.remoteAddr
+}
+
+type fakeTsnetNode fakeTsnetFactory
+
+func (n *fakeTsnetNode) Listen(network string, _ string) (net.Listener, error) {
+	f := (*fakeTsnetFactory)(n)
+	if f.listenErr != nil {
+		return nil, f.listenErr
+	}
+	ln, err := net.Listen(network, "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	f.ln = ln
+	f.mu.Unlock()
+	close(f.ready)
+	return ln, nil
+}
+
+func (n *fakeTsnetNode) TailscaleIPs() (netip.Addr, netip.Addr) {
+	return netip.MustParseAddr("100.64.0.10"), netip.MustParseAddr("fd7a:115c:a1e0::10")
+}
+
+func (n *fakeTsnetNode) WhoIs(_ context.Context, remoteAddr string) (*TsnetPeer, error) {
+	f := (*fakeTsnetFactory)(n)
+	f.mu.Lock()
+	f.remoteAddr = remoteAddr
+	if !f.whoisCalled {
+		f.whoisCalled = true
+		close(f.whois)
+	}
+	peer := f.peer
+	f.mu.Unlock()
+	return &peer, nil
+}
+
+func (n *fakeTsnetNode) Close() error {
+	f := (*fakeTsnetFactory)(n)
+	f.mu.Lock()
+	f.closeCalled = true
+	ln := f.ln
+	f.mu.Unlock()
+	if ln != nil {
+		_ = ln.Close()
+	}
+	return nil
+}
+
 func waitForSocket(t *testing.T, path string) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
@@ -195,6 +575,18 @@ func waitForSocket(t *testing.T, path string) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("socket %s was not created", path)
+}
+
+func waitForLog(t *testing.T, logs *logger.Capture, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if logs.HasMessage(msg) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("missing log %q: %+v", msg, logs.Records())
 }
 
 func TestDaemonSnapshotList(t *testing.T) {

--- a/internal/serve/tsnet.go
+++ b/internal/serve/tsnet.go
@@ -1,0 +1,209 @@
+package serve
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/logger"
+	"tailscale.com/tsnet"
+)
+
+// TsnetStatus is the health payload for the embedded tailnet listener.
+type TsnetStatus struct {
+	Enabled    bool   `json:"enabled"`
+	Hostname   string `json:"hostname,omitempty"`
+	ListenAddr string `json:"listen_addr,omitempty"`
+	IPv4       string `json:"ipv4,omitempty"`
+	IPv6       string `json:"ipv6,omitempty"`
+}
+
+// TsnetConfig is the tsnet and Spectra-side policy configuration the daemon
+// normalizes before constructing a node.
+type TsnetConfig struct {
+	StateDir    string
+	Hostname    string
+	Ephemeral   bool
+	Tags        []string
+	AllowLogins []string
+	AllowNodes  []string
+	UserLogf    func(format string, args ...any)
+}
+
+// TsnetPeer is the Tailscale identity attached to a remote tsnet connection.
+type TsnetPeer struct {
+	LoginName   string
+	DisplayName string
+	NodeName    string
+}
+
+// TsnetNode is the tsnet surface the daemon needs. Tests inject fakes so unit
+// tests never enroll or start a real tailnet node.
+type TsnetNode interface {
+	Listen(network string, addr string) (net.Listener, error)
+	TailscaleIPs() (netip.Addr, netip.Addr)
+	WhoIs(ctx context.Context, remoteAddr string) (*TsnetPeer, error)
+	Close() error
+}
+
+// TsnetFactory constructs a tsnet node from Spectra's normalized config.
+type TsnetFactory func(TsnetConfig) TsnetNode
+
+// NewTsnetServer returns the production embedded Tailscale node.
+func NewTsnetServer(cfg TsnetConfig) TsnetNode {
+	return &realTsnetNode{server: &tsnet.Server{
+		Dir:           cfg.StateDir,
+		Hostname:      cfg.Hostname,
+		Ephemeral:     cfg.Ephemeral,
+		AdvertiseTags: cfg.Tags,
+		UserLogf:      cfg.UserLogf,
+	}}
+}
+
+type realTsnetNode struct {
+	server *tsnet.Server
+}
+
+func (n *realTsnetNode) Listen(network string, addr string) (net.Listener, error) {
+	return n.server.Listen(network, addr)
+}
+
+func (n *realTsnetNode) TailscaleIPs() (netip.Addr, netip.Addr) {
+	return n.server.TailscaleIPs()
+}
+
+func (n *realTsnetNode) WhoIs(ctx context.Context, remoteAddr string) (*TsnetPeer, error) {
+	lc, err := n.server.LocalClient()
+	if err != nil {
+		return nil, err
+	}
+	who, err := lc.WhoIs(ctx, remoteAddr)
+	if err != nil {
+		return nil, err
+	}
+	peer := &TsnetPeer{}
+	if who.UserProfile != nil {
+		peer.LoginName = who.UserProfile.LoginName
+		peer.DisplayName = who.UserProfile.DisplayName
+	}
+	if who.Node != nil {
+		peer.NodeName = who.Node.Name
+	}
+	return peer, nil
+}
+
+func (n *realTsnetNode) Close() error {
+	return n.server.Close()
+}
+
+type tsnetIdentityListener struct {
+	net.Listener
+	node   TsnetNode
+	log    logger.Logger
+	policy tsnetPolicy
+}
+
+func (l *tsnetIdentityListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		remoteAddr := conn.RemoteAddr().String()
+		if !l.policy.Enabled() {
+			go logTsnetPeer(l.node, l.log, remoteAddr)
+			return conn, nil
+		}
+		peer, err := lookupTsnetPeer(l.node, remoteAddr)
+		if err != nil {
+			l.log.Warn("daemon tsnet peer rejected", "remote_addr", remoteAddr, "error", err.Error())
+			_ = conn.Close()
+			continue
+		}
+		if peer == nil {
+			l.log.Warn("daemon tsnet peer rejected", "remote_addr", remoteAddr, "error", "empty whois response")
+			_ = conn.Close()
+			continue
+		}
+		if !l.policy.Allows(peer) {
+			l.log.Warn(
+				"daemon tsnet peer rejected",
+				"remote_addr", remoteAddr,
+				"login", peer.LoginName,
+				"display_name", peer.DisplayName,
+				"node", peer.NodeName,
+			)
+			_ = conn.Close()
+			continue
+		}
+		logTsnetPeerIdentity(l.log, remoteAddr, peer)
+		return conn, nil
+	}
+}
+
+func logTsnetPeer(node TsnetNode, log logger.Logger, remoteAddr string) {
+	peer, err := lookupTsnetPeer(node, remoteAddr)
+	if err != nil {
+		log.Debug("daemon tsnet peer identity unavailable", "remote_addr", remoteAddr, "error", err.Error())
+		return
+	}
+	if peer == nil {
+		log.Debug("daemon tsnet peer identity unavailable", "remote_addr", remoteAddr, "error", "empty whois response")
+		return
+	}
+	logTsnetPeerIdentity(log, remoteAddr, peer)
+}
+
+func lookupTsnetPeer(node TsnetNode, remoteAddr string) (*TsnetPeer, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return node.WhoIs(ctx, remoteAddr)
+}
+
+func logTsnetPeerIdentity(log logger.Logger, remoteAddr string, peer *TsnetPeer) {
+	log.Info(
+		"daemon tsnet peer connected",
+		"remote_addr", remoteAddr,
+		"login", peer.LoginName,
+		"display_name", peer.DisplayName,
+		"node", peer.NodeName,
+	)
+}
+
+type tsnetPolicy struct {
+	AllowedLogins []string
+	AllowedNodes  []string
+}
+
+func (p tsnetPolicy) Enabled() bool {
+	return len(p.AllowedLogins) > 0 || len(p.AllowedNodes) > 0
+}
+
+func (p tsnetPolicy) Allows(peer *TsnetPeer) bool {
+	if peer == nil {
+		return false
+	}
+	login := normalizeTsnetLogin(peer.LoginName)
+	node := normalizeTsnetNode(peer.NodeName)
+	for _, allowed := range p.AllowedLogins {
+		if login != "" && login == normalizeTsnetLogin(allowed) {
+			return true
+		}
+	}
+	for _, allowed := range p.AllowedNodes {
+		if node != "" && node == normalizeTsnetNode(allowed) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeTsnetLogin(login string) string {
+	return strings.ToLower(strings.TrimSpace(login))
+}
+
+func normalizeTsnetNode(node string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(node)), ".")
+}


### PR DESCRIPTION
## Summary

- Add a fakeable tsnet seam so daemon unit tests can cover the tsnet path without constructing a real `tsnet.Server`.
- Add tsnet health metadata, `WhoIs` peer logging, and optional Spectra-side allowlists for Tailscale login and node names.
- Add `--discover-daemons` for `spectra hosts` and `spectra fan` to probe Tailscale peers and keep only reachable Spectra daemons.
- Update CLI, daemon, and remote-operation docs for the new policy and discovery behavior.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./internal/serve -run 'TestRunTsnetUsesFactoryAndServesRPC|TestTsnetIdentityListenerRejectsDisallowedPeer' -count=1`
- `make docs-validate`
