### PR TITLE
Add connect network capture aliases

### DIFF
--- a/cmd/spectra/connect.go
+++ b/cmd/spectra/connect.go
@@ -81,6 +81,8 @@ func printConnectUsage(w io.Writer) {
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> jvm-flamegraph <pid> [dest]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> jvm-heap-dump <pid> [dest] | jvm-jfr-start <pid> [name] | jvm-jfr-dump <pid> <dest> [name] | jvm-jfr-stop <pid> [dest] | jvm-jfr-summary <path>")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> metrics [pid] [limit]")
+	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> network-capture-start <iface> [duration_ms=N] [snap_len=N] [proto=tcp|udp] [host=HOST] [port=N]")
+	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> network-capture-stop <handle>")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> cache [stats|clear [kind]]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> sample <pid> [duration] [interval]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> snapshot [list|create|get|diff|processes|login-items|granted-perms|prune] ...")
@@ -169,6 +171,10 @@ func parseConnectShortcut(args []string) (string, json.RawMessage, bool, error) 
 		return parseConnectJFRSummary(args)
 	case "metrics":
 		return parseConnectMetrics(args)
+	case "network-capture-start", "netcap-start":
+		return parseConnectNetworkCaptureStart(args)
+	case "network-capture-stop", "netcap-stop":
+		return parseConnectNetworkCaptureStop(args)
 	case "sample":
 		return parseConnectSample(args)
 	case "storage":
@@ -373,6 +379,44 @@ func parseConnectMetrics(args []string) (string, json.RawMessage, bool, error) {
 	default:
 		return "", nil, true, fmt.Errorf("connect metrics accepts optional pid and limit only")
 	}
+}
+
+func parseConnectNetworkCaptureStart(args []string) (string, json.RawMessage, bool, error) {
+	if len(args) < 2 {
+		return "", nil, true, fmt.Errorf("connect %s requires <iface>", args[0])
+	}
+	params := map[string]any{"interface": args[1]}
+	for _, raw := range args[2:] {
+		key, value, ok := strings.Cut(raw, "=")
+		if !ok || value == "" {
+			return "", nil, true, fmt.Errorf("connect %s optional args must be key=value", args[0])
+		}
+		switch key {
+		case "duration_ms", "snap_len", "port":
+			n, err := parseConnectPositiveInt(value, key)
+			if err != nil {
+				return "", nil, true, err
+			}
+			params[key] = n
+		case "proto":
+			if value != "tcp" && value != "udp" {
+				return "", nil, true, fmt.Errorf("connect %s proto must be tcp or udp", args[0])
+			}
+			params[key] = value
+		case "host":
+			params[key] = value
+		default:
+			return "", nil, true, fmt.Errorf("connect %s unknown option %q", args[0], key)
+		}
+	}
+	return "helper.net_capture.start", connectParams(params), true, nil
+}
+
+func parseConnectNetworkCaptureStop(args []string) (string, json.RawMessage, bool, error) {
+	if len(args) != 2 {
+		return "", nil, true, fmt.Errorf("connect %s requires <handle>", args[0])
+	}
+	return "helper.net_capture.stop", connectParams(map[string]string{"handle": args[1]}), true, nil
 }
 
 func connectPIDShortcuts() map[string]string {

--- a/cmd/spectra/connect_test.go
+++ b/cmd/spectra/connect_test.go
@@ -115,6 +115,8 @@ func TestParseConnectTypedCalls(t *testing.T) {
 		{name: "network", args: []string{"network"}, wantMethod: "network.state"},
 		{name: "connections", args: []string{"connections"}, wantMethod: "network.connections"},
 		{name: "network by app", args: []string{"network-by-app", "/Applications/Slack.app"}, wantMethod: "network.byApp", wantParams: `{"bundles":["/Applications/Slack.app"]}`},
+		{name: "network capture start", args: []string{"network-capture-start", "en0", "duration_ms=5000", "snap_len=4096", "proto=tcp", "host=api.example.com", "port=443"}, wantMethod: "helper.net_capture.start", wantParams: `{"duration_ms":5000,"host":"api.example.com","interface":"en0","port":443,"proto":"tcp","snap_len":4096}`},
+		{name: "network capture stop", args: []string{"network-capture-stop", "netcap-1"}, wantMethod: "helper.net_capture.stop", wantParams: `{"handle":"netcap-1"}`},
 		{name: "storage system", args: []string{"storage"}, wantMethod: "storage.system"},
 		{name: "storage by app", args: []string{"storage", "/Applications/Slack.app", "/Applications/Cursor.app"}, wantMethod: "storage.byApp", wantParams: `{"paths":["/Applications/Slack.app","/Applications/Cursor.app"]}`},
 		{name: "power", args: []string{"power"}, wantMethod: "power.state"},

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -428,6 +428,8 @@ or MagicDNS names for daemons started with `--tsnet`.
 | `spectra connect <target> network` | Call `network.state` |
 | `spectra connect <target> connections` | Call `network.connections` |
 | `spectra connect <target> network-by-app [App.app ...]` | Call `network.byApp` |
+| `spectra connect <target> network-capture-start <iface> [duration_ms=N] [snap_len=N] [proto=tcp\|udp] [host=HOST] [port=N]` | Call `helper.net_capture.start` |
+| `spectra connect <target> network-capture-stop <handle>` | Call `helper.net_capture.stop` |
 | `spectra connect <target> storage` | Call `storage.system` |
 | `spectra connect <target> storage <App.app> [more.apps]` | Call `storage.byApp` |
 | `spectra connect <target> power` | Call `power.state` |


### PR DESCRIPTION
## Summary

- Add `spectra connect <target> network-capture-start` and `network-capture-stop` aliases.
- Support optional key/value capture params for duration, snap length, proto, host, and port.
- Document the new remote capture aliases in CLI operations docs.

## Validation

- `go test ./cmd/spectra -run TestParseConnectTypedCalls -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
