### PR TITLE
Decode loopback pcap packets

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -60,7 +60,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `tcpdump -i <iface>` | raw packet capture to helper-generated pcap path | helper | streaming, high | `helper.net_capture.start` / `helper.net_capture.stop` |
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
 | `internal/netcap` pcap reader | classic pcap packet records and link type | user | streaming, low | shared plumbing for future capture summaries |
-| `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints and transport payload from Ethernet/raw pcap packets | user | low per packet | shared plumbing for future capture summaries |
+| `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints and transport payload from Ethernet, raw IPv4, and loopback pcap packets | user | low per packet | shared plumbing for future capture summaries |
 | `internal/netcap` pcap summarizer | bounded DNS, TLS ClientHello, HTTP/1 header, and WebSocket upgrade metadata from pcap streams | user | streaming, low | shared plumbing for capture summaries |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,

--- a/internal/netcap/packet.go
+++ b/internal/netcap/packet.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	etherTypeIPv4 = 0x0800
-	ipProtoTCP    = 6
-	ipProtoUDP    = 17
+	etherTypeIPv4  = 0x0800
+	loopFamilyIPv4 = 2
+	ipProtoTCP     = 6
+	ipProtoUDP     = 17
 )
 
 // FlowPacket is a decoded IPv4 TCP/UDP packet and its transport payload.
@@ -36,9 +37,23 @@ func DecodeFlowPacket(linkType uint32, data []byte) (FlowPacket, error) {
 		return decodeIPv4Flow(data[14:])
 	case LinkTypeRaw:
 		return decodeIPv4Flow(data)
+	case LinkTypeNull, LinkTypeLoop:
+		return decodeLoopbackFlow(data)
 	default:
 		return FlowPacket{}, fmt.Errorf("unsupported link type %d", linkType)
 	}
+}
+
+func decodeLoopbackFlow(data []byte) (FlowPacket, error) {
+	if len(data) < 4 {
+		return FlowPacket{}, fmt.Errorf("loopback packet too short")
+	}
+	familyBE := binary.BigEndian.Uint32(data[:4])
+	familyLE := binary.LittleEndian.Uint32(data[:4])
+	if familyBE != loopFamilyIPv4 && familyLE != loopFamilyIPv4 {
+		return FlowPacket{}, fmt.Errorf("unsupported loopback family")
+	}
+	return decodeIPv4Flow(data[4:])
 }
 
 func decodeIPv4Flow(data []byte) (FlowPacket, error) {

--- a/internal/netcap/packet_test.go
+++ b/internal/netcap/packet_test.go
@@ -36,6 +36,32 @@ func TestDecodeRawIPv4UDP(t *testing.T) {
 	}
 }
 
+func TestDecodeLoopbackIPv4TCP(t *testing.T) {
+	payload := []byte("HTTP/1.1 200 OK\r\n\r\n")
+	packet := loopbackPacket(binary.LittleEndian, ipv4Packet(6, tcpSegment(80, 53124, payload)))
+
+	pkt, err := DecodeFlowPacket(LinkTypeNull, packet)
+	if err != nil {
+		t.Fatalf("DecodeFlowPacket: %v", err)
+	}
+	if pkt.TransportProto != "tcp" || pkt.SrcPort != 80 || pkt.DstPort != 53124 || !bytes.Equal(pkt.Payload, payload) {
+		t.Fatalf("loopback packet = %+v", pkt)
+	}
+}
+
+func TestDecodeLoopIPv4UDP(t *testing.T) {
+	payload := []byte{1, 2, 3}
+	packet := loopbackPacket(binary.BigEndian, ipv4Packet(17, udpDatagram(53, 53000, payload)))
+
+	pkt, err := DecodeFlowPacket(LinkTypeLoop, packet)
+	if err != nil {
+		t.Fatalf("DecodeFlowPacket: %v", err)
+	}
+	if pkt.TransportProto != "udp" || pkt.SrcPort != 53 || pkt.DstPort != 53000 || !bytes.Equal(pkt.Payload, payload) {
+		t.Fatalf("loop packet = %+v", pkt)
+	}
+}
+
 func TestDecodeFlowPacketRejectsUnsupportedPackets(t *testing.T) {
 	tests := []struct {
 		name string
@@ -45,6 +71,8 @@ func TestDecodeFlowPacketRejectsUnsupportedPackets(t *testing.T) {
 		{name: "link", link: LinkTypeLinuxSLL, data: []byte{1, 2, 3}},
 		{name: "short ethernet", link: LinkTypeEthernet, data: []byte{1, 2, 3}},
 		{name: "non ipv4 ethernet", link: LinkTypeEthernet, data: append(make([]byte, 12), 0x86, 0xdd)},
+		{name: "short loopback", link: LinkTypeNull, data: []byte{1, 2, 3}},
+		{name: "non ipv4 loopback", link: LinkTypeNull, data: loopbackPacket(binary.LittleEndian, []byte{0x60, 0})},
 		{name: "short ipv4", link: LinkTypeRaw, data: []byte{0x45, 0}},
 		{name: "unsupported ip proto", link: LinkTypeRaw, data: ipv4Packet(1, []byte{1, 2, 3, 4})},
 		{name: "fragmented ipv4", link: LinkTypeRaw, data: fragmentedIPv4Packet()},
@@ -72,6 +100,13 @@ func ethernetFrame(ip []byte) []byte {
 	frame[13] = 0x00
 	copy(frame[14:], ip)
 	return frame
+}
+
+func loopbackPacket(order binary.ByteOrder, ip []byte) []byte {
+	packet := make([]byte, 4+len(ip))
+	order.PutUint32(packet[:4], loopFamilyIPv4)
+	copy(packet[4:], ip)
+	return packet
 }
 
 func ipv4Packet(proto byte, body []byte) []byte {

--- a/internal/netcap/pcap.go
+++ b/internal/netcap/pcap.go
@@ -10,6 +10,7 @@ const pcapHeaderLen = 24
 
 // PCAP link-layer types Spectra currently recognizes.
 const (
+	LinkTypeNull     = 0
 	LinkTypeEthernet = 1
 	LinkTypeRaw      = 101
 	LinkTypeLoop     = 108


### PR DESCRIPTION
## Summary
- add DLT_NULL and DLT_LOOP IPv4 decoding for loopback pcaps
- cover little-endian and big-endian loopback family headers in netcap tests
- update the network live data source matrix

## Validation
- go test ./internal/netcap -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
