### PR TITLE
Add power thermal inspection seams

### DIFF
--- a/cmd/spectra/power.go
+++ b/cmd/spectra/power.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -11,61 +12,67 @@ import (
 )
 
 func runPower(args []string) int {
+	return runPowerWithIO(args, os.Stdout, os.Stderr, func() sysinfo.PowerState {
+		return sysinfo.CollectPower(sysinfo.DefaultRunner)
+	})
+}
+
+func runPowerWithIO(args []string, stdout, stderr io.Writer, collect func() sysinfo.PowerState) int {
 	fs := flag.NewFlagSet("spectra power", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	state := sysinfo.CollectPower(sysinfo.DefaultRunner)
+	state := collect()
 
 	if *asJSON {
-		enc := json.NewEncoder(os.Stdout)
+		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
 		_ = enc.Encode(state)
 		return 0
 	}
 
-	printPowerState(state)
+	printPowerState(stdout, state)
 	return 0
 }
 
-func printPowerState(s sysinfo.PowerState) {
-	fmt.Println("=== Power state ===")
+func printPowerState(w io.Writer, s sysinfo.PowerState) {
+	fmt.Fprintln(w, "=== Power state ===")
 
 	if s.OnBattery {
-		fmt.Printf("source:    battery (%d%%)\n", s.BatteryPct)
+		fmt.Fprintf(w, "source:    battery (%d%%)\n", s.BatteryPct)
 	} else {
-		fmt.Printf("source:    AC power\n")
+		fmt.Fprintf(w, "source:    AC power\n")
 		if s.BatteryPct > 0 {
-			fmt.Printf("battery:   %d%% (charging)\n", s.BatteryPct)
+			fmt.Fprintf(w, "battery:   %d%% (charging)\n", s.BatteryPct)
 		}
 	}
 
 	if s.ThermalPressure != "" {
-		fmt.Printf("thermal:   %s\n", s.ThermalPressure)
+		fmt.Fprintf(w, "thermal:   %s\n", s.ThermalPressure)
 	}
 
 	if len(s.Assertions) > 0 {
-		fmt.Println()
-		fmt.Printf("assertions (%d):\n", len(s.Assertions))
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "assertions (%d):\n", len(s.Assertions))
 		for _, a := range s.Assertions {
 			name := ""
 			if a.Name != "" {
 				name = fmt.Sprintf(" %q", a.Name)
 			}
-			fmt.Printf("  pid %-7d  %-30s%s\n", a.PID, a.Type, name)
+			fmt.Fprintf(w, "  pid %-7d  %-30s%s\n", a.PID, a.Type, name)
 		}
 	}
 
 	if len(s.EnergyTopUsers) > 0 {
-		fmt.Println()
-		fmt.Printf("energy top users:\n")
-		fmt.Printf("  %-7s  %-8s  %s\n", "PID", "IMPACT", "COMMAND")
-		fmt.Println("  " + strings.Repeat("-", 40))
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "energy top users:\n")
+		fmt.Fprintf(w, "  %-7s  %-8s  %s\n", "PID", "IMPACT", "COMMAND")
+		fmt.Fprintln(w, "  "+strings.Repeat("-", 40))
 		for _, u := range s.EnergyTopUsers {
-			fmt.Printf("  %-7d  %-8.1f  %s\n", u.PID, u.EnergyImpact, u.Command)
+			fmt.Fprintf(w, "  %-7d  %-8.1f  %s\n", u.PID, u.EnergyImpact, u.Command)
 		}
 	}
 }

--- a/cmd/spectra/power_test.go
+++ b/cmd/spectra/power_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/sysinfo"
+)
+
+func fakePowerState() sysinfo.PowerState {
+	return sysinfo.PowerState{
+		OnBattery:       true,
+		BatteryPct:      85,
+		ThermalPressure: "serious",
+		Assertions: []sysinfo.PowerAssertion{
+			{Type: "PreventUserIdleSleep", PID: 412, Name: "playing audio"},
+		},
+		EnergyTopUsers: []sysinfo.EnergyUser{
+			{PID: 501, EnergyImpact: 4.2, Command: "Google Chrome Helper"},
+		},
+	}
+}
+
+func TestRunPowerHumanOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO(nil, &stdout, &stderr, fakePowerState)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"=== Power state ===",
+		"source:    battery (85%)",
+		"thermal:   serious",
+		"PreventUserIdleSleep",
+		"Google Chrome Helper",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunPowerJSONOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO([]string{"--json"}, &stdout, &stderr, fakePowerState)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	var got sysinfo.PowerState
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.OnBattery || got.BatteryPct != 85 || got.ThermalPressure != "serious" {
+		t.Fatalf("state = %+v, want fake power state", got)
+	}
+	if len(got.EnergyTopUsers) != 1 || got.EnergyTopUsers[0].Command != "Google Chrome Helper" {
+		t.Fatalf("energy users = %+v, want Google Chrome Helper", got.EnergyTopUsers)
+	}
+}
+
+func TestRunPowerFlagError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO([]string{"--nope"}, &stdout, &stderr, fakePowerState)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}

--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -206,6 +206,7 @@ PowerState {
 
 Source: `pmset -g assertions`, `pmset -g batt`, `pmset -g therm`,
 `top -l 1 -o power`. See
+[../inspection/power-thermal.md](../inspection/power-thermal.md) and
 [../inspection/live-data-sources.md](../inspection/live-data-sources.md).
 
 ## EnvSnapshot

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -80,7 +80,7 @@ summaries after link-layer and IPv4 TCP/UDP decoding. HTTP parsing redacts
 sensitive headers by default. TLS parsing exposes SNI and ALPN when the client
 sends them in cleartext; it cannot decrypt HTTPS traffic.
 
-## Energy and power
+## Power and thermal
 
 | Source | Output | Privilege | Cost | Used by |
 |---|---|---|---|---|
@@ -92,7 +92,8 @@ sends them in cleartext; it cannot decrypt HTTPS traffic.
 
 `pmset` plus `top` covers the unprivileged power story. `powermetrics`
 provides deeper CPU/GPU/network/disk energy breakdown when the privileged
-helper is installed and reachable.
+helper is installed and reachable. See
+[power-thermal.md](power-thermal.md) for the command, RPC, and JSON shape.
 
 ## JVM observation
 

--- a/docs/inspection/power-thermal.md
+++ b/docs/inspection/power-thermal.md
@@ -1,0 +1,95 @@
+# Power and thermal inspection
+
+Spectra treats power and thermal state as host inspection data. It is separate
+from app bundle detection and separate from remote fan-out.
+
+The local command is:
+
+```bash
+spectra power
+spectra power --json
+```
+
+Remote callers use the same collector through the daemon RPC method:
+
+```bash
+spectra connect work-mac power
+spectra fan --hosts work-mac,alice-laptop power
+```
+
+`spectra fan` means fan-out across remote Spectra daemons. It does not control,
+query, or tune hardware fans.
+
+## Data model
+
+`power.state` returns `sysinfo.PowerState`:
+
+```go
+type PowerState struct {
+    OnBattery       bool             `json:"on_battery"`
+    BatteryPct      int              `json:"battery_pct"`
+    ThermalPressure string           `json:"thermal_pressure,omitempty"`
+    Assertions      []PowerAssertion `json:"assertions,omitempty"`
+    EnergyTopUsers  []EnergyUser     `json:"energy_top_users,omitempty"`
+}
+```
+
+The JSON fields are:
+
+| Field | Meaning |
+|---|---|
+| `on_battery` | Whether macOS reports the current power source as battery |
+| `battery_pct` | Current battery percentage when reported by `pmset` |
+| `thermal_pressure` | macOS thermal state such as `nominal`, `fair`, `serious`, or `critical` |
+| `assertions` | Active sleep/display assertions attributed to owning PIDs |
+| `energy_top_users` | A short `top` sample sorted by the macOS power column |
+
+## Collectors
+
+The unprivileged collector uses only built-in macOS tools:
+
+| Source | Output | Privilege | Used for |
+|---|---|---|---|
+| `pmset -g batt` | Current AC/battery source and battery percentage | user | `on_battery`, `battery_pct` |
+| `pmset -g therm` | Current thermal pressure state | user | `thermal_pressure` |
+| `pmset -g assertions` | Wake, sleep, and display assertions by process | user | `assertions` |
+| `top -l 1 -n 10 -o power -stats pid,power,command` | One-shot process energy-impact list | user | `energy_top_users` |
+
+Failures are intentionally partial. If one command is unavailable or returns
+an unexpected format, the collector still returns whatever the other sources
+produced.
+
+The privileged helper can expose deeper `powermetrics` samples through
+`helper.powermetrics.sample`, but that is a separate helper RPC because it
+requires elevated privileges and costs more than the default `power.state`
+snapshot.
+
+## Output
+
+Human output is optimized for a quick terminal read:
+
+```text
+=== Power state ===
+source:    battery (85%)
+thermal:   nominal
+
+assertions (1):
+  pid 412      PreventUserIdleSleep          "playing audio"
+
+energy top users:
+  PID      IMPACT    COMMAND
+  ----------------------------------------
+  99647    12.5      Slack
+```
+
+JSON output preserves the same fields for daemon, snapshot, and remote
+fan-out consumers.
+
+## Related docs
+
+- [live-data-sources.md](live-data-sources.md) lists the cost and privilege
+  profile of the underlying commands.
+- [../design/system-inventory.md](../design/system-inventory.md) shows where
+  power state fits in a full host snapshot.
+- [../operations/remote.md](../operations/remote.md) covers remote fan-out
+  naming and examples.

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -297,6 +297,25 @@ spectra jvm jfr summary --json /tmp/app.jfr
 spectra jvm jfr stop 4012 --name spectra
 ```
 
+## `spectra power`
+
+Shows current host power and thermal state: AC/battery source, battery
+percentage, thermal pressure, active sleep/display assertions, and a short
+per-process energy-impact sample. This command is about power state, not
+hardware fan control. For remote multi-host execution, use `spectra fan ... power`;
+`fan` means fan-out to multiple daemons.
+
+### Examples
+
+```bash
+spectra power
+spectra power --json
+spectra connect work-mac power
+spectra fan --hosts work-mac,alice-laptop power
+```
+
+See [../inspection/power-thermal.md](../inspection/power-thermal.md).
+
 ## `spectra network`
 
 Shows unprivileged network state by default, including current routes,

--- a/internal/sysinfo/power.go
+++ b/internal/sysinfo/power.go
@@ -30,21 +30,72 @@ type PowerAssertion struct {
 	Name string `json:"name,omitempty"`
 }
 
+// PowerSource provides the raw macOS command output for power collection.
+type PowerSource interface {
+	Battery() ([]byte, error)
+	Thermal() ([]byte, error)
+	Assertions() ([]byte, error)
+	EnergyTop() ([]byte, error)
+}
+
+// CommandPowerSource shells out to the built-in macOS power tools.
+type CommandPowerSource struct {
+	Run CmdRunner
+}
+
+func (s CommandPowerSource) runner() CmdRunner {
+	if s.Run == nil {
+		return DefaultRunner
+	}
+	return s.Run
+}
+
+func (s CommandPowerSource) Battery() ([]byte, error) {
+	return s.runner()("pmset", "-g", "batt")
+}
+
+func (s CommandPowerSource) Thermal() ([]byte, error) {
+	return s.runner()("pmset", "-g", "therm")
+}
+
+func (s CommandPowerSource) Assertions() ([]byte, error) {
+	return s.runner()("pmset", "-g", "assertions")
+}
+
+func (s CommandPowerSource) EnergyTop() ([]byte, error) {
+	return s.runner()("top", "-l", "1", "-n", "10", "-o", "power", "-stats", "pid,power,command")
+}
+
+// PowerCollector turns raw source output into structured power state.
+type PowerCollector struct {
+	Source PowerSource
+}
+
 // CollectPower gathers PowerState from pmset. Any sub-command failure is
 // silently absorbed; partial results are still valid.
 func CollectPower(run CmdRunner) PowerState {
-	var ps PowerState
+	return PowerCollector{Source: CommandPowerSource{Run: run}}.Collect()
+}
 
-	if out, err := run("pmset", "-g", "batt"); err == nil {
+// Collect gathers PowerState. Any source failure is silently absorbed; partial
+// results are still valid.
+func (c PowerCollector) Collect() PowerState {
+	var ps PowerState
+	src := c.Source
+	if src == nil {
+		src = CommandPowerSource{}
+	}
+
+	if out, err := src.Battery(); err == nil {
 		parseBatt(string(out), &ps)
 	}
-	if out, err := run("pmset", "-g", "therm"); err == nil {
-		parsTherm(string(out), &ps)
+	if out, err := src.Thermal(); err == nil {
+		parseTherm(string(out), &ps)
 	}
-	if out, err := run("pmset", "-g", "assertions"); err == nil {
+	if out, err := src.Assertions(); err == nil {
 		ps.Assertions = parseAssertions(string(out))
 	}
-	if out, err := run("top", "-l", "1", "-n", "10", "-o", "power", "-stats", "pid,power,command"); err == nil {
+	if out, err := src.EnergyTop(); err == nil {
 		ps.EnergyTopUsers = parseEnergyTop(string(out))
 	}
 
@@ -70,7 +121,7 @@ func parseEnergyTop(out string) []EnergyUser {
 		if err != nil {
 			continue
 		}
-		result = append(result, EnergyUser{PID: pid, EnergyImpact: impact, Command: fields[2]})
+		result = append(result, EnergyUser{PID: pid, EnergyImpact: impact, Command: strings.Join(fields[2:], " ")})
 	}
 	return result
 }
@@ -101,10 +152,10 @@ func extractPct(line string) int {
 	return n
 }
 
-// parsTherm extracts thermal pressure from `pmset -g therm`.
+// parseTherm extracts thermal pressure from `pmset -g therm`.
 //
 // Example: "CPU_Speed_Limit	= 100" and "System thermal state: nominal"
-func parsTherm(out string, ps *PowerState) {
+func parseTherm(out string, ps *PowerState) {
 	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "System thermal state:") {

--- a/internal/sysinfo/power_test.go
+++ b/internal/sysinfo/power_test.go
@@ -37,6 +37,10 @@ const topEnergyOutput = `PID    POWER  COMMAND
 1      0.0    launchd
 `
 
+const topEnergyOutputWithSpaces = `PID    POWER  COMMAND
+501    4.2    Google Chrome Helper
+`
+
 func stubPower(batt, therm, assertions, topEnergy string) CmdRunner {
 	return func(name string, args ...string) ([]byte, error) {
 		if name == "top" {
@@ -71,6 +75,41 @@ func stubPower(batt, therm, assertions, topEnergy string) CmdRunner {
 
 func stubPmset(batt, therm, assertions string) CmdRunner {
 	return stubPower(batt, therm, assertions, "")
+}
+
+type fakePowerSource struct {
+	batt       string
+	therm      string
+	assertions string
+	topEnergy  string
+}
+
+func (f fakePowerSource) Battery() ([]byte, error) {
+	if f.batt == "" {
+		return nil, errors.New("no batt")
+	}
+	return []byte(f.batt), nil
+}
+
+func (f fakePowerSource) Thermal() ([]byte, error) {
+	if f.therm == "" {
+		return nil, errors.New("no therm")
+	}
+	return []byte(f.therm), nil
+}
+
+func (f fakePowerSource) Assertions() ([]byte, error) {
+	if f.assertions == "" {
+		return nil, errors.New("no assertions")
+	}
+	return []byte(f.assertions), nil
+}
+
+func (f fakePowerSource) EnergyTop() ([]byte, error) {
+	if f.topEnergy == "" {
+		return nil, errors.New("no top")
+	}
+	return []byte(f.topEnergy), nil
 }
 
 func TestCollectPowerOnBattery(t *testing.T) {
@@ -150,6 +189,16 @@ func TestParseEnergyTop(t *testing.T) {
 	}
 }
 
+func TestParseEnergyTopPreservesCommandWithSpaces(t *testing.T) {
+	users := parseEnergyTop(topEnergyOutputWithSpaces)
+	if len(users) != 1 {
+		t.Fatalf("len = %d, want 1", len(users))
+	}
+	if users[0].Command != "Google Chrome Helper" {
+		t.Errorf("Command = %q, want Google Chrome Helper", users[0].Command)
+	}
+}
+
 func TestCollectPowerEnergyTopUsers(t *testing.T) {
 	ps := CollectPower(stubPower("", "", "", topEnergyOutput))
 	if len(ps.EnergyTopUsers) != 3 {
@@ -157,5 +206,26 @@ func TestCollectPowerEnergyTopUsers(t *testing.T) {
 	}
 	if ps.EnergyTopUsers[1].PID != 412 {
 		t.Errorf("second PID = %d, want 412", ps.EnergyTopUsers[1].PID)
+	}
+}
+
+func TestPowerCollectorWithFakeSource(t *testing.T) {
+	ps := PowerCollector{Source: fakePowerSource{
+		batt:       battOnBattery,
+		therm:      thermSerious,
+		assertions: assertionsOutput,
+		topEnergy:  topEnergyOutputWithSpaces,
+	}}.Collect()
+	if !ps.OnBattery {
+		t.Error("OnBattery = false, want true")
+	}
+	if ps.ThermalPressure != "serious" {
+		t.Errorf("ThermalPressure = %q, want serious", ps.ThermalPressure)
+	}
+	if len(ps.Assertions) != 1 {
+		t.Fatalf("Assertions = %d, want 1", len(ps.Assertions))
+	}
+	if len(ps.EnergyTopUsers) != 1 || ps.EnergyTopUsers[0].Command != "Google Chrome Helper" {
+		t.Fatalf("EnergyTopUsers = %+v, want Google Chrome Helper entry", ps.EnergyTopUsers)
 	}
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Helpers and XPC: inspection/helpers-and-xpc.md
       - Login items: inspection/login-items.md
       - Running processes: inspection/running-processes.md
+      - Power and thermal: inspection/power-thermal.md
       - Toolchains (planned): inspection/toolchains.md
       - JVM (planned): inspection/jvm.md
       - Live data sources: inspection/live-data-sources.md


### PR DESCRIPTION
## What changed

- Added an interface-backed power/thermal collector with a command source implementation and fake-source unit coverage.
- Made `spectra power` testable by injecting output streams and a collector function.
- Added CLI tests for human output, JSON output, and flag errors.
- Added `docs/inspection/power-thermal.md` and linked it from MkDocs, CLI docs, live data sources, and system inventory docs.
- Clarified that `spectra fan` is remote fan-out, not hardware fan control.

## Why

Power and thermal state should be its own host inspection surface, while `fan` naming needs to stay clearly scoped to remote fan-out.

## Validation

- `go test ./internal/sysinfo ./cmd/spectra -count=1`
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
