### PR TITLE
Handle out-of-order TCP summary headers

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -61,7 +61,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
 | `internal/netcap` pcap reader | classic pcap packet records and link type | user | streaming, low | shared plumbing for future capture summaries |
 | `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints, TCP sequence metadata, and transport payload from Ethernet, raw IPv4, loopback, and Linux cooked pcap packets | user | low per packet | shared plumbing for future capture summaries |
-| `internal/netcap` pcap summarizer | bounded DNS, TLS ClientHello, HTTP/1 header, and WebSocket upgrade metadata from pcap streams with small TCP reassembly buffers | user | streaming, low | shared plumbing for capture summaries |
+| `internal/netcap` pcap summarizer | bounded DNS, TLS ClientHello, HTTP/1 header, and WebSocket upgrade metadata from pcap streams with small TCP reassembly buffers | user | streaming, low; handles contiguous and directly preceding out-of-order TCP payloads | shared plumbing for capture summaries |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
 `nettop`, and `/etc/hosts`. `lsof` is also where current socket owner

--- a/internal/netcap/summary.go
+++ b/internal/netcap/summary.go
@@ -161,6 +161,7 @@ type tcpSummaryStreams struct {
 
 type tcpSummaryStream struct {
 	data       []byte
+	startSeq   uint32
 	nextSeq    uint32
 	parsedTLS  bool
 	parsedHTTP bool
@@ -183,10 +184,13 @@ func (s *tcpSummaryStreams) add(flow FlowPacket) (*tcpSummaryStream, bool) {
 	}
 	stream := s.streams[key]
 	if stream == nil {
-		stream = &tcpSummaryStream{nextSeq: dataSeq}
+		stream = &tcpSummaryStream{startSeq: dataSeq, nextSeq: dataSeq}
 		s.streams[key] = stream
 	}
 	payload := flow.Payload
+	if dataSeq < stream.startSeq {
+		return prependTCPPayload(stream, dataSeq, payload)
+	}
 	if dataSeq < stream.nextSeq {
 		overlap := int(stream.nextSeq - dataSeq)
 		if overlap >= len(payload) {
@@ -205,6 +209,34 @@ func (s *tcpSummaryStreams) add(flow FlowPacket) (*tcpSummaryStream, bool) {
 	}
 	stream.data = append(stream.data, payload...)
 	stream.nextSeq += uint32(len(payload))
+	return stream, true
+}
+
+func prependTCPPayload(stream *tcpSummaryStream, dataSeq uint32, payload []byte) (*tcpSummaryStream, bool) {
+	endSeq := dataSeq + uint32(len(payload))
+	if endSeq < stream.startSeq {
+		return stream, false
+	}
+	if endSeq > stream.startSeq {
+		overlap := int(endSeq - stream.startSeq)
+		if overlap >= len(payload) {
+			return stream, true
+		}
+		payload = payload[:len(payload)-overlap]
+	}
+	if len(stream.data) >= maxTCPReassemblyBytes {
+		return stream, true
+	}
+	remaining := maxTCPReassemblyBytes - len(stream.data)
+	if len(payload) > remaining {
+		payload = payload[len(payload)-remaining:]
+		dataSeq = stream.startSeq - uint32(len(payload))
+	}
+	next := make([]byte, 0, len(payload)+len(stream.data))
+	next = append(next, payload...)
+	next = append(next, stream.data...)
+	stream.data = next
+	stream.startSeq = dataSeq
 	return stream, true
 }
 

--- a/internal/netcap/summary_test.go
+++ b/internal/netcap/summary_test.go
@@ -103,6 +103,29 @@ func TestSummarizePCAPReassemblesSplitTCPHeaders(t *testing.T) {
 	}
 }
 
+func TestSummarizePCAPPrependsOutOfOrderTCPHeaders(t *testing.T) {
+	var b bytes.Buffer
+	writePCAPHeader(t, &b, binary.LittleEndian, false, 2048, LinkTypeEthernet)
+	first := []byte("GET /late HTTP/1.1\r\nHost: ex")
+	second := []byte("ample.com\r\n\r\n")
+	writePCAPPacket(t, &b, binary.LittleEndian, 1, 0,
+		ethernetFrame(ipv4Packet(6, tcpSegmentWithMeta(53125, 80, 1000+uint32(len(first)), 0, 0x18, second))), 0)
+	writePCAPPacket(t, &b, binary.LittleEndian, 2, 0,
+		ethernetFrame(ipv4Packet(6, tcpSegmentWithMeta(53125, 80, 1000, 0, 0x18, first))), 0)
+
+	summary, err := SummarizePCAP(&b, 10)
+	if err != nil {
+		t.Fatalf("SummarizePCAP: %v", err)
+	}
+	if len(summary.HTTP) != 1 {
+		t.Fatalf("http summaries = %+v", summary.HTTP)
+	}
+	msg := summary.HTTP[0].Message
+	if msg.Method != "GET" || msg.Target != "/late" {
+		t.Fatalf("http message = %+v", msg)
+	}
+}
+
 func dnsQuery(name string) []byte {
 	var b bytes.Buffer
 	b.Write([]byte{0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0})


### PR DESCRIPTION
## Summary
- allow pcap TCP summary buffers to prepend directly preceding out-of-order payloads
- add coverage for reconstructing HTTP headers when the later segment is seen first
- document the out-of-order scope in live data sources

## Validation
- go test ./internal/netcap -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
