### PR TITLE
Add Spectra MCP server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: build build-helper build-all test vet fmt lint complexity security licenses tidy ci clean all \
+.PHONY: build build-mcp build-helper build-all test vet fmt lint complexity security licenses tidy ci clean all \
 	release-check validate-workflows \
 	docs-validate docs-nav docs-lychee docs-build docs-serve docs-install
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS = -s -w -X main.version=$(VERSION)
 BIN ?= spectra
+MCP_BIN ?= spectra-mcp
 HELPER_BIN ?= spectra-helper
 
 # --- Build -------------------------------------------------------------------
@@ -12,10 +13,13 @@ HELPER_BIN ?= spectra-helper
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BIN) ./cmd/spectra/
 
+build-mcp:
+	go build -ldflags "$(LDFLAGS)" -o $(MCP_BIN) ./cmd/spectra-mcp/
+
 build-helper:
 	go build -ldflags "$(LDFLAGS)" -o $(HELPER_BIN) ./cmd/spectra-helper/
 
-build-all: build build-helper
+build-all: build build-mcp build-helper
 
 # --- Quality -----------------------------------------------------------------
 
@@ -74,7 +78,7 @@ docs-validate: docs-nav docs-lychee docs-build
 # --- Cleanup -----------------------------------------------------------------
 
 clean:
-	rm -f $(BIN) $(HELPER_BIN) junit-report.xml gosec-report.xml
+	rm -f $(BIN) $(MCP_BIN) $(HELPER_BIN) junit-report.xml gosec-report.xml
 	rm -rf site/
 
 all: build vet test docs-validate

--- a/cmd/spectra-mcp/main.go
+++ b/cmd/spectra-mcp/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/kaeawc/spectra/internal/mcp"
+)
+
+var version = "dev"
+
+func main() {
+	versionFlag := flag.Bool("version", false, "Print version")
+	verboseFlag := flag.Bool("verbose", false, "Enable lifecycle logging to stderr")
+	flag.BoolVar(verboseFlag, "v", false, "Alias for --verbose")
+	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println("spectra-mcp", version)
+		os.Exit(0)
+	}
+
+	log.SetOutput(os.Stderr)
+	server := mcp.NewServer(bufio.NewReader(os.Stdin), os.Stdout)
+	server.Version = version
+	server.Verbose = *verboseFlag
+	server.Run()
+}

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -1,0 +1,148 @@
+// Package jsonrpc implements Content-Length-framed JSON-RPC 2.0 transport primitives.
+package jsonrpc
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/kaeawc/spectra/internal/logger"
+)
+
+// pkgLog routes transport errors when message marshaling fails.
+var pkgLog logger.Logger = logger.New(logger.Config{Format: logger.FormatText, Level: slog.LevelInfo})
+
+// SetLogger replaces the package-level logger used by WriteMessage transport helpers.
+func SetLogger(l logger.Logger) { pkgLog = l }
+
+// Request is a JSON-RPC 2.0 request or notification.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response is a JSON-RPC 2.0 response.
+type Response struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result"`
+	Error   *Error      `json:"error,omitempty"`
+}
+
+type successResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result"`
+}
+
+type errorResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Error   *Error      `json:"error"`
+}
+
+// Error represents JSON-RPC transport/application errors.
+type Error struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// Notification is a one-way JSON-RPC notification.
+type Notification struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+// ReadMessage reads a single JSON-RPC body from Content-Length framing.
+func ReadMessage(r *bufio.Reader) ([]byte, error) {
+	var contentLength int
+	headerDone := false
+
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			headerDone = true
+			break
+		}
+		if strings.HasPrefix(line, "Content-Length: ") {
+			trim := strings.TrimPrefix(line, "Content-Length: ")
+			contentLength, err = strconv.Atoi(trim)
+			if err != nil {
+				return nil, fmt.Errorf("parse Content-Length %q: %w", trim, err)
+			}
+		}
+	}
+	if !headerDone {
+		return nil, fmt.Errorf("unexpected EOF while reading headers")
+	}
+	if contentLength <= 0 {
+		return nil, fmt.Errorf("invalid content-length %d", contentLength)
+	}
+	body := make([]byte, contentLength)
+	_, err := io.ReadFull(r, body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// WriteMessage serializes and writes one Message with Content-Length framing.
+func WriteMessage(w io.Writer, mu *sync.Mutex, msg any) {
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		pkgLog.Error("jsonrpc marshal failed", "err", err)
+		return
+	}
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(payload))
+	mu.Lock()
+	defer mu.Unlock()
+	if _, err := w.Write([]byte(header)); err != nil {
+		pkgLog.Error("jsonrpc write header failed", "err", err)
+		return
+	}
+	if _, err := w.Write(payload); err != nil {
+		pkgLog.Error("jsonrpc write body failed", "err", err)
+	}
+}
+
+// SendResponse writes a JSON-RPC response with either result or error.
+func SendResponse(w io.Writer, mu *sync.Mutex, id interface{}, result interface{}, rpcErr *Error) {
+	var msg interface{}
+	if rpcErr != nil {
+		msg = errorResponse{
+			JSONRPC: "2.0",
+			ID:      id,
+			Error:   rpcErr,
+		}
+	} else {
+		msg = successResponse{
+			JSONRPC: "2.0",
+			ID:      id,
+			Result:  result,
+		}
+	}
+	WriteMessage(w, mu, msg)
+}
+
+// SendNotification writes a JSON-RPC notification.
+func SendNotification(w io.Writer, mu *sync.Mutex, method string, params interface{}) {
+	msg := Notification{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  params,
+	}
+	WriteMessage(w, mu, msg)
+}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func promptDefinitions() []PromptDefinition {
+	return []PromptDefinition{
+		{
+			Name:        "incident-triage",
+			Description: "Triage an app, PID, host, or symptom.",
+			Arguments: []PromptArgument{
+				{Name: "target", Description: "App path, PID, bundle ID, host, or symptom.", Required: true},
+			},
+		},
+		{
+			Name:        "jvm-memory-debug",
+			Description: "Debug JVM heap, GC, and native memory.",
+			Arguments: []PromptArgument{
+				{Name: "pid", Description: "JVM PID.", Required: true},
+			},
+		},
+		{
+			Name:        "baseline-diff-review",
+			Description: "Review changes between two snapshots.",
+			Arguments: []PromptArgument{
+				{Name: "id_a", Description: "Baseline snapshot ID.", Required: true},
+				{Name: "id_b", Description: "New snapshot ID.", Required: true},
+			},
+		},
+	}
+}
+
+func (s *Server) getPrompt(name string, args map[string]string) (PromptGetResult, *RPCError) {
+	switch name {
+	case "incident-triage":
+		return buildPromptResult("Start with triage. Then use diagnose, process, network, jvm, or toolchain only when the evidence points there.", args)
+	case "jvm-memory-debug":
+		return buildPromptResult("Use jvm inspect, gc_stats, vm_memory, and explain first. Request heap_dump or flamegraph only with confirm_sensitive=true.", args)
+	case "baseline-diff-review":
+		return buildPromptResult("Use snapshot operation=diff. Summarize changed apps, processes, JVMs, network, and toolchains. Give next actions.", args)
+	default:
+		return PromptGetResult{}, &RPCError{
+			Code:    -32602,
+			Message: fmt.Sprintf("unknown prompt: %s", name),
+		}
+	}
+}
+
+func buildPromptResult(message string, args map[string]string) (PromptGetResult, *RPCError) {
+	raw, _ := json.MarshalIndent(args, "", "  ")
+	return PromptGetResult{
+		Description: message,
+		Messages: []PromptMessage{
+			{
+				Role:    "user",
+				Content: ContentBlock{Type: "text", Text: message + "\n\nContext:\n" + string(raw)},
+			},
+		},
+	}, nil
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -1,0 +1,129 @@
+// Package mcp defines the MCP server protocol types used by the Spectra MCP server.
+package mcp
+
+import (
+	"encoding/json"
+
+	"github.com/kaeawc/spectra/internal/jsonrpc"
+)
+
+type (
+	Request  = jsonrpc.Request
+	Response = jsonrpc.Response
+	RPCError = jsonrpc.Error
+)
+
+type InitializeParams struct {
+	ProtocolVersion string      `json:"protocolVersion"`
+	Capabilities    ClientCaps  `json:"capabilities"`
+	ClientInfo      *ClientInfo `json:"clientInfo,omitempty"`
+}
+
+type ClientCaps struct{}
+
+type ClientInfo struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type InitializeResult struct {
+	ProtocolVersion string     `json:"protocolVersion"`
+	Capabilities    ServerCaps `json:"capabilities"`
+	ServerInfo      ServerInfo `json:"serverInfo"`
+}
+
+type ServerCaps struct {
+	Tools     *ToolsCap     `json:"tools,omitempty"`
+	Resources *ResourcesCap `json:"resources,omitempty"`
+	Prompts   *PromptsCap   `json:"prompts,omitempty"`
+}
+
+type ToolsCap struct{}
+type ResourcesCap struct{}
+type PromptsCap struct{}
+
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type ToolDefinition struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	InputSchema interface{} `json:"inputSchema"`
+}
+
+type ToolsListResult struct {
+	Tools []ToolDefinition `json:"tools"`
+}
+
+type ToolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type ToolResult struct {
+	Content []ContentBlock `json:"content"`
+	IsError bool           `json:"isError,omitempty"`
+}
+
+type ContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type ResourceDefinition struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	MimeType    string `json:"mimeType"`
+}
+
+type ResourcesListResult struct {
+	Resources []ResourceDefinition `json:"resources"`
+}
+
+type ResourceReadParams struct {
+	URI string `json:"uri"`
+}
+
+type ResourceReadResult struct {
+	Contents []ResourceContent `json:"contents"`
+}
+
+type ResourceContent struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+}
+
+type PromptDefinition struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Arguments   []PromptArgument `json:"arguments,omitempty"`
+}
+
+type PromptArgument struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Required    bool   `json:"required"`
+}
+
+type PromptsListResult struct {
+	Prompts []PromptDefinition `json:"prompts"`
+}
+
+type PromptGetParams struct {
+	Name      string            `json:"name"`
+	Arguments map[string]string `json:"arguments,omitempty"`
+}
+
+type PromptMessage struct {
+	Role    string       `json:"role"`
+	Content ContentBlock `json:"content"`
+}
+
+type PromptGetResult struct {
+	Description string          `json:"description,omitempty"`
+	Messages    []PromptMessage `json:"messages"`
+}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,70 @@
+package mcp
+
+import "fmt"
+
+func resourceDefinitions() []ResourceDefinition {
+	return []ResourceDefinition{
+		{
+			URI:         "spectra://capabilities",
+			Name:        "Capabilities",
+			Description: "Tool list and when to use each one.",
+			MimeType:    "text/markdown",
+		},
+		{
+			URI:         "spectra://workflows/debugging",
+			Name:        "Debug Workflows",
+			Description: "Short app, JVM, network, and baseline workflows.",
+			MimeType:    "text/markdown",
+		},
+	}
+}
+
+func readResource(uri string) (string, string, error) {
+	switch uri {
+	case "spectra://capabilities":
+		return readResourceText(uri), "text/markdown", nil
+	case "spectra://workflows/debugging":
+		return readResourceText(uri), "text/markdown", nil
+	default:
+		return "", "", fmt.Errorf("resource not found: %s", uri)
+	}
+}
+
+func readResourceText(uri string) string {
+	resources := map[string]string{
+		"spectra://capabilities": `# Capabilities
+
+- triage: start here
+- inspect_app: explain one app bundle
+- snapshot: create, list, get, diff
+- diagnose: run rules
+- process: live processes
+- jvm: JVM debug
+- network: routes, DNS, sockets
+- toolchain: JDKs, runtimes, build tools
+- issues: track findings
+- remote: call a Spectra daemon
+
+Ask:
+- What looks wrong with this app?
+- What changed since the baseline?
+- Why is this JVM slow?
+- What is this app connected to?
+`,
+		"spectra://workflows/debugging": `# Debug Workflows
+
+Start with triage.
+
+Then use:
+- inspect_app for bundle facts
+- process for live state
+- jvm for Java/HotSpot
+- network for routes, DNS, VPN, sockets
+- snapshot diff for "what changed?"
+
+Heap dumps and flamegraphs require confirm_sensitive=true.
+Helper-only actions use remote operation=rpc.
+`,
+	}
+	return resources[uri]
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,215 @@
+// Package mcp implements a Spectra MCP server over stdio.
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+
+	"github.com/kaeawc/spectra/internal/jsonrpc"
+	"github.com/kaeawc/spectra/internal/logger"
+)
+
+const protocolVersion = "2024-11-05"
+
+// Server routes MCP JSON-RPC calls.
+type Server struct {
+	reader  *bufio.Reader
+	writer  io.Writer
+	mu      sync.Mutex
+	Version string
+	Verbose bool
+	log     logger.Logger
+}
+
+// NewServer returns a configured MCP server from stdin/stdout handles.
+func NewServer(reader io.Reader, writer io.Writer) *Server {
+	return &Server{
+		reader:  bufio.NewReader(reader),
+		writer:  writer,
+		Version: "dev",
+		log:     logger.New(logger.Config{Format: logger.FormatText, Level: slog.LevelInfo}),
+	}
+}
+
+// SetLogger overrides log output (mainly for tests).
+func (s *Server) SetLogger(l logger.Logger) { s.log = l }
+
+// Run reads framed messages and processes them until EOF.
+func (s *Server) Run() {
+	for {
+		msg, err := jsonrpc.ReadMessage(s.reader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			s.log.Error("jsonrpc read failed", "err", err)
+			return
+		}
+		var req Request
+		if err := json.Unmarshal(msg, &req); err != nil {
+			s.sendResponse(nil, &RPCError{Code: -32700, Message: "parse error: " + err.Error()})
+			continue
+		}
+		if req.JSONRPC != "2.0" {
+			s.sendResponse(req.ID, &RPCError{Code: -32600, Message: "invalid request"})
+			continue
+		}
+		s.route(req)
+	}
+}
+
+func (s *Server) sendResponse(id interface{}, rpcErr *RPCError, result ...any) {
+	var payload any
+	if len(result) == 1 {
+		payload = result[0]
+	}
+	if id == nil {
+		return
+	}
+	jsonrpc.SendResponse(s.writer, &s.mu, id, payload, rpcErr)
+}
+
+func (s *Server) route(req Request) {
+	switch req.Method {
+	case "initialize":
+		s.handleInitialize(req)
+	case "tools/list":
+		s.handleToolsList(req)
+	case "tools/call":
+		s.handleToolsCall(req)
+	case "resources/list":
+		s.handleResourcesList(req)
+	case "resources/read":
+		s.handleResourcesRead(req)
+	case "prompts/list":
+		s.handlePromptsList(req)
+	case "prompts/get":
+		s.handlePromptsGet(req)
+	case "shutdown":
+		s.sendResponse(req.ID, nil, map[string]bool{"ok": true})
+	case "exit":
+		s.sendResponse(req.ID, nil, map[string]bool{"ok": true})
+	default:
+		s.sendResponse(req.ID, &RPCError{Code: -32601, Message: "method not found: " + req.Method})
+	}
+}
+
+func (s *Server) handleInitialize(req Request) {
+	var params InitializeParams
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			s.sendResponse(req.ID, &RPCError{Code: -32602, Message: "invalid params: " + err.Error()})
+			return
+		}
+		if params.ProtocolVersion != "" && params.ProtocolVersion != protocolVersion {
+			s.log.Info("initialize with unsupported protocol", "protocol", params.ProtocolVersion)
+		}
+		_ = params
+	}
+	_ = req
+	s.sendResponse(req.ID, nil, InitializeResult{
+		ProtocolVersion: protocolVersion,
+		ServerInfo: ServerInfo{
+			Name:    "spectra-mcp",
+			Version: s.Version,
+		},
+		Capabilities: ServerCaps{
+			Tools:     &ToolsCap{},
+			Resources: &ResourcesCap{},
+			Prompts:   &PromptsCap{},
+		},
+	})
+}
+
+func (s *Server) handleToolsList(req Request) {
+	s.sendResponse(req.ID, nil, ToolsListResult{
+		Tools: toolDefinitions(),
+	})
+}
+
+func (s *Server) handleToolsCall(req Request) {
+	var params ToolCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.sendResponse(req.ID, &RPCError{Code: -32602, Message: "invalid params: " + err.Error()})
+		return
+	}
+	var result ToolResult
+	switch params.Name {
+	case "triage":
+		result = s.toolTriage(params.Arguments)
+	case "inspect_app":
+		result = s.toolInspectApp(params.Arguments)
+	case "snapshot":
+		result = s.toolSnapshot(params.Arguments)
+	case "diagnose":
+		result = s.toolDiagnose(params.Arguments)
+	case "process":
+		result = s.toolProcess(params.Arguments)
+	case "jvm":
+		result = s.toolJVM(params.Arguments)
+	case "network":
+		result = s.toolNetwork(params.Arguments)
+	case "toolchain":
+		result = s.toolToolchain(params.Arguments)
+	case "issues":
+		result = s.toolIssues(params.Arguments)
+	case "remote":
+		result = s.toolRemote(params.Arguments)
+	default:
+		result = ToolResult{
+			Content: []ContentBlock{{Type: "text", Text: "unknown tool: " + params.Name}},
+			IsError: true,
+		}
+	}
+	s.sendResponse(req.ID, nil, result)
+}
+
+func (s *Server) handleResourcesList(req Request) {
+	s.sendResponse(req.ID, nil, ResourcesListResult{
+		Resources: resourceDefinitions(),
+	})
+}
+
+func (s *Server) handleResourcesRead(req Request) {
+	var params ResourceReadParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.sendResponse(req.ID, &RPCError{Code: -32602, Message: "invalid params: " + err.Error()})
+		return
+	}
+	content, mimeType, err := readResource(params.URI)
+	if err != nil {
+		s.sendResponse(req.ID, &RPCError{Code: -32602, Message: err.Error()})
+		return
+	}
+	s.sendResponse(req.ID, nil, ResourceReadResult{
+		Contents: []ResourceContent{{
+			URI:      params.URI,
+			MimeType: mimeType,
+			Text:     content,
+		}},
+	})
+}
+
+func (s *Server) handlePromptsList(req Request) {
+	s.sendResponse(req.ID, nil, PromptsListResult{
+		Prompts: promptDefinitions(),
+	})
+}
+
+func (s *Server) handlePromptsGet(req Request) {
+	var params PromptGetParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.sendResponse(req.ID, &RPCError{Code: -32602, Message: "invalid params: " + err.Error()})
+		return
+	}
+	result, err := s.getPrompt(params.Name, params.Arguments)
+	if err != nil {
+		s.sendResponse(req.ID, err)
+		return
+	}
+	s.sendResponse(req.ID, nil, result)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,1177 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/diff"
+	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/netstate"
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+type toolEnvelope struct {
+	Summary     string      `json:"summary"`
+	Evidence    []string    `json:"evidence,omitempty"`
+	NextActions []string    `json:"next_actions,omitempty"`
+	Raw         interface{} `json:"raw,omitempty"`
+	Timestamp   time.Time   `json:"timestamp"`
+}
+
+func toolDefinitions() []ToolDefinition {
+	return []ToolDefinition{
+		triageToolDef(),
+		inspectAppToolDef(),
+		snapshotToolDef(),
+		diagnoseToolDef(),
+		operationToolDef("process", "Live processes. Ops: list, tree, by_app, sample. Ask: \"What is using memory?\" \"Sample PID 123.\"", []string{"list", "tree", "history", "sample", "by_app"}),
+		operationToolDef("jvm", "JVM debug. Ops: list, inspect, explain, thread_dump, gc_stats, vm_memory. Ask: \"Why is PID 123 using heap?\"", []string{"list", "inspect", "explain", "thread_dump", "gc_stats", "vm_memory", "heap_histogram", "heap_dump", "flamegraph"}),
+		operationToolDef("network", "Network state and sockets. Ops: state, connections, by_app, diagnose. Ask: \"What is this app connected to?\"", []string{"state", "connections", "by_app", "firewall", "diagnose", "capture_start", "capture_stop"}),
+		operationToolDef("toolchain", "Dev tools and drift. Ops: scan, jdk, runtimes, build_tools, brew, drift. Ask: \"Which JDKs are installed?\"", []string{"scan", "jdk", "runtimes", "build_tools", "brew", "drift"}),
+		operationToolDef("issues", "Persisted findings. Ops: check, list, acknowledge, dismiss, record_fix, fix_history. Ask: \"What issues are open?\"", []string{"check", "list", "acknowledge", "dismiss", "record_fix", "fix_history"}),
+		operationToolDef("remote", "Call a Spectra daemon. Ops: health, rpc, fanout. Ask: \"Check host health.\" \"Run snapshot.create remotely.\"", []string{"health", "rpc", "triage", "fanout"}),
+	}
+}
+
+func triageToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name:        "triage",
+		Description: "Best first tool. Give app_path, pid, bundle_id, or symptom. Returns summary, evidence, next steps. Ask: \"What looks wrong with Slack?\"",
+		InputSchema: objectSchema(map[string]interface{}{
+			"app_path":    stringProp(".app path."),
+			"pid":         integerProp("PID."),
+			"bundle_id":   stringProp("Bundle ID."),
+			"symptom":     stringProp("Problem to investigate."),
+			"network":     boolProp("Scan app URLs."),
+			"include_raw": boolProp("Return raw data."),
+		}, nil),
+	}
+}
+
+func inspectAppToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name:        "inspect_app",
+		Description: "Inspect .app bundles: runtime, security, helpers, deps, storage, processes. Ask: \"What is this app built with?\"",
+		InputSchema: objectSchema(map[string]interface{}{
+			"paths":       arrayStringProp(".app paths."),
+			"network":     boolProp("Scan app URLs."),
+			"include_raw": boolProp("Return raw data."),
+		}, []string{"paths"}),
+	}
+}
+
+func snapshotToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name:        "snapshot",
+		Description: "Capture or compare host state. Ops: create, list, get, diff, baseline. Ask: \"What changed since baseline?\"",
+		InputSchema: objectSchema(map[string]interface{}{
+			"operation":     enumProp([]string{"create", "list", "get", "diff", "baseline"}, "create"),
+			"id":            stringProp("Snapshot ID."),
+			"id_a":          stringProp("Diff left ID."),
+			"id_b":          stringProp("Diff right ID."),
+			"name":          stringProp("Baseline name."),
+			"network":       boolProp("Scan app URLs."),
+			"skip_apps":     boolProp("Skip apps."),
+			"store":         boolProp("Save snapshot."),
+			"kind":          stringProp("live or baseline."),
+			"include_raw":   boolProp("Return raw data."),
+			"limit_summary": integerProp("Summary row limit."),
+		}, []string{"operation"}),
+	}
+}
+
+func diagnoseToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name:        "diagnose",
+		Description: "Run rules. Finds risky app, JVM, network, storage, and toolchain state. Ask: \"What needs attention?\"",
+		InputSchema: objectSchema(map[string]interface{}{
+			"snapshot_id":  stringProp("Snapshot ID."),
+			"rules_config": stringProp("spectra.yml path."),
+			"persist":      boolProp("Save as issues."),
+			"include_raw":  boolProp("Return raw findings."),
+		}, nil),
+	}
+}
+
+func operationToolDef(name, description string, operations []string) ToolDefinition {
+	return ToolDefinition{
+		Name:        name,
+		Description: description,
+		InputSchema: objectSchema(map[string]interface{}{
+			"operation":         enumProp(operations, operations[0]),
+			"pid":               integerProp("PID."),
+			"paths":             arrayStringProp("App paths."),
+			"bundles":           arrayStringProp("App paths."),
+			"snapshot_id":       stringProp("Snapshot ID."),
+			"machine_uuid":      stringProp("Machine UUID."),
+			"status":            stringProp("Issue status."),
+			"id":                stringProp("ID."),
+			"issue_id":          stringProp("Issue ID."),
+			"duration_seconds":  integerProp("Duration."),
+			"interval_millis":   integerProp("Interval."),
+			"event":             stringProp("Profiler event."),
+			"dest":              stringProp("Output path."),
+			"confirm_sensitive": boolProp("Allow sensitive artifact."),
+			"deep":              boolProp("More process detail."),
+			"include_raw":       boolProp("Return raw data."),
+			"network":           stringProp("unix or tcp."),
+			"address":           stringProp("Daemon address."),
+			"method":            stringProp("Daemon RPC method."),
+			"params":            map[string]interface{}{"type": "object", "description": "RPC params."},
+			"hosts":             arrayStringProp("Daemon addresses."),
+			"command":           stringProp("Fix command."),
+			"output":            stringProp("Fix output."),
+			"exit_code":         integerProp("Exit code."),
+			"applied_by":        stringProp("Actor."),
+			"interface":         stringProp("Network interface."),
+			"host":              stringProp("Host filter."),
+			"port":              integerProp("Port filter."),
+			"proto":             stringProp("Protocol."),
+			"handle":            stringProp("Capture handle."),
+			"limit":             integerProp("Limit."),
+		}, []string{"operation"}),
+	}
+}
+
+func objectSchema(properties map[string]interface{}, required []string) map[string]interface{} {
+	out := map[string]interface{}{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		out["required"] = required
+	}
+	return out
+}
+
+func stringProp(description string) map[string]interface{} {
+	return map[string]interface{}{"type": "string", "description": description}
+}
+
+func integerProp(description string) map[string]interface{} {
+	return map[string]interface{}{"type": "integer", "description": description}
+}
+
+func boolProp(description string) map[string]interface{} {
+	return map[string]interface{}{"type": "boolean", "description": description}
+}
+
+func arrayStringProp(description string) map[string]interface{} {
+	return map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}, "description": description}
+}
+
+func enumProp(values []string, def string) map[string]interface{} {
+	return map[string]interface{}{"type": "string", "enum": values, "default": def}
+}
+
+func (s *Server) toolTriage(raw json.RawMessage) ToolResult {
+	var p struct {
+		AppPath    string `json:"app_path"`
+		PID        int    `json:"pid"`
+		BundleID   string `json:"bundle_id"`
+		Symptom    string `json:"symptom"`
+		Network    bool   `json:"network"`
+		IncludeRaw bool   `json:"include_raw"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+
+	evidence := []string{}
+	next := []string{}
+	rawOut := map[string]interface{}{}
+	if p.Symptom != "" {
+		evidence = append(evidence, "symptom: "+p.Symptom)
+	}
+
+	if p.AppPath != "" {
+		app, err := detect.DetectWith(p.AppPath, detect.Options{ScanNetwork: p.Network})
+		if err != nil {
+			evidence = append(evidence, fmt.Sprintf("app inspection failed: %v", err))
+		} else {
+			evidence = append(evidence, summarizeApp(app)...)
+			rawOut["app"] = app
+			if app.Runtime == "JVM" || app.Language == "Java" || app.Language == "Kotlin" {
+				next = append(next, "Use jvm operation=list or inspect to inspect running JVMs for this app.")
+			}
+			if len(app.NetworkEndpoints) > 0 {
+				next = append(next, "Use network operation=diagnose with host/port when a specific endpoint is failing.")
+			}
+		}
+		procs := process.CollectAll(context.Background(), process.CollectOptions{BundlePaths: []string{p.AppPath}, Deep: true})
+		appProcs := filterAppProcesses(procs, p.AppPath)
+		if len(appProcs) > 0 {
+			evidence = append(evidence, summarizeProcesses(appProcs, 5)...)
+			rawOut["processes"] = appProcs
+		}
+	}
+
+	if p.PID > 0 {
+		procs := process.CollectAll(context.Background(), process.CollectOptions{Deep: true})
+		if proc, ok := findProcess(procs, p.PID); ok {
+			evidence = append(evidence, summarizeProcesses([]process.Info{proc}, 1)...)
+			rawOut["process"] = proc
+		} else {
+			evidence = append(evidence, fmt.Sprintf("pid %d not found in process list", p.PID))
+		}
+		if info := inspectJVM(p.PID); info != nil {
+			evidence = append(evidence, summarizeJVM(*info)...)
+			rawOut["jvm"] = info
+			next = append(next, "Use jvm operation=explain for GC/thread/memory interpretation.")
+		}
+	}
+
+	if p.BundleID != "" {
+		snap := snapshot.Build(context.Background(), snapshot.Options{SpectraVersion: s.Version, DetectOpts: detect.Options{ScanNetwork: p.Network}})
+		for _, app := range snap.Apps {
+			if app.BundleID == p.BundleID {
+				evidence = append(evidence, summarizeApp(app)...)
+				rawOut["matched_app"] = app
+				break
+			}
+		}
+	}
+
+	findings, err := evaluateLiveRules(s.Version, "")
+	if err == nil && len(findings) > 0 {
+		evidence = append(evidence, summarizeFindings(findings, 5)...)
+		rawOut["findings"] = findings
+		next = append(next, "Use diagnose include_raw=true for the full rules output.")
+	}
+	if len(next) == 0 {
+		next = append(next, "Use snapshot operation=create store=true to preserve current state for later diffing.")
+	}
+
+	env := toolEnvelope{
+		Summary:     triageSummary(evidence),
+		Evidence:    evidence,
+		NextActions: next,
+		Timestamp:   time.Now().UTC(),
+	}
+	if p.IncludeRaw {
+		env.Raw = rawOut
+	}
+	return toolText(env)
+}
+
+func (s *Server) toolInspectApp(raw json.RawMessage) ToolResult {
+	var p struct {
+		Paths      []string `json:"paths"`
+		Network    bool     `json:"network"`
+		IncludeRaw bool     `json:"include_raw"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+	if len(p.Paths) == 0 {
+		return toolError("paths is required")
+	}
+	results := make([]inspectResult, 0, len(p.Paths))
+	evidence := []string{}
+	for _, path := range p.Paths {
+		r, err := detect.DetectWith(path, detect.Options{ScanNetwork: p.Network})
+		item := inspectResult{Path: path}
+		if err != nil {
+			item.Error = err.Error()
+			evidence = append(evidence, fmt.Sprintf("%s: %v", path, err))
+		} else {
+			item.Success = true
+			item.Result = r
+			evidence = append(evidence, summarizeApp(r)...)
+		}
+		results = append(results, item)
+	}
+	env := toolEnvelope{
+		Summary:     fmt.Sprintf("inspected %d app path(s)", len(p.Paths)),
+		Evidence:    evidence,
+		NextActions: []string{"Use triage with app_path for prioritized process/network/rules context."},
+		Timestamp:   time.Now().UTC(),
+	}
+	if p.IncludeRaw {
+		env.Raw = results
+	}
+	return toolText(env)
+}
+
+func (s *Server) toolSnapshot(raw json.RawMessage) ToolResult {
+	var p struct {
+		Operation    string `json:"operation"`
+		ID           string `json:"id"`
+		IDA          string `json:"id_a"`
+		IDB          string `json:"id_b"`
+		Name         string `json:"name"`
+		Network      bool   `json:"network"`
+		SkipApps     bool   `json:"skip_apps"`
+		Store        bool   `json:"store"`
+		Kind         string `json:"kind"`
+		IncludeRaw   bool   `json:"include_raw"`
+		LimitSummary int    `json:"limit_summary"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+	if p.Operation == "" {
+		p.Operation = "create"
+	}
+	switch p.Operation {
+	case "create", "baseline":
+		snap := snapshot.Build(context.Background(), snapshot.Options{
+			SpectraVersion: s.Version,
+			DetectOpts:     detect.Options{ScanNetwork: p.Network},
+			SkipApps:       p.SkipApps,
+		})
+		if p.Operation == "baseline" {
+			snap.Kind = snapshot.KindBaseline
+		}
+		if p.Store {
+			if err := saveSnapshot(snap); err != nil {
+				return toolError(err.Error())
+			}
+		}
+		evidence := summarizeSnapshot(snap, p.LimitSummary)
+		if p.Store {
+			evidence = append(evidence, "snapshot persisted")
+		}
+		env := toolEnvelope{
+			Summary:     fmt.Sprintf("created %s snapshot %s", snap.Kind, snap.ID),
+			Evidence:    evidence,
+			NextActions: []string{"Use snapshot operation=diff against a baseline to inspect changes."},
+			Timestamp:   time.Now().UTC(),
+		}
+		if p.IncludeRaw {
+			env.Raw = snap
+		}
+		return toolText(env)
+	case "list":
+		db, err := openStore()
+		if err != nil {
+			return toolError(err.Error())
+		}
+		defer db.Close()
+		rows, err := db.ListSnapshots(context.Background(), p.Kind)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("found %d stored snapshot(s)", len(rows)), Raw: rows, Timestamp: time.Now().UTC()})
+	case "get":
+		if p.ID == "" {
+			return toolError("snapshot get requires id")
+		}
+		snap, err := loadStoredSnapshot(p.ID)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		env := toolEnvelope{Summary: "loaded snapshot " + p.ID, Evidence: summarizeSnapshot(snap, p.LimitSummary), Timestamp: time.Now().UTC()}
+		if p.IncludeRaw {
+			env.Raw = snap
+		}
+		return toolText(env)
+	case "diff":
+		if p.IDA == "" || p.IDB == "" {
+			return toolError("snapshot diff requires id_a and id_b")
+		}
+		a, err := loadStoredSnapshot(p.IDA)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		b, err := loadStoredSnapshot(p.IDB)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		result := diff.Compare(a, b)
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("diffed %s against %s", p.IDA, p.IDB), Raw: result, Timestamp: time.Now().UTC()})
+	default:
+		return toolError("unknown snapshot operation: " + p.Operation)
+	}
+}
+
+func (s *Server) toolDiagnose(raw json.RawMessage) ToolResult {
+	var p struct {
+		SnapshotID  string `json:"snapshot_id"`
+		RulesConfig string `json:"rules_config"`
+		Persist     bool   `json:"persist"`
+		IncludeRaw  bool   `json:"include_raw"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+	snap, findings, err := evaluateRules(s.Version, p.SnapshotID, p.RulesConfig)
+	if err != nil {
+		return toolError(err.Error())
+	}
+	evidence := summarizeFindings(findings, 10)
+	next := []string{"Use issues operation=check to persist these findings if they should be tracked."}
+	if p.Persist {
+		ids, err := persistFindings(snap, findings)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		evidence = append(evidence, fmt.Sprintf("persisted %d issue(s)", len(ids)))
+		next = []string{"Use issues operation=list with this machine_uuid to inspect persisted issue lifecycle."}
+	}
+	env := toolEnvelope{Summary: fmt.Sprintf("%d finding(s)", len(findings)), Evidence: evidence, NextActions: next, Timestamp: time.Now().UTC()}
+	if p.IncludeRaw {
+		env.Raw = findings
+	}
+	return toolText(env)
+}
+
+func (s *Server) toolProcess(raw json.RawMessage) ToolResult {
+	var p struct {
+		Operation       string   `json:"operation"`
+		PID             int      `json:"pid"`
+		Bundles         []string `json:"bundles"`
+		Paths           []string `json:"paths"`
+		Deep            bool     `json:"deep"`
+		Limit           int      `json:"limit"`
+		DurationSeconds int      `json:"duration_seconds"`
+		IntervalMillis  int      `json:"interval_millis"`
+		IncludeRaw      bool     `json:"include_raw"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+	bundles := append([]string{}, p.Bundles...)
+	bundles = append(bundles, p.Paths...)
+	switch p.Operation {
+	case "list", "":
+		procs := process.CollectAll(context.Background(), process.CollectOptions{BundlePaths: bundles, Deep: p.Deep})
+		sortProcesses(procs)
+		if p.Limit > 0 && p.Limit < len(procs) {
+			procs = procs[:p.Limit]
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("collected %d process(es)", len(procs)), Evidence: summarizeProcesses(procs, 10), Raw: optionalRaw(p.IncludeRaw, procs), Timestamp: time.Now().UTC()})
+	case "tree":
+		procs := process.CollectAll(context.Background(), process.CollectOptions{BundlePaths: bundles})
+		tree := process.BuildTree(procs)
+		return toolText(toolEnvelope{Summary: "built process tree", Raw: tree, Timestamp: time.Now().UTC()})
+	case "by_app":
+		if len(bundles) == 0 {
+			return toolError("process by_app requires paths or bundles")
+		}
+		procs := process.CollectAll(context.Background(), process.CollectOptions{BundlePaths: bundles, Deep: p.Deep})
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("collected processes for %d app bundle(s)", len(bundles)), Evidence: summarizeProcesses(procs, 20), Raw: optionalRaw(p.IncludeRaw, procs), Timestamp: time.Now().UTC()})
+	case "sample":
+		if p.PID == 0 {
+			return toolError("process sample requires pid")
+		}
+		duration := p.DurationSeconds
+		if duration <= 0 {
+			duration = 1
+		}
+		interval := p.IntervalMillis
+		if interval <= 0 {
+			interval = 10
+		}
+		out, err := sampleProcess(p.PID, duration, interval)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("sampled pid %d for %ds", p.PID, duration), Raw: map[string]interface{}{"pid": p.PID, "output": out}, Timestamp: time.Now().UTC()})
+	case "history":
+		return toolError("process history requires a running spectra daemon; use remote operation=rpc method=process.history")
+	default:
+		return toolError("unknown process operation: " + p.Operation)
+	}
+}
+
+func (s *Server) toolJVM(raw json.RawMessage) ToolResult {
+	var p struct {
+		Operation        string `json:"operation"`
+		PID              int    `json:"pid"`
+		Samples          int    `json:"samples"`
+		IntervalMillis   int    `json:"interval_millis"`
+		Dest             string `json:"dest"`
+		Event            string `json:"event"`
+		DurationSeconds  int    `json:"duration_seconds"`
+		ConfirmSensitive bool   `json:"confirm_sensitive"`
+		AsprofPath       string `json:"asprof_path"`
+		IncludeRaw       bool   `json:"include_raw"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+	switch p.Operation {
+	case "list", "":
+		jvms := jvm.CollectAll(context.Background(), jvmOptions())
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("found %d JVM process(es)", len(jvms)), Evidence: summarizeJVMs(jvms), Raw: optionalRaw(p.IncludeRaw, jvms), Timestamp: time.Now().UTC()})
+	case "inspect":
+		if p.PID == 0 {
+			return toolError("jvm inspect requires pid")
+		}
+		info := inspectJVM(p.PID)
+		if info == nil {
+			return toolError(fmt.Sprintf("JVM pid %d not found", p.PID))
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("inspected JVM pid %d", p.PID), Evidence: summarizeJVM(*info), Raw: optionalRaw(p.IncludeRaw, info), Timestamp: time.Now().UTC()})
+	case "explain":
+		if p.PID == 0 {
+			return toolError("jvm explain requires pid")
+		}
+		explanation, err := jvm.CollectExplanation(context.Background(), p.PID, jvm.ExplainOptions{Samples: p.Samples, Interval: time.Duration(p.IntervalMillis) * time.Millisecond, SoftRefs: true})
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("explained JVM pid %d", p.PID), Raw: explanation, Timestamp: time.Now().UTC()})
+	case "thread_dump":
+		return jcmdText(p.PID, "thread dump", jvm.ThreadDump)
+	case "gc_stats":
+		if p.PID == 0 {
+			return toolError("jvm gc_stats requires pid")
+		}
+		stats, err := jvm.CollectGCStats(p.PID, nil)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("collected GC stats for pid %d", p.PID), Raw: stats, Timestamp: time.Now().UTC()})
+	case "vm_memory":
+		if p.PID == 0 {
+			return toolError("jvm vm_memory requires pid")
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("collected VM memory diagnostics for pid %d", p.PID), Raw: jvm.CollectVMMemoryDiagnostics(p.PID, nil), Timestamp: time.Now().UTC()})
+	case "heap_histogram":
+		return jcmdText(p.PID, "heap histogram", jvm.HeapHistogram)
+	case "heap_dump":
+		if !p.ConfirmSensitive {
+			return toolError("jvm heap_dump requires confirm_sensitive=true")
+		}
+		if p.PID == 0 {
+			return toolError("jvm heap_dump requires pid")
+		}
+		if p.Dest == "" {
+			p.Dest = fmt.Sprintf("/tmp/spectra-heap-%d.hprof", p.PID)
+		}
+		if err := jvm.HeapDump(p.PID, p.Dest, nil); err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("wrote heap dump for pid %d", p.PID), Raw: map[string]interface{}{"pid": p.PID, "dest": p.Dest}, Timestamp: time.Now().UTC()})
+	case "flamegraph":
+		if !p.ConfirmSensitive {
+			return toolError("jvm flamegraph requires confirm_sensitive=true")
+		}
+		if p.PID == 0 {
+			return toolError("jvm flamegraph requires pid")
+		}
+		if p.Dest == "" {
+			p.Dest = fmt.Sprintf("/tmp/spectra-flamegraph-%d.html", p.PID)
+		}
+		err := jvm.CaptureFlamegraph(p.PID, jvm.FlamegraphOptions{AsprofPath: p.AsprofPath, Event: p.Event, DurationSeconds: p.DurationSeconds, OutputPath: p.Dest})
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("wrote flamegraph for pid %d", p.PID), Raw: map[string]interface{}{"pid": p.PID, "dest": p.Dest}, Timestamp: time.Now().UTC()})
+	default:
+		return toolError("unknown jvm operation: " + p.Operation)
+	}
+}
+
+func (s *Server) toolNetwork(raw json.RawMessage) ToolResult {
+	var p struct {
+		Operation  string   `json:"operation"`
+		Bundles    []string `json:"bundles"`
+		Paths      []string `json:"paths"`
+		Host       string   `json:"host"`
+		Port       int      `json:"port"`
+		IncludeRaw bool     `json:"include_raw"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+	switch p.Operation {
+	case "state", "":
+		state := netstate.Collect(netstate.DefaultRunner)
+		return toolText(toolEnvelope{Summary: summarizeNetworkState(state), Evidence: networkEvidence(state), Raw: optionalRaw(p.IncludeRaw, state), Timestamp: time.Now().UTC()})
+	case "connections":
+		conns := netstate.CollectConnections(netstate.DefaultRunner)
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("found %d active connection(s)", len(conns)), Raw: optionalRaw(true, conns), Timestamp: time.Now().UTC()})
+	case "by_app":
+		bundles := append([]string{}, p.Bundles...)
+		bundles = append(bundles, p.Paths...)
+		conns := netstate.CollectConnections(netstate.DefaultRunner)
+		procs := process.CollectAll(context.Background(), process.CollectOptions{BundlePaths: bundles})
+		grouped := netstate.GroupConnectionsByApp(conns, procs)
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("grouped %d connection(s) by app", len(conns)), Raw: grouped, Timestamp: time.Now().UTC()})
+	case "diagnose":
+		state := netstate.Collect(netstate.DefaultRunner)
+		conns := netstate.CollectConnections(netstate.DefaultRunner)
+		evidence := networkEvidence(state)
+		if p.Host != "" {
+			evidence = append(evidence, connectionEvidenceForHost(conns, p.Host)...)
+		}
+		if p.Port > 0 {
+			evidence = append(evidence, connectionEvidenceForPort(conns, p.Port)...)
+		}
+		return toolText(toolEnvelope{Summary: "network diagnostic snapshot collected", Evidence: evidence, Raw: optionalRaw(p.IncludeRaw, map[string]interface{}{"state": state, "connections": conns}), Timestamp: time.Now().UTC()})
+	case "firewall", "capture_start", "capture_stop":
+		return toolError("network " + p.Operation + " requires the privileged helper via a running spectra daemon; use remote operation=rpc")
+	default:
+		return toolError("unknown network operation: " + p.Operation)
+	}
+}
+
+func (s *Server) toolToolchain(raw json.RawMessage) ToolResult {
+	var p struct {
+		Operation  string `json:"operation"`
+		IncludeRaw bool   `json:"include_raw"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+	tc := toolchain.Collect(context.Background(), toolchain.CollectOptions{})
+	switch p.Operation {
+	case "scan", "":
+		return toolText(toolEnvelope{Summary: summarizeToolchains(tc), Raw: optionalRaw(p.IncludeRaw, tc), Timestamp: time.Now().UTC()})
+	case "jdk":
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("found %d JDK install(s)", len(tc.JDKs)), Raw: tc.JDKs, Timestamp: time.Now().UTC()})
+	case "runtimes":
+		return toolText(toolEnvelope{Summary: "collected language runtimes", Raw: map[string]interface{}{"node": tc.Node, "python": tc.Python, "go": tc.Go, "ruby": tc.Ruby, "rust": tc.Rust}, Timestamp: time.Now().UTC()})
+	case "build_tools":
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("found %d build tool install(s)", len(tc.BuildTools)), Raw: tc.BuildTools, Timestamp: time.Now().UTC()})
+	case "brew":
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("brew: %d formulae, %d casks, %d taps", len(tc.Brew.Formulae), len(tc.Brew.Casks), len(tc.Brew.Taps)), Raw: tc.Brew, Timestamp: time.Now().UTC()})
+	case "drift":
+		findings := toolchainDriftEvidence(tc)
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("found %d toolchain drift signal(s)", len(findings)), Evidence: findings, Raw: optionalRaw(p.IncludeRaw, tc), Timestamp: time.Now().UTC()})
+	default:
+		return toolError("unknown toolchain operation: " + p.Operation)
+	}
+}
+
+func (s *Server) toolIssues(raw json.RawMessage) ToolResult {
+	var p struct {
+		Operation   string `json:"operation"`
+		SnapshotID  string `json:"snapshot_id"`
+		MachineUUID string `json:"machine_uuid"`
+		Status      string `json:"status"`
+		ID          string `json:"id"`
+		IssueID     string `json:"issue_id"`
+		AppliedBy   string `json:"applied_by"`
+		Command     string `json:"command"`
+		Output      string `json:"output"`
+		ExitCode    int    `json:"exit_code"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+	db, err := openStore()
+	if err != nil {
+		return toolError(err.Error())
+	}
+	defer db.Close()
+	switch p.Operation {
+	case "check", "":
+		snap, findings, err := evaluateRules(s.Version, p.SnapshotID, "")
+		if err != nil {
+			return toolError(err.Error())
+		}
+		ids, err := persistFindingsWithDB(db, snap, findings)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("persisted %d issue(s)", len(ids)), Evidence: summarizeFindings(findings, 10), Raw: map[string]interface{}{"snapshot_id": snap.ID, "ids": ids}, Timestamp: time.Now().UTC()})
+	case "list":
+		if p.MachineUUID == "" {
+			return toolError("issues list requires machine_uuid")
+		}
+		rows, err := db.ListIssues(context.Background(), p.MachineUUID, store.IssueStatus(p.Status))
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("found %d issue(s)", len(rows)), Raw: rows, Timestamp: time.Now().UTC()})
+	case "acknowledge", "dismiss":
+		if p.ID == "" {
+			return toolError("issues " + p.Operation + " requires id")
+		}
+		status := store.IssueAcknowledged
+		if p.Operation == "dismiss" {
+			status = store.IssueDismissed
+		}
+		if err := db.UpdateIssueStatus(context.Background(), p.ID, status); err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("set issue %s to %s", p.ID, status), Timestamp: time.Now().UTC()})
+	case "record_fix":
+		if p.IssueID == "" {
+			return toolError("issues record_fix requires issue_id")
+		}
+		id, err := db.RecordAppliedFix(context.Background(), store.AppliedFixInput{IssueID: p.IssueID, AppliedBy: p.AppliedBy, Command: p.Command, Output: p.Output, ExitCode: p.ExitCode})
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: "recorded applied fix", Raw: map[string]interface{}{"id": id}, Timestamp: time.Now().UTC()})
+	case "fix_history":
+		if p.IssueID == "" {
+			return toolError("issues fix_history requires issue_id")
+		}
+		rows, err := db.ListAppliedFixes(context.Background(), p.IssueID)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("found %d fix attempt(s)", len(rows)), Raw: rows, Timestamp: time.Now().UTC()})
+	default:
+		return toolError("unknown issues operation: " + p.Operation)
+	}
+}
+
+func (s *Server) toolRemote(raw json.RawMessage) ToolResult {
+	var p struct {
+		Operation string                 `json:"operation"`
+		Network   string                 `json:"network"`
+		Address   string                 `json:"address"`
+		Method    string                 `json:"method"`
+		Params    map[string]interface{} `json:"params"`
+		Hosts     []string               `json:"hosts"`
+	}
+	if err := decodeArgs(raw, &p); err != nil {
+		return toolError(err.Error())
+	}
+	if p.Network == "" {
+		p.Network = "tcp"
+	}
+	switch p.Operation {
+	case "health", "":
+		address := p.Address
+		if address == "" {
+			address = "127.0.0.1:7878"
+		}
+		resp, err := callDaemon(p.Network, address, "health", nil)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: "remote health check completed", Raw: resp, Timestamp: time.Now().UTC()})
+	case "rpc":
+		if p.Address == "" || p.Method == "" {
+			return toolError("remote rpc requires address and method")
+		}
+		resp, err := callDaemon(p.Network, p.Address, p.Method, p.Params)
+		if err != nil {
+			return toolError(err.Error())
+		}
+		return toolText(toolEnvelope{Summary: "remote rpc completed: " + p.Method, Raw: resp, Timestamp: time.Now().UTC()})
+	case "triage":
+		return toolError("remote triage is not a daemon RPC yet; use remote operation=rpc with method names such as snapshot.create, rules.check, jvm.list")
+	case "fanout":
+		if len(p.Hosts) == 0 || p.Method == "" {
+			return toolError("remote fanout requires hosts and method")
+		}
+		out := make(map[string]interface{}, len(p.Hosts))
+		for _, host := range p.Hosts {
+			resp, err := callDaemon(p.Network, host, p.Method, p.Params)
+			if err != nil {
+				out[host] = map[string]string{"error": err.Error()}
+			} else {
+				out[host] = resp
+			}
+		}
+		return toolText(toolEnvelope{Summary: fmt.Sprintf("fanout completed for %d host(s)", len(p.Hosts)), Raw: out, Timestamp: time.Now().UTC()})
+	default:
+		return toolError("unknown remote operation: " + p.Operation)
+	}
+}
+
+type inspectResult struct {
+	Path    string        `json:"path"`
+	Success bool          `json:"success"`
+	Result  detect.Result `json:"result,omitempty"`
+	Error   string        `json:"error,omitempty"`
+}
+
+func decodeArgs(raw json.RawMessage, dst interface{}) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(raw, dst); err != nil {
+		return fmt.Errorf("invalid params: %w", err)
+	}
+	return nil
+}
+
+func toolText(value interface{}) ToolResult {
+	payload, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return toolError(fmt.Sprintf("marshal tool result: %v", err))
+	}
+	return ToolResult{Content: []ContentBlock{{Type: "text", Text: string(payload)}}}
+}
+
+func toolError(msg string) ToolResult {
+	return ToolResult{IsError: true, Content: []ContentBlock{{Type: "text", Text: msg}}}
+}
+
+func optionalRaw(include bool, value interface{}) interface{} {
+	if include {
+		return value
+	}
+	return nil
+}
+
+func openStore() (*store.DB, error) {
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		return nil, err
+	}
+	return store.Open(dbPath)
+}
+
+func resolveRulesCatalog(path string) ([]rules.Rule, error) {
+	base := rules.V1Catalog()
+	if path == "" {
+		if _, err := os.Stat("spectra.yml"); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return base, nil
+			}
+			return nil, err
+		}
+		path = "spectra.yml"
+	}
+	overrides, err := rules.LoadOverrides(path)
+	if err != nil {
+		return nil, err
+	}
+	return rules.ApplyOverrides(base, overrides), nil
+}
+
+func loadStoredSnapshot(id string) (snapshot.Snapshot, error) {
+	var empty snapshot.Snapshot
+	db, err := openStore()
+	if err != nil {
+		return empty, err
+	}
+	defer db.Close()
+	raw, err := db.GetSnapshotJSON(context.Background(), id)
+	if err != nil {
+		return empty, err
+	}
+	if len(raw) == 0 {
+		return empty, fmt.Errorf("snapshot %q has no JSON payload", id)
+	}
+	if err := json.Unmarshal(raw, &empty); err != nil {
+		return empty, fmt.Errorf("unmarshal snapshot %q: %w", id, err)
+	}
+	return empty, nil
+}
+
+func saveSnapshot(snap snapshot.Snapshot) error {
+	db, err := openStore()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if err := db.SaveSnapshot(context.Background(), store.FromSnapshot(snap)); err != nil {
+		return err
+	}
+	_ = db.SaveSnapshotProcesses(context.Background(), snap.ID, store.ProcessesFromSnapshot(snap))
+	_ = db.SaveLoginItems(context.Background(), snap.ID, store.LoginItemsFromSnapshot(snap))
+	_ = db.SaveGrantedPerms(context.Background(), snap.ID, store.GrantedPermsFromSnapshot(snap))
+	return nil
+}
+
+func evaluateLiveRules(version, config string) ([]rules.Finding, error) {
+	_, findings, err := evaluateRules(version, "", config)
+	return findings, err
+}
+
+func evaluateRules(version, snapshotID, config string) (snapshot.Snapshot, []rules.Finding, error) {
+	var snap snapshot.Snapshot
+	var err error
+	if snapshotID != "" {
+		snap, err = loadStoredSnapshot(snapshotID)
+		if err != nil {
+			return snap, nil, err
+		}
+	} else {
+		snap = snapshot.Build(context.Background(), snapshot.Options{SpectraVersion: version})
+	}
+	catalog, err := resolveRulesCatalog(config)
+	if err != nil {
+		return snap, nil, err
+	}
+	return snap, rules.Evaluate(snap, catalog), nil
+}
+
+func persistFindings(snap snapshot.Snapshot, findings []rules.Finding) ([]string, error) {
+	db, err := openStore()
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	return persistFindingsWithDB(db, snap, findings)
+}
+
+func persistFindingsWithDB(db *store.DB, snap snapshot.Snapshot, findings []rules.Finding) ([]string, error) {
+	if err := db.SaveSnapshot(context.Background(), store.FromSnapshot(snap)); err != nil {
+		return nil, err
+	}
+	inputs := make([]store.FindingInput, 0, len(findings))
+	for _, f := range findings {
+		inputs = append(inputs, store.FindingInput{RuleID: f.RuleID, Subject: f.Subject, Severity: string(f.Severity), Message: f.Message, Fix: f.Fix})
+	}
+	machineUUID := snap.Host.MachineUUID
+	if machineUUID == "" {
+		machineUUID = snap.Host.Hostname
+	}
+	if machineUUID == "" {
+		machineUUID = "local"
+	}
+	return db.UpsertIssues(context.Background(), machineUUID, snap.ID, inputs)
+}
+
+func jvmOptions() jvm.CollectOptions {
+	tc := toolchain.Collect(context.Background(), toolchain.CollectOptions{})
+	return jvm.CollectOptions{JDKs: tc.JDKs}
+}
+
+func inspectJVM(pid int) *jvm.Info {
+	return jvm.InspectPID(context.Background(), pid, jvmOptions())
+}
+
+func jcmdText(pid int, label string, fn func(int, jvm.CmdRunner) ([]byte, error)) ToolResult {
+	if pid == 0 {
+		return toolError("jvm " + label + " requires pid")
+	}
+	out, err := fn(pid, nil)
+	if err != nil {
+		return toolError(err.Error())
+	}
+	return toolText(toolEnvelope{Summary: fmt.Sprintf("collected %s for pid %d", label, pid), Raw: map[string]interface{}{"pid": pid, "output": string(out)}, Timestamp: time.Now().UTC()})
+}
+
+func sampleProcess(pid, durationSec, intervalMS int) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(durationSec+5)*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "sample", fmt.Sprint(pid), fmt.Sprint(durationSec), fmt.Sprint(intervalMS)).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("sample pid %d: %w: %s", pid, err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func callDaemon(network, address, method string, params interface{}) (interface{}, error) {
+	conn, err := net.DialTimeout(network, address, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	if params == nil {
+		params = map[string]interface{}{}
+	}
+	req := map[string]interface{}{"jsonrpc": "2.0", "id": 1, "method": method, "params": params}
+	if err := json.NewEncoder(conn).Encode(req); err != nil {
+		return nil, err
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	var resp struct {
+		Result interface{} `json:"result"`
+		Error  *RPCError   `json:"error"`
+	}
+	if err := json.NewDecoder(bufio.NewReader(conn)).Decode(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != nil {
+		return nil, fmt.Errorf("remote error %d: %s", resp.Error.Code, resp.Error.Message)
+	}
+	return resp.Result, nil
+}
+
+func summarizeApp(r detect.Result) []string {
+	out := []string{fmt.Sprintf("%s: UI=%s runtime=%s language=%s confidence=%s", r.Path, r.UI, r.Runtime, r.Language, r.Confidence)}
+	if r.BundleID != "" || r.AppVersion != "" {
+		out = append(out, fmt.Sprintf("bundle=%s version=%s build=%s", r.BundleID, r.AppVersion, r.BuildNumber))
+	}
+	if len(r.NativeModules) > 0 {
+		out = append(out, fmt.Sprintf("native modules: %d", len(r.NativeModules)))
+	}
+	if r.Sandboxed || r.HardenedRuntime || len(r.Entitlements) > 0 {
+		out = append(out, fmt.Sprintf("security: sandboxed=%t hardened_runtime=%t entitlements=%d", r.Sandboxed, r.HardenedRuntime, len(r.Entitlements)))
+	}
+	if r.Helpers != nil && (len(r.LoginItems) > 0 || len(r.Helpers.XPCServices) > 0 || len(r.Helpers.HelperApps) > 0) {
+		out = append(out, fmt.Sprintf("helpers: login_items=%d xpc=%d helper_apps=%d", len(r.LoginItems), len(r.Helpers.XPCServices), len(r.Helpers.HelperApps)))
+	}
+	if len(r.NetworkEndpoints) > 0 {
+		out = append(out, fmt.Sprintf("embedded network endpoints: %d", len(r.NetworkEndpoints)))
+	}
+	return out
+}
+
+func summarizeSnapshot(s snapshot.Snapshot, limit int) []string {
+	if limit <= 0 {
+		limit = 5
+	}
+	out := []string{
+		fmt.Sprintf("host=%s os=%s %s apps=%d processes=%d jvms=%d", s.Host.Hostname, s.Host.OSName, s.Host.OSVersion, len(s.Apps), len(s.Processes), len(s.JVMs)),
+		fmt.Sprintf("network: vpn=%t dns=%d listening_ports=%d", s.Network.VPNActive, len(s.Network.DNSServers), len(s.Network.ListeningPorts)),
+		fmt.Sprintf("toolchains: jdks=%d brew_formulae=%d build_tools=%d", len(s.Toolchains.JDKs), len(s.Toolchains.Brew.Formulae), len(s.Toolchains.BuildTools)),
+	}
+	for i, app := range s.Apps {
+		if i >= limit {
+			break
+		}
+		out = append(out, fmt.Sprintf("app[%d]: %s %s/%s", i, app.Path, app.UI, app.Runtime))
+	}
+	return out
+}
+
+func summarizeProcesses(procs []process.Info, limit int) []string {
+	if limit <= 0 || limit > len(procs) {
+		limit = len(procs)
+	}
+	out := make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		p := procs[i]
+		out = append(out, fmt.Sprintf("pid=%d ppid=%d cpu=%.1f rss=%dKiB threads=%d cmd=%s app=%s", p.PID, p.PPID, p.CPUPct, p.RSSKiB, p.ThreadCount, p.Command, p.AppPath))
+	}
+	return out
+}
+
+func summarizeJVM(info jvm.Info) []string {
+	return []string{fmt.Sprintf("jvm pid=%d main=%s java=%s vendor=%s threads=%d jdk=%s", info.PID, info.MainClass, info.JDKVersion, info.JDKVendor, info.ThreadCount, info.JDKPath)}
+}
+
+func summarizeJVMs(infos []jvm.Info) []string {
+	out := make([]string, 0, len(infos))
+	for _, info := range infos {
+		out = append(out, summarizeJVM(info)...)
+	}
+	return out
+}
+
+func summarizeFindings(findings []rules.Finding, limit int) []string {
+	if limit <= 0 || limit > len(findings) {
+		limit = len(findings)
+	}
+	out := make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		f := findings[i]
+		subject := f.Subject
+		if subject == "" {
+			subject = "host"
+		}
+		out = append(out, fmt.Sprintf("%s %s [%s]: %s", f.Severity, f.RuleID, subject, f.Message))
+	}
+	return out
+}
+
+func triageSummary(evidence []string) string {
+	if len(evidence) == 0 {
+		return "no target-specific evidence collected"
+	}
+	return fmt.Sprintf("collected %d diagnostic signal(s)", len(evidence))
+}
+
+func filterAppProcesses(procs []process.Info, appPath string) []process.Info {
+	var out []process.Info
+	for _, p := range procs {
+		if p.AppPath == appPath {
+			out = append(out, p)
+		}
+	}
+	sortProcesses(out)
+	return out
+}
+
+func findProcess(procs []process.Info, pid int) (process.Info, bool) {
+	for _, p := range procs {
+		if p.PID == pid {
+			return p, true
+		}
+	}
+	return process.Info{}, false
+}
+
+func sortProcesses(procs []process.Info) {
+	sort.SliceStable(procs, func(i, j int) bool {
+		if procs[i].RSSKiB != procs[j].RSSKiB {
+			return procs[i].RSSKiB > procs[j].RSSKiB
+		}
+		return procs[i].PID < procs[j].PID
+	})
+}
+
+func summarizeNetworkState(s netstate.State) string {
+	return fmt.Sprintf("network iface=%s vpn=%t dns=%d established=%d listening=%d", s.DefaultRouteIface, s.VPNActive, len(s.DNSServers), s.EstablishedConnectionsCount, len(s.ListeningPorts))
+}
+
+func networkEvidence(s netstate.State) []string {
+	out := []string{fmt.Sprintf("default route: iface=%s gateway=%s", s.DefaultRouteIface, s.DefaultRouteGW)}
+	if len(s.DNSServers) > 0 {
+		out = append(out, "dns: "+strings.Join(s.DNSServers, ", "))
+	}
+	if s.Proxy.HTTP != "" || s.Proxy.HTTPS != "" || s.Proxy.SOCKS != "" {
+		out = append(out, fmt.Sprintf("proxy: http=%s https=%s socks=%s", s.Proxy.HTTP, s.Proxy.HTTPS, s.Proxy.SOCKS))
+	}
+	if s.VPNActive {
+		out = append(out, "vpn interfaces: "+strings.Join(s.VPNInterfaces, ", "))
+	}
+	return out
+}
+
+func connectionEvidenceForHost(conns []netstate.Connection, host string) []string {
+	var out []string
+	for _, c := range conns {
+		if strings.Contains(c.RemoteAddr, host) || strings.Contains(c.LocalAddr, host) {
+			out = append(out, fmt.Sprintf("connection pid=%d cmd=%s %s %s->%s state=%s", c.PID, c.Command, c.Proto, c.LocalAddr, c.RemoteAddr, c.State))
+		}
+	}
+	if len(out) == 0 {
+		out = append(out, "no active connection matched host "+host)
+	}
+	return out
+}
+
+func connectionEvidenceForPort(conns []netstate.Connection, port int) []string {
+	needle := fmt.Sprintf(":%d", port)
+	var out []string
+	for _, c := range conns {
+		if strings.Contains(c.RemoteAddr, needle) || strings.Contains(c.LocalAddr, needle) {
+			out = append(out, fmt.Sprintf("connection pid=%d cmd=%s %s %s->%s state=%s", c.PID, c.Command, c.Proto, c.LocalAddr, c.RemoteAddr, c.State))
+		}
+	}
+	if len(out) == 0 {
+		out = append(out, fmt.Sprintf("no active connection matched port %d", port))
+	}
+	return out
+}
+
+func summarizeToolchains(tc toolchain.Toolchains) string {
+	return fmt.Sprintf("toolchains jdks=%d node=%d python=%d go=%d ruby=%d rust=%d build_tools=%d", len(tc.JDKs), len(tc.Node), len(tc.Python), len(tc.Go), len(tc.Ruby), len(tc.Rust), len(tc.BuildTools))
+}
+
+func toolchainDriftEvidence(tc toolchain.Toolchains) []string {
+	var out []string
+	byMajor := map[int]int{}
+	for _, jdk := range tc.JDKs {
+		byMajor[jdk.VersionMajor]++
+	}
+	for major, count := range byMajor {
+		if count > 1 {
+			out = append(out, fmt.Sprintf("multiple JDK %d installs: %d", major, count))
+		}
+	}
+	if tc.Env.JavaHome != "" {
+		matched := false
+		for _, jdk := range tc.JDKs {
+			if strings.HasPrefix(tc.Env.JavaHome, jdk.Path) || strings.HasPrefix(jdk.Path, tc.Env.JavaHome) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			out = append(out, "JAVA_HOME does not match a discovered JDK: "+tc.Env.JavaHome)
+		}
+	}
+	return out
+}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestToolDefinitionsExposeWorkflowSurface(t *testing.T) {
+	got := map[string]bool{}
+	for _, def := range toolDefinitions() {
+		got[def.Name] = true
+	}
+	for _, name := range []string{
+		"triage",
+		"inspect_app",
+		"snapshot",
+		"diagnose",
+		"process",
+		"jvm",
+		"network",
+		"toolchain",
+		"issues",
+		"remote",
+	} {
+		if !got[name] {
+			t.Fatalf("missing tool definition %q", name)
+		}
+	}
+}
+
+func TestInspectAppRequiresPaths(t *testing.T) {
+	s := NewServer(strings.NewReader(""), &strings.Builder{})
+	result := s.toolInspectApp(json.RawMessage(`{}`))
+	if !result.IsError {
+		t.Fatal("expected inspect_app without paths to fail")
+	}
+	if len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, "paths is required") {
+		t.Fatalf("unexpected error content: %+v", result.Content)
+	}
+}
+
+func TestRemoteHealthDefaultsToTCP(t *testing.T) {
+	schema := operationToolDef("remote", "remote", []string{"health"})
+	raw, err := json.Marshal(schema.InputSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "operation") {
+		t.Fatalf("remote schema does not expose operation: %s", raw)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a `spectra-mcp` stdio MCP server entrypoint.
- Add Content-Length framed JSON-RPC transport shared by the MCP server.
- Add workflow-oriented MCP tools for triage, app inspection, snapshots, diagnosis, process, JVM, network, toolchain, issues, and remote daemon calls.
- Include concise MCP resources/prompts and focused tool definition tests.
- Update `make build-all`/`clean` to include `spectra-mcp`.

## Validation
- `go test ./internal/mcp ./cmd/spectra-mcp`
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `make build-all`
