### PR TITLE
Decode Linux cooked pcap packets

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -60,7 +60,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `tcpdump -i <iface>` | raw packet capture to helper-generated pcap path | helper | streaming, high | `helper.net_capture.start` / `helper.net_capture.stop` |
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
 | `internal/netcap` pcap reader | classic pcap packet records and link type | user | streaming, low | shared plumbing for future capture summaries |
-| `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints and transport payload from Ethernet, raw IPv4, and loopback pcap packets | user | low per packet | shared plumbing for future capture summaries |
+| `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints and transport payload from Ethernet, raw IPv4, loopback, and Linux cooked pcap packets | user | low per packet | shared plumbing for future capture summaries |
 | `internal/netcap` pcap summarizer | bounded DNS, TLS ClientHello, HTTP/1 header, and WebSocket upgrade metadata from pcap streams | user | streaming, low | shared plumbing for capture summaries |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,

--- a/internal/netcap/packet.go
+++ b/internal/netcap/packet.go
@@ -39,9 +39,21 @@ func DecodeFlowPacket(linkType uint32, data []byte) (FlowPacket, error) {
 		return decodeIPv4Flow(data)
 	case LinkTypeNull, LinkTypeLoop:
 		return decodeLoopbackFlow(data)
+	case LinkTypeLinuxSLL:
+		return decodeLinuxSLLFlow(data)
 	default:
 		return FlowPacket{}, fmt.Errorf("unsupported link type %d", linkType)
 	}
+}
+
+func decodeLinuxSLLFlow(data []byte) (FlowPacket, error) {
+	if len(data) < 16 {
+		return FlowPacket{}, fmt.Errorf("linux sll packet too short")
+	}
+	if binary.BigEndian.Uint16(data[14:16]) != etherTypeIPv4 {
+		return FlowPacket{}, fmt.Errorf("unsupported linux sll protocol")
+	}
+	return decodeIPv4Flow(data[16:])
 }
 
 func decodeLoopbackFlow(data []byte) (FlowPacket, error) {

--- a/internal/netcap/packet_test.go
+++ b/internal/netcap/packet_test.go
@@ -62,13 +62,28 @@ func TestDecodeLoopIPv4UDP(t *testing.T) {
 	}
 }
 
+func TestDecodeLinuxSLLIPv4TCP(t *testing.T) {
+	payload := []byte("GET /linux HTTP/1.1\r\n\r\n")
+	packet := linuxSLLPacket(ipv4Packet(6, tcpSegment(53124, 8080, payload)))
+
+	pkt, err := DecodeFlowPacket(LinkTypeLinuxSLL, packet)
+	if err != nil {
+		t.Fatalf("DecodeFlowPacket: %v", err)
+	}
+	if pkt.TransportProto != "tcp" || pkt.SrcPort != 53124 || pkt.DstPort != 8080 || !bytes.Equal(pkt.Payload, payload) {
+		t.Fatalf("linux sll packet = %+v", pkt)
+	}
+}
+
 func TestDecodeFlowPacketRejectsUnsupportedPackets(t *testing.T) {
 	tests := []struct {
 		name string
 		link uint32
 		data []byte
 	}{
-		{name: "link", link: LinkTypeLinuxSLL, data: []byte{1, 2, 3}},
+		{name: "link", link: 999, data: []byte{1, 2, 3}},
+		{name: "short linux sll", link: LinkTypeLinuxSLL, data: []byte{1, 2, 3}},
+		{name: "non ipv4 linux sll", link: LinkTypeLinuxSLL, data: append(make([]byte, 14), 0x86, 0xdd)},
 		{name: "short ethernet", link: LinkTypeEthernet, data: []byte{1, 2, 3}},
 		{name: "non ipv4 ethernet", link: LinkTypeEthernet, data: append(make([]byte, 12), 0x86, 0xdd)},
 		{name: "short loopback", link: LinkTypeNull, data: []byte{1, 2, 3}},
@@ -106,6 +121,13 @@ func loopbackPacket(order binary.ByteOrder, ip []byte) []byte {
 	packet := make([]byte, 4+len(ip))
 	order.PutUint32(packet[:4], loopFamilyIPv4)
 	copy(packet[4:], ip)
+	return packet
+}
+
+func linuxSLLPacket(ip []byte) []byte {
+	packet := make([]byte, 16+len(ip))
+	binary.BigEndian.PutUint16(packet[14:16], etherTypeIPv4)
+	copy(packet[16:], ip)
 	return packet
 }
 


### PR DESCRIPTION
## Summary
- decode classic Linux cooked capture (SLL) IPv4 packets in internal/netcap
- add packet decoder tests for SLL success and rejection paths
- update live data source coverage docs

## Validation
- go test ./internal/netcap -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
