### PR TITLE
Add app bandwidth diagnosis context

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -112,6 +112,7 @@ func printNetworkDiagnosis(report netdiag.Report) {
 	printNetworkDiagnosisProcesses(report.Processes)
 	printNetworkDiagnosisConnections(report.Connections)
 	printNetworkDiagnosisThroughput(report.Throughput)
+	printNetworkDiagnosisTopThroughput(report.TopThroughput)
 	printNetworkDiagnosisEndpoints(report.Endpoints)
 	printNetworkDiagnosisFindings(report.Findings)
 }
@@ -159,6 +160,17 @@ func printNetworkDiagnosisThroughput(rows []netstate.Throughput) {
 	fmt.Printf("app throughput (%d active):\n", len(rows))
 	for _, t := range rows {
 		fmt.Printf("  pid=%d %-24s in=%d B/s out=%d B/s\n", t.PID, truncate(t.Command, 24), t.BytesInPerSec, t.BytesOutPerSec)
+	}
+}
+
+func printNetworkDiagnosisTopThroughput(rows []netstate.Throughput) {
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("top network consumers (%d):\n", len(rows))
+	for _, t := range rows {
+		fmt.Printf("  pid=%d %-24s total=%d B/s\n", t.PID, truncate(t.Command, 24), t.BytesInPerSec+t.BytesOutPerSec)
 	}
 }
 

--- a/cmd/spectra/network_capture_test.go
+++ b/cmd/spectra/network_capture_test.go
@@ -227,6 +227,10 @@ func TestRunNetworkDiagnose(t *testing.T) {
 			Processes:   []netdiag.ProcessSummary{{PID: 412, Command: "Slack", ExecutablePath: "/Applications/Slack.app/Contents/MacOS/Slack"}},
 			Connections: []netstate.Connection{{PID: 412, Proto: "tcp", State: "established", LocalAddr: "192.0.2.10:50000", RemoteAddr: "api.example.com:443"}},
 			Throughput:  []netstate.Throughput{{PID: 412, Command: "Slack", BytesInPerSec: 100, BytesOutPerSec: 50}},
+			TopThroughput: []netstate.Throughput{
+				{PID: 900, Command: "backupd", BytesInPerSec: 1000, BytesOutPerSec: 1000},
+				{PID: 412, Command: "Slack", BytesInPerSec: 100, BytesOutPerSec: 50},
+			},
 			Endpoints: []netdiag.EndpointDiagnosis{{
 				Host:       "api.example.com",
 				DNS:        netdiag.DNSProbe{OK: true, Addresses: []string{"203.0.113.10"}},
@@ -244,7 +248,7 @@ func TestRunNetworkDiagnose(t *testing.T) {
 			t.Fatalf("exit code = %d, want 0", code)
 		}
 	})
-	for _, want := range []string{"Network diagnosis", "app:      /Applications/Slack.app", "active app connections", "endpoint probes", "vpn/tunnel interfaces active"} {
+	for _, want := range []string{"Network diagnosis", "app:      /Applications/Slack.app", "active app connections", "top network consumers", "endpoint probes", "vpn/tunnel interfaces active"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("stdout = %q, want %q", out, want)
 		}

--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -44,15 +45,16 @@ type TLSProber interface {
 
 // Report is the app-centric diagnosis result.
 type Report struct {
-	AppPath     string                `json:"app_path,omitempty"`
-	PID         int                   `json:"pid,omitempty"`
-	Command     string                `json:"command,omitempty"`
-	Network     netstate.State        `json:"network"`
-	Processes   []ProcessSummary      `json:"processes,omitempty"`
-	Connections []netstate.Connection `json:"connections,omitempty"`
-	Throughput  []netstate.Throughput `json:"throughput,omitempty"`
-	Endpoints   []EndpointDiagnosis   `json:"endpoints,omitempty"`
-	Findings    []Finding             `json:"findings,omitempty"`
+	AppPath       string                `json:"app_path,omitempty"`
+	PID           int                   `json:"pid,omitempty"`
+	Command       string                `json:"command,omitempty"`
+	Network       netstate.State        `json:"network"`
+	Processes     []ProcessSummary      `json:"processes,omitempty"`
+	Connections   []netstate.Connection `json:"connections,omitempty"`
+	Throughput    []netstate.Throughput `json:"throughput,omitempty"`
+	TopThroughput []netstate.Throughput `json:"top_throughput,omitempty"`
+	Endpoints     []EndpointDiagnosis   `json:"endpoints,omitempty"`
+	Findings      []Finding             `json:"findings,omitempty"`
 }
 
 // ProcessSummary is the process identity included in reports.
@@ -158,6 +160,7 @@ func Diagnose(ctx context.Context, opts Options) (Report, error) {
 	report.Processes = filterProcesses(procs, opts)
 	report.Connections = filterConnections(conns, report.Processes, opts)
 	report.Throughput = filterThroughput(state.ProcessThroughput, report.Processes, opts)
+	report.TopThroughput = topThroughput(state.ProcessThroughput, 5)
 
 	targets := endpointTargets(opts.Targets, report.Connections, opts.Ports)
 	for _, target := range targets {
@@ -234,6 +237,24 @@ func filterThroughput(rows []netstate.Throughput, procs []ProcessSummary, opts O
 		out = append(out, row)
 	}
 	return out
+}
+
+func topThroughput(rows []netstate.Throughput, limit int) []netstate.Throughput {
+	if limit <= 0 || len(rows) == 0 {
+		return nil
+	}
+	out := append([]netstate.Throughput(nil), rows...)
+	sort.Slice(out, func(i, j int) bool {
+		return throughputTotal(out[i]) > throughputTotal(out[j])
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func throughputTotal(row netstate.Throughput) int64 {
+	return row.BytesInPerSec + row.BytesOutPerSec
 }
 
 func processPIDSet(procs []ProcessSummary) map[int]bool {
@@ -439,6 +460,15 @@ func tlsVersion(v uint16) string {
 
 func findings(report Report) []Finding {
 	var out []Finding
+	if len(report.Processes) == 0 && (report.AppPath != "" || report.PID > 0 || report.Command != "") {
+		out = append(out, Finding{Severity: "warning", Title: "no matching running process", Detail: "diagnosis may only reflect explicit targets and host network state"})
+	}
+	if len(report.Connections) == 0 && len(report.Processes) > 0 {
+		out = append(out, Finding{Severity: "info", Title: "matched app has no active network sockets"})
+	}
+	if f, ok := bandwidthFinding(report); ok {
+		out = append(out, f)
+	}
 	if report.Network.Proxy.HTTP != "" || report.Network.Proxy.HTTPS != "" || report.Network.Proxy.SOCKS != "" {
 		out = append(out, Finding{Severity: "info", Title: "system proxy configured", Detail: proxyDetail(report.Network.Proxy)})
 	}
@@ -446,22 +476,56 @@ func findings(report Report) []Finding {
 		out = append(out, Finding{Severity: "info", Title: "vpn/tunnel interfaces active", Detail: strings.Join(report.Network.VPNInterfaces, ", ")})
 	}
 	for _, ep := range report.Endpoints {
-		if !ep.DNS.OK {
-			out = append(out, Finding{Severity: "warning", Title: "dns lookup failed", Detail: ep.Host + ": " + ep.DNS.Error})
-		}
-		if len(ep.Traceroute.Hops) > 0 && ep.Traceroute.Hops[len(ep.Traceroute.Hops)-1].Timeout {
-			out = append(out, Finding{Severity: "info", Title: "traceroute has unanswered hops", Detail: ep.Host})
-		}
-		for _, port := range ep.Ports {
-			if !port.TCP.OK {
-				out = append(out, Finding{Severity: "warning", Title: "tcp connect failed", Detail: fmt.Sprintf("%s:%d %s", ep.Host, port.Port, port.TCP.Error)})
-			}
-			if port.TLS != nil && port.TLS.ZscalerHint {
-				out = append(out, Finding{Severity: "info", Title: "zscaler tls issuer/subject observed", Detail: ep.Host})
-			}
-		}
+		out = append(out, endpointFindings(ep)...)
 	}
 	return out
+}
+
+func endpointFindings(ep EndpointDiagnosis) []Finding {
+	var out []Finding
+	if !ep.DNS.OK {
+		out = append(out, Finding{Severity: "warning", Title: "dns lookup failed", Detail: ep.Host + ": " + ep.DNS.Error})
+	}
+	if len(ep.Traceroute.Hops) > 0 && ep.Traceroute.Hops[len(ep.Traceroute.Hops)-1].Timeout {
+		out = append(out, Finding{Severity: "info", Title: "traceroute has unanswered hops", Detail: ep.Host})
+	}
+	for _, port := range ep.Ports {
+		out = append(out, portFindings(ep.Host, port)...)
+	}
+	return out
+}
+
+func portFindings(host string, port PortDiagnosis) []Finding {
+	var out []Finding
+	if !port.TCP.OK {
+		out = append(out, Finding{Severity: "warning", Title: "tcp connect failed", Detail: fmt.Sprintf("%s:%d %s", host, port.Port, port.TCP.Error)})
+	}
+	if port.TLS != nil && port.TLS.ZscalerHint {
+		out = append(out, Finding{Severity: "info", Title: "zscaler tls issuer/subject observed", Detail: host})
+	}
+	return out
+}
+
+func bandwidthFinding(report Report) (Finding, bool) {
+	appPIDs := processPIDSet(report.Processes)
+	var appBytes int64
+	for _, row := range report.Throughput {
+		appBytes += throughputTotal(row)
+	}
+	for _, row := range report.TopThroughput {
+		if appPIDs[row.PID] {
+			continue
+		}
+		total := throughputTotal(row)
+		if total > 0 && (appBytes == 0 || total >= appBytes*4) {
+			return Finding{
+				Severity: "info",
+				Title:    "other process dominates current network throughput",
+				Detail:   fmt.Sprintf("pid=%d %s total=%d B/s diagnosed_app_total=%d B/s", row.PID, row.Command, total, appBytes),
+			}, true
+		}
+	}
+	return Finding{}, false
 }
 
 func proxyDetail(proxy netstate.ProxyConfig) string {

--- a/internal/netdiag/netdiag_test.go
+++ b/internal/netdiag/netdiag_test.go
@@ -29,6 +29,9 @@ func TestDiagnoseAppNetworkBehavior(t *testing.T) {
 	if len(report.Processes) != 1 || len(report.Connections) != 1 || len(report.Throughput) != 1 {
 		t.Fatalf("report process state = %+v", report)
 	}
+	if len(report.TopThroughput) != 2 || report.TopThroughput[0].Command != "backupd" {
+		t.Fatalf("top throughput = %+v", report.TopThroughput)
+	}
 	if len(report.Endpoints) != 1 || report.Endpoints[0].Host != "api.example.com" {
 		t.Fatalf("endpoints = %+v", report.Endpoints)
 	}
@@ -47,7 +50,7 @@ func appBehaviorRunner(t *testing.T) func(string, ...string) ([]byte, error) {
 		"scutil --dns":         []byte("nameserver[0] : 1.1.1.1\n"),
 		"scutil --proxy":       []byte("HTTPSEnable : 1\nHTTPSProxy : zscaler.example\nHTTPSPort : 9443\n"),
 		"ifconfig":             []byte("utun4: flags=8051<UP,POINTOPOINT,RUNNING>\n\tinet 100.64.0.1\n"),
-		"nettop -P -L 2 -x -d -J bytes_in,bytes_out -t external": []byte(",bytes_in,bytes_out,\nSlack.412,100,50,\n"),
+		"nettop -P -L 2 -x -d -J bytes_in,bytes_out -t external": []byte(",bytes_in,bytes_out,\nSlack.412,100,50,\nbackupd.900,1000,1000,\n"),
 		"lsof -i -P -n": []byte("COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nSlack 412 alice 29u IPv4 0xabc 0t0 TCP 192.0.2.10:55123->api.example.com:443 (ESTABLISHED)\n"),
 		"dig +short +time=2 +tries=1 api.example.com": []byte("203.0.113.10\n"),
 		"traceroute -n -m 12 -w 1 api.example.com":    []byte("1 192.0.2.1 1.0 ms\n2 203.0.113.10 10.0 ms\n"),


### PR DESCRIPTION
## Summary
- add top network consumers to app network diagnosis reports
- flag when another process dominates current throughput versus the diagnosed app
- print top consumers in human `network diagnose` output

## Validation
- go test ./internal/netdiag ./cmd/spectra -run 'Test(Diagnose|RunNetworkDiagnose)' -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
