### PR TITLE
Warn when app endpoint filters match no active connections

### DIFF
--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -172,6 +172,9 @@ func Diagnose(ctx context.Context, opts Options) (Report, error) {
 	report.TopThroughput = topThroughput(state.ProcessThroughput, 5)
 
 	targets := endpointTargets(opts.Targets, report.Connections, opts.Ports)
+	diagnosticNoEndpoints := len(report.Connections) > 0 &&
+		len(targets) == 0 &&
+		(len(opts.Targets) > 0 || len(opts.Ports) > 0)
 	for _, target := range targets {
 		diag := EndpointDiagnosis{
 			Host:       target.host,
@@ -192,6 +195,13 @@ func Diagnose(ctx context.Context, opts Options) (Report, error) {
 		report.Endpoints = append(report.Endpoints, diag)
 	}
 	report.Findings = findings(report)
+	if diagnosticNoEndpoints {
+		report.Findings = append(report.Findings, Finding{
+			Severity: "warning",
+			Title:    "app endpoint filters matched no active connections",
+			Detail:   "use broader --ports or positional hosts to include additional remote endpoints",
+		})
+	}
 	return report, nil
 }
 

--- a/internal/netdiag/netdiag_test.go
+++ b/internal/netdiag/netdiag_test.go
@@ -106,6 +106,28 @@ func TestDiagnoseExplicitTargetAndFailures(t *testing.T) {
 	}
 }
 
+func TestDiagnoseEndpointFilterNoMatches(t *testing.T) {
+	run := appBehaviorRunner(t)
+	report, err := Diagnose(context.Background(), Options{
+		AppPath:   "/Applications/Slack.app",
+		Targets:   []string{"other.example"},
+		Ports:     []int{443, 9443},
+		NetRunner: run,
+		ProcRunner: func(context.Context, process.CollectOptions) []process.Info {
+			return []process.Info{{PID: 412, Command: "Slack", ExecutablePath: "/Applications/Slack.app/Contents/MacOS/Slack", AppPath: "/Applications/Slack.app"}}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Diagnose: %v", err)
+	}
+	if len(report.Endpoints) != 0 {
+		t.Fatalf("expected no endpoint probes, got %+v", report.Endpoints)
+	}
+	if !hasFinding(report.Findings, "app endpoint filters matched no active connections") {
+		t.Fatalf("missing no-match finding: %+v", report.Findings)
+	}
+}
+
 func TestEndpointTargetsInferAndFilterAppConnections(t *testing.T) {
 	conns := []netstate.Connection{
 		{RemoteAddr: "api.example.com:443"},


### PR DESCRIPTION
## Summary
- Add a diagnosis finding when app-scoped network diagnostics have active sockets but filters remove all inferred endpoints.
- Keep explicit target behavior unchanged.
- Add a regression test for the no-match filter case.

## Validation
- gofmt on changed files.
