### PR TITLE
Add network capture summary CLI

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/helperclient"
+	"github.com/kaeawc/spectra/internal/netcap"
 	"github.com/kaeawc/spectra/internal/netstate"
 )
 
@@ -20,6 +21,14 @@ var (
 	}
 	networkCaptureStop = func(handle string) (map[string]any, error) {
 		return helperclient.New().NetCaptureStop(handle)
+	}
+	networkCaptureSummarize = func(path string, limit int) (netcap.PCAPSummary, error) {
+		f, err := os.Open(path)
+		if err != nil {
+			return netcap.PCAPSummary{}, fmt.Errorf("open pcap: %w", err)
+		}
+		defer f.Close()
+		return netcap.SummarizePCAP(f, limit)
 	}
 )
 
@@ -56,7 +65,7 @@ func runNetwork(args []string) int {
 
 func runNetworkCapture(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: spectra network capture [start|stop] ...")
+		fmt.Fprintln(os.Stderr, "usage: spectra network capture [start|stop|summarize] ...")
 		return 2
 	}
 	switch args[0] {
@@ -64,6 +73,8 @@ func runNetworkCapture(args []string) int {
 		return runNetworkCaptureStart(args[1:])
 	case "stop":
 		return runNetworkCaptureStop(args[1:])
+	case "summarize", "summary":
+		return runNetworkCaptureSummarize(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown network capture command %q\n", args[0])
 		return 2
@@ -123,6 +134,33 @@ func runNetworkCaptureStop(args []string) int {
 	return printNetworkCaptureResult(result, *asJSON, "capture stopped")
 }
 
+func runNetworkCaptureSummarize(args []string) int {
+	fs := flag.NewFlagSet("spectra network capture summarize", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	limit := fs.Int("limit", netcap.DefaultSummaryEventLimit, "Maximum protocol events to include")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra network capture summarize [--json] [--limit N] <pcap-path>")
+		return 2
+	}
+	summary, err := networkCaptureSummarize(fs.Arg(0), *limit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "network capture summarize: %v\n", err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(summary)
+		return 0
+	}
+	printNetworkCaptureSummary(summary)
+	return 0
+}
+
 func printNetworkCaptureResult(result map[string]any, asJSON bool, label string) int {
 	if asJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -137,6 +175,52 @@ func printNetworkCaptureResult(result map[string]any, asJSON bool, label string)
 		}
 	}
 	return 0
+}
+
+func printNetworkCaptureSummary(summary netcap.PCAPSummary) {
+	fmt.Println("capture summary")
+	fmt.Printf("  packets: %d\n", summary.Packets)
+	fmt.Printf("  decoded_flows: %d\n", summary.DecodedFlows)
+	if summary.DecodeErrors > 0 {
+		fmt.Printf("  decode_errors: %d\n", summary.DecodeErrors)
+	}
+	fmt.Printf("  dns: %d\n", len(summary.DNS))
+	fmt.Printf("  tls_client_hello: %d\n", len(summary.TLS))
+	fmt.Printf("  http: %d\n", len(summary.HTTP))
+	if summary.EventsDropped > 0 {
+		fmt.Printf("  events_dropped: %d\n", summary.EventsDropped)
+	}
+	for _, event := range summary.DNS {
+		for _, q := range event.Message.Questions {
+			fmt.Printf("  dns_query: %s %s %s -> %s\n", q.Name, q.Type, formatFlowEndpoint(event.Flow), formatFlowDestination(event.Flow))
+		}
+	}
+	for _, event := range summary.TLS {
+		hello := event.ClientHello
+		target := hello.SNI
+		if target == "" && hello.ECHPresent {
+			target = "ech-present"
+		}
+		if target != "" {
+			fmt.Printf("  tls_client_hello: %s %s -> %s\n", target, formatFlowEndpoint(event.Flow), formatFlowDestination(event.Flow))
+		}
+	}
+	for _, event := range summary.HTTP {
+		msg := event.Message
+		if msg.IsRequest {
+			fmt.Printf("  http_request: %s %s %s -> %s\n", msg.Method, msg.Target, formatFlowEndpoint(event.Flow), formatFlowDestination(event.Flow))
+		} else {
+			fmt.Printf("  http_response: %d %s %s -> %s\n", msg.StatusCode, msg.Reason, formatFlowEndpoint(event.Flow), formatFlowDestination(event.Flow))
+		}
+	}
+}
+
+func formatFlowEndpoint(flow netcap.FlowSummary) string {
+	return fmt.Sprintf("%s:%d", flow.SrcAddr, flow.SrcPort)
+}
+
+func formatFlowDestination(flow netcap.FlowSummary) string {
+	return fmt.Sprintf("%s:%d", flow.DstAddr, flow.DstPort)
 }
 
 func formatCaptureValue(v any) string {

--- a/cmd/spectra/network_capture_test.go
+++ b/cmd/spectra/network_capture_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/kaeawc/spectra/internal/helperclient"
+	"github.com/kaeawc/spectra/internal/netcap"
+	"github.com/kaeawc/spectra/internal/netproto"
 )
 
 func TestRunNetworkCaptureStartCallsHelper(t *testing.T) {
@@ -73,6 +75,60 @@ func TestRunNetworkCaptureStopCallsHelper(t *testing.T) {
 	}
 }
 
+func TestRunNetworkCaptureSummarize(t *testing.T) {
+	restore := stubNetworkCaptureSummarize(t, func(path string, limit int) (netcap.PCAPSummary, error) {
+		if path != "/tmp/capture.pcap" || limit != 2 {
+			t.Fatalf("params = %q %d", path, limit)
+		}
+		return netcap.PCAPSummary{
+			Packets:      3,
+			DecodedFlows: 3,
+			DNS: []netcap.DNSFlowSummary{{
+				Flow:    netcap.FlowSummary{SrcAddr: "192.0.2.10", SrcPort: 53123, DstAddr: "198.51.100.20", DstPort: 53},
+				Message: netproto.DNSMessage{Questions: []netproto.DNSQuestion{{Name: "example.com", Type: "A", Class: "IN"}}},
+			}},
+			TLS: []netcap.TLSFlowSummary{{
+				Flow:        netcap.FlowSummary{SrcAddr: "192.0.2.10", SrcPort: 53124, DstAddr: "198.51.100.20", DstPort: 443},
+				ClientHello: netproto.TLSClientHello{SNI: "example.com"},
+			}},
+			HTTP: []netcap.HTTPFlowSummary{{
+				Flow:    netcap.FlowSummary{SrcAddr: "192.0.2.10", SrcPort: 53125, DstAddr: "198.51.100.20", DstPort: 80},
+				Message: netproto.HTTPMessage{IsRequest: true, Method: "GET", Target: "/chat", WebSocket: true},
+			}},
+		}, nil
+	})
+	defer restore()
+
+	out := captureStdout(t, func() {
+		code := runNetwork([]string{"capture", "summarize", "--limit", "2", "/tmp/capture.pcap"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	})
+	for _, want := range []string{"capture summary", "packets: 3", "dns_query: example.com A", "tls_client_hello: example.com", "http_request: GET /chat"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
+	}
+}
+
+func TestRunNetworkCaptureSummarizeJSON(t *testing.T) {
+	restore := stubNetworkCaptureSummarize(t, func(string, int) (netcap.PCAPSummary, error) {
+		return netcap.PCAPSummary{Packets: 1, DecodedFlows: 1}, nil
+	})
+	defer restore()
+
+	out := captureStdout(t, func() {
+		code := runNetwork([]string{"capture", "summary", "--json", "/tmp/capture.pcap"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, `"packets": 1`) {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
 func TestRunNetworkCaptureRequiresInterface(t *testing.T) {
 	restore := stubNetworkCaptureStart(t, func(string, int, int, string, string, int) (map[string]any, error) {
 		t.Fatal("helper should not be called")
@@ -108,6 +164,13 @@ func stubNetworkCaptureStop(t *testing.T, fn func(string) (map[string]any, error
 	old := networkCaptureStop
 	networkCaptureStop = fn
 	return func() { networkCaptureStop = old }
+}
+
+func stubNetworkCaptureSummarize(t *testing.T, fn func(string, int) (netcap.PCAPSummary, error)) func() {
+	t.Helper()
+	old := networkCaptureSummarize
+	networkCaptureSummarize = fn
+	return func() { networkCaptureSummarize = old }
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -303,8 +303,9 @@ Shows unprivileged network state by default, including current routes,
 DNS, VPN state, listening ports, and active per-process throughput from
 `nettop`. Listening ports include bind address and process attribution when
 `lsof` exposes it. `spectra network capture` asks the privileged helper for
-bounded tcpdump captures. `spectra network firewall` asks the privileged helper
-for current pf firewall rules.
+bounded tcpdump captures and can summarize completed pcap files without
+retaining request or response bodies. `spectra network firewall` asks the
+privileged helper for current pf firewall rules.
 
 ### Examples
 
@@ -314,6 +315,7 @@ spectra network --json
 spectra network connections --proto tcp --state established
 spectra network capture start --interface en0 --duration 30s --proto tcp --host api.example.com --port 443
 spectra network capture stop netcap-1
+spectra network capture summarize --json /var/tmp/spectra-netcap/501/netcap-1.pcap
 spectra network firewall
 spectra network firewall --json
 ```


### PR DESCRIPTION
## Summary
- add `spectra network capture summarize|summary` for completed classic pcap files
- emit JSON summaries or compact human output for DNS, TLS ClientHello, and HTTP events
- document the new CLI workflow

## Validation
- go test ./cmd/spectra -run TestRunNetworkCapture -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
