### PR TITLE
Proxy network capture helper RPC

### DIFF
--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -77,7 +77,8 @@ JSON-RPC 2.0 methods, organized by concern:
   `process.tree`, `process.sample`
 - **Helper** — `helper.health`, `helper.powermetrics.sample`,
   `helper.tcc.system.query`, `helper.firewall.rules`,
-  `helper.fs_usage.start`, `helper.fs_usage.stop`
+  `helper.fs_usage.start`, `helper.fs_usage.stop`,
+  `helper.net_capture.start`, `helper.net_capture.stop`
 - **JVM** — `jvm.list`, `jvm.inspect`, `jvm.explain`,
   `jvm.threadDump`, `jvm.heapDump`, `jvm.heapHistogram`, `jvm.gcStats`, `jvm.vmMemory`,
   `jvm.jmx.status`, `jvm.jmx.startLocal`, `jvm.flamegraph`,
@@ -94,7 +95,8 @@ JSON-RPC 2.0 methods, organized by concern:
 - **Cache** — `cache.stats`, `cache.clear`
 - **Helper proxy** — `helper.health`, `helper.powermetrics.sample`,
   `helper.tcc.system.query`, `helper.firewall.rules`,
-  `helper.fs_usage.start`, `helper.fs_usage.stop`
+  `helper.fs_usage.start`, `helper.fs_usage.stop`,
+  `helper.net_capture.start`, `helper.net_capture.stop`
 
 Snake-case and camel-case aliases exist for selected older JVM methods
 (`jvm.thread_dump` / `jvm.threadDump`, etc.).

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1325,6 +1325,45 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		return result, nil
 	})
 
+	d.Register("helper.net_capture.start", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Interface  string `json:"interface"`
+			DurationMS int    `json:"duration_ms"`
+			SnapLen    int    `json:"snap_len"`
+			Proto      string `json:"proto"`
+			Host       string `json:"host"`
+			Port       int    `json:"port"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.Interface == "" {
+			return nil, fmt.Errorf("helper.net_capture.start requires {\"interface\": \"...\"}")
+		}
+		result, err := hc.NetCaptureStart(p.Interface, p.DurationMS, p.SnapLen, p.Proto, p.Host, p.Port)
+		if err != nil {
+			if helperclient.IsUnavailable(err) {
+				return nil, fmt.Errorf("privileged helper not running; install with: sudo spectra install-helper")
+			}
+			return nil, err
+		}
+		return result, nil
+	})
+
+	d.Register("helper.net_capture.stop", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Handle string `json:"handle"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.Handle == "" {
+			return nil, fmt.Errorf("helper.net_capture.stop requires {\"handle\": \"...\"}")
+		}
+		result, err := hc.NetCaptureStop(p.Handle)
+		if err != nil {
+			if helperclient.IsUnavailable(err) {
+				return nil, fmt.Errorf("privileged helper not running; install with: sudo spectra install-helper")
+			}
+			return nil, err
+		}
+		return result, nil
+	})
+
 	d.Register("helper.tcc.system.query", func(params json.RawMessage) (any, error) {
 		var p struct {
 			BundleID string `json:"bundle_id"`

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -1272,6 +1272,33 @@ func TestDaemonHelperFSUsageStopRequiresHandle(t *testing.T) {
 	}
 }
 
+func TestDaemonHelperNetCaptureStartRequiresInterface(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 158, "helper.net_capture.start", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when interface missing")
+	}
+}
+
+func TestDaemonHelperNetCaptureStopRequiresHandle(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 159, "helper.net_capture.stop", `{}`)
+	if resp.Error == nil {
+		t.Error("expected error when handle missing")
+	}
+}
+
+func TestDaemonHelperNetCaptureStartRequiresHelper(t *testing.T) {
+	enc, dec, cancel := testDaemon(t)
+	defer cancel()
+	resp := rpcCall(t, enc, dec, 160, "helper.net_capture.start", `{"interface":"en0"}`)
+	if resp.Error == nil {
+		t.Error("expected error when helper not running")
+	}
+}
+
 func TestDaemonHelperTCCRequiresBundleID(t *testing.T) {
 	enc, dec, cancel := testDaemon(t)
 	defer cancel()


### PR DESCRIPTION
## Summary

- Add daemon JSON-RPC proxy methods for `helper.net_capture.start` and `helper.net_capture.stop`.
- Validate required `interface` and `handle` params before calling the helper client.
- Document the new helper proxy methods in daemon operations docs.

## Validation

- `go test ./internal/serve -run 'TestDaemonHelperNetCapture|TestDaemonHelperFSUsage' -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
