### PR TITLE
Decode pcap TCP and UDP flows

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -60,6 +60,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `tcpdump -i <iface>` | raw packet capture to helper-generated pcap path | helper | streaming, high | `helper.net_capture.start` / `helper.net_capture.stop` |
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
 | `internal/netcap` pcap reader | classic pcap packet records and link type | user | streaming, low | shared plumbing for future capture summaries |
+| `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints and transport payload from Ethernet/raw pcap packets | user | low per packet | shared plumbing for future capture summaries |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
 `nettop`, and `/etc/hosts`. `lsof` is also where current socket owner

--- a/internal/netcap/packet.go
+++ b/internal/netcap/packet.go
@@ -1,0 +1,106 @@
+package netcap
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+)
+
+const (
+	etherTypeIPv4 = 0x0800
+	ipProtoTCP    = 6
+	ipProtoUDP    = 17
+)
+
+// FlowPacket is a decoded IPv4 TCP/UDP packet and its transport payload.
+type FlowPacket struct {
+	NetworkProto   string
+	TransportProto string
+	SrcAddr        netip.Addr
+	DstAddr        netip.Addr
+	SrcPort        uint16
+	DstPort        uint16
+	Payload        []byte
+}
+
+// DecodeFlowPacket decodes a packet from a supported pcap link type.
+func DecodeFlowPacket(linkType uint32, data []byte) (FlowPacket, error) {
+	switch linkType {
+	case LinkTypeEthernet:
+		if len(data) < 14 {
+			return FlowPacket{}, fmt.Errorf("ethernet packet too short")
+		}
+		if binary.BigEndian.Uint16(data[12:14]) != etherTypeIPv4 {
+			return FlowPacket{}, fmt.Errorf("unsupported ethernet ethertype")
+		}
+		return decodeIPv4Flow(data[14:])
+	case LinkTypeRaw:
+		return decodeIPv4Flow(data)
+	default:
+		return FlowPacket{}, fmt.Errorf("unsupported link type %d", linkType)
+	}
+}
+
+func decodeIPv4Flow(data []byte) (FlowPacket, error) {
+	if len(data) < 20 {
+		return FlowPacket{}, fmt.Errorf("ipv4 packet too short")
+	}
+	version := data[0] >> 4
+	if version != 4 {
+		return FlowPacket{}, fmt.Errorf("unsupported ip version %d", version)
+	}
+	ihl := int(data[0]&0x0f) * 4
+	if ihl < 20 || len(data) < ihl {
+		return FlowPacket{}, fmt.Errorf("invalid ipv4 header length")
+	}
+	totalLen := int(binary.BigEndian.Uint16(data[2:4]))
+	if totalLen < ihl || totalLen > len(data) {
+		return FlowPacket{}, fmt.Errorf("invalid ipv4 total length")
+	}
+	frag := binary.BigEndian.Uint16(data[6:8])
+	if frag&0x3fff != 0 {
+		return FlowPacket{}, fmt.Errorf("fragmented ipv4 packet unsupported")
+	}
+	src := netip.AddrFrom4([4]byte{data[12], data[13], data[14], data[15]})
+	dst := netip.AddrFrom4([4]byte{data[16], data[17], data[18], data[19]})
+	body := data[ihl:totalLen]
+	out := FlowPacket{NetworkProto: "ipv4", SrcAddr: src, DstAddr: dst}
+	switch data[9] {
+	case ipProtoTCP:
+		return decodeTCPFlow(out, body)
+	case ipProtoUDP:
+		return decodeUDPFlow(out, body)
+	default:
+		return FlowPacket{}, fmt.Errorf("unsupported ip protocol %d", data[9])
+	}
+}
+
+func decodeTCPFlow(out FlowPacket, data []byte) (FlowPacket, error) {
+	if len(data) < 20 {
+		return FlowPacket{}, fmt.Errorf("tcp segment too short")
+	}
+	headerLen := int(data[12]>>4) * 4
+	if headerLen < 20 || len(data) < headerLen {
+		return FlowPacket{}, fmt.Errorf("invalid tcp header length")
+	}
+	out.TransportProto = "tcp"
+	out.SrcPort = binary.BigEndian.Uint16(data[:2])
+	out.DstPort = binary.BigEndian.Uint16(data[2:4])
+	out.Payload = data[headerLen:]
+	return out, nil
+}
+
+func decodeUDPFlow(out FlowPacket, data []byte) (FlowPacket, error) {
+	if len(data) < 8 {
+		return FlowPacket{}, fmt.Errorf("udp datagram too short")
+	}
+	udpLen := int(binary.BigEndian.Uint16(data[4:6]))
+	if udpLen < 8 || udpLen > len(data) {
+		return FlowPacket{}, fmt.Errorf("invalid udp length")
+	}
+	out.TransportProto = "udp"
+	out.SrcPort = binary.BigEndian.Uint16(data[:2])
+	out.DstPort = binary.BigEndian.Uint16(data[2:4])
+	out.Payload = data[8:udpLen]
+	return out, nil
+}

--- a/internal/netcap/packet_test.go
+++ b/internal/netcap/packet_test.go
@@ -1,0 +1,105 @@
+package netcap
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestDecodeEthernetIPv4TCP(t *testing.T) {
+	payload := []byte("GET / HTTP/1.1\r\n\r\n")
+	frame := ethernetFrame(ipv4Packet(6, tcpSegment(53124, 80, payload)))
+
+	pkt, err := DecodeFlowPacket(LinkTypeEthernet, frame)
+	if err != nil {
+		t.Fatalf("DecodeFlowPacket: %v", err)
+	}
+	if pkt.NetworkProto != "ipv4" || pkt.TransportProto != "tcp" {
+		t.Fatalf("protocols = %+v", pkt)
+	}
+	if pkt.SrcAddr.String() != "192.0.2.10" || pkt.DstAddr.String() != "198.51.100.20" {
+		t.Fatalf("addresses = %s -> %s", pkt.SrcAddr, pkt.DstAddr)
+	}
+	if pkt.SrcPort != 53124 || pkt.DstPort != 80 || !bytes.Equal(pkt.Payload, payload) {
+		t.Fatalf("transport = %+v", pkt)
+	}
+}
+
+func TestDecodeRawIPv4UDP(t *testing.T) {
+	payload := []byte{1, 2, 3}
+	pkt, err := DecodeFlowPacket(LinkTypeRaw, ipv4Packet(17, udpDatagram(53000, 53, payload)))
+	if err != nil {
+		t.Fatalf("DecodeFlowPacket: %v", err)
+	}
+	if pkt.TransportProto != "udp" || pkt.SrcPort != 53000 || pkt.DstPort != 53 || !bytes.Equal(pkt.Payload, payload) {
+		t.Fatalf("udp packet = %+v", pkt)
+	}
+}
+
+func TestDecodeFlowPacketRejectsUnsupportedPackets(t *testing.T) {
+	tests := []struct {
+		name string
+		link uint32
+		data []byte
+	}{
+		{name: "link", link: LinkTypeLinuxSLL, data: []byte{1, 2, 3}},
+		{name: "short ethernet", link: LinkTypeEthernet, data: []byte{1, 2, 3}},
+		{name: "non ipv4 ethernet", link: LinkTypeEthernet, data: append(make([]byte, 12), 0x86, 0xdd)},
+		{name: "short ipv4", link: LinkTypeRaw, data: []byte{0x45, 0}},
+		{name: "unsupported ip proto", link: LinkTypeRaw, data: ipv4Packet(1, []byte{1, 2, 3, 4})},
+		{name: "fragmented ipv4", link: LinkTypeRaw, data: fragmentedIPv4Packet()},
+		{name: "short tcp", link: LinkTypeRaw, data: ipv4Packet(6, []byte{1, 2, 3})},
+		{name: "short udp", link: LinkTypeRaw, data: ipv4Packet(17, []byte{1, 2, 3})},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := DecodeFlowPacket(tt.link, tt.data); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func fragmentedIPv4Packet() []byte {
+	packet := ipv4Packet(17, udpDatagram(1, 2, nil))
+	binary.BigEndian.PutUint16(packet[6:8], 0x2000)
+	return packet
+}
+
+func ethernetFrame(ip []byte) []byte {
+	frame := make([]byte, 14+len(ip))
+	frame[12] = 0x08
+	frame[13] = 0x00
+	copy(frame[14:], ip)
+	return frame
+}
+
+func ipv4Packet(proto byte, body []byte) []byte {
+	packet := make([]byte, 20+len(body))
+	packet[0] = 0x45
+	binary.BigEndian.PutUint16(packet[2:4], uint16(len(packet)))
+	packet[8] = 64
+	packet[9] = proto
+	copy(packet[12:16], []byte{192, 0, 2, 10})
+	copy(packet[16:20], []byte{198, 51, 100, 20})
+	copy(packet[20:], body)
+	return packet
+}
+
+func tcpSegment(src, dst uint16, payload []byte) []byte {
+	seg := make([]byte, 20+len(payload))
+	binary.BigEndian.PutUint16(seg[:2], src)
+	binary.BigEndian.PutUint16(seg[2:4], dst)
+	seg[12] = 0x50
+	copy(seg[20:], payload)
+	return seg
+}
+
+func udpDatagram(src, dst uint16, payload []byte) []byte {
+	dg := make([]byte, 8+len(payload))
+	binary.BigEndian.PutUint16(dg[:2], src)
+	binary.BigEndian.PutUint16(dg[2:4], dst)
+	binary.BigEndian.PutUint16(dg[4:6], uint16(len(dg)))
+	copy(dg[8:], payload)
+	return dg
+}


### PR DESCRIPTION
## Summary

- Add IPv4 TCP/UDP packet decoding for Ethernet and raw pcap packets.
- Return source/destination addresses, ports, protocol names, and transport payloads for future capture summaries.
- Reject unsupported link types, unsupported IP protocols, truncated packets, invalid lengths, and fragmented IPv4 packets.

## Validation

- `go test ./internal/netcap -count=1`
- `go build ./... && go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
