### PR TITLE
Add Tauri inspection seams and docs

### DIFF
--- a/docs/detection/frameworks.md
+++ b/docs/detection/frameworks.md
@@ -22,6 +22,7 @@ confirmed examples from real apps. Layer numbers refer to
 - **Layer 2:** AppKit + WebKit linked.
 - **Layer 3:** Rust panic strings ≥ 100.
 - **Confirmed:** Conductor (204 Rust strings), Polyscope.
+- **Inspection details:** [../inspection/tauri.md](../inspection/tauri.md).
 
 ### Wails (Go + WebKit)
 - **Layer 2:** AppKit + WebKit linked.

--- a/docs/detection/overview.md
+++ b/docs/detection/overview.md
@@ -65,6 +65,11 @@ The Rust threshold (100) was chosen empirically: a single bundled Rust
 dylib in a non-Rust app produces under 30 hits; native Rust apps
 produce hundreds.
 
+For Tauri specifically, Layer 2 first records the app as an
+`AppKit+WebKit` suspect; Layer 3 promotes that verdict to `Tauri` only
+when the main binary has strong Rust evidence. See
+[../inspection/tauri.md](../inspection/tauri.md).
+
 ## Shim launcher handling
 
 Some apps use a tiny launcher binary (Chrome, Edge, Brave) that loads

--- a/docs/inspection/metadata.md
+++ b/docs/inspection/metadata.md
@@ -11,6 +11,7 @@ versions, architectures, on-disk size, packaging, MAS receipt.
 | `AppVersion` | `Info.plist` `CFBundleShortVersionString` |
 | `BuildNumber` | `Info.plist` `CFBundleVersion` |
 | `ElectronVersion` | Electron Framework's own `Info.plist` `CFBundleVersion` |
+| `FrameworkVersions["Tauri"]` | `Contents/Resources/tauri.conf.json` or JSON-compatible `tauri.conf.json5` |
 | `Architectures` | `file <executable>` parsed for `arm64` / `x86_64` |
 | `BundleSizeBytes` | walk over bundle, sparse-aware (see [storage-footprint.md](storage-footprint.md)) |
 | `TeamID` | `codesign -dv` |

--- a/docs/inspection/tauri.md
+++ b/docs/inspection/tauri.md
@@ -1,0 +1,67 @@
+# Tauri app inspection
+
+Tauri apps on macOS look like small native AppKit shells that host web UI in
+WebKit while running most app logic in Rust. Spectra therefore treats Tauri as
+a cross-layer verdict, not a single bundle marker.
+
+## Detection path
+
+Tauri classification requires both of these signals:
+
+| Layer | Signal | Why it matters |
+|---|---|---|
+| Layer 2 | Main executable links `AppKit.framework` and `WebKit.framework` | The app is a native macOS WebKit host rather than Chromium/Electron |
+| Layer 3 | Binary contains at least 100 Rust panic-site strings | The host is a real Rust binary, not a plain Obj-C or Swift WebKit wrapper |
+
+Layer 2 alone produces the intermediate verdict `AppKit+WebKit` with medium
+confidence. Layer 3 promotes that verdict to `Tauri`, sets `Runtime` and
+`Language` to `Rust`, and raises confidence to high.
+
+This split keeps WebKit wrappers distinct:
+
+- `Tauri` — AppKit + WebKit + strong Rust binary evidence.
+- `Wails` — AppKit + WebKit + Go buildinfo + `github.com/wailsapp/wails`.
+- `Go+WebKit` — AppKit + WebKit + Go buildinfo, but no Wails marker.
+- `WKWebView wrapper` — AppKit + WebKit + bundled `index.html`, with no
+  Rust or Go runtime marker.
+
+## Version metadata
+
+Spectra also tries to populate `FrameworkVersions["Tauri"]` from:
+
+- `Contents/Resources/tauri.conf.json`
+- `Contents/Resources/tauri.conf.json5`
+
+The version comes from `package.version` first, then top-level `version`.
+This is best-effort metadata only. A missing version does not affect the
+Tauri verdict, and JSON5 files must be JSON-compatible for the current reader
+to parse them.
+
+## Signals
+
+A verbose Tauri result should include evidence similar to:
+
+```text
+links AppKit + WebKit (Tauri suspect)
+204 Rust panic-site strings
+```
+
+The exact Rust count depends on compiler version, optimization, dependencies,
+and whether the binary is universal.
+
+## Implementation reference
+
+`internal/detect/detect.go`:
+
+- `classifyByLinkedLibs(exe, *Result)` identifies the `AppKit+WebKit`
+  suspect state from `otool -L`.
+- `classifyByStrings(exe, *Result)` promotes that suspect state to `Tauri`
+  when Rust markers cross the threshold.
+- `readTauriVersion(appPath)` extracts best-effort version metadata from
+  Tauri config files.
+
+## See also
+
+- [../detection/overview.md](../detection/overview.md) — layer ordering
+- [../detection/frameworks.md](../detection/frameworks.md) — framework signal table
+- [metadata.md](metadata.md) — bundle and framework version metadata

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -264,6 +264,16 @@ func defaultNodeAppInspector() nodeAppInspector {
 	return nodeAppInspector{fs: osNodeAppFS{}, cmd: execNodeAppCommands{}}
 }
 
+type markerScanner interface {
+	ScanMarkers(exe string) binaryMarkers
+}
+
+type fileMarkerScanner struct{}
+
+func (fileMarkerScanner) ScanMarkers(exe string) binaryMarkers {
+	return scanBinaryMarkers(exe)
+}
+
 // Detect inspects the bundle at appPath and returns a Result.
 // It never returns an error for "unknown" — instead it fills the result
 // with what it found and Confidence="low".
@@ -396,11 +406,15 @@ func firstPlistString(plist string, keys ...string) string {
 }
 
 func readTauriVersion(appPath string) string {
+	return readTauriVersionWith(appPath, osNodeAppFS{})
+}
+
+func readTauriVersionWith(appPath string, files nodeAppFS) string {
 	for _, rel := range []string{
 		filepath.Join("Contents", "Resources", "tauri.conf.json"),
 		filepath.Join("Contents", "Resources", "tauri.conf.json5"),
 	} {
-		data, err := os.ReadFile(filepath.Join(appPath, rel))
+		data, err := files.ReadFile(filepath.Join(appPath, rel))
 		if err != nil {
 			continue
 		}
@@ -722,10 +736,14 @@ func classifyJVMMarkers(appPath, contents, jvmRoot string, jarCount int, r *Resu
 // --- Layer 2: linked dylibs --------------------------------------------------
 
 func classifyByLinkedLibs(exe string, r *Result) {
+	classifyByLinkedLibsWith(exe, r, execNodeAppCommands{})
+}
+
+func classifyByLinkedLibsWith(exe string, r *Result, cmds nodeAppCommands) {
 	if exe == "" {
 		return
 	}
-	libs := otoolL(exe)
+	libs := cmds.OtoolL(exe)
 	if len(libs) == 0 {
 		return
 	}
@@ -791,10 +809,14 @@ func classifyByLinkedLibs(exe string, r *Result) {
 // --- Layer 3: binary strings -------------------------------------------------
 
 func classifyByStrings(exe string, r *Result) {
+	classifyByStringsWith(exe, r, fileMarkerScanner{})
+}
+
+func classifyByStringsWith(exe string, r *Result, scanner markerScanner) {
 	if exe == "" {
 		return
 	}
-	m := scanBinaryMarkers(exe)
+	m := scanner.ScanMarkers(exe)
 
 	// Go wins outright — the buildinfo magic only appears in Go binaries.
 	if m.hasGoBuildID {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -261,6 +261,63 @@ func TestReadTauriVersion(t *testing.T) {
 	}
 }
 
+func TestReadTauriVersionFallsBackToJSON5WithFakeReader(t *testing.T) {
+	app := filepath.Join(t.TempDir(), "FakeTauri.app")
+	fsys := newFakeNodeFS()
+	fsys.addFile(filepath.Join(app, "Contents", "Resources", "tauri.conf.json5"), `{"version":"2.2.0"}`)
+	if got := readTauriVersionWith(app, fsys); got != "2.2.0" {
+		t.Errorf("readTauriVersionWith = %q, want 2.2.0", got)
+	}
+}
+
+func TestTauriInspectionPromotesAppKitWebKitWithRustMarkers(t *testing.T) {
+	r := Result{UI: "Unknown", Runtime: "unknown", Confidence: "low"}
+	exe := "/Fake.app/Contents/MacOS/main"
+	classifyByLinkedLibsWith(exe, &r, fakeNodeCommands{
+		libs: map[string][]string{filepath.Clean(exe): {
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+			"/System/Library/Frameworks/WebKit.framework/Versions/A/WebKit",
+		}},
+	})
+	classifyByStringsWith(exe, &r, fakeMarkerScanner{
+		markers: binaryMarkers{rustHits: 204},
+	})
+
+	if r.UI != "Tauri" {
+		t.Fatalf("UI = %q, want Tauri; signals=%v", r.UI, r.Signals)
+	}
+	if r.Runtime != "Rust" || r.Language != "Rust" || r.Confidence != "high" {
+		t.Fatalf("got runtime=%q language=%q confidence=%q", r.Runtime, r.Language, r.Confidence)
+	}
+	if !hasHint(r.Signals, "links AppKit + WebKit (Tauri suspect)") {
+		t.Fatalf("signals = %v, want AppKit+WebKit signal", r.Signals)
+	}
+	if !hasHint(r.Signals, "204 Rust panic-site strings") {
+		t.Fatalf("signals = %v, want Rust marker count", r.Signals)
+	}
+}
+
+func TestTauriInspectionDoesNotPromoteWeakRustMarkers(t *testing.T) {
+	r := Result{UI: "Unknown", Runtime: "unknown", Confidence: "low"}
+	exe := "/Fake.app/Contents/MacOS/main"
+	classifyByLinkedLibsWith(exe, &r, fakeNodeCommands{
+		libs: map[string][]string{filepath.Clean(exe): {
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+			"/System/Library/Frameworks/WebKit.framework/Versions/A/WebKit",
+		}},
+	})
+	classifyByStringsWith(exe, &r, fakeMarkerScanner{
+		markers: binaryMarkers{rustHits: 30},
+	})
+
+	if r.UI != "AppKit+WebKit" {
+		t.Fatalf("UI = %q, want AppKit+WebKit", r.UI)
+	}
+	if r.Confidence != "medium" {
+		t.Fatalf("confidence = %q, want medium", r.Confidence)
+	}
+}
+
 func TestDetectComposeDesktop(t *testing.T) {
 	app := makeBundle(t, "FakeKMP")
 	// Bundled JVM
@@ -688,6 +745,14 @@ func hasHint(hints []string, want string) bool {
 		}
 	}
 	return false
+}
+
+type fakeMarkerScanner struct {
+	markers binaryMarkers
+}
+
+func (f fakeMarkerScanner) ScanMarkers(string) binaryMarkers {
+	return f.markers
 }
 
 func TestNativeModuleRootsOnlyExistingElectronPayloads(t *testing.T) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Storage footprint: inspection/storage-footprint.md
       - Node-based apps: inspection/node-based-apps.md
       - Network endpoints: inspection/network-endpoints.md
+      - Tauri apps: inspection/tauri.md
       - Helpers and XPC: inspection/helpers-and-xpc.md
       - Login items: inspection/login-items.md
       - Running processes: inspection/running-processes.md


### PR DESCRIPTION
## Summary
- document Tauri app inspection and wire the page into MkDocs navigation
- add narrow detector interfaces for linked-library reads, binary marker scans, and config reads
- add fake-backed unit tests for Tauri promotion and version fallback behavior

## Validation
- make docs-validate
- go test ./internal/detect/ -run 'Test(ReadTauriVersion|TauriInspection)' -count=1
- go build ./...
- go vet ./...
- go test ./... -count=1