### PR TITLE
Add node app inspection components

### DIFF
--- a/docs/detection/native-modules.md
+++ b/docs/detection/native-modules.md
@@ -126,3 +126,8 @@ useful classification than "Electron."
 
 - Expand `RiskHints` as more Electron native modules show repeatable
   security-sensitive patterns in real apps.
+
+## See also
+
+- [../inspection/node-based-apps.md](../inspection/node-based-apps.md) —
+  broader Node/Electron bundle inspection.

--- a/docs/inspection/node-based-apps.md
+++ b/docs/inspection/node-based-apps.md
@@ -1,0 +1,104 @@
+# Node-based app inspection
+
+Node-based macOS apps usually ship JavaScript bundles, npm dependencies,
+native add-ons, and a runtime wrapper. Spectra inspects those bundle
+artifacts without executing app code. Today this mostly means Electron,
+but the same model also applies to Node payloads embedded in other
+wrappers.
+
+## What it finds today
+
+For confirmed Electron apps, Spectra can report:
+
+| Signal | Source | Output |
+|---|---|---|
+| Node runtime wrapper | `Contents/Frameworks/Electron Framework.framework/` plus `Resources/app.asar` or `Resources/app/` | `UI=Electron`, `Runtime=Node+Chromium` |
+| Electron version | Electron framework `Info.plist` | `ElectronVersion`, `FrameworkVersions["Electron"]` |
+| npm package inventory | top-level directories under unpacked `node_modules` payloads | `Dependencies.NPMPackages` |
+| Native add-ons | `.node` files under unpacked `node_modules` trees | `NativeModules` |
+| Embedded URL hosts | main executable and `Contents/Resources/app.asar` when `--network` is set | `NetworkEndpoints` |
+| Helper layout | helper `.app` bundles under `Contents/Frameworks/` | `Helpers.HelperApps` |
+
+These signals answer different questions. The framework verdict says
+"this is Electron." The package and native-module passes say what kind
+of Node app it is: a mostly stock JavaScript shell, a terminal app with
+`node-pty`, a credential-touching app with `keytar`, or a hybrid app
+with Swift/Rust native bridges.
+
+## Package inventory
+
+Spectra treats npm package inventory as a dependency summary, not as a
+lockfile audit. It records package names that are visible in unpacked
+payloads and keeps the scan bounded:
+
+- `Contents/Resources/app.asar.unpacked/node_modules/<package>/`
+- `Contents/Resources/app.asar.unpacked/node_modules/@scope/<package>/`
+The inventory is intentionally shallow. Top-level packages are useful
+for quickly spotting major capabilities (`node-pty`, `better-sqlite3`,
+`keytar`, `playwright`, `puppeteer`, `sharp`) without expanding every
+transitive dependency into noisy output.
+
+## Native add-ons
+
+Node native add-ons are the highest-signal part of Node app inspection.
+They are Mach-O dynamic libraries loaded by Node, conventionally named
+with the `.node` extension. Spectra walks unpacked package payloads,
+finds each `.node` file, attributes it back to its owning npm package
+when possible, and classifies the native implementation language.
+
+See [../detection/native-modules.md](../detection/native-modules.md)
+for the full classifier. In short:
+
+- Rust is detected from leaked Cargo target paths or Rust panic-site
+  strings.
+- Swift is detected from Swift runtime links or Swift sidecar dylibs.
+- C++ is inferred from `libc++` links when no stronger language signal
+  is present.
+- Known packages add capability and risk hints, such as pseudoterminal,
+  Keychain, global input, USB/HID, serial, filesystem event, and privacy
+  permission access.
+
+## Network literals
+
+When `--network` is set, Electron app inspection also scans
+`Contents/Resources/app.asar` for URL host literals. This is not live
+traffic capture; it is a static reference inventory. It is useful for
+finding telemetry providers, OAuth hosts, staging endpoints, embedded
+documentation links, and supply-chain surprises in bundled JavaScript.
+
+See [network-endpoints.md](network-endpoints.md) for details and
+limitations.
+
+## Current limits
+
+- `app.asar` is scanned for URL literals, but not unpacked into a full
+  JavaScript module graph.
+- Package inventory is shallow and best-effort. It does not replace
+  `package-lock.json`, `pnpm-lock.yaml`, or SBOM analysis.
+- npm package inventory only covers `app.asar.unpacked/node_modules`
+  today. Native modules also include unpacked `Contents/Resources/app`
+  payloads.
+- Arbitrary embedded Node runtimes may need additional
+  wrapper-specific paths.
+- Spectra does not execute Node, load app JavaScript, or evaluate dynamic
+  imports. All signals come from bundle files.
+
+## Implementation reference
+
+`internal/detect/detect.go`:
+
+- `scanDependencies(appPath)` — collects third-party frameworks, npm
+  packages, and jar counts.
+- `scanNativeModules(appPath)` — walks unpacked Node native add-ons.
+- `scanNetworkEndpoints(appPath, exe)` — scans executable and Electron
+  `app.asar` URL literals when network scanning is enabled.
+
+## See also
+
+- [../detection/overview.md](../detection/overview.md) — framework and
+  runtime classification
+- [../detection/native-modules.md](../detection/native-modules.md) —
+  `.node` add-on classification
+- [network-endpoints.md](network-endpoints.md) — static URL host
+  extraction
+- [helpers-and-xpc.md](helpers-and-xpc.md) — Electron helper app layout

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -141,4 +141,6 @@ window in the daemon RPC schema once that lands.
 
 - [../detection/overview.md](../detection/overview.md) — how the verdict
   fields are computed
+- [../inspection/node-based-apps.md](../inspection/node-based-apps.md) —
+  Node/Electron package, native add-on, and URL-host inspection
 - [../inspection/](../inspection/) — per-field deep-dives

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -168,6 +169,62 @@ type NativeModule struct {
 type Options struct {
 	ScanNetwork bool // scan binary + app.asar for embedded URL hosts
 	Now         func() time.Time
+}
+
+type nodeAppFS interface {
+	Exists(path string) bool
+	IsDir(path string) bool
+	Open(path string) (io.ReadCloser, error)
+	ReadDir(path string) ([]os.DirEntry, error)
+	ReadFile(path string) ([]byte, error)
+	WalkDir(root string, fn fs.WalkDirFunc) error
+}
+
+type nodeAppCommands interface {
+	OtoolL(path string) []string
+}
+
+type osNodeAppFS struct{}
+
+func (osNodeAppFS) Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func (osNodeAppFS) IsDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func (osNodeAppFS) Open(path string) (io.ReadCloser, error) {
+	return os.Open(path)
+}
+
+func (osNodeAppFS) ReadDir(path string) ([]os.DirEntry, error) {
+	return os.ReadDir(path)
+}
+
+func (osNodeAppFS) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func (osNodeAppFS) WalkDir(root string, fn fs.WalkDirFunc) error {
+	return filepath.WalkDir(root, fn)
+}
+
+type execNodeAppCommands struct{}
+
+func (execNodeAppCommands) OtoolL(path string) []string {
+	return otoolL(path)
+}
+
+type nodeAppInspector struct {
+	fs  nodeAppFS
+	cmd nodeAppCommands
+}
+
+func defaultNodeAppInspector() nodeAppInspector {
+	return nodeAppInspector{fs: osNodeAppFS{}, cmd: execNodeAppCommands{}}
 }
 
 // Detect inspects the bundle at appPath and returns a Result.
@@ -834,7 +891,11 @@ func otoolL(exe string) []string {
 // plus framework-specific tells (Wails). We avoid `strings(1)` to skip a fork
 // and to handle multi-arch binaries uniformly.
 func scanBinaryMarkers(exe string) (m binaryMarkers) {
-	f, err := os.Open(exe)
+	return defaultNodeAppInspector().scanBinaryMarkers(exe)
+}
+
+func (ins nodeAppInspector) scanBinaryMarkers(exe string) (m binaryMarkers) {
+	f, err := ins.fs.Open(exe)
 	if err != nil {
 		return m
 	}
@@ -926,10 +987,14 @@ func findJVMRoot(contents string) string {
 // add-ons and classifies each by language using its link map and binary
 // fingerprint.
 func scanNativeModules(appPath string) []NativeModule {
+	return defaultNodeAppInspector().scanNativeModules(appPath)
+}
+
+func (ins nodeAppInspector) scanNativeModules(appPath string) []NativeModule {
 	var mods []NativeModule
 	seen := map[string]struct{}{}
-	for _, root := range nativeModuleRoots(appPath) {
-		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, _ error) error {
+	for _, root := range ins.nativeModuleRoots(appPath) {
+		_ = ins.fs.WalkDir(root, func(path string, d os.DirEntry, _ error) error {
 			if d == nil || d.IsDir() {
 				return nil
 			}
@@ -945,7 +1010,7 @@ func scanNativeModules(appPath string) []NativeModule {
 				return nil
 			}
 			seen[rel] = struct{}{}
-			mods = append(mods, classifyNativeModule(path, rel))
+			mods = append(mods, ins.classifyNativeModule(path, rel))
 			return nil
 		})
 	}
@@ -956,6 +1021,10 @@ func scanNativeModules(appPath string) []NativeModule {
 }
 
 func nativeModuleRoots(appPath string) []string {
+	return defaultNodeAppInspector().nativeModuleRoots(appPath)
+}
+
+func (ins nodeAppInspector) nativeModuleRoots(appPath string) []string {
 	resources := filepath.Join(appPath, "Contents", "Resources")
 	candidates := []string{
 		filepath.Join(resources, "app.asar.unpacked"),
@@ -963,7 +1032,7 @@ func nativeModuleRoots(appPath string) []string {
 	}
 	var roots []string
 	for _, root := range candidates {
-		if isDir(root) {
+		if ins.fs.IsDir(root) {
 			roots = append(roots, root)
 		}
 	}
@@ -975,16 +1044,20 @@ func nativeModuleRoots(appPath string) []string {
 // libswift* references reveal Swift. Everything else falls through to
 // rust-strings scanning, then C++.
 func classifyNativeModule(absPath, relPath string) NativeModule {
+	return defaultNodeAppInspector().classifyNativeModule(absPath, relPath)
+}
+
+func (ins nodeAppInspector) classifyNativeModule(absPath, relPath string) NativeModule {
 	m := NativeModule{Name: filepath.Base(absPath), Path: relPath, Language: "C++"}
-	readNativeModulePackage(absPath, &m)
+	ins.readNativeModulePackage(absPath, &m)
 	appendNativeModuleCapabilityHints(&m)
 	appendNativeModuleRiskHints(&m)
-	libs := otoolL(absPath)
+	libs := ins.cmd.OtoolL(absPath)
 	joined := strings.Join(libs, "\n")
 
 	// Resolve @rpath references to actual sibling dylibs so we can also
 	// inspect the real implementation library (e.g. libClaudeSwift.dylib).
-	sidecars := nativeModuleSidecars(absPath, libs, &m)
+	sidecars := ins.nativeModuleSidecars(absPath, libs, &m)
 
 	// Rust signal #1: Cargo target path leaks into the load command.
 	if strings.Contains(joined, "/target/") && (strings.Contains(joined, "-apple-darwin/release/") || strings.Contains(joined, "-apple-darwin/debug/")) {
@@ -1013,9 +1086,9 @@ func classifyNativeModule(absPath, relPath string) NativeModule {
 	}
 
 	// Rust signal #2: panic strings in the .node file or any sidecar.
-	rust := scanBinaryMarkers(absPath).rustHits
+	rust := ins.scanBinaryMarkers(absPath).rustHits
 	for _, s := range sidecars {
-		rust += scanBinaryMarkers(s).rustHits
+		rust += ins.scanBinaryMarkers(s).rustHits
 	}
 	if rust >= 50 {
 		m.Language = "Rust"
@@ -1075,11 +1148,15 @@ func appendNativeModuleRiskHints(m *NativeModule) {
 }
 
 func readNativeModulePackage(absPath string, m *NativeModule) {
+	defaultNodeAppInspector().readNativeModulePackage(absPath, m)
+}
+
+func (ins nodeAppInspector) readNativeModulePackage(absPath string, m *NativeModule) {
 	root := nativeModulePackageRoot(absPath)
 	if root == "" {
 		return
 	}
-	data, err := os.ReadFile(filepath.Join(root, "package.json"))
+	data, err := ins.fs.ReadFile(filepath.Join(root, "package.json"))
 	if err != nil {
 		return
 	}
@@ -1117,13 +1194,17 @@ func nativeModulePackageRoot(absPath string) string {
 }
 
 func nativeModuleSidecars(absPath string, libs []string, m *NativeModule) []string {
+	return defaultNodeAppInspector().nativeModuleSidecars(absPath, libs, m)
+}
+
+func (ins nodeAppInspector) nativeModuleSidecars(absPath string, libs []string, m *NativeModule) []string {
 	var sidecars []string
 	for _, lib := range libs {
 		if !strings.HasPrefix(lib, "@rpath/") {
 			continue
 		}
 		sib := filepath.Join(filepath.Dir(absPath), strings.TrimPrefix(lib, "@rpath/"))
-		if exists(sib) {
+		if ins.fs.Exists(sib) {
 			sidecars = append(sidecars, sib)
 			m.Hints = append(m.Hints, "rpath sibling: "+filepath.Base(sib))
 		}
@@ -1214,8 +1295,12 @@ func followWrapper(exe string) string {
 // countJars returns the number of .jar files anywhere under root.
 // Bounded by walk; bundles aren't deep.
 func countJars(root string) int {
+	return defaultNodeAppInspector().countJars(root)
+}
+
+func (ins nodeAppInspector) countJars(root string) int {
 	var n int
-	_ = filepath.WalkDir(root, func(_ string, d os.DirEntry, _ error) error {
+	_ = ins.fs.WalkDir(root, func(_ string, d os.DirEntry, _ error) error {
 		if d == nil || d.IsDir() {
 			return nil
 		}
@@ -1553,9 +1638,13 @@ func readPrivacyDescriptions(appPath string) map[string]string {
 // scanDependencies summarises third-party libraries embedded in the bundle.
 // Apple frameworks and Helper sub-apps are filtered out.
 func scanDependencies(appPath string) *Dependencies {
+	return defaultNodeAppInspector().scanDependencies(appPath)
+}
+
+func (ins nodeAppInspector) scanDependencies(appPath string) *Dependencies {
 	d := &Dependencies{}
 	frameworks := filepath.Join(appPath, "Contents", "Frameworks")
-	if entries, err := os.ReadDir(frameworks); err == nil {
+	if entries, err := ins.fs.ReadDir(frameworks); err == nil {
 		for _, e := range entries {
 			name := e.Name()
 			if !strings.HasSuffix(name, ".framework") {
@@ -1574,7 +1663,7 @@ func scanDependencies(appPath string) *Dependencies {
 
 	// npm packages: top-level dirs under app.asar.unpacked/node_modules.
 	nm := filepath.Join(appPath, "Contents", "Resources", "app.asar.unpacked", "node_modules")
-	if entries, err := os.ReadDir(nm); err == nil {
+	if entries, err := ins.fs.ReadDir(nm); err == nil {
 		for _, e := range entries {
 			if !e.IsDir() {
 				continue
@@ -1582,7 +1671,7 @@ func scanDependencies(appPath string) *Dependencies {
 			n := e.Name()
 			if strings.HasPrefix(n, "@") {
 				// Scoped: list each scoped package as @scope/pkg.
-				if subs, err := os.ReadDir(filepath.Join(nm, n)); err == nil {
+				if subs, err := ins.fs.ReadDir(filepath.Join(nm, n)); err == nil {
 					for _, s := range subs {
 						if s.IsDir() {
 							d.NPMPackages = append(d.NPMPackages, n+"/"+s.Name())
@@ -1596,7 +1685,7 @@ func scanDependencies(appPath string) *Dependencies {
 		sort.Strings(d.NPMPackages)
 	}
 
-	d.JavaJars = countJars(filepath.Join(appPath, "Contents"))
+	d.JavaJars = ins.countJars(filepath.Join(appPath, "Contents"))
 
 	if len(d.ThirdPartyFrameworks) == 0 && len(d.NPMPackages) == 0 && d.JavaJars == 0 {
 		return nil
@@ -1608,6 +1697,10 @@ func scanDependencies(appPath string) *Dependencies {
 // in the main executable and app.asar (when present). Cheap-but-effective:
 // most apps don't bother to obfuscate URL literals.
 func scanNetworkEndpoints(appPath, exe string) []string {
+	return defaultNodeAppInspector().scanNetworkEndpoints(appPath, exe)
+}
+
+func (ins nodeAppInspector) scanNetworkEndpoints(appPath, exe string) []string {
 	hosts := map[string]struct{}{}
 	urlRe := regexp.MustCompile(`(?i)https?://([a-zA-Z0-9._-]+\.[a-zA-Z]{2,})`)
 
@@ -1616,7 +1709,7 @@ func scanNetworkEndpoints(appPath, exe string) []string {
 			return
 		}
 		// Stream in chunks; we only care about ASCII URL substrings.
-		f, err := os.Open(path)
+		f, err := ins.fs.Open(path)
 		if err != nil {
 			return
 		}
@@ -1646,7 +1739,7 @@ func scanNetworkEndpoints(appPath, exe string) []string {
 
 	addFrom(exe)
 	asar := filepath.Join(appPath, "Contents", "Resources", "app.asar")
-	if exists(asar) {
+	if ins.fs.Exists(asar) {
 		addFrom(asar)
 	}
 

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -1,12 +1,151 @@
 package detect
 
 import (
+	"bytes"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 )
+
+type fakeNodeFS struct {
+	files map[string][]byte
+	dirs  map[string]bool
+}
+
+func newFakeNodeFS() *fakeNodeFS {
+	return &fakeNodeFS{files: map[string][]byte{}, dirs: map[string]bool{}}
+}
+
+func (f *fakeNodeFS) addDir(path string) {
+	path = filepath.Clean(path)
+	for {
+		f.dirs[path] = true
+		parent := filepath.Dir(path)
+		if parent == path || parent == "." {
+			return
+		}
+		path = parent
+	}
+}
+
+func (f *fakeNodeFS) addFile(path string, data string) {
+	path = filepath.Clean(path)
+	f.addDir(filepath.Dir(path))
+	f.files[path] = []byte(data)
+}
+
+func (f *fakeNodeFS) Exists(path string) bool {
+	path = filepath.Clean(path)
+	_, file := f.files[path]
+	return file || f.dirs[path]
+}
+
+func (f *fakeNodeFS) IsDir(path string) bool {
+	return f.dirs[filepath.Clean(path)]
+}
+
+func (f *fakeNodeFS) Open(path string) (io.ReadCloser, error) {
+	data, ok := f.files[filepath.Clean(path)]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (f *fakeNodeFS) ReadDir(path string) ([]os.DirEntry, error) {
+	path = filepath.Clean(path)
+	if !f.dirs[path] {
+		return nil, os.ErrNotExist
+	}
+	children := map[string]fakeDirEntry{}
+	prefix := path + string(os.PathSeparator)
+	for p := range f.dirs {
+		if !strings.HasPrefix(p, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(p, prefix)
+		if rest == "" || strings.Contains(rest, string(os.PathSeparator)) {
+			continue
+		}
+		children[rest] = fakeDirEntry{name: rest, dir: true}
+	}
+	for p := range f.files {
+		if !strings.HasPrefix(p, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(p, prefix)
+		if rest == "" || strings.Contains(rest, string(os.PathSeparator)) {
+			continue
+		}
+		children[rest] = fakeDirEntry{name: rest}
+	}
+	names := make([]string, 0, len(children))
+	for name := range children {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	entries := make([]os.DirEntry, 0, len(names))
+	for _, name := range names {
+		entries = append(entries, children[name])
+	}
+	return entries, nil
+}
+
+func (f *fakeNodeFS) ReadFile(path string) ([]byte, error) {
+	data, ok := f.files[filepath.Clean(path)]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return data, nil
+}
+
+func (f *fakeNodeFS) WalkDir(root string, fn fs.WalkDirFunc) error {
+	root = filepath.Clean(root)
+	if !f.Exists(root) {
+		return os.ErrNotExist
+	}
+	var paths []string
+	for p := range f.dirs {
+		if p == root || strings.HasPrefix(p, root+string(os.PathSeparator)) {
+			paths = append(paths, p)
+		}
+	}
+	for p := range f.files {
+		if p == root || strings.HasPrefix(p, root+string(os.PathSeparator)) {
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		if err := fn(p, fakeDirEntry{name: filepath.Base(p), dir: f.dirs[p]}, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type fakeDirEntry struct {
+	name string
+	dir  bool
+}
+
+func (e fakeDirEntry) Name() string               { return e.name }
+func (e fakeDirEntry) IsDir() bool                { return e.dir }
+func (e fakeDirEntry) Type() os.FileMode          { return 0 }
+func (e fakeDirEntry) Info() (os.FileInfo, error) { return nil, nil }
+
+type fakeNodeCommands struct {
+	libs map[string][]string
+}
+
+func (c fakeNodeCommands) OtoolL(path string) []string {
+	return c.libs[filepath.Clean(path)]
+}
 
 // makeBundle creates a synthetic .app skeleton at t.TempDir()/Name.app
 // and returns its path. Subsequent helpers add markers.
@@ -299,6 +438,79 @@ func TestDependenciesNPMPackages(t *testing.T) {
 	}
 	if len(want) != 0 {
 		t.Errorf("missing packages: %v", want)
+	}
+}
+
+func TestNodeAppInspectorDependenciesWithFakeFS(t *testing.T) {
+	app := "/Apps/Fake.app"
+	fsys := newFakeNodeFS()
+	fsys.addDir(filepath.Join(app, "Contents/Frameworks/Electron Framework.framework"))
+	fsys.addDir(filepath.Join(app, "Contents/Frameworks/Squirrel.framework"))
+	fsys.addDir(filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/node-pty"))
+	fsys.addDir(filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/@scope/pkg"))
+	fsys.addFile(filepath.Join(app, "Contents/lib/runtime/a.jar"), "")
+	fsys.addFile(filepath.Join(app, "Contents/lib/runtime/readme.txt"), "")
+
+	deps := (nodeAppInspector{fs: fsys, cmd: fakeNodeCommands{}}).scanDependencies(app)
+	if deps == nil {
+		t.Fatal("Dependencies nil")
+	}
+	if got := strings.Join(deps.ThirdPartyFrameworks, ","); got != "Squirrel" {
+		t.Fatalf("ThirdPartyFrameworks = %q, want Squirrel", got)
+	}
+	if got := strings.Join(deps.NPMPackages, ","); got != "@scope/pkg,node-pty" {
+		t.Fatalf("NPMPackages = %q, want @scope/pkg,node-pty", got)
+	}
+	if deps.JavaJars != 1 {
+		t.Fatalf("JavaJars = %d, want 1", deps.JavaJars)
+	}
+}
+
+func TestNodeAppInspectorNativeModuleWithFakes(t *testing.T) {
+	app := "/Apps/Fake.app"
+	mod := filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/keytar/build/Release/keytar.node")
+	sidecar := filepath.Join(filepath.Dir(mod), "libKeytarSwift.dylib")
+	fsys := newFakeNodeFS()
+	fsys.addFile(filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/keytar/package.json"), `{"name":"keytar","version":"7.9.0"}`)
+	fsys.addFile(mod, "native addon")
+	fsys.addFile(sidecar, "sidecar")
+	fsys.addFile(filepath.Join(app, "Contents/Resources/app.asar.unpacked/node_modules/keytar/keytar.node.dSYM/Contents/Resources/DWARF/keytar.node"), "debug")
+	cmds := fakeNodeCommands{libs: map[string][]string{
+		filepath.Clean(mod): {
+			"@rpath/libKeytarSwift.dylib",
+			"/System/Library/Frameworks/AppKit.framework/AppKit",
+		},
+	}}
+
+	mods := (nodeAppInspector{fs: fsys, cmd: cmds}).scanNativeModules(app)
+	if len(mods) != 1 {
+		t.Fatalf("NativeModules len = %d, want 1: %#v", len(mods), mods)
+	}
+	m := mods[0]
+	if m.Language != "Swift" {
+		t.Fatalf("Language = %q, want Swift; hints=%v", m.Language, m.Hints)
+	}
+	if m.PackageName != "keytar" || m.PackageVersion != "7.9.0" {
+		t.Fatalf("Package = %q@%q, want keytar@7.9.0", m.PackageName, m.PackageVersion)
+	}
+	if !hasHint(m.Hints, "uses macOS Keychain") || !hasHint(m.RiskHints, "credential store access") {
+		t.Fatalf("hints = %v risk hints = %v, want keytar capability and risk hints", m.Hints, m.RiskHints)
+	}
+	if !hasHint(m.Hints, "rpath sibling: libKeytarSwift.dylib") {
+		t.Fatalf("hints = %v, want sidecar hint", m.Hints)
+	}
+}
+
+func TestNodeAppInspectorNetworkEndpointsWithFakeFS(t *testing.T) {
+	app := "/Apps/Fake.app"
+	exe := filepath.Join(app, "Contents/MacOS/main")
+	fsys := newFakeNodeFS()
+	fsys.addFile(exe, "https://api.example.com https://www.w3.org")
+	fsys.addFile(filepath.Join(app, "Contents/Resources/app.asar"), strings.Repeat("x", 300)+"https://Telemetry.Example.com/path")
+
+	hosts := (nodeAppInspector{fs: fsys, cmd: fakeNodeCommands{}}).scanNetworkEndpoints(app, exe)
+	if got := strings.Join(hosts, ","); got != "api.example.com,telemetry.example.com" {
+		t.Fatalf("hosts = %q, want api.example.com,telemetry.example.com", got)
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Metadata: inspection/metadata.md
       - Security: inspection/security.md
       - Storage footprint: inspection/storage-footprint.md
+      - Node-based apps: inspection/node-based-apps.md
       - Network endpoints: inspection/network-endpoints.md
       - Helpers and XPC: inspection/helpers-and-xpc.md
       - Login items: inspection/login-items.md


### PR DESCRIPTION
## Summary
- document Node-based app inspection and link it from the docs nav
- add fakeable Node app inspection interfaces for filesystem and otool access
- add fake-backed unit tests for npm dependencies, native modules, and static URL host scanning

## Validation
- make docs-validate
- go test ./internal/detect/ -run 'TestNodeAppInspector|TestDependenciesNPMPackages|TestElectronNativeModulesScanned|TestNativeModule' -count=1\n- go build ./... && go vet ./...\n- go test ./... -count=1