### PR TITLE
Expose TCP packet metadata

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -60,7 +60,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `tcpdump -i <iface>` | raw packet capture to helper-generated pcap path | helper | streaming, high | `helper.net_capture.start` / `helper.net_capture.stop` |
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
 | `internal/netcap` pcap reader | classic pcap packet records and link type | user | streaming, low | shared plumbing for future capture summaries |
-| `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints and transport payload from Ethernet, raw IPv4, loopback, and Linux cooked pcap packets | user | low per packet | shared plumbing for future capture summaries |
+| `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints, TCP sequence metadata, and transport payload from Ethernet, raw IPv4, loopback, and Linux cooked pcap packets | user | low per packet | shared plumbing for future capture summaries |
 | `internal/netcap` pcap summarizer | bounded DNS, TLS ClientHello, HTTP/1 header, and WebSocket upgrade metadata from pcap streams | user | streaming, low | shared plumbing for capture summaries |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,

--- a/internal/netcap/packet.go
+++ b/internal/netcap/packet.go
@@ -21,6 +21,9 @@ type FlowPacket struct {
 	DstAddr        netip.Addr
 	SrcPort        uint16
 	DstPort        uint16
+	TCPSeq         uint32
+	TCPAck         uint32
+	TCPFlags       uint8
 	Payload        []byte
 }
 
@@ -113,6 +116,9 @@ func decodeTCPFlow(out FlowPacket, data []byte) (FlowPacket, error) {
 	out.TransportProto = "tcp"
 	out.SrcPort = binary.BigEndian.Uint16(data[:2])
 	out.DstPort = binary.BigEndian.Uint16(data[2:4])
+	out.TCPSeq = binary.BigEndian.Uint32(data[4:8])
+	out.TCPAck = binary.BigEndian.Uint32(data[8:12])
+	out.TCPFlags = data[13]
 	out.Payload = data[headerLen:]
 	return out, nil
 }

--- a/internal/netcap/packet_test.go
+++ b/internal/netcap/packet_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDecodeEthernetIPv4TCP(t *testing.T) {
 	payload := []byte("GET / HTTP/1.1\r\n\r\n")
-	frame := ethernetFrame(ipv4Packet(6, tcpSegment(53124, 80, payload)))
+	frame := ethernetFrame(ipv4Packet(6, tcpSegmentWithMeta(53124, 80, 1000, 2000, 0x18, payload)))
 
 	pkt, err := DecodeFlowPacket(LinkTypeEthernet, frame)
 	if err != nil {
@@ -22,6 +22,9 @@ func TestDecodeEthernetIPv4TCP(t *testing.T) {
 	}
 	if pkt.SrcPort != 53124 || pkt.DstPort != 80 || !bytes.Equal(pkt.Payload, payload) {
 		t.Fatalf("transport = %+v", pkt)
+	}
+	if pkt.TCPSeq != 1000 || pkt.TCPAck != 2000 || pkt.TCPFlags != 0x18 {
+		t.Fatalf("tcp metadata = %+v", pkt)
 	}
 }
 
@@ -144,10 +147,17 @@ func ipv4Packet(proto byte, body []byte) []byte {
 }
 
 func tcpSegment(src, dst uint16, payload []byte) []byte {
+	return tcpSegmentWithMeta(src, dst, 0, 0, 0, payload)
+}
+
+func tcpSegmentWithMeta(src, dst uint16, seq, ack uint32, flags uint8, payload []byte) []byte {
 	seg := make([]byte, 20+len(payload))
 	binary.BigEndian.PutUint16(seg[:2], src)
 	binary.BigEndian.PutUint16(seg[2:4], dst)
+	binary.BigEndian.PutUint32(seg[4:8], seq)
+	binary.BigEndian.PutUint32(seg[8:12], ack)
 	seg[12] = 0x50
+	seg[13] = flags
 	copy(seg[20:], payload)
 	return seg
 }


### PR DESCRIPTION
## Summary
- expose TCP sequence, acknowledgement, and flags metadata from decoded packets
- cover metadata extraction in packet decoder tests
- document sequence metadata in live data sources

## Validation
- go test ./internal/netcap -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
