### PR TITLE
Reassemble TCP headers in pcap summaries

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -61,7 +61,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
 | `internal/netcap` pcap reader | classic pcap packet records and link type | user | streaming, low | shared plumbing for future capture summaries |
 | `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints, TCP sequence metadata, and transport payload from Ethernet, raw IPv4, loopback, and Linux cooked pcap packets | user | low per packet | shared plumbing for future capture summaries |
-| `internal/netcap` pcap summarizer | bounded DNS, TLS ClientHello, HTTP/1 header, and WebSocket upgrade metadata from pcap streams | user | streaming, low | shared plumbing for capture summaries |
+| `internal/netcap` pcap summarizer | bounded DNS, TLS ClientHello, HTTP/1 header, and WebSocket upgrade metadata from pcap streams with small TCP reassembly buffers | user | streaming, low | shared plumbing for capture summaries |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
 `nettop`, and `/etc/hosts`. `lsof` is also where current socket owner

--- a/internal/netcap/summary.go
+++ b/internal/netcap/summary.go
@@ -3,12 +3,16 @@ package netcap
 import (
 	"bytes"
 	"io"
+	"net/netip"
 	"strings"
 
 	"github.com/kaeawc/spectra/internal/netproto"
 )
 
 const DefaultSummaryEventLimit = 100
+
+const maxTCPReassemblyBytes = 256 * 1024
+const tcpFlagSYN = 0x02
 
 // PCAPSummary is a bounded metadata-only summary of a classic pcap stream.
 type PCAPSummary struct {
@@ -61,6 +65,7 @@ func SummarizePCAP(r io.Reader, eventLimit int) (PCAPSummary, error) {
 		eventLimit = DefaultSummaryEventLimit
 	}
 	summary := PCAPSummary{LinkType: reader.LinkType}
+	tcpStreams := newTCPSummaryStreams()
 	for {
 		pkt, err := reader.Next()
 		if err != nil {
@@ -76,11 +81,11 @@ func SummarizePCAP(r io.Reader, eventLimit int) (PCAPSummary, error) {
 			continue
 		}
 		summary.DecodedFlows++
-		summarizeFlow(&summary, flow, eventLimit)
+		summarizeFlow(&summary, flow, eventLimit, tcpStreams)
 	}
 }
 
-func summarizeFlow(summary *PCAPSummary, flow FlowPacket, eventLimit int) {
+func summarizeFlow(summary *PCAPSummary, flow FlowPacket, eventLimit int, tcpStreams *tcpSummaryStreams) {
 	if len(flow.Payload) == 0 {
 		return
 	}
@@ -91,16 +96,25 @@ func summarizeFlow(summary *PCAPSummary, flow FlowPacket, eventLimit int) {
 		}
 		return
 	}
-	if flow.TransportProto == "tcp" && isTLSClientHelloPayload(flow.Payload) {
-		hello, err := netproto.ParseTLSClientHello(flow.Payload)
+	if flow.TransportProto != "tcp" {
+		return
+	}
+	stream, ok := tcpStreams.add(flow)
+	if !ok {
+		return
+	}
+	if !stream.parsedTLS && isTLSClientHelloPayload(stream.data) {
+		hello, err := netproto.ParseTLSClientHello(stream.data)
 		if err == nil {
+			stream.parsedTLS = true
 			appendTLSSummary(summary, flow, hello, eventLimit)
 		}
 		return
 	}
-	if flow.TransportProto == "tcp" && isHTTP1Payload(flow.Payload) {
-		msg, err := netproto.ParseHTTP1Headers(flow.Payload)
+	if !stream.parsedHTTP && isHTTP1Payload(stream.data) && hasHTTPHeaderTerminator(stream.data) {
+		msg, err := netproto.ParseHTTP1Headers(stream.data)
 		if err == nil {
+			stream.parsedHTTP = true
 			appendHTTPSummary(summary, flow, msg, eventLimit)
 		}
 	}
@@ -128,6 +142,70 @@ func isHTTP1Payload(payload []byte) bool {
 	default:
 		return false
 	}
+}
+
+func hasHTTPHeaderTerminator(payload []byte) bool {
+	return bytes.Contains(payload, []byte("\r\n\r\n")) || bytes.Contains(payload, []byte("\n\n"))
+}
+
+type tcpFlowKey struct {
+	srcAddr netip.Addr
+	dstAddr netip.Addr
+	srcPort uint16
+	dstPort uint16
+}
+
+type tcpSummaryStreams struct {
+	streams map[tcpFlowKey]*tcpSummaryStream
+}
+
+type tcpSummaryStream struct {
+	data       []byte
+	nextSeq    uint32
+	parsedTLS  bool
+	parsedHTTP bool
+}
+
+func newTCPSummaryStreams() *tcpSummaryStreams {
+	return &tcpSummaryStreams{streams: make(map[tcpFlowKey]*tcpSummaryStream)}
+}
+
+func (s *tcpSummaryStreams) add(flow FlowPacket) (*tcpSummaryStream, bool) {
+	key := tcpFlowKey{
+		srcAddr: flow.SrcAddr,
+		dstAddr: flow.DstAddr,
+		srcPort: flow.SrcPort,
+		dstPort: flow.DstPort,
+	}
+	dataSeq := flow.TCPSeq
+	if flow.TCPFlags&tcpFlagSYN != 0 {
+		dataSeq++
+	}
+	stream := s.streams[key]
+	if stream == nil {
+		stream = &tcpSummaryStream{nextSeq: dataSeq}
+		s.streams[key] = stream
+	}
+	payload := flow.Payload
+	if dataSeq < stream.nextSeq {
+		overlap := int(stream.nextSeq - dataSeq)
+		if overlap >= len(payload) {
+			return stream, true
+		}
+		payload = payload[overlap:]
+	} else if dataSeq > stream.nextSeq {
+		return stream, false
+	}
+	if len(stream.data) >= maxTCPReassemblyBytes {
+		return stream, true
+	}
+	remaining := maxTCPReassemblyBytes - len(stream.data)
+	if len(payload) > remaining {
+		payload = payload[:remaining]
+	}
+	stream.data = append(stream.data, payload...)
+	stream.nextSeq += uint32(len(payload))
+	return stream, true
 }
 
 func appendDNSSummary(summary *PCAPSummary, flow FlowPacket, msg netproto.DNSMessage, limit int) {

--- a/internal/netcap/summary_test.go
+++ b/internal/netcap/summary_test.go
@@ -68,6 +68,41 @@ func TestSummarizePCAPBoundsEventsAndCountsDecodeErrors(t *testing.T) {
 	}
 }
 
+func TestSummarizePCAPReassemblesSplitTCPHeaders(t *testing.T) {
+	var b bytes.Buffer
+	writePCAPHeader(t, &b, binary.LittleEndian, false, 2048, LinkTypeEthernet)
+	first := []byte("GET /split HTTP/1.1\r\nHost: ex")
+	second := []byte("ample.com\r\nAuthorization: secret\r\n\r\nbody")
+	writePCAPPacket(t, &b, binary.LittleEndian, 1, 0,
+		ethernetFrame(ipv4Packet(6, tcpSegmentWithMeta(53125, 80, 1000, 0, 0x18, first))), 0)
+	writePCAPPacket(t, &b, binary.LittleEndian, 2, 0,
+		ethernetFrame(ipv4Packet(6, tcpSegmentWithMeta(53125, 80, 1000+uint32(len(first)), 0, 0x18, second))), 0)
+
+	summary, err := SummarizePCAP(&b, 10)
+	if err != nil {
+		t.Fatalf("SummarizePCAP: %v", err)
+	}
+	if len(summary.HTTP) != 1 {
+		t.Fatalf("http summaries = %+v", summary.HTTP)
+	}
+	msg := summary.HTTP[0].Message
+	if msg.Method != "GET" || msg.Target != "/split" || msg.Truncated {
+		t.Fatalf("http message = %+v", msg)
+	}
+	var sawHost, sawRedactedAuth bool
+	for _, h := range msg.Headers {
+		if h.Name == "Host" && h.Value == "example.com" {
+			sawHost = true
+		}
+		if h.Name == "Authorization" && h.Redacted && h.Value == "[redacted]" {
+			sawRedactedAuth = true
+		}
+	}
+	if !sawHost || !sawRedactedAuth {
+		t.Fatalf("headers = %+v", msg.Headers)
+	}
+}
+
 func dnsQuery(name string) []byte {
 	var b bytes.Buffer
 	b.Write([]byte{0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0})


### PR DESCRIPTION
## Summary
- add bounded same-direction TCP payload reassembly to pcap summaries
- wait for complete HTTP header blocks before emitting HTTP summaries
- cover split HTTP headers and sensitive-header redaction across packet boundaries

## Validation
- go test ./internal/netcap -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
