### PR TITLE
Add process profiling services

### DIFF
--- a/cmd/spectra/sample.go
+++ b/cmd/spectra/sample.go
@@ -1,16 +1,30 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"time"
 
 	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/cache"
+	"github.com/kaeawc/spectra/internal/process"
 )
+
+type sampleCacheStore struct {
+	store *cache.ShardedStore
+}
+
+func (s sampleCacheStore) PutSample(_ context.Context, sample process.SampleResult) error {
+	key := cache.Key([]byte(fmt.Sprintf("sample:%d:%d", sample.PID, sample.TakenAt.UnixNano())))
+	if err := s.store.Put(key, []byte(sample.Output)); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "cached as samples/%x\n", key[:4])
+	return nil
+}
 
 func runSample(args []string) int {
 	fs := flag.NewFlagSet("spectra sample", flag.ContinueOnError)
@@ -31,27 +45,22 @@ func runSample(args []string) int {
 		return 2
 	}
 
-	// Run: sample <pid> <duration> <interval> -e (stderr only for errors)
-	// stdout receives the formatted call tree.
-	// #nosec G204 -- PID, duration, and interval are parsed integers.
-	cmd := exec.Command("sample",
-		strconv.Itoa(pid),
-		strconv.Itoa(*duration),
-		strconv.Itoa(*interval),
-	)
-	cmd.Stderr = os.Stderr
-	data, err := cmd.Output()
+	var store process.SampleStore
+	if !*noCache && cacheStores != nil && cacheStores.Samples != nil {
+		store = sampleCacheStore{store: cacheStores.Samples}
+	}
+	sampler := process.NewSampler(nil, store)
+	result, err := sampler.Capture(context.Background(), process.SampleOptions{
+		PID:        pid,
+		Duration:   time.Duration(*duration) * time.Second,
+		IntervalMS: *interval,
+		Store:      store != nil,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "sample failed for PID %d: %v\n", pid, err)
 		return 1
 	}
 
-	if !*noCache && cacheStores != nil && cacheStores.Samples != nil {
-		key := cache.Key([]byte(fmt.Sprintf("sample:%d:%d", pid, time.Now().UnixNano())))
-		if putErr := cacheStores.Samples.Put(key, data); putErr == nil {
-			fmt.Fprintf(os.Stderr, "cached as samples/%x\n", key[:4])
-		}
-	}
 	recordArtifactCLI(artifact.Record{
 		Kind:        artifact.KindProcessSample,
 		Sensitivity: artifact.SensitivityMedium,
@@ -59,13 +68,13 @@ func runSample(args []string) int {
 		Command:     "spectra sample",
 		CacheKind:   cache.KindSamples,
 		PID:         pid,
-		SizeBytes:   int64(len(data)),
+		SizeBytes:   int64(len(result.Output)),
 		Metadata: map[string]string{
 			"duration": strconv.Itoa(*duration),
 			"interval": strconv.Itoa(*interval),
 		},
 	})
 
-	os.Stdout.Write(data)
+	fmt.Fprint(os.Stdout, result.Output)
 	return 0
 }

--- a/docs/inspection/process-profiling.md
+++ b/docs/inspection/process-profiling.md
@@ -1,0 +1,210 @@
+# Process profiling
+
+Process profiling is the active side of Spectra's process inspection. The
+running-process view answers "what belongs to this app right now?" Profiling
+answers "what is it doing, how did it get here, and is the behavior changing?"
+
+This page covers four related workflows:
+
+- point-in-time samples with `sample`
+- process trees and app-scoped child process attribution
+- daemon-backed process history
+- CPU and RSS trend interpretation
+
+## Workflow
+
+Start with the cheapest view and escalate only when the question needs it:
+
+```bash
+spectra process --deep
+spectra connect local process-tree /Applications/Slack.app
+spectra connect local metrics
+spectra connect local metrics 4012 120
+spectra connect local sample 4012 5 1
+```
+
+`spectra process --deep` gives the flat inventory with CPU%, RSS, thread
+counts, open file descriptor counts, listening ports, and outbound
+connections. `process-tree` adds parent/child context. `metrics` shows recent
+daemon samples. `sample` captures call stacks when the process is actively
+burning CPU.
+
+## Samples
+
+macOS ships `sample <pid>`, which records stack traces over a bounded interval.
+Spectra exposes it as an explicit action because sampling can be noisy,
+potentially sensitive, and slow compared with the normal inventory path.
+
+```bash
+spectra sample --duration 5 --interval 10 4012
+spectra connect local sample 4012 5 1
+spectra connect work-mac sample 4012 10 1
+```
+
+The first positional value is the duration in seconds. The second is the sample
+interval in milliseconds. The local `spectra sample` command writes sample
+output to stdout and stores it in the sample blob cache unless `--no-cache` is
+set. The daemon `process.sample` RPC returns the text output to the caller;
+persisting remote sample metadata and blob keys is the storage-backed shape for
+future history views.
+
+Use samples when:
+
+- CPU is high now and you need hot call paths.
+- A renderer/helper process is stuck and the command line alone is ambiguous.
+- You need a text artifact to compare across machines or across time.
+
+Avoid treating one sample as a full diagnosis. A short capture is best at
+showing where time was spent during that window. It does not prove that the
+same stack was hot before or after the capture.
+
+## Process trees
+
+Flat process lists hide ownership. Electron, Chromium, Java launchers,
+updaters, login items, and XPC services often produce many sibling processes
+with similar names. The tree view joins process rows by PID and PPID, then
+optionally scopes the result to one or more app bundles:
+
+```bash
+spectra connect local process-tree
+spectra connect local process-tree /Applications/Claude.app
+```
+
+The scoped view is useful for answering:
+
+- Which helper is the parent of the hot child?
+- Did a GUI app spawn a long-lived updater or login item?
+- Is an orphaned helper still running after the main app exited?
+- Are JVM, Node, or Python child processes part of the app or user-launched?
+
+The unprivileged daemon can only see process details visible to the current
+user. The privileged helper design reserves `helper.process.tree()` for a
+full-system tree when root-owned daemons or other users' processes matter.
+
+## Process history
+
+When `spectra serve` is running, the daemon samples process-level CPU%, RSS,
+and virtual size at about 1Hz into an in-memory ring buffer. Recent samples are
+served through `process.live`; per-PID history is served through
+`process.history`:
+
+```bash
+spectra metrics
+spectra connect local metrics
+spectra connect local metrics 4012 120
+```
+
+The ring buffer is for immediate troubleshooting: "what changed in the last few
+minutes?" The daemon also flushes one-minute aggregates to SQLite so longer
+views can be queried without storing every per-second row forever.
+
+History rows should carry:
+
+- timestamp
+- PID and stable process identity fields
+- CPU percent
+- RSS KiB
+- virtual size KiB
+- command or executable path when visible
+- host identity when queried remotely
+
+PIDs are reused, so history consumers should treat `(pid, process_start_time)`
+or the daemon's internal process identity as the stable key. PID-only joins are
+acceptable for a short live window but unsafe for longer history.
+
+## CPU trends
+
+CPU% from `ps` is point-in-time. It is good for ranking active processes, but
+bad for explaining whether load is sustained. Use daemon history for trend
+questions:
+
+- **Short spike** — a high value for one or two samples, then back to idle.
+- **Sustained burn** — repeated high values across many samples.
+- **Sawtooth** — regular bursts, often timers, polling, rendering, or GC.
+- **Load shift** — one helper cools down while another heats up, common in
+  multi-process apps.
+
+For a sustained burn, capture `sample` while CPU is high. For a sawtooth, use a
+longer history window first, then sample during the hot phase.
+
+## RSS trends
+
+RSS is resident memory attributed to a process. It includes shared pages, so
+sum-of-process RSS overstates unique memory pressure for apps with many
+helpers. It is still the right first signal for "what does Activity Monitor
+blame this app for?"
+
+Use history to separate normal warm-up from suspicious growth:
+
+- **Warm-up plateau** — RSS climbs after launch, then stabilizes.
+- **Linear growth** — RSS increases steadily under similar workload.
+- **Step growth** — RSS jumps after a specific action and never returns.
+- **Helper churn** — total app RSS is stable, but memory moves between child
+  processes.
+
+RSS alone does not identify leaks. Pair it with process trees, app actions,
+JVM heap data for Java processes, and samples only when CPU behavior is also
+interesting.
+
+## Stored metrics
+
+The storage model splits process metrics by density:
+
+- recent per-second samples stay in the daemon's in-memory ring buffer
+- one-minute aggregates are flushed to SQLite
+- heavyweight artifacts such as `sample` output live in the sharded blob store
+
+This keeps the common local workflow cheap while still supporting remote
+debugging questions such as:
+
+- "Was Slack already hot before I connected?"
+- "Which process grew over the last 30 minutes?"
+- "Did the helper process restart between snapshots?"
+- "Can two Macs compare the same app's CPU/RSS pattern?"
+
+Stored rows should avoid sensitive payloads. Command lines can contain secrets,
+so logs and persisted metadata should keep only the fields needed for
+attribution and debugging.
+
+## Remote profiling
+
+The same RPC surface works through a local Unix socket, explicit TCP, or
+Tailscale `tsnet` listener:
+
+```bash
+spectra connect work-mac processes
+spectra connect work-mac process-tree /Applications/IntelliJ\ IDEA.app
+spectra connect work-mac metrics 4012 120
+spectra connect work-mac sample 4012 5 1
+```
+
+Remote sampling is intentionally explicit. It can expose stack frames,
+filenames, class names, and library names. Sensitive captures should require
+the same confirmation posture as heap dumps, JFR recordings, and network
+captures when they are persisted or copied off-host.
+
+## Limitations
+
+- `sample` requires permission to inspect the target process. Same-user
+  processes usually work; other users' or protected processes may require the
+  privileged helper or may remain unavailable.
+- CPU% is scheduler-time attribution, not a business-level explanation of what
+  the app is doing.
+- RSS counts shared pages and is not unique set size.
+- PID reuse means historical views need a process start time or other stable
+  identity.
+- Daemon history only exists while the daemon is running. Snapshots can show
+  past point-in-time state, but not pre-daemon per-second trends.
+
+## Implementation reference
+
+- [running-processes.md](running-processes.md) — base process inventory and
+  app attribution.
+- [live-data-sources.md](live-data-sources.md) — source commands and expected
+  costs for `ps`, `libproc`, `lsof`, `sample`, and `nettop`.
+- [../operations/daemon.md](../operations/daemon.md) — daemon RPC surface and
+  live data ring buffer.
+- [../design/storage.md](../design/storage.md) — SQLite, blob store, and
+  in-memory metrics tiers.
+- [../design/threat-model.md](../design/threat-model.md) — sensitive artifact
+  and remote-operation posture.

--- a/internal/process/sample.go
+++ b/internal/process/sample.go
@@ -1,0 +1,117 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+// CommandRunner runs a command and returns its stdout.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// CommandRunnerFunc adapts a function into a CommandRunner.
+type CommandRunnerFunc func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// Run calls f(ctx, name, args...).
+func (f CommandRunnerFunc) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return f(ctx, name, args...)
+}
+
+// ExecRunner runs commands through os/exec.
+type ExecRunner struct{}
+
+// Run executes name with args and returns stdout.
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+// SampleStore stores raw sample output.
+type SampleStore interface {
+	PutSample(ctx context.Context, sample SampleResult) error
+}
+
+// SampleOptions controls a bounded macOS sample capture.
+type SampleOptions struct {
+	PID        int
+	Duration   time.Duration
+	IntervalMS int
+	Store      bool
+	TakenAt    time.Time
+}
+
+// SampleResult is the output and metadata from one sample capture.
+type SampleResult struct {
+	PID        int       `json:"pid"`
+	TakenAt    time.Time `json:"taken_at"`
+	DurationMS int64     `json:"duration_ms"`
+	IntervalMS int       `json:"interval_ms"`
+	Output     string    `json:"output"`
+}
+
+// Sampler captures call stacks with macOS sample(1).
+type Sampler struct {
+	runner CommandRunner
+	store  SampleStore
+	now    func() time.Time
+}
+
+// NewSampler constructs a process sampler. Nil runner uses ExecRunner.
+func NewSampler(runner CommandRunner, store SampleStore) *Sampler {
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+	return &Sampler{
+		runner: runner,
+		store:  store,
+		now:    func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Capture runs `sample <pid> <duration-seconds> <interval-ms>`.
+func (s *Sampler) Capture(ctx context.Context, opts SampleOptions) (SampleResult, error) {
+	if opts.PID <= 0 {
+		return SampleResult{}, fmt.Errorf("sample requires positive pid")
+	}
+	if opts.Duration <= 0 {
+		opts.Duration = time.Second
+	}
+	if opts.IntervalMS <= 0 {
+		opts.IntervalMS = 10
+	}
+	if opts.TakenAt.IsZero() {
+		opts.TakenAt = s.now()
+	}
+	timeout := opts.Duration + 5*time.Second
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	durationSeconds := int(opts.Duration.Round(time.Second) / time.Second)
+	if durationSeconds <= 0 {
+		durationSeconds = 1
+	}
+	out, err := s.runner.Run(runCtx, "sample",
+		strconv.Itoa(opts.PID),
+		strconv.Itoa(durationSeconds),
+		strconv.Itoa(opts.IntervalMS),
+	)
+	if err != nil {
+		return SampleResult{}, fmt.Errorf("sample pid %d: %w", opts.PID, err)
+	}
+	result := SampleResult{
+		PID:        opts.PID,
+		TakenAt:    opts.TakenAt,
+		DurationMS: opts.Duration.Milliseconds(),
+		IntervalMS: opts.IntervalMS,
+		Output:     string(out),
+	}
+	if opts.Store && s.store != nil {
+		if err := s.store.PutSample(ctx, result); err != nil {
+			return SampleResult{}, fmt.Errorf("store sample: %w", err)
+		}
+	}
+	return result, nil
+}

--- a/internal/process/sample_test.go
+++ b/internal/process/sample_test.go
@@ -1,0 +1,120 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeCommandRunner struct {
+	output []byte
+	err    error
+	calls  []fakeCommandCall
+}
+
+type fakeCommandCall struct {
+	name string
+	args []string
+}
+
+func (r *fakeCommandRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, fakeCommandCall{name: name, args: append([]string(nil), args...)})
+	return r.output, r.err
+}
+
+type fakeSampleStore struct {
+	samples []SampleResult
+	err     error
+}
+
+func (s *fakeSampleStore) PutSample(_ context.Context, sample SampleResult) error {
+	s.samples = append(s.samples, sample)
+	return s.err
+}
+
+func TestSamplerCaptureRunsSampleCommand(t *testing.T) {
+	runner := &fakeCommandRunner{output: []byte("Call graph:\n")}
+	store := &fakeSampleStore{}
+	sampler := NewSampler(runner, store)
+	sampler.now = func() time.Time { return time.Unix(100, 0).UTC() }
+
+	result, err := sampler.Capture(context.Background(), SampleOptions{
+		PID:        4012,
+		Duration:   5 * time.Second,
+		IntervalMS: 20,
+		Store:      true,
+	})
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if result.PID != 4012 {
+		t.Errorf("PID = %d, want 4012", result.PID)
+	}
+	if result.DurationMS != 5000 {
+		t.Errorf("DurationMS = %d, want 5000", result.DurationMS)
+	}
+	if result.IntervalMS != 20 {
+		t.Errorf("IntervalMS = %d, want 20", result.IntervalMS)
+	}
+	if result.Output != "Call graph:\n" {
+		t.Errorf("Output = %q", result.Output)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d, want 1", len(runner.calls))
+	}
+	wantArgs := []string{"4012", "5", "20"}
+	if runner.calls[0].name != "sample" || !reflect.DeepEqual(runner.calls[0].args, wantArgs) {
+		t.Errorf("runner call = %+v, want sample %v", runner.calls[0], wantArgs)
+	}
+	if len(store.samples) != 1 {
+		t.Fatalf("stored samples = %d, want 1", len(store.samples))
+	}
+	if store.samples[0].Output != result.Output {
+		t.Errorf("stored output = %q, want %q", store.samples[0].Output, result.Output)
+	}
+}
+
+func TestSamplerCaptureDefaults(t *testing.T) {
+	runner := &fakeCommandRunner{output: []byte("ok")}
+	sampler := NewSampler(runner, nil)
+
+	_, err := sampler.Capture(context.Background(), SampleOptions{PID: 99})
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	wantArgs := []string{"99", "1", "10"}
+	if !reflect.DeepEqual(runner.calls[0].args, wantArgs) {
+		t.Errorf("runner args = %v, want %v", runner.calls[0].args, wantArgs)
+	}
+}
+
+func TestSamplerCaptureRejectsInvalidPID(t *testing.T) {
+	_, err := NewSampler(&fakeCommandRunner{}, nil).Capture(context.Background(), SampleOptions{PID: 0})
+	if err == nil {
+		t.Fatal("Capture succeeded, want error")
+	}
+}
+
+func TestSamplerCaptureWrapsRunnerError(t *testing.T) {
+	_, err := NewSampler(&fakeCommandRunner{err: errors.New("denied")}, nil).Capture(context.Background(), SampleOptions{PID: 42})
+	if err == nil {
+		t.Fatal("Capture succeeded, want error")
+	}
+	if got, want := err.Error(), "sample pid 42"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want it to contain %q", got, want)
+	}
+}
+
+func TestSamplerCaptureReturnsStoreError(t *testing.T) {
+	_, err := NewSampler(&fakeCommandRunner{output: []byte("ok")}, &fakeSampleStore{err: errors.New("disk full")}).
+		Capture(context.Background(), SampleOptions{PID: 42, Store: true})
+	if err == nil {
+		t.Fatal("Capture succeeded, want error")
+	}
+	if got, want := err.Error(), "store sample"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want it to contain %q", got, want)
+	}
+}

--- a/internal/process/tree.go
+++ b/internal/process/tree.go
@@ -1,0 +1,86 @@
+package process
+
+import "context"
+
+// Collector collects process inventory for higher-level profiling services.
+type Collector interface {
+	Collect(ctx context.Context, opts CollectOptions) []Info
+}
+
+// CollectorFunc adapts a function into a Collector.
+type CollectorFunc func(ctx context.Context, opts CollectOptions) []Info
+
+// Collect calls f(ctx, opts).
+func (f CollectorFunc) Collect(ctx context.Context, opts CollectOptions) []Info {
+	return f(ctx, opts)
+}
+
+// SystemCollector collects process inventory from the local system.
+type SystemCollector struct{}
+
+// Collect returns all visible local processes.
+func (SystemCollector) Collect(ctx context.Context, opts CollectOptions) []Info {
+	return CollectAll(ctx, opts)
+}
+
+// TreeOptions controls tree collection.
+type TreeOptions struct {
+	Bundles []string
+	Deep    bool
+}
+
+// TreeService builds process trees from an injected collector.
+type TreeService struct {
+	collector Collector
+}
+
+// NewTreeService constructs a tree service. Nil collector uses SystemCollector.
+func NewTreeService(collector Collector) *TreeService {
+	if collector == nil {
+		collector = SystemCollector{}
+	}
+	return &TreeService{collector: collector}
+}
+
+// Build collects processes and returns a parent-child tree.
+func (s *TreeService) Build(ctx context.Context, opts TreeOptions) []*TreeNode {
+	procs := s.collector.Collect(ctx, CollectOptions{
+		BundlePaths: opts.Bundles,
+		Deep:        opts.Deep,
+	})
+	if len(opts.Bundles) > 0 {
+		procs = ScopeTreeProcesses(procs)
+	}
+	return BuildTree(procs)
+}
+
+// ScopeTreeProcesses keeps app-attributed processes and their ancestors so a
+// scoped tree still explains parentage without returning unrelated branches.
+func ScopeTreeProcesses(procs []Info) []Info {
+	if len(procs) == 0 {
+		return nil
+	}
+	byPID := make(map[int]Info, len(procs))
+	keep := make(map[int]bool)
+	for _, p := range procs {
+		byPID[p.PID] = p
+		if p.AppPath != "" {
+			keep[p.PID] = true
+		}
+	}
+	for _, p := range procs {
+		if p.AppPath == "" {
+			continue
+		}
+		for parent, ok := byPID[p.PPID]; ok && parent.PID != p.PID; parent, ok = byPID[parent.PPID] {
+			keep[parent.PID] = true
+		}
+	}
+	out := make([]Info, 0, len(keep))
+	for _, p := range procs {
+		if keep[p.PID] {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/process/tree_test.go
+++ b/internal/process/tree_test.go
@@ -1,0 +1,73 @@
+package process
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeProcessCollector struct {
+	procs []Info
+	opts  []CollectOptions
+}
+
+func (c *fakeProcessCollector) Collect(_ context.Context, opts CollectOptions) []Info {
+	c.opts = append(c.opts, opts)
+	return append([]Info(nil), c.procs...)
+}
+
+func TestTreeServiceBuildPassesCollectionOptions(t *testing.T) {
+	collector := &fakeProcessCollector{procs: []Info{{PID: 1, PPID: 0, Command: "launchd"}}}
+	roots := NewTreeService(collector).Build(context.Background(), TreeOptions{
+		Bundles: []string{"/Applications/App.app"},
+		Deep:    true,
+	})
+	if len(roots) != 0 {
+		t.Fatalf("roots = %d, want 0 because no process matched bundle scope", len(roots))
+	}
+	if len(collector.opts) != 1 {
+		t.Fatalf("collector calls = %d, want 1", len(collector.opts))
+	}
+	if !collector.opts[0].Deep {
+		t.Error("Deep = false, want true")
+	}
+	if len(collector.opts[0].BundlePaths) != 1 || collector.opts[0].BundlePaths[0] != "/Applications/App.app" {
+		t.Errorf("BundlePaths = %v", collector.opts[0].BundlePaths)
+	}
+}
+
+func TestScopeTreeProcessesKeepsMatchedProcessesAndAncestors(t *testing.T) {
+	procs := []Info{
+		{PID: 1, PPID: 0, Command: "launchd"},
+		{PID: 10, PPID: 1, Command: "App", AppPath: "/Applications/App.app"},
+		{PID: 11, PPID: 10, Command: "Helper", AppPath: "/Applications/App.app"},
+		{PID: 99, PPID: 1, Command: "Other"},
+	}
+	scoped := ScopeTreeProcesses(procs)
+	if len(scoped) != 3 {
+		t.Fatalf("scoped len = %d, want 3", len(scoped))
+	}
+	for _, pid := range []int{1, 10, 11} {
+		if !hasPID(scoped, pid) {
+			t.Errorf("scoped missing PID %d", pid)
+		}
+	}
+	if hasPID(scoped, 99) {
+		t.Error("scoped includes unrelated PID 99")
+	}
+	roots := BuildTree(scoped)
+	if len(roots) != 1 || roots[0].Info.PID != 1 {
+		t.Fatalf("root = %+v, want PID 1", roots)
+	}
+	if len(roots[0].Children) != 1 || roots[0].Children[0].Info.PID != 10 {
+		t.Fatalf("root children = %+v, want PID 10", roots[0].Children)
+	}
+}
+
+func hasPID(procs []Info, pid int) bool {
+	for _, p := range procs {
+		if p.PID == pid {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -11,9 +11,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1468,15 +1466,16 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 	d.Register("process.tree", func(params json.RawMessage) (any, error) {
 		var p struct {
 			Bundles []string `json:"bundles"`
+			Deep    bool     `json:"deep"`
 		}
 		_ = json.Unmarshal(params, &p)
-		procs := process.CollectAll(context.Background(), process.CollectOptions{
-			BundlePaths: p.Bundles,
-		})
-		return process.BuildTree(procs), nil
+		return process.NewTreeService(nil).Build(context.Background(), process.TreeOptions{
+			Bundles: p.Bundles,
+			Deep:    p.Deep,
+		}), nil
 	})
 
-	// process.sample — run `sample <pid> <duration>` and return the text output.
+	// process.sample — run `sample <pid> <duration> <interval>` and return the text output.
 	// Required: {"pid": <pid>}. Optional: {"duration": 1, "interval": 10}.
 	d.Register("process.sample", func(params json.RawMessage) (any, error) {
 		var p struct {
@@ -1508,12 +1507,16 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err := authorizeArtifact(log, artifactPolicy, rec, true); err != nil {
 			return nil, err
 		}
-		out, err := runSampleCmd(p.PID, p.Duration, p.Interval)
+		result, err := process.NewSampler(nil, nil).Capture(context.Background(), process.SampleOptions{
+			PID:        p.PID,
+			Duration:   time.Duration(p.Duration) * time.Second,
+			IntervalMS: p.Interval,
+		})
 		if err != nil {
-			return nil, fmt.Errorf("sample pid %d: %w", p.PID, err)
+			return nil, err
 		}
-		rec.SizeBytes = int64(len(out))
-		return recordArtifact(context.Background(), log, artifactRecorder, rec, map[string]any{"pid": p.PID, "output": string(out)}), nil
+		rec.SizeBytes = int64(len(result.Output))
+		return recordArtifact(context.Background(), log, artifactRecorder, rec, map[string]any{"pid": result.PID, "output": result.Output, "taken_at": result.TakenAt, "duration_ms": result.DurationMS, "interval_ms": result.IntervalMS}), nil
 	})
 
 	// power.state — battery level, thermal pressure, assertions, and top energy users.
@@ -1783,17 +1786,4 @@ func recordArtifact(ctx context.Context, log logger.Logger, recorder artifact.Re
 
 func daemonJVMOptions() jvm.CollectOptions {
 	return jvm.CollectOptions{JDKs: collectJDKs(context.Background(), toolchain.CollectOptions{})}
-}
-
-// runSampleCmd runs `sample <pid> <duration> <interval>` and returns stdout.
-func runSampleCmd(pid, durationSec, intervalMS int) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(),
-		time.Duration(durationSec+5)*time.Second)
-	defer cancel()
-	// #nosec G204 -- PID, duration, and interval are integer arguments.
-	return exec.CommandContext(ctx, "sample",
-		strconv.Itoa(pid),
-		strconv.Itoa(durationSec),
-		strconv.Itoa(intervalMS),
-	).Output()
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - Power and thermal: inspection/power-thermal.md
       - Python-based apps: inspection/python-apps.md
       - Rust-based apps: inspection/rust-based-apps.md
+      - Process profiling: inspection/process-profiling.md
       - Toolchains: inspection/toolchains.md
       - JVM: inspection/jvm.md
       - Live data sources: inspection/live-data-sources.md


### PR DESCRIPTION
## Summary
- add process profiling docs covering samples, process trees, history, stored metrics, and CPU/RSS trends
- introduce process sampling and tree services with runner, store, and collector interfaces
- wire the CLI sample command and daemon process profiling RPC handlers through the new services
- add fake-backed unit tests for sampling and tree scoping

## Validation
- go test ./internal/process ./cmd/spectra ./internal/serve -count=1
- go build ./...
- go vet ./...
- go test ./... -count=1
- make docs-validate