### PR TITLE
Add app network diagnosis probes

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/netcap"
+	"github.com/kaeawc/spectra/internal/netdiag"
 	"github.com/kaeawc/spectra/internal/netstate"
 )
 
@@ -30,6 +32,9 @@ var (
 		defer f.Close()
 		return netcap.SummarizePCAP(f, limit)
 	}
+	networkDiagnose = func(ctx context.Context, opts netdiag.Options) (netdiag.Report, error) {
+		return netdiag.Diagnose(ctx, opts)
+	}
 )
 
 func runNetwork(args []string) int {
@@ -41,6 +46,9 @@ func runNetwork(args []string) int {
 	}
 	if len(args) > 0 && args[0] == "capture" {
 		return runNetworkCapture(args[1:])
+	}
+	if len(args) > 0 && args[0] == "diagnose" {
+		return runNetworkDiagnose(args[1:])
 	}
 
 	fs := flag.NewFlagSet("spectra network", flag.ContinueOnError)
@@ -61,6 +69,165 @@ func runNetwork(args []string) int {
 
 	printNetworkState(state)
 	return 0
+}
+
+func runNetworkDiagnose(args []string) int {
+	fs := flag.NewFlagSet("spectra network diagnose", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	app := fs.String("app", "", "App bundle path to diagnose")
+	pid := fs.Int("pid", 0, "PID to diagnose")
+	command := fs.String("command", "", "Process command/name to diagnose")
+	portsRaw := fs.String("ports", "443", "Comma-separated ports to probe for explicit host targets")
+	timeout := fs.Duration("timeout", 3*time.Second, "Per-probe timeout")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	report, err := networkDiagnose(context.Background(), netdiag.Options{
+		AppPath: *app,
+		PID:     *pid,
+		Command: *command,
+		Targets: fs.Args(),
+		Ports:   parsePortList(*portsRaw),
+		Timeout: *timeout,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "network diagnose: %v\n", err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+		return 0
+	}
+	printNetworkDiagnosis(report)
+	return 0
+}
+
+func printNetworkDiagnosis(report netdiag.Report) {
+	fmt.Println("=== Network diagnosis ===")
+	printNetworkDiagnosisScope(report)
+	printNetworkOverview(report.Network)
+	printNetworkDiagnosisProcesses(report.Processes)
+	printNetworkDiagnosisConnections(report.Connections)
+	printNetworkDiagnosisThroughput(report.Throughput)
+	printNetworkDiagnosisEndpoints(report.Endpoints)
+	printNetworkDiagnosisFindings(report.Findings)
+}
+
+func printNetworkDiagnosisScope(report netdiag.Report) {
+	switch {
+	case report.AppPath != "":
+		fmt.Printf("app:      %s\n", report.AppPath)
+	case report.PID > 0:
+		fmt.Printf("pid:      %d\n", report.PID)
+	case report.Command != "":
+		fmt.Printf("command:  %s\n", report.Command)
+	default:
+		fmt.Println("scope:    explicit targets / current network state")
+	}
+}
+
+func printNetworkDiagnosisProcesses(rows []netdiag.ProcessSummary) {
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("matched processes (%d):\n", len(rows))
+	for _, p := range rows {
+		fmt.Printf("  pid=%d %-24s %s\n", p.PID, truncate(p.Command, 24), p.ExecutablePath)
+	}
+}
+
+func printNetworkDiagnosisConnections(rows []netstate.Connection) {
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("active app connections (%d):\n", len(rows))
+	for _, c := range rows {
+		fmt.Printf("  pid=%d %-5s %-11s %s -> %s\n", c.PID, c.Proto, stateOrDash(c.State), c.LocalAddr, c.RemoteAddr)
+	}
+}
+
+func printNetworkDiagnosisThroughput(rows []netstate.Throughput) {
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("app throughput (%d active):\n", len(rows))
+	for _, t := range rows {
+		fmt.Printf("  pid=%d %-24s in=%d B/s out=%d B/s\n", t.PID, truncate(t.Command, 24), t.BytesInPerSec, t.BytesOutPerSec)
+	}
+}
+
+func printNetworkDiagnosisEndpoints(rows []netdiag.EndpointDiagnosis) {
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("endpoint probes (%d):\n", len(rows))
+	for _, ep := range rows {
+		fmt.Printf("  %s dns=%s trace_hops=%d\n", ep.Host, okLabel(ep.DNS.OK, ep.DNS.Error), len(ep.Traceroute.Hops))
+		for _, p := range ep.Ports {
+			printNetworkDiagnosisPort(p)
+		}
+	}
+}
+
+func printNetworkDiagnosisPort(p netdiag.PortDiagnosis) {
+	fmt.Printf("    tcp/%d=%s", p.Port, okLabel(p.TCP.OK, p.TCP.Error))
+	if p.TLS != nil {
+		fmt.Printf(" tls=%s", okLabel(p.TLS.OK, p.TLS.Error))
+		if p.TLS.Issuer != "" {
+			fmt.Printf(" issuer=%s", truncate(p.TLS.Issuer, 48))
+		}
+	}
+	fmt.Println()
+}
+
+func printNetworkDiagnosisFindings(rows []netdiag.Finding) {
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("findings (%d):\n", len(rows))
+	for _, f := range rows {
+		fmt.Printf("  [%s] %s", f.Severity, f.Title)
+		if f.Detail != "" {
+			fmt.Printf(": %s", f.Detail)
+		}
+		fmt.Println()
+	}
+}
+
+func parsePortList(raw string) []int {
+	var ports []int
+	for _, part := range strings.Split(raw, ",") {
+		port, err := strconv.Atoi(strings.TrimSpace(part))
+		if err == nil && port > 0 {
+			ports = append(ports, port)
+		}
+	}
+	return ports
+}
+
+func okLabel(ok bool, errText string) string {
+	if ok {
+		return "ok"
+	}
+	if errText == "" {
+		return "fail"
+	}
+	return "fail(" + truncate(errText, 40) + ")"
+}
+
+func stateOrDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
 }
 
 func runNetworkCapture(args []string) int {

--- a/cmd/spectra/network_capture_test.go
+++ b/cmd/spectra/network_capture_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -10,7 +11,9 @@ import (
 
 	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/netcap"
+	"github.com/kaeawc/spectra/internal/netdiag"
 	"github.com/kaeawc/spectra/internal/netproto"
+	"github.com/kaeawc/spectra/internal/netstate"
 )
 
 func TestRunNetworkCaptureStartCallsHelper(t *testing.T) {
@@ -204,6 +207,50 @@ func TestRunNetworkCaptureUnavailableHelper(t *testing.T) {
 	}
 }
 
+func TestRunNetworkDiagnose(t *testing.T) {
+	restore := stubNetworkDiagnose(t, func(_ context.Context, opts netdiag.Options) (netdiag.Report, error) {
+		if opts.AppPath != "/Applications/Slack.app" || opts.PID != 412 || len(opts.Targets) != 1 || opts.Targets[0] != "api.example.com" {
+			t.Fatalf("opts = %+v", opts)
+		}
+		if len(opts.Ports) != 2 || opts.Ports[0] != 443 || opts.Ports[1] != 8443 {
+			t.Fatalf("ports = %+v", opts.Ports)
+		}
+		return netdiag.Report{
+			AppPath: "/Applications/Slack.app",
+			Network: netstate.State{
+				DefaultRouteIface: "en0",
+				DefaultRouteGW:    "192.0.2.1",
+				DNSServers:        []string{"1.1.1.1"},
+				VPNActive:         true,
+				VPNInterfaces:     []string{"utun4"},
+			},
+			Processes:   []netdiag.ProcessSummary{{PID: 412, Command: "Slack", ExecutablePath: "/Applications/Slack.app/Contents/MacOS/Slack"}},
+			Connections: []netstate.Connection{{PID: 412, Proto: "tcp", State: "established", LocalAddr: "192.0.2.10:50000", RemoteAddr: "api.example.com:443"}},
+			Throughput:  []netstate.Throughput{{PID: 412, Command: "Slack", BytesInPerSec: 100, BytesOutPerSec: 50}},
+			Endpoints: []netdiag.EndpointDiagnosis{{
+				Host:       "api.example.com",
+				DNS:        netdiag.DNSProbe{OK: true, Addresses: []string{"203.0.113.10"}},
+				Traceroute: netdiag.TraceProbe{OK: true, Hops: []netdiag.TraceHop{{TTL: 1}}},
+				Ports:      []netdiag.PortDiagnosis{{Port: 443, TCP: netdiag.TCPProbe{OK: true}}},
+			}},
+			Findings: []netdiag.Finding{{Severity: "info", Title: "vpn/tunnel interfaces active", Detail: "utun4"}},
+		}, nil
+	})
+	defer restore()
+
+	out := captureStdout(t, func() {
+		code := runNetwork([]string{"diagnose", "--app", "/Applications/Slack.app", "--pid", "412", "--ports", "443,8443", "api.example.com"})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+	})
+	for _, want := range []string{"Network diagnosis", "app:      /Applications/Slack.app", "active app connections", "endpoint probes", "vpn/tunnel interfaces active"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, want %q", out, want)
+		}
+	}
+}
+
 func stubNetworkCaptureStart(t *testing.T, fn func(string, int, int, string, string, int) (map[string]any, error)) func() {
 	t.Helper()
 	old := networkCaptureStart
@@ -223,6 +270,13 @@ func stubNetworkCaptureSummarize(t *testing.T, fn func(string, int) (netcap.PCAP
 	old := networkCaptureSummarize
 	networkCaptureSummarize = fn
 	return func() { networkCaptureSummarize = old }
+}
+
+func stubNetworkDiagnose(t *testing.T, fn func(context.Context, netdiag.Options) (netdiag.Report, error)) func() {
+	t.Helper()
+	old := networkDiagnose
+	networkDiagnose = fn
+	return func() { networkDiagnose = old }
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -56,6 +56,9 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `scutil --proxy` | system proxy config | user | <10ms | `network.proxy_config` |
 | `scutil --dns` | DNS resolver config | user | <10ms | `network.dns_servers` |
 | `route -n get default` | default route + interface | user | <10ms | `network.default_route_*` |
+| `dig +short +time=2 +tries=1 <host>` | bounded DNS resolution probe for an app endpoint | user | active network probe, capped | `spectra network diagnose` |
+| `traceroute -n -m 12 -w 1 <host>` | hop path, unanswered hops, rough latency by hop | user | active network probe, capped | `spectra network diagnose` |
+| TCP/TLS connect probe | connect timing, TLS version, ALPN, issuer/subject interception hints | user | active network probe, capped | `spectra network diagnose` |
 | `pfctl -s rules` | firewall rules | helper | one-shot | `helper.firewall.rules`, `spectra network firewall` |
 | `tcpdump -i <iface>` | raw packet capture to helper-generated pcap path | helper | streaming, high | `helper.net_capture.start` / `helper.net_capture.stop` |
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -306,6 +306,9 @@ DNS, VPN state, listening ports, and active per-process throughput from
 bounded tcpdump captures and can summarize completed pcap files without
 retaining request or response bodies. `spectra network firewall` asks the
 privileged helper for current pf firewall rules.
+`spectra network diagnose` starts from a running application, PID, command,
+or explicit host target and joins current sockets, per-process throughput,
+DNS, route/proxy/VPN context, TCP/TLS probes, and traceroute output.
 
 ### Examples
 
@@ -313,6 +316,8 @@ privileged helper for current pf firewall rules.
 spectra network
 spectra network --json
 spectra network connections --proto tcp --state established
+spectra network diagnose --app /Applications/Slack.app api.example.com
+spectra network diagnose --pid 412 --ports 443,8443 api.example.com
 spectra network capture start --interface en0 --duration 30s --proto tcp --host api.example.com --port 443
 spectra network capture stop --summarize netcap-1
 spectra network capture summarize --json /var/tmp/spectra-netcap/501/netcap-1.pcap

--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -1,0 +1,479 @@
+// Package netdiag diagnoses network behavior for a running application by
+// joining current process/socket state with bounded endpoint probes.
+package netdiag
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/netstate"
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+const defaultTimeout = 3 * time.Second
+
+// Options controls one app-focused network diagnosis.
+type Options struct {
+	AppPath string
+	PID     int
+	Command string
+	Targets []string
+	Ports   []int
+	Timeout time.Duration
+
+	NetRunner  netstate.CmdRunner
+	ProcRunner func(context.Context, process.CollectOptions) []process.Info
+	Dialer     Dialer
+	TLSProbe   TLSProber
+}
+
+// Dialer is the subset of net.Dialer used by diagnosis probes.
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// TLSProber captures TLS handshake metadata for a host:port.
+type TLSProber interface {
+	ProbeTLS(ctx context.Context, host string, port int, timeout time.Duration) (TLSProbe, error)
+}
+
+// Report is the app-centric diagnosis result.
+type Report struct {
+	AppPath     string                `json:"app_path,omitempty"`
+	PID         int                   `json:"pid,omitempty"`
+	Command     string                `json:"command,omitempty"`
+	Network     netstate.State        `json:"network"`
+	Processes   []ProcessSummary      `json:"processes,omitempty"`
+	Connections []netstate.Connection `json:"connections,omitempty"`
+	Throughput  []netstate.Throughput `json:"throughput,omitempty"`
+	Endpoints   []EndpointDiagnosis   `json:"endpoints,omitempty"`
+	Findings    []Finding             `json:"findings,omitempty"`
+}
+
+// ProcessSummary is the process identity included in reports.
+type ProcessSummary struct {
+	PID            int    `json:"pid"`
+	Command        string `json:"command"`
+	ExecutablePath string `json:"executable_path,omitempty"`
+	AppPath        string `json:"app_path,omitempty"`
+}
+
+// EndpointDiagnosis is the probe result for one remote host.
+type EndpointDiagnosis struct {
+	Host       string          `json:"host"`
+	Ports      []PortDiagnosis `json:"ports,omitempty"`
+	DNS        DNSProbe        `json:"dns"`
+	Traceroute TraceProbe      `json:"traceroute"`
+}
+
+// PortDiagnosis contains connect/TLS timing for one host:port.
+type PortDiagnosis struct {
+	Port int       `json:"port"`
+	TCP  TCPProbe  `json:"tcp"`
+	TLS  *TLSProbe `json:"tls,omitempty"`
+}
+
+type DNSProbe struct {
+	OK         bool     `json:"ok"`
+	DurationMS int64    `json:"duration_ms,omitempty"`
+	Addresses  []string `json:"addresses,omitempty"`
+	Error      string   `json:"error,omitempty"`
+}
+
+type TCPProbe struct {
+	OK         bool   `json:"ok"`
+	DurationMS int64  `json:"duration_ms,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+type TLSProbe struct {
+	OK          bool     `json:"ok"`
+	DurationMS  int64    `json:"duration_ms,omitempty"`
+	ServerName  string   `json:"server_name,omitempty"`
+	Version     string   `json:"version,omitempty"`
+	Issuer      string   `json:"issuer,omitempty"`
+	Subject     string   `json:"subject,omitempty"`
+	ALPN        string   `json:"alpn,omitempty"`
+	DNSNames    []string `json:"dns_names,omitempty"`
+	ZscalerHint bool     `json:"zscaler_hint,omitempty"`
+	Error       string   `json:"error,omitempty"`
+}
+
+type TraceProbe struct {
+	OK    bool       `json:"ok"`
+	Hops  []TraceHop `json:"hops,omitempty"`
+	Error string     `json:"error,omitempty"`
+}
+
+type TraceHop struct {
+	TTL     int      `json:"ttl"`
+	Hosts   []string `json:"hosts,omitempty"`
+	Latency string   `json:"latency,omitempty"`
+	Timeout bool     `json:"timeout,omitempty"`
+}
+
+type Finding struct {
+	Severity string `json:"severity"`
+	Title    string `json:"title"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+// Diagnose collects local app network state and runs bounded probes against
+// explicitly supplied targets plus currently connected remote endpoints.
+func Diagnose(ctx context.Context, opts Options) (Report, error) {
+	if opts.Timeout <= 0 {
+		opts.Timeout = defaultTimeout
+	}
+	run := opts.NetRunner
+	if run == nil {
+		run = netstate.DefaultRunner
+	}
+	procRun := opts.ProcRunner
+	if procRun == nil {
+		procRun = process.CollectAll
+	}
+	dialer := opts.Dialer
+	if dialer == nil {
+		dialer = &net.Dialer{Timeout: opts.Timeout}
+	}
+	tlsProbe := opts.TLSProbe
+	if tlsProbe == nil {
+		tlsProbe = realTLSProber{dialer: &net.Dialer{Timeout: opts.Timeout}}
+	}
+
+	state := netstate.Collect(run)
+	procs := procRun(ctx, process.CollectOptions{CmdRunner: run})
+	conns := netstate.CollectConnections(run)
+	report := Report{
+		AppPath: opts.AppPath,
+		PID:     opts.PID,
+		Command: opts.Command,
+		Network: state,
+	}
+	report.Processes = filterProcesses(procs, opts)
+	report.Connections = filterConnections(conns, report.Processes, opts)
+	report.Throughput = filterThroughput(state.ProcessThroughput, report.Processes, opts)
+
+	targets := endpointTargets(opts.Targets, report.Connections, opts.Ports)
+	for _, target := range targets {
+		diag := EndpointDiagnosis{
+			Host:       target.host,
+			DNS:        probeDNS(run, target.host),
+			Traceroute: probeTrace(run, target.host),
+		}
+		for _, port := range target.ports {
+			pd := PortDiagnosis{Port: port, TCP: probeTCP(ctx, dialer, target.host, port)}
+			if port == 443 || port == 8443 {
+				tp, err := tlsProbe.ProbeTLS(ctx, target.host, port, opts.Timeout)
+				if err != nil {
+					tp = TLSProbe{Error: err.Error()}
+				}
+				pd.TLS = &tp
+			}
+			diag.Ports = append(diag.Ports, pd)
+		}
+		report.Endpoints = append(report.Endpoints, diag)
+	}
+	report.Findings = findings(report)
+	return report, nil
+}
+
+func filterProcesses(procs []process.Info, opts Options) []ProcessSummary {
+	var out []ProcessSummary
+	for _, p := range procs {
+		if opts.PID > 0 && p.PID != opts.PID {
+			continue
+		}
+		if opts.AppPath != "" && p.AppPath != opts.AppPath && !strings.HasPrefix(p.ExecutablePath, opts.AppPath+"/") {
+			continue
+		}
+		if opts.Command != "" && !strings.EqualFold(p.Command, opts.Command) && !strings.Contains(strings.ToLower(p.FullCommandLine), strings.ToLower(opts.Command)) {
+			continue
+		}
+		out = append(out, ProcessSummary{PID: p.PID, Command: p.Command, ExecutablePath: p.ExecutablePath, AppPath: p.AppPath})
+	}
+	return out
+}
+
+func filterConnections(conns []netstate.Connection, procs []ProcessSummary, opts Options) []netstate.Connection {
+	pids := processPIDSet(procs)
+	var out []netstate.Connection
+	for _, c := range conns {
+		if opts.PID > 0 && c.PID != opts.PID {
+			continue
+		}
+		if len(pids) > 0 && !pids[c.PID] {
+			continue
+		}
+		if opts.Command != "" && !strings.EqualFold(c.Command, opts.Command) && len(pids) == 0 {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func filterThroughput(rows []netstate.Throughput, procs []ProcessSummary, opts Options) []netstate.Throughput {
+	pids := processPIDSet(procs)
+	var out []netstate.Throughput
+	for _, row := range rows {
+		if opts.PID > 0 && row.PID != opts.PID {
+			continue
+		}
+		if len(pids) > 0 && !pids[row.PID] {
+			continue
+		}
+		if opts.Command != "" && !strings.EqualFold(row.Command, opts.Command) && len(pids) == 0 {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+func processPIDSet(procs []ProcessSummary) map[int]bool {
+	out := make(map[int]bool, len(procs))
+	for _, p := range procs {
+		out[p.PID] = true
+	}
+	return out
+}
+
+type target struct {
+	host  string
+	ports []int
+}
+
+func endpointTargets(explicit []string, conns []netstate.Connection, defaultPorts []int) []target {
+	if len(defaultPorts) == 0 {
+		defaultPorts = []int{443}
+	}
+	seen := map[string]map[int]bool{}
+	for _, raw := range explicit {
+		host, ports := splitTarget(raw, defaultPorts)
+		addTarget(seen, host, ports)
+	}
+	for _, c := range conns {
+		if c.RemoteAddr == "" {
+			continue
+		}
+		host, port := splitHostPortLoose(c.RemoteAddr)
+		if host == "" {
+			continue
+		}
+		ports := defaultPorts
+		if port > 0 {
+			ports = []int{port}
+		}
+		addTarget(seen, host, ports)
+	}
+	var out []target
+	for host, ports := range seen {
+		var ps []int
+		for port := range ports {
+			ps = append(ps, port)
+		}
+		out = append(out, target{host: host, ports: ps})
+	}
+	return out
+}
+
+func splitTarget(raw string, defaultPorts []int) (string, []int) {
+	host, port := splitHostPortLoose(raw)
+	if port > 0 {
+		return host, []int{port}
+	}
+	return host, defaultPorts
+}
+
+func addTarget(seen map[string]map[int]bool, host string, ports []int) {
+	host = strings.Trim(host, "[] ")
+	if host == "" || host == "*" {
+		return
+	}
+	if seen[host] == nil {
+		seen[host] = map[int]bool{}
+	}
+	for _, port := range ports {
+		if port > 0 {
+			seen[host][port] = true
+		}
+	}
+}
+
+func splitHostPortLoose(addr string) (string, int) {
+	host, portRaw, err := net.SplitHostPort(addr)
+	if err == nil {
+		port, _ := strconv.Atoi(portRaw)
+		return host, port
+	}
+	idx := strings.LastIndex(addr, ":")
+	if idx <= 0 {
+		return strings.Trim(addr, "[]"), 0
+	}
+	port, err := strconv.Atoi(addr[idx+1:])
+	if err != nil {
+		return strings.Trim(addr, "[]"), 0
+	}
+	return strings.Trim(addr[:idx], "[]"), port
+}
+
+func probeDNS(run netstate.CmdRunner, host string) DNSProbe {
+	start := time.Now()
+	out, err := run("dig", "+short", "+time=2", "+tries=1", host)
+	probe := DNSProbe{DurationMS: time.Since(start).Milliseconds()}
+	if err != nil {
+		probe.Error = err.Error()
+		return probe
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && net.ParseIP(line) != nil {
+			probe.Addresses = append(probe.Addresses, line)
+		}
+	}
+	probe.OK = len(probe.Addresses) > 0
+	if !probe.OK {
+		probe.Error = "no A/AAAA answers"
+	}
+	return probe
+}
+
+func probeTCP(ctx context.Context, dialer Dialer, host string, port int) TCPProbe {
+	start := time.Now()
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	probe := TCPProbe{DurationMS: time.Since(start).Milliseconds()}
+	if err != nil {
+		probe.Error = err.Error()
+		return probe
+	}
+	_ = conn.Close()
+	probe.OK = true
+	return probe
+}
+
+func probeTrace(run netstate.CmdRunner, host string) TraceProbe {
+	out, err := run("traceroute", "-n", "-m", "12", "-w", "1", host)
+	if err != nil {
+		return TraceProbe{Error: err.Error()}
+	}
+	hops := parseTraceroute(string(out))
+	return TraceProbe{OK: len(hops) > 0, Hops: hops}
+}
+
+func parseTraceroute(out string) []TraceHop {
+	var hops []TraceHop
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		ttl, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		hop := TraceHop{TTL: ttl}
+		if strings.Contains(line, "*") {
+			hop.Timeout = true
+		}
+		for _, f := range fields[1:] {
+			if net.ParseIP(f) != nil {
+				hop.Hosts = append(hop.Hosts, f)
+				continue
+			}
+			if strings.HasSuffix(f, "ms") {
+				hop.Latency = f
+			}
+		}
+		hops = append(hops, hop)
+	}
+	return hops
+}
+
+type realTLSProber struct {
+	dialer *net.Dialer
+}
+
+func (p realTLSProber) ProbeTLS(ctx context.Context, host string, port int, timeout time.Duration) (TLSProbe, error) {
+	start := time.Now()
+	d := p.dialer
+	if d == nil {
+		d = &net.Dialer{Timeout: timeout}
+	}
+	conn, err := tls.DialWithDialer(d, "tcp", net.JoinHostPort(host, strconv.Itoa(port)), &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12})
+	probe := TLSProbe{ServerName: host, DurationMS: time.Since(start).Milliseconds()}
+	if err != nil {
+		probe.Error = err.Error()
+		return probe, nil
+	}
+	defer conn.Close()
+	state := conn.ConnectionState()
+	probe.OK = true
+	probe.Version = tlsVersion(state.Version)
+	probe.ALPN = state.NegotiatedProtocol
+	if len(state.PeerCertificates) > 0 {
+		cert := state.PeerCertificates[0]
+		probe.Subject = cert.Subject.String()
+		probe.Issuer = cert.Issuer.String()
+		probe.DNSNames = cert.DNSNames
+		probe.ZscalerHint = strings.Contains(strings.ToLower(probe.Issuer), "zscaler") || strings.Contains(strings.ToLower(probe.Subject), "zscaler")
+	}
+	return probe, nil
+}
+
+func tlsVersion(v uint16) string {
+	switch v {
+	case tls.VersionTLS12:
+		return "TLS 1.2"
+	case tls.VersionTLS13:
+		return "TLS 1.3"
+	default:
+		return fmt.Sprintf("0x%04x", v)
+	}
+}
+
+func findings(report Report) []Finding {
+	var out []Finding
+	if report.Network.Proxy.HTTP != "" || report.Network.Proxy.HTTPS != "" || report.Network.Proxy.SOCKS != "" {
+		out = append(out, Finding{Severity: "info", Title: "system proxy configured", Detail: proxyDetail(report.Network.Proxy)})
+	}
+	if report.Network.VPNActive {
+		out = append(out, Finding{Severity: "info", Title: "vpn/tunnel interfaces active", Detail: strings.Join(report.Network.VPNInterfaces, ", ")})
+	}
+	for _, ep := range report.Endpoints {
+		if !ep.DNS.OK {
+			out = append(out, Finding{Severity: "warning", Title: "dns lookup failed", Detail: ep.Host + ": " + ep.DNS.Error})
+		}
+		if len(ep.Traceroute.Hops) > 0 && ep.Traceroute.Hops[len(ep.Traceroute.Hops)-1].Timeout {
+			out = append(out, Finding{Severity: "info", Title: "traceroute has unanswered hops", Detail: ep.Host})
+		}
+		for _, port := range ep.Ports {
+			if !port.TCP.OK {
+				out = append(out, Finding{Severity: "warning", Title: "tcp connect failed", Detail: fmt.Sprintf("%s:%d %s", ep.Host, port.Port, port.TCP.Error)})
+			}
+			if port.TLS != nil && port.TLS.ZscalerHint {
+				out = append(out, Finding{Severity: "info", Title: "zscaler tls issuer/subject observed", Detail: ep.Host})
+			}
+		}
+	}
+	return out
+}
+
+func proxyDetail(proxy netstate.ProxyConfig) string {
+	var parts []string
+	if proxy.HTTP != "" {
+		parts = append(parts, "http="+proxy.HTTP)
+	}
+	if proxy.HTTPS != "" {
+		parts = append(parts, "https="+proxy.HTTPS)
+	}
+	if proxy.SOCKS != "" {
+		parts = append(parts, "socks="+proxy.SOCKS)
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/netdiag/netdiag_test.go
+++ b/internal/netdiag/netdiag_test.go
@@ -1,0 +1,156 @@
+package netdiag
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+func TestDiagnoseAppNetworkBehavior(t *testing.T) {
+	run := appBehaviorRunner(t)
+	procRun := func(context.Context, process.CollectOptions) []process.Info {
+		return []process.Info{{PID: 412, Command: "Slack", ExecutablePath: "/Applications/Slack.app/Contents/MacOS/Slack", AppPath: "/Applications/Slack.app"}}
+	}
+	report, err := Diagnose(context.Background(), Options{
+		AppPath:    "/Applications/Slack.app",
+		NetRunner:  run,
+		ProcRunner: procRun,
+		Dialer:     fakeDialer{},
+		TLSProbe:   fakeTLS{issuer: "CN=Zscaler Root CA"},
+	})
+	if err != nil {
+		t.Fatalf("Diagnose: %v", err)
+	}
+	if len(report.Processes) != 1 || len(report.Connections) != 1 || len(report.Throughput) != 1 {
+		t.Fatalf("report process state = %+v", report)
+	}
+	if len(report.Endpoints) != 1 || report.Endpoints[0].Host != "api.example.com" {
+		t.Fatalf("endpoints = %+v", report.Endpoints)
+	}
+	if !report.Endpoints[0].DNS.OK || !report.Endpoints[0].Ports[0].TCP.OK {
+		t.Fatalf("probes = %+v", report.Endpoints[0])
+	}
+	if len(report.Findings) < 3 {
+		t.Fatalf("findings = %+v", report.Findings)
+	}
+}
+
+func appBehaviorRunner(t *testing.T) func(string, ...string) ([]byte, error) {
+	t.Helper()
+	fixtures := map[string][]byte{
+		"route -n get default": []byte("interface: en0\ngateway: 192.0.2.1\n"),
+		"scutil --dns":         []byte("nameserver[0] : 1.1.1.1\n"),
+		"scutil --proxy":       []byte("HTTPSEnable : 1\nHTTPSProxy : zscaler.example\nHTTPSPort : 9443\n"),
+		"ifconfig":             []byte("utun4: flags=8051<UP,POINTOPOINT,RUNNING>\n\tinet 100.64.0.1\n"),
+		"nettop -P -L 2 -x -d -J bytes_in,bytes_out -t external": []byte(",bytes_in,bytes_out,\nSlack.412,100,50,\n"),
+		"lsof -i -P -n": []byte("COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nSlack 412 alice 29u IPv4 0xabc 0t0 TCP 192.0.2.10:55123->api.example.com:443 (ESTABLISHED)\n"),
+		"dig +short +time=2 +tries=1 api.example.com": []byte("203.0.113.10\n"),
+		"traceroute -n -m 12 -w 1 api.example.com":    []byte("1 192.0.2.1 1.0 ms\n2 203.0.113.10 10.0 ms\n"),
+	}
+	return func(name string, args ...string) ([]byte, error) {
+		cmd := fakeCommand(name, args...)
+		if cmd == "lsof -i -P -n -sTCP:LISTEN" {
+			return nil, errors.New("none")
+		}
+		if out, ok := fixtures[cmd]; ok {
+			return out, nil
+		}
+		t.Fatalf("unexpected command: %s", cmd)
+		return nil, nil
+	}
+}
+
+func TestDiagnoseExplicitTargetAndFailures(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		cmd := fakeCommand(name, args...)
+		switch {
+		case strings.HasPrefix(cmd, "dig "):
+			return []byte(""), nil
+		case strings.HasPrefix(cmd, "traceroute "):
+			return nil, errors.New("traceroute unavailable")
+		case cmd == "route -n get default", cmd == "scutil --dns", cmd == "scutil --proxy", cmd == "ifconfig", strings.HasPrefix(cmd, "lsof "), strings.HasPrefix(cmd, "nettop "):
+			return []byte(""), nil
+		default:
+			t.Fatalf("unexpected command: %s", cmd)
+		}
+		return nil, nil
+	}
+	report, err := Diagnose(context.Background(), Options{
+		Targets:   []string{"blocked.example:443"},
+		NetRunner: run,
+		ProcRunner: func(context.Context, process.CollectOptions) []process.Info {
+			return nil
+		},
+		Dialer: fakeDialer{err: errors.New("timeout")},
+		TLSProbe: fakeTLS{
+			err: errors.New("tls timeout"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Diagnose: %v", err)
+	}
+	if len(report.Endpoints) != 1 || report.Endpoints[0].DNS.OK {
+		t.Fatalf("endpoint = %+v", report.Endpoints)
+	}
+	if len(report.Findings) < 2 {
+		t.Fatalf("findings = %+v", report.Findings)
+	}
+}
+
+func fakeCommand(name string, args ...string) string {
+	if len(args) == 0 {
+		return name
+	}
+	return name + " " + strings.Join(args, " ")
+}
+
+func TestParseTraceroute(t *testing.T) {
+	hops := parseTraceroute("1 192.0.2.1 1.2 ms\n2 * * *\n3 203.0.113.10 12.0 ms\n")
+	if len(hops) != 3 || hops[1].TTL != 2 || !hops[1].Timeout || hops[2].Hosts[0] != "203.0.113.10" {
+		t.Fatalf("hops = %+v", hops)
+	}
+}
+
+type fakeDialer struct {
+	err error
+}
+
+func (d fakeDialer) DialContext(context.Context, string, string) (net.Conn, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	return fakeConn{}, nil
+}
+
+type fakeConn struct{}
+
+func (fakeConn) Read([]byte) (int, error)         { return 0, nil }
+func (fakeConn) Write([]byte) (int, error)        { return 0, nil }
+func (fakeConn) Close() error                     { return nil }
+func (fakeConn) LocalAddr() net.Addr              { return fakeAddr("local") }
+func (fakeConn) RemoteAddr() net.Addr             { return fakeAddr("remote") }
+func (fakeConn) SetDeadline(time.Time) error      { return nil }
+func (fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (fakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+type fakeAddr string
+
+func (a fakeAddr) Network() string { return string(a) }
+func (a fakeAddr) String() string  { return string(a) }
+
+type fakeTLS struct {
+	issuer string
+	err    error
+}
+
+func (f fakeTLS) ProbeTLS(context.Context, string, int, time.Duration) (TLSProbe, error) {
+	if f.err != nil {
+		return TLSProbe{}, f.err
+	}
+	return TLSProbe{OK: true, Issuer: f.issuer, ZscalerHint: strings.Contains(strings.ToLower(f.issuer), "zscaler")}, nil
+}


### PR DESCRIPTION
## Summary
- add internal/netdiag for app-centric network diagnosis from running process/app state
- join matched processes, current sockets, app throughput, DNS/proxy/VPN/route context, TCP/TLS probes, and traceroute
- expose `spectra network diagnose` with app/PID/command/target filters and JSON output

## Validation
- go test ./internal/netdiag ./cmd/spectra -run 'Test(Diagnose|RunNetworkDiagnose)' -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
