### PR TITLE
[codex] add objc app inspection

### DIFF
--- a/cmd/spectra/inspect.go
+++ b/cmd/spectra/inspect.go
@@ -172,6 +172,7 @@ func printMeta(r detect.Result) {
 	printPrivacyMeta(r)
 	printSwiftMeta(r)
 	printDependencyMeta(r)
+	printObjCMeta(r)
 	printStructureMeta(r)
 	printRuntimeMeta(r)
 	printStorageMeta(r)
@@ -283,6 +284,43 @@ func printDependencyMeta(r detect.Result) {
 	if len(r.NetworkEndpoints) > 0 {
 		fmt.Printf("    hosts (%d): %s\n", len(r.NetworkEndpoints),
 			truncateList(r.NetworkEndpoints, 8))
+	}
+}
+
+func printObjCMeta(r detect.Result) {
+	if r.ObjC == nil {
+		return
+	}
+	if r.ObjC.PrincipalClass != "" || r.ObjC.MainNibFile != "" || r.ObjC.MainStoryboardFile != "" {
+		parts := []string{}
+		if r.ObjC.PrincipalClass != "" {
+			parts = append(parts, "principal "+r.ObjC.PrincipalClass)
+		}
+		if r.ObjC.MainNibFile != "" {
+			parts = append(parts, "nib "+r.ObjC.MainNibFile)
+		}
+		if r.ObjC.MainStoryboardFile != "" {
+			parts = append(parts, "storyboard "+r.ObjC.MainStoryboardFile)
+		}
+		fmt.Printf("    objc: %s\n", strings.Join(parts, ", "))
+	}
+	if len(r.ObjC.LinkedFrameworks) > 0 {
+		fmt.Printf("    objc frameworks (%d): %s\n", len(r.ObjC.LinkedFrameworks),
+			truncateList(r.ObjC.LinkedFrameworks, 8))
+	}
+	if len(r.ObjC.URLSchemes) > 0 {
+		fmt.Printf("    url schemes: %s\n", truncateList(r.ObjC.URLSchemes, 6))
+	}
+	if len(r.ObjC.DocumentTypes) > 0 {
+		names := make([]string, 0, len(r.ObjC.DocumentTypes))
+		for _, doc := range r.ObjC.DocumentTypes {
+			if doc.Name != "" {
+				names = append(names, doc.Name)
+			}
+		}
+		if len(names) > 0 {
+			fmt.Printf("    document types: %s\n", truncateList(names, 6))
+		}
 	}
 }
 

--- a/docs/detection/frameworks.md
+++ b/docs/detection/frameworks.md
@@ -60,6 +60,8 @@ confirmed examples from real apps. Layer numbers refer to
 - **Layer 2:** AppKit/Cocoa linked, no Swift dylibs.
 - **Confirmed:** Telegram, Sublime Text, Steam, Alfred 5, Audacity
   (wxWidgets-based, falls under AppKit), Godot.
+- **Inspection:** See
+  [../inspection/objc-based-app.md](../inspection/objc-based-app.md).
 
 ### Mac Catalyst
 - **Layer 2:** Linked path contains `/iOSSupport/...UIKit*.framework/`

--- a/docs/detection/overview.md
+++ b/docs/detection/overview.md
@@ -46,6 +46,8 @@ Mac Catalyst:
 See [catalyst.md](catalyst.md) for the Catalyst path.
 See [../inspection/swift-apps.md](../inspection/swift-apps.md) for the
 deeper app-level Swift inspection surface.
+See [../inspection/objc-based-app.md](../inspection/objc-based-app.md)
+for the AppKit/Objective-C inspection profile.
 
 ### Layer 3 — Binary content scanning
 

--- a/docs/inspection/objc-based-app.md
+++ b/docs/inspection/objc-based-app.md
@@ -1,0 +1,141 @@
+# Objective-C based app inspection
+
+Objective-C based apps are native Cocoa/AppKit bundles where the main
+executable links AppKit but does not link Swift runtime dylibs. Spectra
+classifies these as `AppKit (Obj-C)` and treats the result as a real
+native Mac app, not an unknown fallback.
+
+This page documents the inspection signals that make that verdict useful
+for debugging older Cocoa apps, mixed C/C++ apps using Cocoa shells, and
+toolkit apps that ultimately host their UI through AppKit.
+
+## Detection boundary
+
+Objective-C based inspection starts from the Layer 2 framework verdict:
+
+| Signal | Interpretation |
+|---|---|
+| `/AppKit.framework/` or `/Cocoa.framework/` linked | Native Mac UI surface |
+| No `libswift*.dylib` linked | No Swift runtime evidence |
+| No `/SwiftUI.framework/` linked | Not SwiftUI-first |
+| No `/WebKit.framework/` linked | Not a WebKit shell such as Tauri/Wails/custom Go bridge |
+| No Catalyst paths | Not UIKit-on-Mac |
+
+The verdict is intentionally medium confidence. It says "native AppKit
+without stronger language/runtime evidence", which is the correct result
+for many long-lived Mac apps.
+
+## What Spectra inspects
+
+Objective-C apps are often diagnostic-heavy even when the classifier
+surface is small. The useful inspection is a bundle-level profile, not a
+single marker.
+
+| Area | Source | Why it matters |
+|---|---|---|
+| Linked frameworks | `otool -L <executable>` | Shows AppKit, Cocoa, WebKit, Security, CoreData, SQLite, Sparkle, and private toolkit dependencies |
+| App delegate / principal class | `Info.plist` `NSPrincipalClass`, `NSMainNibFile`, `NSMainStoryboardFile` | Distinguishes nib/storyboard-era Cocoa apps from custom launcher shells |
+| Document types | `Info.plist` `CFBundleDocumentTypes` | Explains Finder integrations and file ownership |
+| URL schemes | `Info.plist` `CFBundleURLTypes` | Reveals deep-link and IPC entry points |
+| Services | `Info.plist` `NSServices` | Shows macOS Services menu integrations |
+| Apple events | Entitlements and usage strings | Explains automation, scripting, and inter-app control needs |
+| Helpers and XPC | `Contents/Frameworks/`, `Contents/XPCServices/`, `Contents/PlugIns/` | Finds updater helpers, crash reporters, importers, Quick Look generators, and extensions |
+| Persistence | Bundle ID derived paths in `~/Library` | Finds preferences, Application Support, caches, logs, containers, and saved state |
+| Update mechanism | `Contents/Frameworks/`, `Info.plist` | Native apps commonly use Sparkle, MAS receipts, or no embedded updater |
+
+These rows overlap with the general metadata, security, helper, and
+storage collectors. The `ObjC` result profile assembles the AppKit-native
+pieces that are not obvious from the top-level verdict alone.
+
+## Common patterns
+
+### Classic Cocoa app
+
+Signals:
+
+- AppKit or Cocoa linked.
+- `NSMainNibFile` or `NSPrincipalClass` present.
+- No Swift dylibs.
+- Zero or one helper.
+- Optional Sparkle framework.
+
+Examples include older productivity tools, utilities, and apps that have
+kept a stable Objective-C codebase for years.
+
+### C++ toolkit with AppKit host
+
+Signals:
+
+- AppKit linked because every Mac GUI eventually talks to AppKit.
+- Large C++ dependency surface.
+- Toolkit-specific frameworks or dylibs.
+- No Swift dylibs.
+
+wxWidgets, custom OpenGL/Metal editors, and some game/editor shells can
+land here. Spectra reports the AppKit verdict while leaving enough
+linked-framework detail to explain that the app is not a plain Cocoa UI.
+
+### Objective-C shell around another runtime
+
+Signals:
+
+- Small launcher executable.
+- Larger sibling or framework binary.
+- AppKit linked in the launcher.
+- Runtime evidence appears only after following the real executable.
+
+The shim and wrapper handling in the classifier exists for this case. If
+the real binary contains Go, Rust, JVM, Electron, or WebKit evidence, that
+stronger runtime verdict should win.
+
+## Output guidance
+
+Verbose output should keep the framework verdict concise and then expose
+the supporting bundle facts:
+
+```text
+Alfred 5
+  ui: AppKit (Obj-C)  confidence: medium
+  id: com.runningwithcrayons.Alfred  version: 5.x
+  arch: arm64,x86_64  team: XZZXE9SED4
+  packaging: Sparkle
+  helpers: Alfred Preferences
+```
+
+JSON output uses the canonical `ObjC` field documented in
+[`result-schema.md`](../reference/result-schema.md). The profile is
+present only for plain AppKit/Objective-C verdicts.
+
+## Limitations
+
+- Objective-C symbols are often stripped in release builds, so method or
+  class-name inspection is best-effort enrichment, not a classifier
+  requirement.
+- AppKit linkage alone does not prove that all UI is hand-written Cocoa.
+  Toolkit and game apps still rely on AppKit at the platform boundary.
+- Absence of Swift dylibs is not proof that no Swift code exists anywhere
+  in the bundle; a plugin or helper may carry Swift independently.
+- Private framework names can be useful diagnostically, but Spectra
+  reports them as linked dependencies rather than inferring unsupported
+  private API behavior.
+
+## Implementation reference
+
+`internal/detect/detect.go`:
+
+- Layer 2 `otool -L` parsing produces the `AppKit (Obj-C)` verdict when
+  AppKit/Cocoa is present without Swift, SwiftUI, WebKit, or Catalyst
+  signals.
+- Shim and wrapper resolution should run before binary-content scanning so
+  Objective-C launcher shells do not hide stronger runtime evidence.
+- Reuse existing collectors for metadata, security, helpers/XPC, login
+  items, running processes, and storage footprint.
+
+Related docs:
+
+- [../detection/overview.md](../detection/overview.md) — classifier layers.
+- [../detection/frameworks.md](../detection/frameworks.md) — AppKit
+  framework signal table.
+- [metadata.md](metadata.md) — bundle plist and architecture fields.
+- [helpers-and-xpc.md](helpers-and-xpc.md) — embedded helpers, XPC services,
+  and plugins.

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -17,6 +17,7 @@ Source of truth: `internal/detect/detect.go`.
 | `Confidence` | string | high / medium / low |
 | `Signals` | []string | Human-readable evidence trail |
 | `NativeModules` | []NativeModule | Per-Electron-app native add-on classifications |
+| `ObjC` | *ObjCInspection | Per-AppKit Objective-C bundle profile |
 
 ## Metadata fields
 
@@ -71,6 +72,28 @@ type NativeModule struct {
     Language       string   // Rust, Swift, C++, unknown
     Hints          []string // additional context (linked frameworks, etc.)
     RiskHints      []string // security-sensitive capability patterns to review
+}
+```
+
+### ObjCInspection
+
+```go
+type ObjCInspection struct {
+    LinkedFrameworks       []string
+    PrincipalClass         string
+    MainNibFile            string
+    MainStoryboardFile     string
+    DocumentTypes          []ObjCDocumentType
+    URLSchemes             []string
+    Services               []string
+    AutomationEntitlements []string
+    UpdateMechanism        string
+}
+
+type ObjCDocumentType struct {
+    Name       string
+    Role       string
+    Extensions []string
 }
 ```
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -30,13 +30,14 @@ import (
 // Result is the diagnosis for one .app bundle.
 type Result struct {
 	Path          string
-	UI            string         // Electron, SwiftUI, AppKit, Tauri, Flutter, Qt, ComposeDesktop, Swing, SWT, NetBeansPlatform, EclipseRCP, Wxwidgets, Unknown
-	Runtime       string         // Node+Chromium, Swift, ObjC, Rust, Dart, JVM, Go, C++, mixed, unknown
-	Language      string         // best guess: TypeScript/JS, Swift, Kotlin, Java, Rust, Go, Dart, C++, ObjC
-	Packaging     string         // Squirrel, Sparkle, jpackage, install4j, none
-	Confidence    string         // high | medium | low
-	Signals       []string       // human-readable reasons we picked this
-	NativeModules []NativeModule // sub-detection: custom native code embedded in the bundle
+	UI            string          // Electron, SwiftUI, AppKit, Tauri, Flutter, Qt, ComposeDesktop, Swing, SWT, NetBeansPlatform, EclipseRCP, Wxwidgets, Unknown
+	Runtime       string          // Node+Chromium, Swift, ObjC, Rust, Dart, JVM, Go, C++, mixed, unknown
+	Language      string          // best guess: TypeScript/JS, Swift, Kotlin, Java, Rust, Go, Dart, C++, ObjC
+	Packaging     string          // Squirrel, Sparkle, jpackage, install4j, none
+	Confidence    string          // high | medium | low
+	Signals       []string        // human-readable reasons we picked this
+	NativeModules []NativeModule  // sub-detection: custom native code embedded in the bundle
+	ObjC          *ObjCInspection // Objective-C/AppKit bundle profile, when applicable
 
 	// Metadata pulled from Info.plist and frameworks. Best-effort; any
 	// field may be empty if the bundle doesn't expose it.
@@ -146,6 +147,27 @@ type SwiftInspection struct {
 	UsesAppIntents    bool
 	UsesScreenCapture bool
 	AppGroups         []string
+}
+
+// ObjCInspection summarizes AppKit/Objective-C bundle structure that is
+// useful once the framework classifier lands on plain AppKit.
+type ObjCInspection struct {
+	LinkedFrameworks       []string
+	PrincipalClass         string
+	MainNibFile            string
+	MainStoryboardFile     string
+	DocumentTypes          []ObjCDocumentType
+	URLSchemes             []string
+	Services               []string
+	AutomationEntitlements []string
+	UpdateMechanism        string
+}
+
+// ObjCDocumentType is one CFBundleDocumentTypes entry from Info.plist.
+type ObjCDocumentType struct {
+	Name       string
+	Role       string
+	Extensions []string
 }
 
 // StorageFootprint is the on-disk size, in bytes, of each well-known
@@ -295,6 +317,7 @@ func DetectWith(appPath string, opts Options) (Result, error) {
 	r.PrivacyDescriptions = readPrivacyDescriptions(appPath)
 	r.Dependencies = scanDependencies(appPath)
 	r.Helpers = scanHelpers(appPath)
+	r.ObjC = scanObjCInspection(appPath, exe, r)
 	r.LoginItems = scanLoginItems(appPath, r.BundleID)
 	r.RunningProcesses = scanRunningProcesses(appPath)
 	r.AppStartedAt, r.AppUptimeSeconds = appUptime(r.RunningProcesses, detectNow(opts))

--- a/internal/detect/objc.go
+++ b/internal/detect/objc.go
@@ -1,0 +1,389 @@
+package detect
+
+import (
+	"context"
+	"encoding/xml"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/proc"
+)
+
+type objcSources interface {
+	LinkedLibraries(exe string) ([]string, error)
+	PlistXML(path string) ([]byte, error)
+	Entitlements(appPath string) ([]string, error)
+}
+
+type objcSystemSources struct {
+	runner proc.Runner
+}
+
+func scanObjCInspection(appPath, exe string, r Result) *ObjCInspection {
+	if r.UI != "AppKit" || r.Runtime != "ObjC" {
+		return nil
+	}
+	src := objcSystemSources{runner: proc.Default}
+	return inspectObjCApp(appPath, exe, r, src)
+}
+
+func inspectObjCApp(appPath, exe string, r Result, src objcSources) *ObjCInspection {
+	if src == nil {
+		return nil
+	}
+	plistPath := filepath.Join(appPath, "Contents", "Info.plist")
+	inspect := &ObjCInspection{
+		UpdateMechanism: r.Packaging,
+	}
+
+	if libs, err := src.LinkedLibraries(exe); err == nil {
+		inspect.LinkedFrameworks = objcFrameworkNames(libs)
+	}
+	if plistXML, err := src.PlistXML(plistPath); err == nil {
+		p := parseObjCPlist(plistXML)
+		inspect.PrincipalClass = p.PrincipalClass
+		inspect.MainNibFile = p.MainNibFile
+		inspect.MainStoryboardFile = p.MainStoryboardFile
+		inspect.DocumentTypes = p.DocumentTypes
+		inspect.URLSchemes = p.URLSchemes
+		inspect.Services = p.Services
+	}
+	if ents, err := src.Entitlements(appPath); err == nil {
+		inspect.AutomationEntitlements = objcAutomationEntitlements(ents)
+	}
+	if inspect.UpdateMechanism == "" {
+		inspect.UpdateMechanism = objcUpdateMechanism(appPath)
+	}
+
+	if inspect.empty() {
+		return nil
+	}
+	return inspect
+}
+
+func (s objcSystemSources) LinkedLibraries(exe string) ([]string, error) {
+	if exe == "" {
+		return nil, nil
+	}
+	res, err := s.runner.Run(context.Background(), proc.Cmd{Name: "otool", Args: []string{"-L", exe}})
+	if err != nil || res.ExitCode != 0 {
+		return nil, err
+	}
+	return parseOtoolLibraries(res.Stdout), nil
+}
+
+func (s objcSystemSources) PlistXML(path string) ([]byte, error) {
+	res, err := s.runner.Run(context.Background(), proc.Cmd{Name: "plutil", Args: []string{"-convert", "xml1", "-o", "-", path}})
+	if err != nil || res.ExitCode != 0 {
+		return nil, err
+	}
+	return res.Stdout, nil
+}
+
+func (s objcSystemSources) Entitlements(appPath string) ([]string, error) {
+	res, err := s.runner.Run(context.Background(), proc.Cmd{Name: "codesign", Args: []string{"-d", "--entitlements", ":-", appPath}})
+	if err != nil || res.ExitCode != 0 {
+		return nil, err
+	}
+	return parseEntitlementKeys(string(res.Stdout)), nil
+}
+
+func objcFrameworkNames(libs []string) []string {
+	seen := map[string]struct{}{}
+	for _, lib := range libs {
+		if name := frameworkName(lib); name != "" {
+			seen[name] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func frameworkName(lib string) string {
+	const suffix = ".framework/"
+	idx := strings.Index(lib, suffix)
+	if idx < 0 {
+		return ""
+	}
+	before := lib[:idx]
+	slash := strings.LastIndex(before, "/")
+	if slash < 0 || slash == len(before)-1 {
+		return ""
+	}
+	return before[slash+1:]
+}
+
+type objcPlist struct {
+	PrincipalClass     string
+	MainNibFile        string
+	MainStoryboardFile string
+	DocumentTypes      []ObjCDocumentType
+	URLSchemes         []string
+	Services           []string
+}
+
+func parseObjCPlist(data []byte) objcPlist {
+	var root plistRoot
+	if err := xml.Unmarshal(data, &root); err != nil {
+		return objcPlist{}
+	}
+	dict := root.Dict
+	return objcPlist{
+		PrincipalClass:     dict.stringValue("NSPrincipalClass"),
+		MainNibFile:        dict.stringValue("NSMainNibFile"),
+		MainStoryboardFile: dict.stringValue("NSMainStoryboardFile"),
+		DocumentTypes:      dict.documentTypes(),
+		URLSchemes:         uniqueSorted(dict.urlSchemes()),
+		Services:           uniqueSorted(dict.services()),
+	}
+}
+
+type plistRoot struct {
+	Dict plistDict `xml:"dict"`
+}
+
+type plistDict struct {
+	Entries []plistEntry
+}
+
+type plistEntry struct {
+	Key    string
+	String string
+	Dict   plistDict
+	Array  plistArray
+	True   bool
+	False  bool
+}
+
+type plistArray struct {
+	Strings []string
+	Dicts   []plistDict
+}
+
+func (d *plistDict) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local != "key" {
+				if err := dec.Skip(); err != nil {
+					return err
+				}
+				continue
+			}
+			var key string
+			if err := dec.DecodeElement(&key, &t); err != nil {
+				return err
+			}
+			entry := plistEntry{Key: key}
+			if err := decodePlistValue(dec, &entry); err != nil {
+				return err
+			}
+			d.Entries = append(d.Entries, entry)
+		case xml.EndElement:
+			if t.Name.Local == start.Name.Local {
+				return nil
+			}
+		}
+	}
+}
+
+func decodePlistValue(dec *xml.Decoder, entry *plistEntry) error {
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		switch start.Name.Local {
+		case "string":
+			return dec.DecodeElement(&entry.String, &start)
+		case "dict":
+			return dec.DecodeElement(&entry.Dict, &start)
+		case "array":
+			return dec.DecodeElement(&entry.Array, &start)
+		case "true":
+			entry.True = true
+			return dec.Skip()
+		case "false":
+			entry.False = true
+			return dec.Skip()
+		default:
+			return dec.Skip()
+		}
+	}
+}
+
+func (a *plistArray) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "string":
+				var s string
+				if err := dec.DecodeElement(&s, &t); err != nil {
+					return err
+				}
+				a.Strings = append(a.Strings, s)
+			case "dict":
+				var d plistDict
+				if err := dec.DecodeElement(&d, &t); err != nil {
+					return err
+				}
+				a.Dicts = append(a.Dicts, d)
+			default:
+				if err := dec.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			if t.Name.Local == start.Name.Local {
+				return nil
+			}
+		}
+	}
+}
+
+func (d plistDict) stringValue(key string) string {
+	for _, e := range d.Entries {
+		if e.Key == key {
+			return strings.TrimSpace(e.String)
+		}
+	}
+	return ""
+}
+
+func (d plistDict) arrayValue(key string) plistArray {
+	for _, e := range d.Entries {
+		if e.Key == key {
+			return e.Array
+		}
+	}
+	return plistArray{}
+}
+
+func (d plistDict) documentTypes() []ObjCDocumentType {
+	arr := d.arrayValue("CFBundleDocumentTypes")
+	out := make([]ObjCDocumentType, 0, len(arr.Dicts))
+	for _, doc := range arr.Dicts {
+		item := ObjCDocumentType{
+			Name:       doc.stringValue("CFBundleTypeName"),
+			Role:       doc.stringValue("CFBundleTypeRole"),
+			Extensions: uniqueSorted(doc.arrayValue("CFBundleTypeExtensions").Strings),
+		}
+		if item.Name != "" || item.Role != "" || len(item.Extensions) > 0 {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func (d plistDict) urlSchemes() []string {
+	arr := d.arrayValue("CFBundleURLTypes")
+	var schemes []string
+	for _, urlType := range arr.Dicts {
+		schemes = append(schemes, urlType.arrayValue("CFBundleURLSchemes").Strings...)
+	}
+	return schemes
+}
+
+func (d plistDict) services() []string {
+	arr := d.arrayValue("NSServices")
+	services := make([]string, 0, len(arr.Dicts))
+	for _, service := range arr.Dicts {
+		name := service.stringValue("NSPortName")
+		if name == "" {
+			name = service.stringValue("NSMessage")
+		}
+		if name == "" {
+			name = service.stringValue("NSMenuItem")
+		}
+		if name != "" {
+			services = append(services, name)
+		}
+	}
+	return services
+}
+
+func uniqueSorted(in []string) []string {
+	seen := map[string]struct{}{}
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		seen[s] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func objcAutomationEntitlements(ents []string) []string {
+	var out []string
+	for _, ent := range ents {
+		switch ent {
+		case "com.apple.security.automation.apple-events", "com.apple.security.temporary-exception.apple-events":
+			out = append(out, ent)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func parseEntitlementKeys(xmlText string) []string {
+	var root plistRoot
+	if err := xml.Unmarshal([]byte(xmlText), &root); err != nil {
+		return nil
+	}
+	var keys []string
+	for _, entry := range root.Dict.Entries {
+		if entry.True {
+			keys = append(keys, entry.Key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func objcUpdateMechanism(appPath string) string {
+	frameworks := filepath.Join(appPath, "Contents", "Frameworks")
+	switch {
+	case exists(filepath.Join(frameworks, "Sparkle.framework")):
+		return "Sparkle"
+	case exists(filepath.Join(appPath, "Contents", "_MASReceipt")):
+		return "MAS"
+	default:
+		return ""
+	}
+}
+
+func (i *ObjCInspection) empty() bool {
+	return len(i.LinkedFrameworks) == 0 &&
+		i.PrincipalClass == "" &&
+		i.MainNibFile == "" &&
+		i.MainStoryboardFile == "" &&
+		len(i.DocumentTypes) == 0 &&
+		len(i.URLSchemes) == 0 &&
+		len(i.Services) == 0 &&
+		len(i.AutomationEntitlements) == 0 &&
+		i.UpdateMechanism == ""
+}

--- a/internal/detect/objc_test.go
+++ b/internal/detect/objc_test.go
@@ -1,0 +1,154 @@
+package detect
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+type fakeObjCSources struct {
+	libs            []string
+	plistXML        []byte
+	entitlements    []string
+	libsErr         error
+	plistErr        error
+	entitlementsErr error
+}
+
+func (f fakeObjCSources) LinkedLibraries(string) ([]string, error) {
+	return f.libs, f.libsErr
+}
+
+func (f fakeObjCSources) PlistXML(string) ([]byte, error) {
+	return f.plistXML, f.plistErr
+}
+
+func (f fakeObjCSources) Entitlements(string) ([]string, error) {
+	return f.entitlements, f.entitlementsErr
+}
+
+func TestInspectObjCAppBuildsProfileFromInjectedSources(t *testing.T) {
+	app := makeBundle(t, "FakeObjCProfile")
+	plist := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>NSPrincipalClass</key><string>NSApplication</string>
+<key>NSMainNibFile</key><string>MainMenu</string>
+<key>CFBundleDocumentTypes</key><array>
+  <dict>
+    <key>CFBundleTypeName</key><string>Spectra Trace</string>
+    <key>CFBundleTypeRole</key><string>Editor</string>
+    <key>CFBundleTypeExtensions</key><array><string>trace</string><string>sptrace</string><string>trace</string></array>
+  </dict>
+</array>
+<key>CFBundleURLTypes</key><array>
+  <dict><key>CFBundleURLSchemes</key><array><string>spectra</string><string>spectra-debug</string></array></dict>
+</array>
+<key>NSServices</key><array>
+  <dict><key>NSPortName</key><string>SpectraService</string></dict>
+</array>
+</dict></plist>`)
+
+	got := inspectObjCApp(app, filepath.Join(app, "Contents/MacOS/main"), Result{
+		UI:        "AppKit",
+		Runtime:   "ObjC",
+		Packaging: "Sparkle",
+	}, fakeObjCSources{
+		libs: []string{
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+			"/System/Library/Frameworks/Security.framework/Versions/A/Security",
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+		},
+		plistXML: plist,
+		entitlements: []string{
+			"com.apple.security.network.client",
+			"com.apple.security.automation.apple-events",
+		},
+	})
+
+	if got == nil {
+		t.Fatal("ObjC inspection nil")
+	}
+	if !reflect.DeepEqual(got.LinkedFrameworks, []string{"AppKit", "Security"}) {
+		t.Fatalf("LinkedFrameworks = %v", got.LinkedFrameworks)
+	}
+	if got.PrincipalClass != "NSApplication" || got.MainNibFile != "MainMenu" {
+		t.Fatalf("principal/nib = %q/%q", got.PrincipalClass, got.MainNibFile)
+	}
+	if len(got.DocumentTypes) != 1 {
+		t.Fatalf("DocumentTypes = %#v", got.DocumentTypes)
+	}
+	doc := got.DocumentTypes[0]
+	if doc.Name != "Spectra Trace" || doc.Role != "Editor" || !reflect.DeepEqual(doc.Extensions, []string{"sptrace", "trace"}) {
+		t.Fatalf("document type = %#v", doc)
+	}
+	if !reflect.DeepEqual(got.URLSchemes, []string{"spectra", "spectra-debug"}) {
+		t.Fatalf("URLSchemes = %v", got.URLSchemes)
+	}
+	if !reflect.DeepEqual(got.Services, []string{"SpectraService"}) {
+		t.Fatalf("Services = %v", got.Services)
+	}
+	if !reflect.DeepEqual(got.AutomationEntitlements, []string{"com.apple.security.automation.apple-events"}) {
+		t.Fatalf("AutomationEntitlements = %v", got.AutomationEntitlements)
+	}
+	if got.UpdateMechanism != "Sparkle" {
+		t.Fatalf("UpdateMechanism = %q", got.UpdateMechanism)
+	}
+}
+
+func TestInspectObjCAppIgnoresMissingOptionalSources(t *testing.T) {
+	app := makeBundle(t, "FakeObjCPartial")
+	got := inspectObjCApp(app, filepath.Join(app, "Contents/MacOS/main"), Result{
+		UI:      "AppKit",
+		Runtime: "ObjC",
+	}, fakeObjCSources{
+		libsErr:         errors.New("otool unavailable"),
+		plistErr:        errors.New("plist unreadable"),
+		entitlementsErr: errors.New("unsigned"),
+	})
+	if got != nil {
+		t.Fatalf("ObjC inspection = %#v, want nil when every source is empty", got)
+	}
+}
+
+func TestScanObjCInspectionOnlyRunsForPlainAppKitObjC(t *testing.T) {
+	app := makeBundle(t, "FakeObjCGate")
+	if got := scanObjCInspection(app, filepath.Join(app, "Contents/MacOS/main"), Result{UI: "AppKit+Swift", Runtime: "Swift"}); got != nil {
+		t.Fatalf("scanObjCInspection = %#v, want nil for Swift AppKit", got)
+	}
+}
+
+func TestObjCUpdateMechanismFallsBackToBundleMarkers(t *testing.T) {
+	app := makeBundle(t, "FakeObjCUpdater")
+	if err := os.MkdirAll(filepath.Join(app, "Contents/Frameworks/Sparkle.framework"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := inspectObjCApp(app, filepath.Join(app, "Contents/MacOS/main"), Result{
+		UI:      "AppKit",
+		Runtime: "ObjC",
+	}, fakeObjCSources{
+		plistXML: []byte(`<?xml version="1.0"?><plist version="1.0"><dict><key>NSPrincipalClass</key><string>NSApplication</string></dict></plist>`),
+	})
+
+	if got == nil {
+		t.Fatal("ObjC inspection nil")
+	}
+	if got.UpdateMechanism != "Sparkle" {
+		t.Fatalf("UpdateMechanism = %q, want Sparkle", got.UpdateMechanism)
+	}
+}
+
+func TestParseEntitlementKeys(t *testing.T) {
+	xml := `<?xml version="1.0"?><plist version="1.0"><dict>
+<key>com.apple.security.app-sandbox</key><true/>
+<key>com.apple.security.network.client</key><false/>
+<key>com.apple.security.automation.apple-events</key><true/>
+</dict></plist>`
+	got := parseEntitlementKeys(xml)
+	want := []string{"com.apple.security.app-sandbox", "com.apple.security.automation.apple-events"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseEntitlementKeys = %v, want %v", got, want)
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - Native modules: detection/native-modules.md
   - Inspection:
       - Metadata: inspection/metadata.md
+      - Objective-C based apps: inspection/objc-based-app.md
       - Security: inspection/security.md
       - Swift apps: inspection/swift-apps.md
       - Storage footprint: inspection/storage-footprint.md


### PR DESCRIPTION
## Summary
- add an Objective-C/AppKit inspection profile to detection results
- collect linked frameworks, plist app structure, URL schemes, document types, services, automation entitlements, and update mechanism via injected sources
- show ObjC metadata in verbose CLI output and document the JSON schema/docs page

## Validation
- go test ./internal/detect -count=1
- go build ./...
- go vet ./...
- go test ./... -count=1
- make docs-validate