### PR TITLE
Summarize captures after stop

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -115,11 +115,13 @@ func runNetworkCaptureStop(args []string) int {
 	fs := flag.NewFlagSet("spectra network capture stop", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	summarize := fs.Bool("summarize", false, "Summarize the completed pcap after stopping")
+	limit := fs.Int("limit", netcap.DefaultSummaryEventLimit, "Maximum protocol events to include when summarizing")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "usage: spectra network capture stop <handle>")
+		fmt.Fprintln(os.Stderr, "usage: spectra network capture stop [--json] [--summarize] [--limit N] <handle>")
 		return 2
 	}
 	result, err := networkCaptureStop(fs.Arg(0))
@@ -130,6 +132,27 @@ func runNetworkCaptureStop(args []string) int {
 		}
 		fmt.Fprintf(os.Stderr, "network capture stop: %v\n", err)
 		return 1
+	}
+	if *summarize {
+		path, _ := result["output_path"].(string)
+		if path == "" {
+			fmt.Fprintln(os.Stderr, "network capture stop: helper result did not include output_path")
+			return 1
+		}
+		summary, err := networkCaptureSummarize(path, *limit)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "network capture summarize: %v\n", err)
+			return 1
+		}
+		if *asJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(map[string]any{"capture": result, "summary": summary})
+			return 0
+		}
+		printNetworkCaptureResult(result, false, "capture stopped")
+		printNetworkCaptureSummary(summary)
+		return 0
 	}
 	return printNetworkCaptureResult(result, *asJSON, "capture stopped")
 }

--- a/cmd/spectra/network_capture_test.go
+++ b/cmd/spectra/network_capture_test.go
@@ -75,6 +75,58 @@ func TestRunNetworkCaptureStopCallsHelper(t *testing.T) {
 	}
 }
 
+func TestRunNetworkCaptureStopSummarizesOutputPath(t *testing.T) {
+	restoreStop := stubNetworkCaptureStop(t, func(handle string) (map[string]any, error) {
+		if handle != "netcap-1" {
+			t.Fatalf("handle = %q, want netcap-1", handle)
+		}
+		return map[string]any{"handle": handle, "output_path": "/tmp/capture.pcap", "size_bytes": 128}, nil
+	})
+	defer restoreStop()
+	restoreSummary := stubNetworkCaptureSummarize(t, func(path string, limit int) (netcap.PCAPSummary, error) {
+		if path != "/tmp/capture.pcap" || limit != 3 {
+			t.Fatalf("summary params = %q %d", path, limit)
+		}
+		return netcap.PCAPSummary{Packets: 2, DecodedFlows: 1}, nil
+	})
+	defer restoreSummary()
+
+	out := captureStdout(t, func() {
+		code := runNetwork([]string{"capture", "stop", "--summarize", "--limit", "3", "netcap-1"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	})
+	for _, want := range []string{"capture stopped", "output_path: /tmp/capture.pcap", "capture summary", "packets: 2"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
+	}
+}
+
+func TestRunNetworkCaptureStopSummarizesJSON(t *testing.T) {
+	restoreStop := stubNetworkCaptureStop(t, func(string) (map[string]any, error) {
+		return map[string]any{"handle": "netcap-1", "output_path": "/tmp/capture.pcap"}, nil
+	})
+	defer restoreStop()
+	restoreSummary := stubNetworkCaptureSummarize(t, func(string, int) (netcap.PCAPSummary, error) {
+		return netcap.PCAPSummary{Packets: 2}, nil
+	})
+	defer restoreSummary()
+
+	out := captureStdout(t, func() {
+		code := runNetwork([]string{"capture", "stop", "--summarize", "--json", "netcap-1"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	})
+	for _, want := range []string{`"capture":`, `"summary":`, `"packets": 2`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
+	}
+}
+
 func TestRunNetworkCaptureSummarize(t *testing.T) {
 	restore := stubNetworkCaptureSummarize(t, func(path string, limit int) (netcap.PCAPSummary, error) {
 		if path != "/tmp/capture.pcap" || limit != 2 {

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -314,7 +314,7 @@ spectra network
 spectra network --json
 spectra network connections --proto tcp --state established
 spectra network capture start --interface en0 --duration 30s --proto tcp --host api.example.com --port 443
-spectra network capture stop netcap-1
+spectra network capture stop --summarize netcap-1
 spectra network capture summarize --json /var/tmp/spectra-netcap/501/netcap-1.pcap
 spectra network firewall
 spectra network firewall --json


### PR DESCRIPTION
## Summary
- add `spectra network capture stop --summarize` to summarize the returned pcap path after stopping
- return combined capture metadata and summary for JSON output
- document the stop-and-summarize workflow

## Validation
- go test ./cmd/spectra -run TestRunNetworkCapture -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
