### PR TITLE
[codex] Add Swift app inspection

### DIFF
--- a/cmd/spectra/inspect.go
+++ b/cmd/spectra/inspect.go
@@ -170,6 +170,7 @@ func printMeta(r detect.Result) {
 	printIdentityMeta(r)
 	printSecurityMeta(r)
 	printPrivacyMeta(r)
+	printSwiftMeta(r)
 	printDependencyMeta(r)
 	printStructureMeta(r)
 	printRuntimeMeta(r)
@@ -233,6 +234,35 @@ func printPrivacyMeta(r detect.Result) {
 		}
 		sort.Strings(keys)
 		fmt.Printf("    privacy declared: %s\n", strings.Join(keys, ", "))
+	}
+}
+
+func printSwiftMeta(r detect.Result) {
+	if r.Swift == nil {
+		return
+	}
+	if len(r.Swift.RuntimeLibraries) > 0 {
+		fmt.Printf("    swift runtime: %s\n", truncateList(r.Swift.RuntimeLibraries, 5))
+	}
+	capabilities := []string{}
+	if r.Swift.UsesSwiftUI {
+		capabilities = append(capabilities, "SwiftUI")
+	}
+	if r.Swift.UsesAppIntents {
+		capabilities = append(capabilities, "AppIntents")
+	}
+	if r.Swift.UsesScreenCapture {
+		capabilities = append(capabilities, "ScreenCaptureKit")
+	}
+	if len(capabilities) > 0 {
+		fmt.Printf("    swift capabilities: %s\n", strings.Join(capabilities, ", "))
+	}
+	if len(r.Swift.AppGroups) > 0 {
+		fmt.Printf("    app groups: %s\n", truncateList(r.Swift.AppGroups, 4))
+	}
+	if len(r.Swift.AppleFrameworks) > 0 {
+		fmt.Printf("    apple frameworks (%d): %s\n", len(r.Swift.AppleFrameworks),
+			truncateList(r.Swift.AppleFrameworks, 6))
 	}
 }
 

--- a/docs/detection/frameworks.md
+++ b/docs/detection/frameworks.md
@@ -49,10 +49,12 @@ confirmed examples from real apps. Layer numbers refer to
 - **Confirmed:** Keynote, Numbers, Ghostty, Tuple, iTerm (hybrid),
   Muse Hub, ChatGPT (no — see AppKit+Swift), Canary Mail, Airtime,
   InYourFace, MindNode, GarageBand.
+- **Inspection:** see [../inspection/swift-apps.md](../inspection/swift-apps.md).
 
 ### AppKit + Swift
 - **Layer 2:** `libswift*.dylib` linked but no SwiftUI.
 - **Confirmed:** ChatGPT, Pages, RemotePlay.
+- **Inspection:** see [../inspection/swift-apps.md](../inspection/swift-apps.md).
 
 ### AppKit (Obj-C)
 - **Layer 2:** AppKit/Cocoa linked, no Swift dylibs.

--- a/docs/detection/overview.md
+++ b/docs/detection/overview.md
@@ -44,6 +44,8 @@ Mac Catalyst:
 | Any `/iOSSupport/...` or `/UIKitMacHelper.framework/` | Mac Catalyst |
 
 See [catalyst.md](catalyst.md) for the Catalyst path.
+See [../inspection/swift-apps.md](../inspection/swift-apps.md) for the
+deeper app-level Swift inspection surface.
 
 ### Layer 3 — Binary content scanning
 

--- a/docs/inspection/swift-apps.md
+++ b/docs/inspection/swift-apps.md
@@ -1,0 +1,182 @@
+# Swift app inspection
+
+Swift-based macOS apps often look deceptively simple from the bundle
+layout alone. Spectra treats Swift as both a framework signal
+([../detection/overview.md](../detection/overview.md)) and an inspection
+surface: linked Swift runtime libraries, Apple framework usage,
+entitlements, privacy declarations, embedded helpers, and app-group
+storage together explain what the app is built to do.
+
+This page covers app-level Swift inspection. Swift native modules inside
+Electron apps are covered separately in
+[../detection/native-modules.md](../detection/native-modules.md).
+
+## When an app is Swift-based
+
+Spectra considers an app Swift-based when `otool -L` on the resolved
+application executable shows one of these signals:
+
+| Signal | Meaning |
+|---|---|
+| `/System/Library/Frameworks/SwiftUI.framework/` | SwiftUI app, or AppKit app with SwiftUI surfaces |
+| `libswift*.dylib` | Swift runtime dependency; usually AppKit+Swift when SwiftUI is absent |
+| `@rpath/libswift*.dylib` | Bundled Swift runtime, common on older deployment targets |
+| `Frameworks/<Name>.framework/<Name>` plus Swift dylibs | Swift code moved into a private framework |
+
+The classifier still reports the UI verdict separately: `SwiftUI`,
+`AppKit+Swift`, `MacCatalyst+SwiftUI`, or another stronger framework
+verdict when Layer 1 wins. The inspection rows remain useful even when
+Swift is only one part of a hybrid app.
+
+## Executable resolution
+
+Swift apps may not put most of their code in `Contents/MacOS/<exe>`.
+Before inspecting Swift signals, Spectra resolves the executable the same
+way the main detector does:
+
+- Follow tiny shim launchers into
+  `Contents/Frameworks/<App> Framework.framework/<App> Framework`.
+- Follow tiny wrapper binaries to a larger sibling executable in
+  `Contents/MacOS/`.
+- Inspect the resolved executable with `otool -L`, `file`, `codesign`,
+  and binary content scanning.
+
+This avoids classifying a launcher instead of the app implementation.
+
+## Linked framework profile
+
+Swift inspection records the Apple frameworks that explain app behavior.
+The raw source is `otool -L <resolved-executable>`; Spectra normalizes the
+paths into framework basenames and filters obvious system noise where a
+field only needs third-party frameworks.
+
+Common Swift framework signals:
+
+| Framework | What it suggests |
+|---|---|
+| `SwiftUI.framework` | Declarative UI layer |
+| `Combine.framework` | Reactive streams or Apple platform integration |
+| `AppIntents.framework` | Shortcuts, Spotlight actions, or system intents |
+| `ScreenCaptureKit.framework` | Screen sharing, recording, or computer-use workflows |
+| `AVFoundation.framework` / `AVFAudio.framework` | Camera, media, microphone, or audio processing |
+| `CoreBluetooth.framework` | Bluetooth device integration |
+| `CoreLocation.framework` | Location access |
+| `AuthenticationServices.framework` | Sign in with Apple, passkeys, web auth sessions |
+| `Security.framework` / `LocalAuthentication.framework` | Keychain, Secure Enclave, Touch ID, or biometric prompts |
+| `Network.framework` | Native networking stack, listeners, or path monitoring |
+| `WebKit.framework` | Embedded web views; possible custom WebKit shell |
+
+Framework presence is a capability signal, not proof of runtime behavior.
+Spectra pairs it with [security inspection](security.md), TCC grants, and
+[running process state](running-processes.md) before drawing conclusions.
+
+## Entitlements and privacy
+
+Swift apps usually interact with macOS through native frameworks, so the
+interesting inspection question is whether the framework profile lines up
+with declared and granted permissions.
+
+Spectra compares:
+
+- Entitlements from `codesign -d --entitlements :- <app>`.
+- Privacy descriptions from `NS*UsageDescription` keys in `Info.plist`.
+- Granted TCC services from per-user and system `TCC.db`.
+- Hardened runtime, sandbox, Team ID, and Gatekeeper status.
+
+Examples of useful mismatches:
+
+| Framework signal | Expected companion signal |
+|---|---|
+| `AVFoundation.framework` or `AVFAudio.framework` | camera / microphone privacy descriptions when capture APIs are used |
+| `CoreBluetooth.framework` | Bluetooth privacy description |
+| `CoreLocation.framework` | location privacy description |
+| `ScreenCaptureKit.framework` | ScreenCapture TCC grant may exist without an `NS*UsageDescription` key |
+| `AppIntents.framework` | shortcuts-related behavior, often without a separate entitlement |
+| `Network.framework` with `network.server` entitlement | local listener or peer-to-peer feature |
+
+The recommendation engine should avoid treating a linked framework alone
+as a defect. Many Apple frameworks are linked by SDK convenience or by
+transitive dependencies and may never be exercised.
+
+## Helpers, XPC, and app groups
+
+Swift apps commonly split privileged or long-running work into embedded
+targets:
+
+- `Contents/Library/LoginItems/*.app` for launch-at-login agents.
+- `Contents/XPCServices/*.xpc` for isolated services.
+- `Contents/Library/LaunchServices/*` for helper executables.
+- `Contents/PlugIns/*.appex` for extensions.
+
+Each helper has its own `Info.plist`, executable, signature, and
+entitlements. Spectra inspects these as separate structural rows in
+[helpers-and-xpc.md](helpers-and-xpc.md) and correlates app-group
+entitlements with storage under `~/Library/Group Containers/`.
+
+For Swift apps, app groups are often the bridge between the GUI app,
+extensions, and login items. A mismatched app group is more interesting
+than the presence of a helper by itself.
+
+## Storage and runtime correlation
+
+Static Swift inspection explains what the app can do. Storage and process
+inspection explain what it appears to be doing on this host:
+
+- [storage-footprint.md](storage-footprint.md) records app container,
+  group container, cache, and log sizes.
+- [running-processes.md](running-processes.md) correlates live processes
+  back to the bundle ID and computes app uptime.
+- [network-endpoints.md](network-endpoints.md) associates listening and
+  connected sockets with the app's processes.
+
+This matters for native Swift apps because the bundle often contains very
+little obvious third-party structure. The strongest operational signal may
+be a long-running helper, a large group container, or a granted TCC
+permission that is not obvious from the visible UI.
+
+## Planned result fields
+
+The current result schema already exposes most Swift-adjacent data through
+generic fields: `UI`, `Runtime`, `Architectures`, `Entitlements`,
+`PrivacyDescriptions`, `GrantedPermissions`, `Helpers`, `Dependencies`,
+and process/network/storage rows.
+
+If Swift inspection becomes a dedicated result section, keep it derived
+from existing collectors first:
+
+```go
+type SwiftInspection struct {
+    RuntimeLibraries []string // libswift*.dylib basenames
+    AppleFrameworks  []string // normalized linked Apple frameworks
+    UsesSwiftUI      bool
+    UsesAppIntents   bool
+    UsesScreenCapture bool
+    AppGroups        []string
+}
+```
+
+Do not add a Swift-only subprocess path unless a generic collector cannot
+represent the signal. `otool`, `codesign`, `plutil`, `file`, and TCC reads
+should remain shared with the rest of app inspection.
+
+## Implementation reference
+
+Relevant collectors live in `internal/detect/`:
+
+- `Detect()` resolves the executable and runs the three-layer classifier.
+- `runOtoolL(exe)` provides the linked-library source for Swift runtime
+  and Apple framework inspection.
+- `readEntitlements(appPath)` and `readPrivacyDescriptions(appPath)`
+  provide declared capability data.
+- `scanGrantedPermissions(bundleID)` provides host-granted TCC state.
+- Helper, login item, storage, and process collectors provide the
+  operational context around the Swift bundle.
+
+## Related docs
+
+- [../detection/frameworks.md](../detection/frameworks.md) — SwiftUI,
+  AppKit+Swift, and Catalyst classifier signals
+- [security.md](security.md) — entitlements, sandbox, privacy, and TCC
+- [helpers-and-xpc.md](helpers-and-xpc.md) — embedded helper inspection
+- [storage-footprint.md](storage-footprint.md) — container and group
+  container storage

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -55,6 +55,7 @@ Source of truth: `internal/detect/detect.go`.
 | `AppUptimeSeconds` | int64 | Seconds between inspection time and `AppStartedAt` |
 | `Storage` | *StorageFootprint | Per-`~/Library`-location size sweep |
 | `Dependencies` | *Dependencies | Third-party frameworks, npm packages, jar count |
+| `Swift` | *SwiftInspection | Swift runtime libraries, Apple frameworks, app-group signals |
 | `NetworkEndpoints` | []string | URL hosts (only when `--network` set) |
 
 ## Nested types
@@ -128,6 +129,19 @@ type Dependencies struct {
     ThirdPartyFrameworks []string // framework basenames, Apple-filtered
     NPMPackages          []string // top-level dirs in app.asar.unpacked
     JavaJars             int      // count of .jar files anywhere in bundle
+}
+```
+
+### SwiftInspection
+
+```go
+type SwiftInspection struct {
+    RuntimeLibraries []string // libswift*.dylib basenames
+    AppleFrameworks  []string // normalized linked Apple frameworks
+    UsesSwiftUI      bool
+    UsesAppIntents   bool
+    UsesScreenCapture bool
+    AppGroups        []string
 }
 ```
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -70,6 +70,10 @@ type Result struct {
 	// embedded npm packages.
 	Dependencies *Dependencies
 
+	// Swift summarises Swift runtime, Apple framework, and app-group
+	// signals for native Swift or Swift-hybrid apps.
+	Swift *SwiftInspection
+
 	// Helpers enumerates the bundle's sub-bundles: helper apps (Electron's
 	// GPU/Renderer/Plugin), XPC services, and plugins/extensions.
 	Helpers *Helpers
@@ -130,6 +134,17 @@ type Dependencies struct {
 	ThirdPartyFrameworks []string // names under Contents/Frameworks/, sans Apple
 	NPMPackages          []string // top-level dirs under app.asar.unpacked/node_modules
 	JavaJars             int      // count of .jar files (JVM apps)
+}
+
+// SwiftInspection describes Swift-specific app signals derived from shared
+// bundle inspection sources.
+type SwiftInspection struct {
+	RuntimeLibraries  []string // libswift*.dylib basenames
+	AppleFrameworks   []string // normalized linked Apple framework basenames
+	UsesSwiftUI       bool
+	UsesAppIntents    bool
+	UsesScreenCapture bool
+	AppGroups         []string
 }
 
 // StorageFootprint is the on-disk size, in bytes, of each well-known
@@ -262,9 +277,11 @@ func populateMetadata(appPath, exe string, r *Result) {
 	}
 	r.BundleSizeBytes, r.ApparentSizeBytes = bundleSizes(appPath)
 	r.TeamID, r.HardenedRuntime = readSigning(appPath)
-	r.Sandboxed, r.Entitlements = readEntitlements(appPath)
+	var appGroups []string
+	r.Sandboxed, r.Entitlements, appGroups = readEntitlementsDetail(appPath)
 	r.MASReceipt = exists(filepath.Join(appPath, "Contents", "_MASReceipt"))
 	r.Storage = scanStorage(appPath, r.BundleID)
+	r.Swift = inspectSwiftApp(appPath, exe, realSwiftInspectionSource{appGroups: appGroups})
 }
 
 func frameworkVersions(appPath string, r *Result) map[string]string {
@@ -490,13 +507,19 @@ func parseGatekeeperOutput(out string) string {
 }
 
 func readEntitlements(appPath string) (sandboxed bool, notable []string) {
+	sandboxed, notable, _ = readEntitlementsDetail(appPath)
+	return sandboxed, notable
+}
+
+func readEntitlementsDetail(appPath string) (sandboxed bool, notable, appGroups []string) {
 	out, err := exec.Command("codesign", "-d", "--entitlements", ":-", appPath).Output()
 	if err != nil || len(out) == 0 {
-		return false, nil
+		return false, nil, nil
 	}
 
 	// Pairs look like <key>NAME</key><true/> in the single-line XML output.
 	xml := string(out)
+	appGroups = applicationGroups(xml)
 	notableKeys := map[string]bool{
 		"com.apple.security.app-sandbox":                         true,
 		"com.apple.security.network.client":                      true,
@@ -523,7 +546,7 @@ func readEntitlements(appPath string) (sandboxed bool, notable []string) {
 		}
 	}
 	sort.Strings(notable)
-	return sandboxed, notable
+	return sandboxed, notable, appGroups
 }
 
 // --- Layer 1 ----------------------------------------------------------------
@@ -817,17 +840,7 @@ func otoolL(exe string) []string {
 	if err != nil {
 		return nil
 	}
-	var libs []string
-	for i, line := range strings.Split(string(out), "\n") {
-		if i == 0 {
-			continue // first line echoes the path
-		}
-		fields := strings.Fields(line)
-		if len(fields) > 0 {
-			libs = append(libs, fields[0])
-		}
-	}
-	return libs
+	return parseOtoolLibraries(out)
 }
 
 // scanBinaryMarkers streams the binary looking for Rust and Go fingerprints,

--- a/internal/detect/swift.go
+++ b/internal/detect/swift.go
@@ -1,0 +1,142 @@
+package detect
+
+import (
+	"bytes"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type swiftInspectionSource interface {
+	LinkedLibraries(exe string) []string
+	ApplicationGroups(appPath string) []string
+}
+
+type realSwiftInspectionSource struct {
+	appGroups []string
+}
+
+func (realSwiftInspectionSource) LinkedLibraries(exe string) []string {
+	return otoolL(exe)
+}
+
+func (s realSwiftInspectionSource) ApplicationGroups(string) []string {
+	return s.appGroups
+}
+
+func inspectSwiftApp(appPath, exe string, src swiftInspectionSource) *SwiftInspection {
+	if exe == "" || src == nil {
+		return nil
+	}
+
+	libs := src.LinkedLibraries(exe)
+	if len(libs) == 0 {
+		return nil
+	}
+
+	s := &SwiftInspection{
+		RuntimeLibraries: swiftRuntimeLibraries(libs),
+		AppleFrameworks:  appleFrameworks(libs),
+		AppGroups:        src.ApplicationGroups(appPath),
+	}
+	s.UsesSwiftUI = containsString(s.AppleFrameworks, "SwiftUI.framework")
+	s.UsesAppIntents = containsString(s.AppleFrameworks, "AppIntents.framework")
+	s.UsesScreenCapture = containsString(s.AppleFrameworks, "ScreenCaptureKit.framework")
+
+	if len(s.RuntimeLibraries) == 0 && !s.UsesSwiftUI && len(s.AppGroups) == 0 {
+		return nil
+	}
+	return s
+}
+
+func swiftRuntimeLibraries(libs []string) []string {
+	seen := map[string]struct{}{}
+	for _, lib := range libs {
+		base := filepath.Base(lib)
+		if strings.HasPrefix(base, "libswift") && strings.HasSuffix(base, ".dylib") {
+			seen[base] = struct{}{}
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func appleFrameworks(libs []string) []string {
+	seen := map[string]struct{}{}
+	for _, lib := range libs {
+		if !isAppleFrameworkPath(lib) {
+			continue
+		}
+		if fw := frameworkBase(lib); fw != "" {
+			seen[fw] = struct{}{}
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func isAppleFrameworkPath(lib string) bool {
+	return strings.HasPrefix(lib, "/System/Library/Frameworks/") ||
+		strings.HasPrefix(lib, "/System/iOSSupport/System/Library/Frameworks/") ||
+		strings.HasPrefix(lib, "/System/Library/PrivateFrameworks/")
+}
+
+func frameworkBase(lib string) string {
+	for _, part := range strings.Split(lib, "/") {
+		if strings.HasSuffix(part, ".framework") {
+			return part
+		}
+	}
+	return ""
+}
+
+var appGroupsBlockRE = regexp.MustCompile(`(?s)<key>com\.apple\.security\.application-groups</key>\s*<array>(.*?)</array>`)
+var plistStringRE = regexp.MustCompile(`(?s)<string>\s*([^<]+?)\s*</string>`)
+
+func applicationGroups(xml string) []string {
+	m := appGroupsBlockRE.FindStringSubmatch(xml)
+	if len(m) != 2 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, sm := range plistStringRE.FindAllStringSubmatch(m[1], -1) {
+		if len(sm) != 2 {
+			continue
+		}
+		group := strings.TrimSpace(sm[1])
+		if group != "" {
+			seen[group] = struct{}{}
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func containsString(list []string, want string) bool {
+	i := sort.SearchStrings(list, want)
+	return i < len(list) && list[i] == want
+}
+
+func parseOtoolLibraries(out []byte) []string {
+	var libs []string
+	for i, line := range strings.Split(string(bytes.TrimSpace(out)), "\n") {
+		if i == 0 {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) > 0 {
+			libs = append(libs, fields[0])
+		}
+	}
+	return libs
+}

--- a/internal/detect/swift_test.go
+++ b/internal/detect/swift_test.go
@@ -1,0 +1,120 @@
+package detect
+
+import (
+	"reflect"
+	"testing"
+)
+
+type fakeSwiftInspectionSource struct {
+	libs      []string
+	appGroups []string
+}
+
+func (f fakeSwiftInspectionSource) LinkedLibraries(string) []string {
+	return f.libs
+}
+
+func (f fakeSwiftInspectionSource) ApplicationGroups(string) []string {
+	return f.appGroups
+}
+
+func TestInspectSwiftAppCollectsRuntimeFrameworksAndAppGroups(t *testing.T) {
+	got := inspectSwiftApp("/Applications/Fake.app", "/Applications/Fake.app/Contents/MacOS/Fake", fakeSwiftInspectionSource{
+		libs: []string{
+			"/usr/lib/libobjc.A.dylib",
+			"/usr/lib/swift/libswiftCore.dylib",
+			"/usr/lib/swift/libswiftDispatch.dylib",
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+			"/System/Library/Frameworks/AppIntents.framework/Versions/A/AppIntents",
+			"/System/Library/Frameworks/ScreenCaptureKit.framework/Versions/A/ScreenCaptureKit",
+			"/System/Library/Frameworks/SwiftUI.framework/Versions/A/SwiftUI",
+			"/System/Library/PrivateFrameworks/WorkflowKit.framework/Versions/A/WorkflowKit",
+			"@rpath/PrivateVendor.framework/PrivateVendor",
+		},
+		appGroups: []string{"group.com.example.fake", "group.com.example.shared"},
+	})
+
+	if got == nil {
+		t.Fatal("inspectSwiftApp returned nil")
+	}
+	assertStrings(t, got.RuntimeLibraries, []string{"libswiftCore.dylib", "libswiftDispatch.dylib"})
+	assertStrings(t, got.AppleFrameworks, []string{
+		"AppIntents.framework",
+		"AppKit.framework",
+		"ScreenCaptureKit.framework",
+		"SwiftUI.framework",
+		"WorkflowKit.framework",
+	})
+	assertStrings(t, got.AppGroups, []string{"group.com.example.fake", "group.com.example.shared"})
+	if !got.UsesSwiftUI {
+		t.Error("UsesSwiftUI = false, want true")
+	}
+	if !got.UsesAppIntents {
+		t.Error("UsesAppIntents = false, want true")
+	}
+	if !got.UsesScreenCapture {
+		t.Error("UsesScreenCapture = false, want true")
+	}
+}
+
+func TestInspectSwiftAppDetectsAppKitSwiftWithoutSwiftUI(t *testing.T) {
+	got := inspectSwiftApp("/Applications/Fake.app", "/Applications/Fake.app/Contents/MacOS/Fake", fakeSwiftInspectionSource{
+		libs: []string{
+			"/usr/lib/swift/libswiftCore.dylib",
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+			"/System/Library/Frameworks/WebKit.framework/Versions/A/WebKit",
+		},
+	})
+
+	if got == nil {
+		t.Fatal("inspectSwiftApp returned nil")
+	}
+	assertStrings(t, got.RuntimeLibraries, []string{"libswiftCore.dylib"})
+	assertStrings(t, got.AppleFrameworks, []string{"AppKit.framework", "WebKit.framework"})
+	if got.UsesSwiftUI {
+		t.Error("UsesSwiftUI = true, want false")
+	}
+}
+
+func TestInspectSwiftAppReturnsNilWithoutSwiftSignals(t *testing.T) {
+	got := inspectSwiftApp("/Applications/Fake.app", "/Applications/Fake.app/Contents/MacOS/Fake", fakeSwiftInspectionSource{
+		libs: []string{
+			"/usr/lib/libobjc.A.dylib",
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+			"/System/Library/Frameworks/WebKit.framework/Versions/A/WebKit",
+		},
+	})
+	if got != nil {
+		t.Fatalf("inspectSwiftApp returned %#v, want nil", got)
+	}
+}
+
+func TestParseOtoolLibraries(t *testing.T) {
+	got := parseOtoolLibraries([]byte(`/Applications/Fake.app/Contents/MacOS/Fake:
+	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
+	/System/Library/Frameworks/SwiftUI.framework/Versions/A/SwiftUI (compatibility version 1.0.0, current version 7.0.0)
+`))
+	assertStrings(t, got, []string{
+		"/usr/lib/libobjc.A.dylib",
+		"/System/Library/Frameworks/SwiftUI.framework/Versions/A/SwiftUI",
+	})
+}
+
+func TestApplicationGroupsParsesEntitlementsXML(t *testing.T) {
+	got := applicationGroups(`<plist version="1.0"><dict>
+<key>com.apple.security.application-groups</key>
+<array>
+<string>group.com.example.fake</string>
+<string>group.com.example.shared</string>
+<string>group.com.example.fake</string>
+</array>
+</dict></plist>`)
+	assertStrings(t, got, []string{"group.com.example.fake", "group.com.example.shared"})
+}
+
+func assertStrings(t *testing.T, got, want []string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
   - Inspection:
       - Metadata: inspection/metadata.md
       - Security: inspection/security.md
+      - Swift apps: inspection/swift-apps.md
       - Storage footprint: inspection/storage-footprint.md
       - Network endpoints: inspection/network-endpoints.md
       - Helpers and XPC: inspection/helpers-and-xpc.md


### PR DESCRIPTION
## Summary

- Add Swift app inspection output to detect.Result and verbose CLI output.

- Add fake-backed unit tests for Swift runtime libraries, Apple framework normalization, app groups, and otool parsing.
- Document Swift app inspection and update the result schema/navigation.
## Validation
- go test ./... -count=1

- go build ./...
- go vet ./...
- make docs-validate
- git diff --check


