### PR TITLE
Capture DNS diagnosis details

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -181,7 +181,14 @@ func printNetworkDiagnosisEndpoints(rows []netdiag.EndpointDiagnosis) {
 	fmt.Println()
 	fmt.Printf("endpoint probes (%d):\n", len(rows))
 	for _, ep := range rows {
-		fmt.Printf("  %s dns=%s trace_hops=%d\n", ep.Host, okLabel(ep.DNS.OK, ep.DNS.Error), len(ep.Traceroute.Hops))
+		fmt.Printf("  %s dns=%s", ep.Host, okLabel(ep.DNS.OK, ep.DNS.Error))
+		if ep.DNS.Status != "" {
+			fmt.Printf(" status=%s", ep.DNS.Status)
+		}
+		if ep.DNS.QueryMS > 0 {
+			fmt.Printf(" dns_ms=%d", ep.DNS.QueryMS)
+		}
+		fmt.Printf(" trace_hops=%d\n", len(ep.Traceroute.Hops))
 		for _, p := range ep.Ports {
 			printNetworkDiagnosisPort(p)
 		}

--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -83,6 +83,9 @@ type PortDiagnosis struct {
 type DNSProbe struct {
 	OK         bool     `json:"ok"`
 	DurationMS int64    `json:"duration_ms,omitempty"`
+	Status     string   `json:"status,omitempty"`
+	Server     string   `json:"server,omitempty"`
+	QueryMS    int64    `json:"query_ms,omitempty"`
 	Addresses  []string `json:"addresses,omitempty"`
 	Error      string   `json:"error,omitempty"`
 }
@@ -346,23 +349,76 @@ func splitHostPortLoose(addr string) (string, int) {
 
 func probeDNS(run netstate.CmdRunner, host string) DNSProbe {
 	start := time.Now()
-	out, err := run("dig", "+short", "+time=2", "+tries=1", host)
+	out, err := run("dig", "+time=2", "+tries=1", host)
 	probe := DNSProbe{DurationMS: time.Since(start).Milliseconds()}
 	if err != nil {
 		probe.Error = err.Error()
 		return probe
 	}
-	for _, line := range strings.Split(string(out), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" && net.ParseIP(line) != nil {
-			probe.Addresses = append(probe.Addresses, line)
-		}
+	probe = parseDig(string(out))
+	if probe.DurationMS == 0 {
+		probe.DurationMS = time.Since(start).Milliseconds()
 	}
-	probe.OK = len(probe.Addresses) > 0
-	if !probe.OK {
-		probe.Error = "no A/AAAA answers"
+	if probe.Status == "" {
+		probe.Status = "unknown"
+	}
+	probe.OK = strings.EqualFold(probe.Status, "NOERROR") && len(probe.Addresses) > 0
+	if !probe.OK && probe.Error == "" {
+		probe.Error = "dns status " + probe.Status
 	}
 	return probe
+}
+
+func parseDig(out string) DNSProbe {
+	var probe DNSProbe
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.Contains(line, "status:"):
+			probe.Status = parseDigStatus(line)
+		case strings.HasPrefix(line, ";; Query time:"):
+			probe.QueryMS = parseDigQueryMS(line)
+		case strings.HasPrefix(line, ";; SERVER:"):
+			probe.Server = strings.TrimSpace(strings.TrimPrefix(line, ";; SERVER:"))
+		default:
+			if ip := firstIPField(line); ip != "" {
+				probe.Addresses = append(probe.Addresses, ip)
+			}
+		}
+	}
+	return probe
+}
+
+func parseDigStatus(line string) string {
+	_, after, ok := strings.Cut(line, "status:")
+	if !ok {
+		return ""
+	}
+	status := strings.TrimSpace(after)
+	if idx := strings.Index(status, ","); idx >= 0 {
+		status = status[:idx]
+	}
+	return strings.TrimSpace(status)
+}
+
+func parseDigQueryMS(line string) int64 {
+	fields := strings.Fields(line)
+	for i, field := range fields {
+		if field == "time:" && i+1 < len(fields) {
+			ms, _ := strconv.ParseInt(fields[i+1], 10, 64)
+			return ms
+		}
+	}
+	return 0
+}
+
+func firstIPField(line string) string {
+	for _, field := range strings.Fields(line) {
+		if net.ParseIP(field) != nil {
+			return field
+		}
+	}
+	return ""
 }
 
 func probeTCP(ctx context.Context, dialer Dialer, host string, port int) TCPProbe {

--- a/internal/netdiag/netdiag_test.go
+++ b/internal/netdiag/netdiag_test.go
@@ -35,7 +35,7 @@ func TestDiagnoseAppNetworkBehavior(t *testing.T) {
 	if len(report.Endpoints) != 1 || report.Endpoints[0].Host != "api.example.com" {
 		t.Fatalf("endpoints = %+v", report.Endpoints)
 	}
-	if !report.Endpoints[0].DNS.OK || !report.Endpoints[0].Ports[0].TCP.OK {
+	if !report.Endpoints[0].DNS.OK || report.Endpoints[0].DNS.Status != "NOERROR" || report.Endpoints[0].DNS.QueryMS != 7 || !report.Endpoints[0].Ports[0].TCP.OK {
 		t.Fatalf("probes = %+v", report.Endpoints[0])
 	}
 	if len(report.Findings) < 3 {
@@ -51,9 +51,9 @@ func appBehaviorRunner(t *testing.T) func(string, ...string) ([]byte, error) {
 		"scutil --proxy":       []byte("HTTPSEnable : 1\nHTTPSProxy : zscaler.example\nHTTPSPort : 9443\n"),
 		"ifconfig":             []byte("utun4: flags=8051<UP,POINTOPOINT,RUNNING>\n\tinet 100.64.0.1\n"),
 		"nettop -P -L 2 -x -d -J bytes_in,bytes_out -t external": []byte(",bytes_in,bytes_out,\nSlack.412,100,50,\nbackupd.900,1000,1000,\n"),
-		"lsof -i -P -n": []byte("COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nSlack 412 alice 29u IPv4 0xabc 0t0 TCP 192.0.2.10:55123->api.example.com:443 (ESTABLISHED)\n"),
-		"dig +short +time=2 +tries=1 api.example.com": []byte("203.0.113.10\n"),
-		"traceroute -n -m 12 -w 1 api.example.com":    []byte("1 192.0.2.1 1.0 ms\n2 203.0.113.10 10.0 ms\n"),
+		"lsof -i -P -n":                            []byte("COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nSlack 412 alice 29u IPv4 0xabc 0t0 TCP 192.0.2.10:55123->api.example.com:443 (ESTABLISHED)\n"),
+		"dig +time=2 +tries=1 api.example.com":     []byte(digNOERRORFixture),
+		"traceroute -n -m 12 -w 1 api.example.com": []byte("1 192.0.2.1 1.0 ms\n2 203.0.113.10 10.0 ms\n"),
 	}
 	return func(name string, args ...string) ([]byte, error) {
 		cmd := fakeCommand(name, args...)
@@ -105,12 +105,33 @@ func TestDiagnoseExplicitTargetAndFailures(t *testing.T) {
 	}
 }
 
+func TestParseDigStatuses(t *testing.T) {
+	ok := parseDig(digNOERRORFixture)
+	if ok.Status != "NOERROR" || ok.QueryMS != 7 || ok.Server != "1.1.1.1#53(1.1.1.1)" || len(ok.Addresses) != 1 {
+		t.Fatalf("NOERROR dig = %+v", ok)
+	}
+	nx := parseDig(";; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 1\n;; Query time: 5 msec\n;; SERVER: 10.0.0.2#53(10.0.0.2)\n")
+	if nx.Status != "NXDOMAIN" || len(nx.Addresses) != 0 {
+		t.Fatalf("NXDOMAIN dig = %+v", nx)
+	}
+}
+
 func fakeCommand(name string, args ...string) string {
 	if len(args) == 0 {
 		return name
 	}
 	return name + " " + strings.Join(args, " ")
 }
+
+const digNOERRORFixture = `; <<>> DiG 9.10 <<>> api.example.com
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 123
+;; QUESTION SECTION:
+;api.example.com. IN A
+;; ANSWER SECTION:
+api.example.com. 60 IN A 203.0.113.10
+;; Query time: 7 msec
+;; SERVER: 1.1.1.1#53(1.1.1.1)
+`
 
 func TestParseTraceroute(t *testing.T) {
 	hops := parseTraceroute("1 192.0.2.1 1.2 ms\n2 * * *\n3 203.0.113.10 12.0 ms\n")


### PR DESCRIPTION
## Summary
- parse full dig output for DNS status, resolver, and query timing
- include DNS status/timing in network diagnose human output
- add tests for NOERROR and NXDOMAIN dig parsing

## Validation
- go test ./internal/netdiag ./cmd/spectra -run 'Test(Diagnose|ParseDig|RunNetworkDiagnose)' -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
