### PR TITLE
Add network capture CLI

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -6,10 +6,21 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/netstate"
+)
+
+var (
+	networkCaptureStart = func(iface string, durationMS, snapLen int, proto, host string, port int) (map[string]any, error) {
+		return helperclient.New().NetCaptureStart(iface, durationMS, snapLen, proto, host, port)
+	}
+	networkCaptureStop = func(handle string) (map[string]any, error) {
+		return helperclient.New().NetCaptureStop(handle)
+	}
 )
 
 func runNetwork(args []string) int {
@@ -18,6 +29,9 @@ func runNetwork(args []string) int {
 	}
 	if len(args) > 0 && args[0] == "firewall" {
 		return runNetworkFirewall(args[1:])
+	}
+	if len(args) > 0 && args[0] == "capture" {
+		return runNetworkCapture(args[1:])
 	}
 
 	fs := flag.NewFlagSet("spectra network", flag.ContinueOnError)
@@ -38,6 +52,101 @@ func runNetwork(args []string) int {
 
 	printNetworkState(state)
 	return 0
+}
+
+func runNetworkCapture(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: spectra network capture [start|stop] ...")
+		return 2
+	}
+	switch args[0] {
+	case "start":
+		return runNetworkCaptureStart(args[1:])
+	case "stop":
+		return runNetworkCaptureStop(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown network capture command %q\n", args[0])
+		return 2
+	}
+}
+
+func runNetworkCaptureStart(args []string) int {
+	fs := flag.NewFlagSet("spectra network capture start", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	iface := fs.String("interface", "", "Network interface to capture, e.g. en0 or utun3")
+	duration := fs.Duration("duration", 30*time.Second, "Maximum capture duration")
+	snapLen := fs.Int("snaplen", 0, "tcpdump snapshot length (0 = default)")
+	proto := fs.String("proto", "", "Optional protocol filter: tcp or udp")
+	host := fs.String("host", "", "Optional host filter")
+	port := fs.Int("port", 0, "Optional port filter")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *iface == "" {
+		fmt.Fprintln(os.Stderr, "network capture start requires --interface")
+		return 2
+	}
+	durationMS := int(duration.Milliseconds())
+	result, err := networkCaptureStart(*iface, durationMS, *snapLen, *proto, *host, *port)
+	if err != nil {
+		if helperclient.IsUnavailable(err) {
+			fmt.Fprintln(os.Stderr, "privileged helper not running; install with: sudo spectra install-helper")
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "network capture start: %v\n", err)
+		return 1
+	}
+	return printNetworkCaptureResult(result, *asJSON, "capture started")
+}
+
+func runNetworkCaptureStop(args []string) int {
+	fs := flag.NewFlagSet("spectra network capture stop", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra network capture stop <handle>")
+		return 2
+	}
+	result, err := networkCaptureStop(fs.Arg(0))
+	if err != nil {
+		if helperclient.IsUnavailable(err) {
+			fmt.Fprintln(os.Stderr, "privileged helper not running; install with: sudo spectra install-helper")
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "network capture stop: %v\n", err)
+		return 1
+	}
+	return printNetworkCaptureResult(result, *asJSON, "capture stopped")
+}
+
+func printNetworkCaptureResult(result map[string]any, asJSON bool, label string) int {
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return 0
+	}
+	fmt.Println(label)
+	for _, key := range []string{"handle", "interface", "duration_ms", "output_path", "size_bytes", "wait_error", "owner_error", "stat_error"} {
+		if v, ok := result[key]; ok && fmt.Sprint(v) != "" {
+			fmt.Printf("  %s: %s\n", key, formatCaptureValue(v))
+		}
+	}
+	return 0
+}
+
+func formatCaptureValue(v any) string {
+	switch n := v.(type) {
+	case float64:
+		if n == float64(int64(n)) {
+			return strconv.FormatInt(int64(n), 10)
+		}
+	}
+	return fmt.Sprint(v)
 }
 
 func runNetworkFirewall(args []string) int {

--- a/cmd/spectra/network_capture_test.go
+++ b/cmd/spectra/network_capture_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/helperclient"
+)
+
+func TestRunNetworkCaptureStartCallsHelper(t *testing.T) {
+	restore := stubNetworkCaptureStart(t, func(iface string, durationMS, snapLen int, proto, host string, port int) (map[string]any, error) {
+		if iface != "en0" || durationMS != 5000 || snapLen != 4096 || proto != "tcp" || host != "api.example.com" || port != 443 {
+			t.Fatalf("params = %q %d %d %q %q %d", iface, durationMS, snapLen, proto, host, port)
+		}
+		return map[string]any{
+			"handle":      "netcap-1",
+			"interface":   iface,
+			"duration_ms": durationMS,
+			"output_path": "/var/tmp/spectra-netcap/501/netcap-1.pcap",
+		}, nil
+	})
+	defer restore()
+
+	out := captureStdout(t, func() {
+		code := runNetwork([]string{"capture", "start", "--interface", "en0", "--duration", "5s", "--snaplen", "4096", "--proto", "tcp", "--host", "api.example.com", "--port", "443"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "capture started") || !strings.Contains(out, "handle: netcap-1") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestRunNetworkCaptureStartJSON(t *testing.T) {
+	restore := stubNetworkCaptureStart(t, func(string, int, int, string, string, int) (map[string]any, error) {
+		return map[string]any{"handle": "netcap-2"}, nil
+	})
+	defer restore()
+
+	out := captureStdout(t, func() {
+		code := runNetwork([]string{"capture", "start", "--interface", "utun3", "--json"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, `"handle": "netcap-2"`) {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestRunNetworkCaptureStopCallsHelper(t *testing.T) {
+	restore := stubNetworkCaptureStop(t, func(handle string) (map[string]any, error) {
+		if handle != "netcap-1" {
+			t.Fatalf("handle = %q, want netcap-1", handle)
+		}
+		return map[string]any{"handle": handle, "size_bytes": 128}, nil
+	})
+	defer restore()
+
+	out := captureStdout(t, func() {
+		code := runNetwork([]string{"capture", "stop", "netcap-1"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "capture stopped") || !strings.Contains(out, "size_bytes: 128") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestRunNetworkCaptureRequiresInterface(t *testing.T) {
+	restore := stubNetworkCaptureStart(t, func(string, int, int, string, string, int) (map[string]any, error) {
+		t.Fatal("helper should not be called")
+		return nil, nil
+	})
+	defer restore()
+
+	if code := runNetwork([]string{"capture", "start"}); code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+}
+
+func TestRunNetworkCaptureUnavailableHelper(t *testing.T) {
+	restore := stubNetworkCaptureStart(t, func(string, int, int, string, string, int) (map[string]any, error) {
+		return nil, helperclient.ErrHelperUnavailable
+	})
+	defer restore()
+
+	if code := runNetwork([]string{"capture", "start", "--interface", "en0"}); code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+}
+
+func stubNetworkCaptureStart(t *testing.T, fn func(string, int, int, string, string, int) (map[string]any, error)) func() {
+	t.Helper()
+	old := networkCaptureStart
+	networkCaptureStart = fn
+	return func() { networkCaptureStart = old }
+}
+
+func stubNetworkCaptureStop(t *testing.T, fn func(string) (map[string]any, error)) func() {
+	t.Helper()
+	old := networkCaptureStop
+	networkCaptureStop = fn
+	return func() { networkCaptureStop = old }
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+	if err := w.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -302,8 +302,9 @@ spectra jvm jfr stop 4012 --name spectra
 Shows unprivileged network state by default, including current routes,
 DNS, VPN state, listening ports, and active per-process throughput from
 `nettop`. Listening ports include bind address and process attribution when
-`lsof` exposes it. `spectra network firewall` asks the privileged helper for
-current pf firewall rules.
+`lsof` exposes it. `spectra network capture` asks the privileged helper for
+bounded tcpdump captures. `spectra network firewall` asks the privileged helper
+for current pf firewall rules.
 
 ### Examples
 
@@ -311,6 +312,8 @@ current pf firewall rules.
 spectra network
 spectra network --json
 spectra network connections --proto tcp --state established
+spectra network capture start --interface en0 --duration 30s --proto tcp --host api.example.com --port 443
+spectra network capture stop netcap-1
 spectra network firewall
 spectra network firewall --json
 ```


### PR DESCRIPTION
## Summary

- Add `spectra network capture start` and `spectra network capture stop`.
- Route capture commands through the privileged helper client instead of invoking tcpdump directly.
- Support JSON and human output plus filters for interface, duration, snap length, proto, host, and port.
- Add faked CLI tests for start, stop, JSON output, missing interface, and helper unavailable handling.

## Validation

- `go test ./cmd/spectra -run 'TestRunNetworkCapture|TestSubcommand' -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
