### PR TITLE
Add classic pcap reader

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -59,6 +59,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `pfctl -s rules` | firewall rules | helper | one-shot | `helper.firewall.rules`, `spectra network firewall` |
 | `tcpdump -i <iface>` | raw packet capture to helper-generated pcap path | helper | streaming, high | `helper.net_capture.start` / `helper.net_capture.stop` |
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
+| `internal/netcap` pcap reader | classic pcap packet records and link type | user | streaming, low | shared plumbing for future capture summaries |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
 `nettop`, and `/etc/hosts`. `lsof` is also where current socket owner

--- a/internal/netcap/pcap.go
+++ b/internal/netcap/pcap.go
@@ -1,0 +1,104 @@
+package netcap
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+const pcapHeaderLen = 24
+
+// PCAP link-layer types Spectra currently recognizes.
+const (
+	LinkTypeEthernet = 1
+	LinkTypeRaw      = 101
+	LinkTypeLoop     = 108
+	LinkTypeLinuxSLL = 113
+)
+
+// PCAPReader streams packets from a classic pcap file. It intentionally does
+// not support pcapng yet.
+type PCAPReader struct {
+	r          io.Reader
+	order      binary.ByteOrder
+	LinkType   uint32
+	SnapLen    uint32
+	Nanosecond bool
+}
+
+// PCAPPacket is one captured packet record.
+type PCAPPacket struct {
+	TimestampSec  uint32
+	TimestampFrac uint32
+	CapturedLen   uint32
+	OriginalLen   uint32
+	Data          []byte
+}
+
+// NewPCAPReader reads and validates the pcap global header.
+func NewPCAPReader(r io.Reader) (*PCAPReader, error) {
+	var hdr [pcapHeaderLen]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, fmt.Errorf("read pcap header: %w", err)
+	}
+	order, nanos, err := pcapByteOrder(hdr[:4])
+	if err != nil {
+		return nil, err
+	}
+	major := order.Uint16(hdr[4:6])
+	if major != 2 {
+		return nil, fmt.Errorf("unsupported pcap version %d.%d", major, order.Uint16(hdr[6:8]))
+	}
+	return &PCAPReader{
+		r:          r,
+		order:      order,
+		SnapLen:    order.Uint32(hdr[16:20]),
+		LinkType:   order.Uint32(hdr[20:24]),
+		Nanosecond: nanos,
+	}, nil
+}
+
+// Next returns the next packet. At EOF it returns io.EOF.
+func (p *PCAPReader) Next() (PCAPPacket, error) {
+	var hdr [16]byte
+	if _, err := io.ReadFull(p.r, hdr[:]); err != nil {
+		if err == io.EOF {
+			return PCAPPacket{}, io.EOF
+		}
+		return PCAPPacket{}, fmt.Errorf("read packet header: %w", err)
+	}
+	inclLen := p.order.Uint32(hdr[8:12])
+	origLen := p.order.Uint32(hdr[12:16])
+	if p.SnapLen > 0 && inclLen > p.SnapLen {
+		return PCAPPacket{}, fmt.Errorf("packet length %d exceeds snaplen %d", inclLen, p.SnapLen)
+	}
+	if inclLen > DefaultSnapLen {
+		return PCAPPacket{}, fmt.Errorf("packet length %d exceeds max supported length %d", inclLen, DefaultSnapLen)
+	}
+	data := make([]byte, inclLen)
+	if _, err := io.ReadFull(p.r, data); err != nil {
+		return PCAPPacket{}, fmt.Errorf("read packet data: %w", err)
+	}
+	return PCAPPacket{
+		TimestampSec:  p.order.Uint32(hdr[:4]),
+		TimestampFrac: p.order.Uint32(hdr[4:8]),
+		CapturedLen:   inclLen,
+		OriginalLen:   origLen,
+		Data:          data,
+	}, nil
+}
+
+func pcapByteOrder(magic []byte) (binary.ByteOrder, bool, error) {
+	switch string(magic) {
+	case "\xd4\xc3\xb2\xa1":
+		return binary.LittleEndian, false, nil
+	case "\xa1\xb2\xc3\xd4":
+		return binary.BigEndian, false, nil
+	case "\x4d\x3c\xb2\xa1":
+		return binary.LittleEndian, true, nil
+	case "\xa1\xb2\x3c\x4d":
+		return binary.BigEndian, true, nil
+	default:
+		return nil, false, fmt.Errorf("unsupported pcap magic 0x%x", magic)
+	}
+}

--- a/internal/netcap/pcap_test.go
+++ b/internal/netcap/pcap_test.go
@@ -1,0 +1,155 @@
+package netcap
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestPCAPReaderReadsPackets(t *testing.T) {
+	var b bytes.Buffer
+	writePCAPHeader(t, &b, binary.LittleEndian, false, 128, LinkTypeEthernet)
+	writePCAPPacket(t, &b, binary.LittleEndian, 10, 25, []byte{1, 2, 3, 4}, 60)
+
+	r, err := NewPCAPReader(&b)
+	if err != nil {
+		t.Fatalf("NewPCAPReader: %v", err)
+	}
+	if r.LinkType != LinkTypeEthernet || r.SnapLen != 128 || r.Nanosecond {
+		t.Fatalf("reader metadata = %+v", r)
+	}
+	pkt, err := r.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if pkt.TimestampSec != 10 || pkt.TimestampFrac != 25 || pkt.CapturedLen != 4 || pkt.OriginalLen != 60 {
+		t.Fatalf("packet metadata = %+v", pkt)
+	}
+	if !bytes.Equal(pkt.Data, []byte{1, 2, 3, 4}) {
+		t.Fatalf("packet data = %v", pkt.Data)
+	}
+	if _, err := r.Next(); !errors.Is(err, io.EOF) {
+		t.Fatalf("Next EOF = %v, want io.EOF", err)
+	}
+}
+
+func TestPCAPReaderReadsBigEndianNanosecondPCAP(t *testing.T) {
+	var b bytes.Buffer
+	writePCAPHeader(t, &b, binary.BigEndian, true, 96, LinkTypeRaw)
+
+	r, err := NewPCAPReader(&b)
+	if err != nil {
+		t.Fatalf("NewPCAPReader: %v", err)
+	}
+	if !r.Nanosecond || r.LinkType != LinkTypeRaw || r.SnapLen != 96 {
+		t.Fatalf("reader metadata = %+v", r)
+	}
+}
+
+func TestPCAPReaderRejectsInvalidInput(t *testing.T) {
+	if _, err := NewPCAPReader(bytes.NewReader([]byte{1, 2, 3})); err == nil {
+		t.Fatal("expected short header error")
+	}
+	var badMagic bytes.Buffer
+	badMagic.Write(bytes.Repeat([]byte{0}, 24))
+	if _, err := NewPCAPReader(&badMagic); err == nil {
+		t.Fatal("expected bad magic error")
+	}
+	var badVersion bytes.Buffer
+	writePCAPHeader(t, &badVersion, binary.LittleEndian, false, 128, LinkTypeEthernet)
+	raw := badVersion.Bytes()
+	raw[4] = 3
+	if _, err := NewPCAPReader(bytes.NewReader(raw)); err == nil {
+		t.Fatal("expected unsupported version error")
+	}
+}
+
+func TestPCAPReaderRejectsPacketLongerThanSnapLen(t *testing.T) {
+	var b bytes.Buffer
+	writePCAPHeader(t, &b, binary.LittleEndian, false, 2, LinkTypeEthernet)
+	writePCAPPacket(t, &b, binary.LittleEndian, 1, 2, []byte{1, 2, 3}, 3)
+
+	r, err := NewPCAPReader(&b)
+	if err != nil {
+		t.Fatalf("NewPCAPReader: %v", err)
+	}
+	if _, err := r.Next(); err == nil {
+		t.Fatal("expected snaplen error")
+	}
+}
+
+func TestPCAPReaderRejectsTruncatedPacketHeader(t *testing.T) {
+	var b bytes.Buffer
+	writePCAPHeader(t, &b, binary.LittleEndian, false, 128, LinkTypeEthernet)
+	b.Write([]byte{1, 2, 3})
+
+	r, err := NewPCAPReader(&b)
+	if err != nil {
+		t.Fatalf("NewPCAPReader: %v", err)
+	}
+	if _, err := r.Next(); err == nil || errors.Is(err, io.EOF) {
+		t.Fatalf("Next = %v, want non-EOF truncated header error", err)
+	}
+}
+
+func TestPCAPReaderRejectsOversizedPacketAllocation(t *testing.T) {
+	var b bytes.Buffer
+	writePCAPHeader(t, &b, binary.LittleEndian, false, 0, LinkTypeEthernet)
+	write32(t, &b, binary.LittleEndian, 1)
+	write32(t, &b, binary.LittleEndian, 2)
+	write32(t, &b, binary.LittleEndian, DefaultSnapLen+1)
+	write32(t, &b, binary.LittleEndian, DefaultSnapLen+1)
+
+	r, err := NewPCAPReader(&b)
+	if err != nil {
+		t.Fatalf("NewPCAPReader: %v", err)
+	}
+	if _, err := r.Next(); err == nil {
+		t.Fatal("expected oversized packet error")
+	}
+}
+
+func writePCAPHeader(t *testing.T, b *bytes.Buffer, order binary.ByteOrder, nanos bool, snapLen, linkType uint32) {
+	t.Helper()
+	switch {
+	case order == binary.LittleEndian && nanos:
+		b.Write([]byte{0x4d, 0x3c, 0xb2, 0xa1})
+	case order == binary.LittleEndian:
+		b.Write([]byte{0xd4, 0xc3, 0xb2, 0xa1})
+	case nanos:
+		b.Write([]byte{0xa1, 0xb2, 0x3c, 0x4d})
+	default:
+		b.Write([]byte{0xa1, 0xb2, 0xc3, 0xd4})
+	}
+	write16(t, b, order, 2)
+	write16(t, b, order, 4)
+	write32(t, b, order, 0)
+	write32(t, b, order, 0)
+	write32(t, b, order, snapLen)
+	write32(t, b, order, linkType)
+}
+
+func writePCAPPacket(t *testing.T, b *bytes.Buffer, order binary.ByteOrder, sec, frac uint32, data []byte, origLen uint32) {
+	t.Helper()
+	write32(t, b, order, sec)
+	write32(t, b, order, frac)
+	write32(t, b, order, uint32(len(data)))
+	write32(t, b, order, origLen)
+	b.Write(data)
+}
+
+func write16(t *testing.T, b *bytes.Buffer, order binary.ByteOrder, n uint16) {
+	t.Helper()
+	var tmp [2]byte
+	order.PutUint16(tmp[:], n)
+	b.Write(tmp[:])
+}
+
+func write32(t *testing.T, b *bytes.Buffer, order binary.ByteOrder, n uint32) {
+	t.Helper()
+	var tmp [4]byte
+	order.PutUint32(tmp[:], n)
+	b.Write(tmp[:])
+}


### PR DESCRIPTION
## Summary

- Add a dependency-free classic pcap reader in `internal/netcap`.
- Read global metadata, packet headers, packet data, link type, snap length, and timestamp precision.
- Cover endian variants, nanosecond pcaps, EOF, bad headers, snaplen violations, truncated headers, and oversized allocation protection.

## Validation

- `go test ./internal/netcap -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
