### PR TITLE
Infer app diagnosis endpoints by default

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -78,7 +78,7 @@ func runNetworkDiagnose(args []string) int {
 	app := fs.String("app", "", "App bundle path to diagnose")
 	pid := fs.Int("pid", 0, "PID to diagnose")
 	command := fs.String("command", "", "Process command/name to diagnose")
-	portsRaw := fs.String("ports", "443", "Comma-separated ports to probe for explicit host targets")
+	portsRaw := fs.String("ports", "", "Comma-separated remote ports to include (filters inferred app endpoints)")
 	timeout := fs.Duration("timeout", 3*time.Second, "Per-probe timeout")
 	if err := fs.Parse(args); err != nil {
 		return 2

--- a/cmd/spectra/network_capture_test.go
+++ b/cmd/spectra/network_capture_test.go
@@ -209,10 +209,10 @@ func TestRunNetworkCaptureUnavailableHelper(t *testing.T) {
 
 func TestRunNetworkDiagnose(t *testing.T) {
 	restore := stubNetworkDiagnose(t, func(_ context.Context, opts netdiag.Options) (netdiag.Report, error) {
-		if opts.AppPath != "/Applications/Slack.app" || opts.PID != 412 || len(opts.Targets) != 1 || opts.Targets[0] != "api.example.com" {
+		if opts.AppPath != "/Applications/Slack.app" || opts.PID != 412 || len(opts.Targets) != 0 {
 			t.Fatalf("opts = %+v", opts)
 		}
-		if len(opts.Ports) != 2 || opts.Ports[0] != 443 || opts.Ports[1] != 8443 {
+		if len(opts.Ports) != 0 {
 			t.Fatalf("ports = %+v", opts.Ports)
 		}
 		return netdiag.Report{
@@ -243,7 +243,7 @@ func TestRunNetworkDiagnose(t *testing.T) {
 	defer restore()
 
 	out := captureStdout(t, func() {
-		code := runNetwork([]string{"diagnose", "--app", "/Applications/Slack.app", "--pid", "412", "--ports", "443,8443", "api.example.com"})
+		code := runNetwork([]string{"diagnose", "--app", "/Applications/Slack.app", "--pid", "412"})
 		if code != 0 {
 			t.Fatalf("exit code = %d, want 0", code)
 		}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -306,9 +306,12 @@ DNS, VPN state, listening ports, and active per-process throughput from
 bounded tcpdump captures and can summarize completed pcap files without
 retaining request or response bodies. `spectra network firewall` asks the
 privileged helper for current pf firewall rules.
-`spectra network diagnose` starts from a running application, PID, command,
-or explicit host target and joins current sockets, per-process throughput,
-DNS, route/proxy/VPN context, TCP/TLS probes, and traceroute output.
+`spectra network diagnose` starts from a running application, PID, or command,
+infers endpoints from that app's current sockets, and joins per-process
+throughput, DNS, route/proxy/VPN context, TCP/TLS probes, and traceroute
+output. Positional hosts and `--ports` narrow the inferred app endpoints; when
+no app scope is provided, positional hosts can be used as explicit probe
+targets.
 
 ### Examples
 
@@ -316,8 +319,9 @@ DNS, route/proxy/VPN context, TCP/TLS probes, and traceroute output.
 spectra network
 spectra network --json
 spectra network connections --proto tcp --state established
-spectra network diagnose --app /Applications/Slack.app api.example.com
-spectra network diagnose --pid 412 --ports 443,8443 api.example.com
+spectra network diagnose --app /Applications/Slack.app
+spectra network diagnose --pid 412
+spectra network diagnose --app /Applications/Slack.app --ports 443 api.example.com
 spectra network capture start --interface en0 --duration 30s --proto tcp --host api.example.com --port 443
 spectra network capture stop --summarize netcap-1
 spectra network capture summarize --json /var/tmp/spectra-netcap/501/netcap-1.pcap

--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -279,14 +279,29 @@ type target struct {
 	ports []int
 }
 
-func endpointTargets(explicit []string, conns []netstate.Connection, defaultPorts []int) []target {
-	if len(defaultPorts) == 0 {
-		defaultPorts = []int{443}
+func endpointTargets(explicit []string, conns []netstate.Connection, portFilters []int) []target {
+	if len(conns) > 0 {
+		return connectionTargets(explicit, conns, portFilters)
 	}
 	seen := map[string]map[int]bool{}
 	for _, raw := range explicit {
-		host, ports := splitTarget(raw, defaultPorts)
+		host, ports := splitTarget(raw, portFilters)
 		addTarget(seen, host, ports)
+	}
+	return targetsFromSeen(seen)
+}
+
+func connectionTargets(filters []string, conns []netstate.Connection, portFilters []int) []target {
+	hostFilters := map[string]bool{}
+	seen := map[string]map[int]bool{}
+	for _, raw := range filters {
+		host, port := splitFilterTarget(raw)
+		if host != "" {
+			hostFilters[strings.ToLower(host)] = true
+		}
+		if port > 0 {
+			portFilters = append(portFilters, port)
+		}
 	}
 	for _, c := range conns {
 		if c.RemoteAddr == "" {
@@ -296,29 +311,44 @@ func endpointTargets(explicit []string, conns []netstate.Connection, defaultPort
 		if host == "" {
 			continue
 		}
-		ports := defaultPorts
-		if port > 0 {
-			ports = []int{port}
+		if len(hostFilters) > 0 && !hostFilters[strings.ToLower(host)] {
+			continue
 		}
-		addTarget(seen, host, ports)
+		if len(portFilters) > 0 && !containsPort(portFilters, port) {
+			continue
+		}
+		addTarget(seen, host, []int{port})
 	}
+	return targetsFromSeen(seen)
+}
+
+func splitFilterTarget(raw string) (string, int) {
+	return splitHostPortLoose(raw)
+}
+
+func targetsFromSeen(seen map[string]map[int]bool) []target {
 	var out []target
 	for host, ports := range seen {
 		var ps []int
 		for port := range ports {
 			ps = append(ps, port)
 		}
+		sort.Ints(ps)
 		out = append(out, target{host: host, ports: ps})
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].host < out[j].host })
 	return out
 }
 
-func splitTarget(raw string, defaultPorts []int) (string, []int) {
+func splitTarget(raw string, portFilters []int) (string, []int) {
 	host, port := splitHostPortLoose(raw)
 	if port > 0 {
 		return host, []int{port}
 	}
-	return host, defaultPorts
+	if len(portFilters) > 0 {
+		return host, portFilters
+	}
+	return host, []int{443}
 }
 
 func addTarget(seen map[string]map[int]bool, host string, ports []int) {
@@ -334,6 +364,15 @@ func addTarget(seen map[string]map[int]bool, host string, ports []int) {
 			seen[host][port] = true
 		}
 	}
+}
+
+func containsPort(ports []int, want int) bool {
+	for _, port := range ports {
+		if port == want {
+			return true
+		}
+	}
+	return false
 }
 
 func splitHostPortLoose(addr string) (string, int) {

--- a/internal/netdiag/netdiag_test.go
+++ b/internal/netdiag/netdiag_test.go
@@ -106,6 +106,33 @@ func TestDiagnoseExplicitTargetAndFailures(t *testing.T) {
 	}
 }
 
+func TestEndpointTargetsInferAndFilterAppConnections(t *testing.T) {
+	conns := []netstate.Connection{
+		{RemoteAddr: "api.example.com:443"},
+		{RemoteAddr: "uploads.example.com:8443"},
+		{RemoteAddr: "api.example.com:5228"},
+	}
+	all := endpointTargets(nil, conns, nil)
+	if len(all) != 2 || all[0].host != "api.example.com" || len(all[0].ports) != 2 {
+		t.Fatalf("all targets = %+v", all)
+	}
+	hostFiltered := endpointTargets([]string{"uploads.example.com"}, conns, nil)
+	if len(hostFiltered) != 1 || hostFiltered[0].host != "uploads.example.com" || hostFiltered[0].ports[0] != 8443 {
+		t.Fatalf("host filtered targets = %+v", hostFiltered)
+	}
+	portFiltered := endpointTargets(nil, conns, []int{443})
+	if len(portFiltered) != 1 || portFiltered[0].host != "api.example.com" || portFiltered[0].ports[0] != 443 {
+		t.Fatalf("port filtered targets = %+v", portFiltered)
+	}
+}
+
+func TestEndpointTargetsUseExplicitHostWhenNoConnections(t *testing.T) {
+	targets := endpointTargets([]string{"api.example.com"}, nil, nil)
+	if len(targets) != 1 || targets[0].host != "api.example.com" || targets[0].ports[0] != 443 {
+		t.Fatalf("targets = %+v", targets)
+	}
+}
+
 func TestParseDigStatuses(t *testing.T) {
 	ok := parseDig(digNOERRORFixture)
 	if ok.Status != "NOERROR" || ok.QueryMS != 7 || ok.Server != "1.1.1.1#53(1.1.1.1)" || len(ok.Addresses) != 1 {


### PR DESCRIPTION
## Summary
- make `network diagnose` examples app/PID-first without requiring hostnames or ports
- infer diagnosis endpoints from active app connections by default
- treat positional hosts and `--ports` as filters over inferred app endpoints when app connections exist

## Validation
- go test ./internal/netdiag ./cmd/spectra -run 'Test(Diagnose|EndpointTargets|RunNetworkDiagnose)' -count=1
- go build ./... && go vet ./...
- go test ./... -count=1
- make docs-validate
