### PR TITLE
Summarize pcap protocol metadata

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -61,6 +61,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
 | `internal/netcap` pcap reader | classic pcap packet records and link type | user | streaming, low | shared plumbing for future capture summaries |
 | `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints and transport payload from Ethernet/raw pcap packets | user | low per packet | shared plumbing for future capture summaries |
+| `internal/netcap` pcap summarizer | bounded DNS, TLS ClientHello, HTTP/1 header, and WebSocket upgrade metadata from pcap streams | user | streaming, low | shared plumbing for capture summaries |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
 `nettop`, and `/etc/hosts`. `lsof` is also where current socket owner
@@ -68,12 +69,13 @@ attribution comes from; its visibility is limited to what the invoking user can
 see unless a future helper-backed collector is used. Raw packet capture is
 reserved for explicit future live workflows.
 
-`internal/netproto` contains protocol parsers that future capture collectors can
-use to summarize packet metadata without storing request or response bodies. The
+`internal/netproto` contains protocol parsers that capture collectors use to
+summarize packet metadata without storing request or response bodies. The
 initial parsers handle plaintext HTTP/1 headers, DNS messages, and TLS
-ClientHello records. HTTP parsing redacts sensitive headers by default. TLS
-parsing exposes SNI and ALPN when the client sends them in cleartext; it cannot
-decrypt HTTPS traffic.
+ClientHello records. `internal/netcap` wires those parsers to bounded pcap
+summaries after link-layer and IPv4 TCP/UDP decoding. HTTP parsing redacts
+sensitive headers by default. TLS parsing exposes SNI and ALPN when the client
+sends them in cleartext; it cannot decrypt HTTPS traffic.
 
 ## Energy and power
 

--- a/internal/netcap/summary.go
+++ b/internal/netcap/summary.go
@@ -1,0 +1,170 @@
+package netcap
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/netproto"
+)
+
+const DefaultSummaryEventLimit = 100
+
+// PCAPSummary is a bounded metadata-only summary of a classic pcap stream.
+type PCAPSummary struct {
+	LinkType      uint32            `json:"link_type"`
+	Packets       int               `json:"packets"`
+	DecodedFlows  int               `json:"decoded_flows"`
+	DecodeErrors  int               `json:"decode_errors,omitempty"`
+	DNS           []DNSFlowSummary  `json:"dns,omitempty"`
+	TLS           []TLSFlowSummary  `json:"tls,omitempty"`
+	HTTP          []HTTPFlowSummary `json:"http,omitempty"`
+	EventsDropped int               `json:"events_dropped,omitempty"`
+}
+
+// FlowSummary identifies the flow that carried a parsed protocol event.
+type FlowSummary struct {
+	NetworkProto   string `json:"network_proto"`
+	TransportProto string `json:"transport_proto"`
+	SrcAddr        string `json:"src_addr"`
+	SrcPort        uint16 `json:"src_port"`
+	DstAddr        string `json:"dst_addr"`
+	DstPort        uint16 `json:"dst_port"`
+}
+
+// DNSFlowSummary is a parsed DNS message with its carrying flow.
+type DNSFlowSummary struct {
+	Flow    FlowSummary         `json:"flow"`
+	Message netproto.DNSMessage `json:"message"`
+}
+
+// TLSFlowSummary is a parsed TLS ClientHello with its carrying flow.
+type TLSFlowSummary struct {
+	Flow        FlowSummary             `json:"flow"`
+	ClientHello netproto.TLSClientHello `json:"client_hello"`
+}
+
+// HTTPFlowSummary is a parsed HTTP/1.x header block with its carrying flow.
+type HTTPFlowSummary struct {
+	Flow    FlowSummary          `json:"flow"`
+	Message netproto.HTTPMessage `json:"message"`
+}
+
+// SummarizePCAP extracts bounded DNS, TLS ClientHello, and HTTP/1.x metadata
+// from a classic pcap stream. Payload bodies are never retained.
+func SummarizePCAP(r io.Reader, eventLimit int) (PCAPSummary, error) {
+	reader, err := NewPCAPReader(r)
+	if err != nil {
+		return PCAPSummary{}, err
+	}
+	if eventLimit <= 0 {
+		eventLimit = DefaultSummaryEventLimit
+	}
+	summary := PCAPSummary{LinkType: reader.LinkType}
+	for {
+		pkt, err := reader.Next()
+		if err != nil {
+			if err == io.EOF {
+				return summary, nil
+			}
+			return PCAPSummary{}, err
+		}
+		summary.Packets++
+		flow, err := DecodeFlowPacket(reader.LinkType, pkt.Data)
+		if err != nil {
+			summary.DecodeErrors++
+			continue
+		}
+		summary.DecodedFlows++
+		summarizeFlow(&summary, flow, eventLimit)
+	}
+}
+
+func summarizeFlow(summary *PCAPSummary, flow FlowPacket, eventLimit int) {
+	if len(flow.Payload) == 0 {
+		return
+	}
+	if isDNSFlow(flow) {
+		msg, err := netproto.ParseDNSMessage(flow.Payload)
+		if err == nil {
+			appendDNSSummary(summary, flow, msg, eventLimit)
+		}
+		return
+	}
+	if flow.TransportProto == "tcp" && isTLSClientHelloPayload(flow.Payload) {
+		hello, err := netproto.ParseTLSClientHello(flow.Payload)
+		if err == nil {
+			appendTLSSummary(summary, flow, hello, eventLimit)
+		}
+		return
+	}
+	if flow.TransportProto == "tcp" && isHTTP1Payload(flow.Payload) {
+		msg, err := netproto.ParseHTTP1Headers(flow.Payload)
+		if err == nil {
+			appendHTTPSummary(summary, flow, msg, eventLimit)
+		}
+	}
+}
+
+func isDNSFlow(flow FlowPacket) bool {
+	return flow.TransportProto == "udp" && (flow.SrcPort == 53 || flow.DstPort == 53)
+}
+
+func isTLSClientHelloPayload(payload []byte) bool {
+	return len(payload) >= 6 && payload[0] == 22 && payload[5] == 1
+}
+
+func isHTTP1Payload(payload []byte) bool {
+	if bytes.HasPrefix(payload, []byte("HTTP/")) {
+		return true
+	}
+	methodEnd := bytes.IndexByte(payload, ' ')
+	if methodEnd <= 0 {
+		return false
+	}
+	switch strings.ToUpper(string(payload[:methodEnd])) {
+	case "CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE":
+		return true
+	default:
+		return false
+	}
+}
+
+func appendDNSSummary(summary *PCAPSummary, flow FlowPacket, msg netproto.DNSMessage, limit int) {
+	if !summaryHasRoom(summary, limit) {
+		summary.EventsDropped++
+		return
+	}
+	summary.DNS = append(summary.DNS, DNSFlowSummary{Flow: newFlowSummary(flow), Message: msg})
+}
+
+func appendTLSSummary(summary *PCAPSummary, flow FlowPacket, hello netproto.TLSClientHello, limit int) {
+	if !summaryHasRoom(summary, limit) {
+		summary.EventsDropped++
+		return
+	}
+	summary.TLS = append(summary.TLS, TLSFlowSummary{Flow: newFlowSummary(flow), ClientHello: hello})
+}
+
+func appendHTTPSummary(summary *PCAPSummary, flow FlowPacket, msg netproto.HTTPMessage, limit int) {
+	if !summaryHasRoom(summary, limit) {
+		summary.EventsDropped++
+		return
+	}
+	summary.HTTP = append(summary.HTTP, HTTPFlowSummary{Flow: newFlowSummary(flow), Message: msg})
+}
+
+func summaryHasRoom(summary *PCAPSummary, limit int) bool {
+	return len(summary.DNS)+len(summary.TLS)+len(summary.HTTP) < limit
+}
+
+func newFlowSummary(flow FlowPacket) FlowSummary {
+	return FlowSummary{
+		NetworkProto:   flow.NetworkProto,
+		TransportProto: flow.TransportProto,
+		SrcAddr:        flow.SrcAddr.String(),
+		SrcPort:        flow.SrcPort,
+		DstAddr:        flow.DstAddr.String(),
+		DstPort:        flow.DstPort,
+	}
+}

--- a/internal/netcap/summary_test.go
+++ b/internal/netcap/summary_test.go
@@ -1,0 +1,107 @@
+package netcap
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestSummarizePCAPExtractsProtocolMetadata(t *testing.T) {
+	var b bytes.Buffer
+	writePCAPHeader(t, &b, binary.LittleEndian, false, 2048, LinkTypeEthernet)
+	writePCAPPacket(t, &b, binary.LittleEndian, 1, 0,
+		ethernetFrame(ipv4Packet(17, udpDatagram(53123, 53, dnsQuery("example.com")))), 0)
+	writePCAPPacket(t, &b, binary.LittleEndian, 2, 0,
+		ethernetFrame(ipv4Packet(6, tcpSegment(53124, 443, tlsClientHello("example.com")))), 0)
+	writePCAPPacket(t, &b, binary.LittleEndian, 3, 0,
+		ethernetFrame(ipv4Packet(6, tcpSegment(53125, 80, []byte(
+			"GET /chat HTTP/1.1\r\nHost: example.com\r\nAuthorization: secret\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\nbody")))), 0)
+
+	summary, err := SummarizePCAP(&b, 10)
+	if err != nil {
+		t.Fatalf("SummarizePCAP: %v", err)
+	}
+	if summary.Packets != 3 || summary.DecodedFlows != 3 || summary.DecodeErrors != 0 {
+		t.Fatalf("summary counts = %+v", summary)
+	}
+	if len(summary.DNS) != 1 {
+		t.Fatalf("dns summaries = %+v", summary.DNS)
+	}
+	if q := summary.DNS[0].Message.Questions[0]; q.Name != "example.com" || q.Type != "A" || q.Class != "IN" {
+		t.Fatalf("dns question = %+v", q)
+	}
+	if len(summary.TLS) != 1 || summary.TLS[0].ClientHello.SNI != "example.com" {
+		t.Fatalf("tls summaries = %+v", summary.TLS)
+	}
+	if len(summary.HTTP) != 1 {
+		t.Fatalf("http summaries = %+v", summary.HTTP)
+	}
+	http := summary.HTTP[0].Message
+	if !http.IsRequest || http.Method != "GET" || http.Target != "/chat" || !http.WebSocket {
+		t.Fatalf("http message = %+v", http)
+	}
+	for _, h := range http.Headers {
+		if h.Name == "Authorization" && (!h.Redacted || h.Value != "[redacted]") {
+			t.Fatalf("authorization header was not redacted: %+v", h)
+		}
+	}
+}
+
+func TestSummarizePCAPBoundsEventsAndCountsDecodeErrors(t *testing.T) {
+	var b bytes.Buffer
+	writePCAPHeader(t, &b, binary.LittleEndian, false, 2048, LinkTypeEthernet)
+	writePCAPPacket(t, &b, binary.LittleEndian, 1, 0,
+		ethernetFrame(ipv4Packet(17, udpDatagram(53123, 53, dnsQuery("one.example")))), 0)
+	writePCAPPacket(t, &b, binary.LittleEndian, 2, 0,
+		ethernetFrame(ipv4Packet(17, udpDatagram(53124, 53, dnsQuery("two.example")))), 0)
+	writePCAPPacket(t, &b, binary.LittleEndian, 3, 0, []byte{1, 2, 3}, 0)
+
+	summary, err := SummarizePCAP(&b, 1)
+	if err != nil {
+		t.Fatalf("SummarizePCAP: %v", err)
+	}
+	if summary.Packets != 3 || summary.DecodedFlows != 2 || summary.DecodeErrors != 1 {
+		t.Fatalf("summary counts = %+v", summary)
+	}
+	if len(summary.DNS) != 1 || summary.EventsDropped != 1 {
+		t.Fatalf("bounded events = %+v", summary)
+	}
+}
+
+func dnsQuery(name string) []byte {
+	var b bytes.Buffer
+	b.Write([]byte{0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+	for _, label := range bytes.Split([]byte(name), []byte(".")) {
+		b.WriteByte(byte(len(label)))
+		b.Write(label)
+	}
+	b.WriteByte(0)
+	b.Write([]byte{0, 1, 0, 1})
+	return b.Bytes()
+}
+
+func tlsClientHello(sni string) []byte {
+	serverName := append([]byte{0, byte(len(sni) >> 8), byte(len(sni))}, []byte(sni)...)
+	serverNameList := append([]byte{0, byte(len(serverName))}, serverName...)
+	serverNameExt := append([]byte{0, 0, 0, byte(len(serverNameList))}, serverNameList...)
+
+	alpnList := []byte{2, 'h', '2', 8, 'h', 't', 't', 'p', '/', '1', '.', '1'}
+	alpnData := append([]byte{0, byte(len(alpnList))}, alpnList...)
+	alpnExt := append([]byte{0, 16, 0, byte(len(alpnData))}, alpnData...)
+
+	extensions := append(serverNameExt, alpnExt...)
+	hello := make([]byte, 0, 128)
+	hello = append(hello, 0x03, 0x03)
+	hello = append(hello, bytes.Repeat([]byte{1}, 32)...)
+	hello = append(hello, 0)
+	hello = append(hello, 0, 2, 0x13, 0x01)
+	hello = append(hello, 1, 0)
+	hello = append(hello, byte(len(extensions)>>8), byte(len(extensions)))
+	hello = append(hello, extensions...)
+
+	handshake := []byte{1, byte(len(hello) >> 16), byte(len(hello) >> 8), byte(len(hello))}
+	handshake = append(handshake, hello...)
+	record := []byte{22, 0x03, 0x01, byte(len(handshake) >> 8), byte(len(handshake))}
+	record = append(record, handshake...)
+	return record
+}


### PR DESCRIPTION
## Summary
- add a bounded classic pcap summarizer for DNS, TLS ClientHello, HTTP/1 headers, and WebSocket upgrade metadata
- include flow endpoint attribution and event drop accounting without retaining bodies
- document the summarizer in the live data source roadmap

## Validation
- go test ./internal/netcap -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
