### PR TITLE
[codex] add rust app inspection

### DIFF
--- a/cmd/spectra/inspect.go
+++ b/cmd/spectra/inspect.go
@@ -153,6 +153,9 @@ func printTable(rs []detect.Result, verbose bool) {
 				}
 			}
 		}
+		if verbose && r.Rust != nil {
+			printRustInspection(r.Rust)
+		}
 	}
 }
 
@@ -176,6 +179,29 @@ func printMeta(r detect.Result) {
 	printStructureMeta(r)
 	printRuntimeMeta(r)
 	printStorageMeta(r)
+}
+
+func printRustInspection(r *detect.RustInspection) {
+	fmt.Printf("    rust: %s", r.Kind)
+	if r.PrimaryBinary != "" {
+		fmt.Printf("  binary=%s", r.PrimaryBinary)
+	}
+	if r.PanicStringHits > 0 {
+		fmt.Printf("  panic_strings=%d", r.PanicStringHits)
+	}
+	fmt.Println()
+	if len(r.LinkedFrameworks) > 0 {
+		fmt.Printf("    rust frameworks: %s\n", strings.Join(r.LinkedFrameworks, ", "))
+	}
+	if len(r.NativeModules) > 0 {
+		fmt.Printf("    rust modules: %s\n", truncateList(r.NativeModules, 4))
+	}
+	if len(r.Sidecars) > 0 {
+		fmt.Printf("    rust sidecars: %s\n", truncateList(r.Sidecars, 4))
+	}
+	if len(r.FollowUps) > 0 {
+		fmt.Printf("    rust follow-ups: %s\n", truncateList(r.FollowUps, 5))
+	}
 }
 
 func printIdentityMeta(r detect.Result) {

--- a/docs/detection/frameworks.md
+++ b/docs/detection/frameworks.md
@@ -109,6 +109,8 @@ confirmed examples from real apps. Layer numbers refer to
 ### Native (Rust)
 - **Layer 3:** Rust panic strings ≥ 100, no AppKit+WebKit (so not Tauri).
 - **Confirmed:** Warp (699 strings), Zed (384 strings).
+- **Inspection:** see
+  [../inspection/rust-based-apps.md](../inspection/rust-based-apps.md).
 
 ### Native (Go)
 - **Layer 3:** Go buildinfo, no AppKit+WebKit.

--- a/docs/detection/overview.md
+++ b/docs/detection/overview.md
@@ -63,7 +63,9 @@ runtimes without dynamic library hints:
 
 The Rust threshold (100) was chosen empirically: a single bundled Rust
 dylib in a non-Rust app produces under 30 hits; native Rust apps
-produce hundreds.
+produce hundreds. See
+[../inspection/rust-based-apps.md](../inspection/rust-based-apps.md) for
+the Rust-specific inspection path.
 
 For Tauri specifically, Layer 2 first records the app as an
 `AppKit+WebKit` suspect; Layer 3 promotes that verdict to `Tauri` only

--- a/docs/inspection/rust-based-apps.md
+++ b/docs/inspection/rust-based-apps.md
@@ -1,0 +1,100 @@
+# Rust-based app inspection
+
+Rust shows up in macOS app bundles in two different ways:
+
+- the primary app executable is Rust, as with native Rust apps such as
+  Warp or Zed;
+- a higher-level shell embeds Rust native code, as with Electron apps
+  that ship `.node` add-ons backed by Cargo-built libraries.
+
+Spectra treats those as separate questions. The top-level detection
+verdict answers "what is this app built on?" while inspection answers
+"where is Rust present, and what does that imply for debugging?"
+
+## Top-level Rust apps
+
+Rust app detection is a Layer 3 binary-content scan. Spectra streams the
+resolved executable and counts Rust panic-site strings. A count of 100 or
+more classifies the runtime as Rust when no stronger bundle marker has
+already identified a higher-level framework.
+
+This catches apps whose macOS surface still looks like AppKit from
+`otool -L`, because Rust GUI stacks commonly bridge through Cocoa,
+WebKit, Metal, or custom Objective-C shims.
+
+| Signal | Interpretation |
+|---|---|
+| Rust panic-site strings >= 100 | primary executable is likely Rust |
+| AppKit linked, no WebKit | native Rust app using Cocoa/AppKit glue |
+| AppKit + WebKit linked, Rust strings >= 100 | Tauri-style Rust + WebKit app |
+| tiny launcher binary | follow the larger framework or sibling binary before scanning |
+
+The threshold is intentionally conservative. A single bundled Rust dylib
+inside an otherwise non-Rust app can leak panic strings, but empirical
+fixtures stayed well below 100 hits. Native Rust apps usually produce
+hundreds.
+
+## Tauri distinction
+
+Tauri is not reported as plain native Rust. Spectra first looks for the
+AppKit + WebKit link pattern, then uses the Rust string scan to confirm
+that the WebKit shell is backed by Rust.
+
+That distinction matters operationally:
+
+- Tauri failures often involve the WebView boundary, app-local protocol
+  handling, entitlements, or frontend bundle state.
+- Native Rust failures often involve the primary Mach-O, embedded assets,
+  GPU/windowing libraries, or native storage paths.
+
+## Embedded Rust in Electron
+
+For confirmed Electron apps, Rust inspection moves to the native-module
+sub-detection. Spectra walks
+`Contents/Resources/app.asar.unpacked/**/*.node` and classifies each
+native add-on independently.
+
+Rust native modules are identified by either:
+
+- Cargo target paths in the link map; or
+- Rust panic-site strings in the `.node` binary or an `@rpath` sidecar.
+
+This keeps the top-level verdict honest. An Electron app with one Rust
+native module is still Electron, but the inspection result can show that
+performance-sensitive or privileged behavior lives in Rust.
+
+See [../detection/native-modules.md](../detection/native-modules.md) for
+the native-module classifier.
+
+## What to inspect next
+
+Rust identification should guide the next diagnostic pass rather than end
+the investigation.
+
+| Finding | Follow-up |
+|---|---|
+| native Rust app | inspect code-signing, entitlements, helpers, storage, and network endpoints |
+| Tauri app | inspect WebKit usage, custom protocols, local resources, and network endpoints |
+| Electron app with Rust modules | inspect each `.node` module, sidecar dylibs, and linked Apple frameworks |
+| universal Rust binary | compare arm64 and x86_64 slices when failures reproduce only under Rosetta |
+
+The most useful companion pages are:
+
+- [security.md](security.md) for sandboxing, hardened runtime, and
+  entitlement context;
+- [helpers-and-xpc.md](helpers-and-xpc.md) for privileged helpers and
+  XPC services;
+- [network-endpoints.md](network-endpoints.md) for static network hints;
+- [storage-footprint.md](storage-footprint.md) for cache and data layout.
+
+## Current limits
+
+Spectra does not decode Rust crate metadata, Cargo dependency graphs, or
+symbol names beyond the lightweight fingerprints above. Stripped release
+binaries often hide meaningful names, and Rust's static linking means
+there is no equivalent of "list dynamic framework versions" for most
+crate-level dependencies.
+
+For now, the inspection target is architectural attribution: identify
+where Rust is present, distinguish native Rust from Tauri and Electron
+hybrids, then route the engineer to the right macOS-level probes.

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -18,6 +18,7 @@ Source of truth: `internal/detect/detect.go`.
 | `Signals` | []string | Human-readable evidence trail |
 | `NativeModules` | []NativeModule | Per-Electron-app native add-on classifications |
 | `ObjC` | *ObjCInspection | Per-AppKit Objective-C bundle profile |
+| `Rust` | *RustInspection | Rust-specific architecture attribution when Rust is present |
 
 ## Metadata fields
 
@@ -94,6 +95,20 @@ type ObjCDocumentType struct {
     Name       string
     Role       string
     Extensions []string
+}
+```
+
+### RustInspection
+
+```go
+type RustInspection struct {
+    Kind            string   // native, tauri, electron-native-module, embedded, none
+    PrimaryBinary   string   // bundle-relative executable inspected for top-level Rust
+    PanicStringHits int      // combined Rust panic-site marker hits
+    LinkedFrameworks []string // notable Apple/UI frameworks linked by the primary binary
+    NativeModules   []string // bundle-relative Rust Electron native modules
+    Sidecars        []string // bundle-relative Rust sidecar dylibs
+    FollowUps       []string // suggested next diagnostic surfaces
 }
 ```
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -38,6 +38,7 @@ type Result struct {
 	Signals       []string        // human-readable reasons we picked this
 	NativeModules []NativeModule  // sub-detection: custom native code embedded in the bundle
 	ObjC          *ObjCInspection // Objective-C/AppKit bundle profile, when applicable
+	Rust          *RustInspection // Rust bundle profile, when applicable
 
 	// Metadata pulled from Info.plist and frameworks. Best-effort; any
 	// field may be empty if the bundle doesn't expose it.
@@ -202,6 +203,18 @@ type NativeModule struct {
 	RiskHints      []string // security-sensitive capability patterns to review
 }
 
+// RustInspection describes where Rust was found inside a bundle and how
+// engineers should interpret that architecture.
+type RustInspection struct {
+	Kind             string   // native, tauri, electron-native-module, embedded, none
+	PrimaryBinary    string   // bundle-relative executable inspected for top-level Rust
+	PanicStringHits  int      // combined Rust panic-site marker hits
+	LinkedFrameworks []string // notable Apple/UI frameworks linked by the primary binary
+	NativeModules    []string // bundle-relative Rust Electron native modules
+	Sidecars         []string // bundle-relative Rust sidecar dylibs
+	FollowUps        []string // suggested next diagnostic surfaces
+}
+
 // Options controls optional, more expensive sub-detections.
 type Options struct {
 	ScanNetwork bool // scan binary + app.asar for embedded URL hosts
@@ -322,6 +335,7 @@ func DetectWith(appPath string, opts Options) (Result, error) {
 	if r.UI == "Electron" {
 		r.NativeModules = scanNativeModules(appPath)
 	}
+	r.Rust = inspectRustApp(appPath, exe, &r)
 
 	populateMetadata(appPath, exe, &r)
 	r.PrivacyDescriptions = readPrivacyDescriptions(appPath)

--- a/internal/detect/rust_inspection.go
+++ b/internal/detect/rust_inspection.go
@@ -1,0 +1,182 @@
+package detect
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type rustMarkerScanner interface {
+	scanMarkers(path string) binaryMarkers
+}
+
+type rustLinker interface {
+	linkedLibs(path string) []string
+}
+
+type rustSidecarResolver interface {
+	sidecars(path string, libs []string) []string
+}
+
+type defaultRustInspectorDeps struct{}
+
+func (defaultRustInspectorDeps) scanMarkers(path string) binaryMarkers {
+	return scanBinaryMarkers(path)
+}
+
+func (defaultRustInspectorDeps) linkedLibs(path string) []string {
+	return otoolL(path)
+}
+
+func (defaultRustInspectorDeps) sidecars(path string, libs []string) []string {
+	var out []string
+	for _, lib := range libs {
+		if !strings.HasPrefix(lib, "@rpath/") {
+			continue
+		}
+		sib := filepath.Join(filepath.Dir(path), strings.TrimPrefix(lib, "@rpath/"))
+		if exists(sib) {
+			out = append(out, sib)
+		}
+	}
+	return out
+}
+
+type rustInspector struct {
+	markers rustMarkerScanner
+	links   rustLinker
+	sidecar rustSidecarResolver
+}
+
+func newRustInspector(markers rustMarkerScanner, links rustLinker, sidecar rustSidecarResolver) rustInspector {
+	deps := defaultRustInspectorDeps{}
+	if markers == nil {
+		markers = deps
+	}
+	if links == nil {
+		links = deps
+	}
+	if sidecar == nil {
+		sidecar = deps
+	}
+	return rustInspector{markers: markers, links: links, sidecar: sidecar}
+}
+
+func inspectRustApp(appPath, exe string, r *Result) *RustInspection {
+	ins := newRustInspector(nil, nil, nil).inspect(appPath, exe, r)
+	if ins == nil || ins.Kind == "none" {
+		return nil
+	}
+	return ins
+}
+
+func (i rustInspector) inspect(appPath, exe string, r *Result) *RustInspection {
+	ins := &RustInspection{Kind: "none"}
+	if exe != "" && (r.Runtime == "Rust" || r.UI == "Tauri") {
+		ins.Kind = rustInspectionKind(r)
+		ins.PrimaryBinary = relToBundle(appPath, exe)
+		markers := i.markers.scanMarkers(exe)
+		ins.PanicStringHits = markers.rustHits
+		ins.LinkedFrameworks = notableRustFrameworks(i.links.linkedLibs(exe))
+	}
+
+	for _, mod := range r.NativeModules {
+		if mod.Language != "Rust" {
+			continue
+		}
+		ins.NativeModules = append(ins.NativeModules, mod.Path)
+		if ins.Kind == "none" {
+			ins.Kind = "electron-native-module"
+		}
+	}
+
+	for _, path := range rustModulePaths(appPath, r.NativeModules) {
+		libs := i.links.linkedLibs(path)
+		for _, sidecar := range i.sidecar.sidecars(path, libs) {
+			if i.markers.scanMarkers(sidecar).rustHits >= 50 {
+				ins.Sidecars = append(ins.Sidecars, relToBundle(appPath, sidecar))
+			}
+		}
+	}
+
+	dedupeStrings(&ins.LinkedFrameworks)
+	dedupeStrings(&ins.NativeModules)
+	dedupeStrings(&ins.Sidecars)
+	ins.FollowUps = rustFollowUps(ins)
+	if ins.Kind == "none" {
+		return nil
+	}
+	return ins
+}
+
+func rustInspectionKind(r *Result) string {
+	switch r.UI {
+	case "Tauri":
+		return "tauri"
+	case "Electron":
+		return "electron-native-module"
+	default:
+		return "native"
+	}
+}
+
+func notableRustFrameworks(libs []string) []string {
+	var out []string
+	for _, lib := range libs {
+		for _, fw := range []string{"AppKit", "WebKit", "Metal", "CoreGraphics", "Security", "Network"} {
+			if strings.Contains(lib, "/"+fw+".framework/") {
+				out = append(out, fw)
+			}
+		}
+	}
+	return out
+}
+
+func rustModulePaths(appPath string, mods []NativeModule) []string {
+	var out []string
+	for _, mod := range mods {
+		if mod.Language != "Rust" || mod.Path == "" {
+			continue
+		}
+		out = append(out, filepath.Join(appPath, mod.Path))
+	}
+	return out
+}
+
+func rustFollowUps(ins *RustInspection) []string {
+	switch ins.Kind {
+	case "tauri":
+		return []string{"inspect WebKit usage", "inspect custom protocols", "inspect local resources", "inspect network endpoints"}
+	case "electron-native-module":
+		return []string{"inspect native modules", "inspect sidecar dylibs", "inspect linked Apple frameworks"}
+	case "native":
+		return []string{"inspect code signing", "inspect entitlements", "inspect helpers", "inspect storage", "inspect network endpoints"}
+	default:
+		return nil
+	}
+}
+
+func relToBundle(appPath, path string) string {
+	rel, err := filepath.Rel(appPath, path)
+	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return path
+	}
+	return rel
+}
+
+func dedupeStrings(values *[]string) {
+	if len(*values) == 0 {
+		return
+	}
+	sort.Strings(*values)
+	out := (*values)[:0]
+	var last string
+	for i, value := range *values {
+		if i > 0 && value == last {
+			continue
+		}
+		out = append(out, value)
+		last = value
+	}
+	*values = out
+}

--- a/internal/detect/rust_inspection_test.go
+++ b/internal/detect/rust_inspection_test.go
@@ -1,0 +1,134 @@
+package detect
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+type fakeRustMarkers map[string]binaryMarkers
+
+func (f fakeRustMarkers) scanMarkers(path string) binaryMarkers {
+	return f[path]
+}
+
+type fakeRustLinks map[string][]string
+
+func (f fakeRustLinks) linkedLibs(path string) []string {
+	return f[path]
+}
+
+type fakeRustSidecars map[string][]string
+
+func (f fakeRustSidecars) sidecars(path string, _ []string) []string {
+	return f[path]
+}
+
+func TestRustInspectorNativeApp(t *testing.T) {
+	app := filepath.Join(t.TempDir(), "Rusty.app")
+	exe := filepath.Join(app, "Contents", "MacOS", "Rusty")
+	r := &Result{UI: "Native (Rust)", Runtime: "Rust"}
+	inspector := newRustInspector(
+		fakeRustMarkers{exe: {rustHits: 384}},
+		fakeRustLinks{exe: {
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+			"/System/Library/Frameworks/Metal.framework/Versions/A/Metal",
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+		}},
+		nil,
+	)
+
+	got := inspector.inspect(app, exe, r)
+	if got == nil {
+		t.Fatal("inspect returned nil")
+	}
+	if got.Kind != "native" {
+		t.Fatalf("Kind = %q, want native", got.Kind)
+	}
+	if got.PrimaryBinary != filepath.Join("Contents", "MacOS", "Rusty") {
+		t.Fatalf("PrimaryBinary = %q", got.PrimaryBinary)
+	}
+	if got.PanicStringHits != 384 {
+		t.Fatalf("PanicStringHits = %d, want 384", got.PanicStringHits)
+	}
+	if want := []string{"AppKit", "Metal"}; !reflect.DeepEqual(got.LinkedFrameworks, want) {
+		t.Fatalf("LinkedFrameworks = %#v, want %#v", got.LinkedFrameworks, want)
+	}
+	if want := []string{"inspect code signing", "inspect entitlements", "inspect helpers", "inspect storage", "inspect network endpoints"}; !reflect.DeepEqual(got.FollowUps, want) {
+		t.Fatalf("FollowUps = %#v, want %#v", got.FollowUps, want)
+	}
+}
+
+func TestRustInspectorTauriApp(t *testing.T) {
+	app := filepath.Join(t.TempDir(), "Tauri.app")
+	exe := filepath.Join(app, "Contents", "MacOS", "Tauri")
+	r := &Result{UI: "Tauri", Runtime: "Rust"}
+	inspector := newRustInspector(
+		fakeRustMarkers{exe: {rustHits: 204}},
+		fakeRustLinks{exe: {
+			"/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+			"/System/Library/Frameworks/WebKit.framework/Versions/A/WebKit",
+		}},
+		nil,
+	)
+
+	got := inspector.inspect(app, exe, r)
+	if got == nil {
+		t.Fatal("inspect returned nil")
+	}
+	if got.Kind != "tauri" {
+		t.Fatalf("Kind = %q, want tauri", got.Kind)
+	}
+	if want := []string{"AppKit", "WebKit"}; !reflect.DeepEqual(got.LinkedFrameworks, want) {
+		t.Fatalf("LinkedFrameworks = %#v, want %#v", got.LinkedFrameworks, want)
+	}
+	if want := []string{"inspect WebKit usage", "inspect custom protocols", "inspect local resources", "inspect network endpoints"}; !reflect.DeepEqual(got.FollowUps, want) {
+		t.Fatalf("FollowUps = %#v, want %#v", got.FollowUps, want)
+	}
+}
+
+func TestRustInspectorElectronNativeModulesAndSidecars(t *testing.T) {
+	app := filepath.Join(t.TempDir(), "Electron.app")
+	modPath := filepath.Join("Contents", "Resources", "app.asar.unpacked", "node_modules", "native", "binding.node")
+	absMod := filepath.Join(app, modPath)
+	sidecar := filepath.Join(app, "Contents", "Resources", "app.asar.unpacked", "node_modules", "native", "libnative.dylib")
+	r := &Result{
+		UI:      "Electron",
+		Runtime: "Node+Chromium",
+		NativeModules: []NativeModule{
+			{Path: modPath, Language: "Rust"},
+			{Path: filepath.Join("Contents", "Resources", "app.asar.unpacked", "node_modules", "sqlite", "sqlite.node"), Language: "C++"},
+			{Path: modPath, Language: "Rust"},
+		},
+	}
+	inspector := newRustInspector(
+		fakeRustMarkers{sidecar: {rustHits: 88}},
+		fakeRustLinks{absMod: {"@rpath/libnative.dylib"}},
+		fakeRustSidecars{absMod: {sidecar}},
+	)
+
+	got := inspector.inspect(app, "", r)
+	if got == nil {
+		t.Fatal("inspect returned nil")
+	}
+	if got.Kind != "electron-native-module" {
+		t.Fatalf("Kind = %q, want electron-native-module", got.Kind)
+	}
+	if want := []string{modPath}; !reflect.DeepEqual(got.NativeModules, want) {
+		t.Fatalf("NativeModules = %#v, want %#v", got.NativeModules, want)
+	}
+	if want := []string{filepath.Join("Contents", "Resources", "app.asar.unpacked", "node_modules", "native", "libnative.dylib")}; !reflect.DeepEqual(got.Sidecars, want) {
+		t.Fatalf("Sidecars = %#v, want %#v", got.Sidecars, want)
+	}
+}
+
+func TestRustInspectorIgnoresNonRustApp(t *testing.T) {
+	app := filepath.Join(t.TempDir(), "Plain.app")
+	exe := filepath.Join(app, "Contents", "MacOS", "Plain")
+	r := &Result{UI: "AppKit", Runtime: "ObjC"}
+
+	got := newRustInspector(fakeRustMarkers{exe: {rustHits: 12}}, nil, nil).inspect(app, exe, r)
+	if got != nil {
+		t.Fatalf("inspect = %#v, want nil", got)
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Login items: inspection/login-items.md
       - Running processes: inspection/running-processes.md
       - Power and thermal: inspection/power-thermal.md
+      - Rust-based apps: inspection/rust-based-apps.md
       - Toolchains (planned): inspection/toolchains.md
       - JVM (planned): inspection/jvm.md
       - Live data sources: inspection/live-data-sources.md


### PR DESCRIPTION
## Summary

- add structured Rust inspection results for native Rust, Tauri, and Electron native-module Rust
- implement the Rust inspector behind fakeable marker/link/sidecar interfaces with unit tests
- surface Rust inspection details in verbose CLI output and document the result schema/docs nav

## Validation

- `go test ./internal/detect/ -run 'TestRust|TestDetectRust' -count=1`
- `go build ./...`
- `go vet ./...`
- `make docs-validate`
- `go test ./... -count=1`
