### PR TITLE
Add issue workflow service

### DIFF
--- a/cmd/spectra/issues.go
+++ b/cmd/spectra/issues.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/kaeawc/spectra/internal/detect"
+	issueflow "github.com/kaeawc/spectra/internal/issues"
 	"github.com/kaeawc/spectra/internal/rules"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/store"
@@ -19,6 +22,8 @@ func issuesSubcommands() []subcommand {
 		{"update", "Update an issue status", runIssuesUpdate},
 		{"acknowledge", "Mark an issue acknowledged", runIssuesAcknowledge},
 		{"dismiss", "Mark an issue dismissed", runIssuesDismiss},
+		{"record-fix", "Record a fix attempt for an issue", runIssuesRecordFix},
+		{"fix-history", "List recorded fix attempts for an issue", runIssuesFixHistory},
 		{"check", "Run rules, record findings as issues, and print a summary", runIssuesCheck},
 	}
 }
@@ -154,6 +159,89 @@ func runIssuesSetStatus(args []string, verb string, status store.IssueStatus) in
 	return 0
 }
 
+func runIssuesRecordFix(args []string) int {
+	fs := flag.NewFlagSet("spectra issues record-fix", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	appliedBy := fs.String("applied-by", "", "Actor that applied the fix")
+	command := fs.String("command", "", "Command or action taken")
+	output := fs.String("output", "", "Command output or result note")
+	exitCode := fs.Int("exit-code", 0, "Command exit code")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "usage: spectra issues record-fix [--applied-by user] [--command cmd] [--output text] [--exit-code code] <issue-id>")
+		return 2
+	}
+
+	db, _, err := openIssuesDB()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+
+	id, err := db.RecordAppliedFix(context.Background(), store.AppliedFixInput{
+		IssueID:   fs.Arg(0),
+		AppliedBy: *appliedBy,
+		Command:   *command,
+		Output:    *output,
+		ExitCode:  *exitCode,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "record fix for %q: %v\n", fs.Arg(0), err)
+		return 1
+	}
+	fmt.Printf("recorded fix %s for issue %s\n", id, fs.Arg(0))
+	return 0
+}
+
+func runIssuesFixHistory(args []string) int {
+	fs := flag.NewFlagSet("spectra issues fix-history", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "usage: spectra issues fix-history [--json] <issue-id>")
+		return 2
+	}
+
+	db, _, err := openIssuesDB()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+
+	rows, err := db.ListAppliedFixes(context.Background(), fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fix history for %q: %v\n", fs.Arg(0), err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(rows)
+		return 0
+	}
+	if len(rows) == 0 {
+		fmt.Printf("no fix history for issue %s\n", fs.Arg(0))
+		return 0
+	}
+	fmt.Printf("%-20s  %-20s  %-12s  %-8s  %s\n", "ID", "APPLIED_AT", "APPLIED_BY", "EXIT", "COMMAND")
+	fmt.Println(strings.Repeat("-", 90))
+	for _, r := range rows {
+		fmt.Printf("%-20s  %-20s  %-12s  %-8d  %s\n",
+			truncate(r.ID, 20), r.AppliedAt.Format(time.RFC3339),
+			truncate(r.AppliedBy, 12), r.ExitCode, truncate(r.Command, 60),
+		)
+	}
+	fmt.Printf("\n%d fix attempt(s)\n", len(rows))
+	return 0
+}
+
 // runIssuesCheck evaluates V1 rules against a live or stored snapshot,
 // persists the findings as issues, and prints a human-readable summary.
 func runIssuesCheck(args []string) int {
@@ -166,49 +254,32 @@ func runIssuesCheck(args []string) int {
 		return 2
 	}
 
-	var snap snapshot.Snapshot
-	if *snapID != "" {
-		s, err := loadStoredSnapshot(*snapID)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "issues check: %v\n", err)
-			return 1
-		}
-		snap = *s
-	} else {
-		snap = snapshot.Build(context.Background(), snapshot.Options{
-			SpectraVersion: version,
-		})
-		// Persist the snapshot so issues can reference it.
-		if err := saveSnapshot(snap); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not persist snapshot: %v\n", err)
-		}
-	}
-
 	catalog, err := loadRuleCatalog(*rulesConfig, os.Stderr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "issues check: %v\n", err)
 		return 1
 	}
-	findings := rules.Evaluate(snap, catalog)
-
-	// Record findings as issues.
-	db, machineUUID, err := openIssuesDB()
-	if err == nil {
-		defer db.Close()
-		var inputs []store.FindingInput
-		for _, f := range findings {
-			inputs = append(inputs, store.FindingInput{
-				RuleID:   f.RuleID,
-				Subject:  f.Subject,
-				Severity: string(f.Severity),
-				Message:  f.Message,
-				Fix:      f.Fix,
-			})
-		}
-		if _, err := db.UpsertIssues(context.Background(), machineUUID, snap.ID, inputs); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not record issues: %v\n", err)
-		}
+	db, _, err := openIssuesDB()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
 	}
+	defer db.Close()
+
+	svc := issueflow.Service{
+		Store:         db,
+		SnapshotStore: cliSnapshotStore{db: db},
+		Snapshots:     cliSnapshotSource{version: version},
+		Engine: issueflow.EngineFunc(func(s snapshot.Snapshot) []rules.Finding {
+			return rules.Evaluate(s, catalog)
+		}),
+	}
+	result, err := svc.Check(context.Background(), issueflow.CheckOptions{SnapshotID: *snapID})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "issues check: %v\n", err)
+		return 1
+	}
+	findings := result.Findings
 
 	if *asJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -223,6 +294,45 @@ func runIssuesCheck(args []string) int {
 	}
 	printFindings(findings)
 	return 0
+}
+
+type cliSnapshotSource struct {
+	version string
+}
+
+func (s cliSnapshotSource) Live(ctx context.Context) (snapshot.Snapshot, error) {
+	return snapshot.Build(ctx, snapshot.Options{
+		SpectraVersion: s.version,
+		DetectOpts:     detect.Options{},
+	}), nil
+}
+
+func (cliSnapshotSource) Stored(_ context.Context, id string) (snapshot.Snapshot, error) {
+	s, err := loadStoredSnapshot(id)
+	if err != nil {
+		return snapshot.Snapshot{}, err
+	}
+	return *s, nil
+}
+
+type cliSnapshotStore struct {
+	db *store.DB
+}
+
+func (s cliSnapshotStore) SaveSnapshot(ctx context.Context, snap store.SnapshotInput) error {
+	return s.db.SaveSnapshot(ctx, snap)
+}
+
+func (s cliSnapshotStore) SaveSnapshotProcesses(ctx context.Context, snapshotID string, processes []store.ProcessSnapshotRow) error {
+	return s.db.SaveSnapshotProcesses(ctx, snapshotID, processes)
+}
+
+func (s cliSnapshotStore) SaveLoginItems(ctx context.Context, snapshotID string, items []store.LoginItemRow) error {
+	return s.db.SaveLoginItems(ctx, snapshotID, items)
+}
+
+func (s cliSnapshotStore) SaveGrantedPerms(ctx context.Context, snapshotID string, perms []store.GrantedPermRow) error {
+	return s.db.SaveGrantedPerms(ctx, snapshotID, perms)
 }
 
 // openIssuesDB opens the default DB and returns the machine UUID from the

--- a/docs/operations/issues.md
+++ b/docs/operations/issues.md
@@ -1,0 +1,171 @@
+# Issues
+
+Spectra issues are the operational layer of the recommendations engine.
+Rules produce point-in-time findings; issues persist those findings across
+snapshots so operators can track acknowledgement, dismissal, and fix history.
+
+## Concepts
+
+- **Rule** — a built-in Spectra check from `internal/rules`.
+- **Finding** — one rule firing against one snapshot subject, such as an app,
+  process, JDK, or host-level condition.
+- **Issue** — the persisted lifecycle record for a finding identity.
+- **Acknowledgement** — an operator has seen the issue and accepts that it
+  remains active.
+- **Dismissal** — the finding is intentionally suppressed. Later matching
+  findings do not reopen or duplicate the dismissed issue.
+- **Applied fix** — a recorded remediation attempt, including actor, command,
+  output, exit code, and timestamp.
+
+Findings are matched to issues by `(rule_id, machine_uuid, subject)` while
+the existing issue is active. Active statuses are `open` and `acknowledged`.
+
+## Lifecycle
+
+```text
+open -> acknowledged -> fixed -> closed
+  \------------------> dismissed
+```
+
+`spectra issues check` evaluates rules and upserts matching active issues.
+When the same active issue is observed again, Spectra refreshes
+`last_seen_snapshot_id` and `updated_at` instead of creating a duplicate.
+
+Dismissed issues are suppression records. A later matching finding is skipped
+instead of reopened. If an operator wants to track that finding again, they
+can move the issue back to `open`.
+
+Fixed and closed issues are historical records. If the same finding appears
+again after being fixed or closed, Spectra may create a new open issue because
+the remediation did not hold or the condition returned.
+
+## CLI
+
+Evaluate rules without persisting:
+
+```bash
+spectra rules
+spectra rules --json
+spectra rules --snapshot <snapshot-id>
+spectra rules --rules-config spectra.yml
+```
+
+Evaluate and persist issues:
+
+```bash
+spectra issues check
+spectra issues check --json
+spectra issues check --snapshot <snapshot-id>
+spectra issues check --rules-config spectra.yml
+```
+
+List and transition issues:
+
+```bash
+spectra issues list
+spectra issues list --status open
+spectra issues list --json
+spectra issues acknowledge <issue-id>
+spectra issues dismiss <issue-id>
+spectra issues update --status fixed <issue-id>
+spectra issues update --status closed <issue-id>
+```
+
+Record and inspect fix history:
+
+```bash
+spectra issues record-fix \
+  --applied-by "$USER" \
+  --command "brew upgrade openjdk@21" \
+  --output "upgraded" \
+  --exit-code 0 \
+  <issue-id>
+
+spectra issues fix-history <issue-id>
+spectra issues fix-history --json <issue-id>
+```
+
+## Storage
+
+Issues are stored in SQLite through `internal/store`.
+
+The `issues` table stores the canonical issue state:
+
+- `id`
+- `rule_id`
+- `machine_uuid`
+- `subject`
+- `severity`
+- `message`
+- `fix`
+- `status`
+- `first_seen_snapshot_id`
+- `last_seen_snapshot_id`
+- `created_at`
+- `updated_at`
+
+The `applied_fixes` table stores remediation history:
+
+- `id`
+- `issue_id`
+- `applied_at`
+- `applied_by`
+- `command`
+- `output`
+- `exit_code`
+
+Snapshots are retained separately. Issues reference snapshot IDs rather than
+duplicating snapshot content.
+
+## Component boundary
+
+Issue orchestration lives in `internal/issues.Service`. The service depends on
+interfaces rather than concrete collectors or SQLite so lifecycle behavior can
+be tested without touching the host machine:
+
+- `Store` — issue rows, status transitions, upserts, and applied fixes.
+- `SnapshotStore` — snapshot persistence used by live checks.
+- `SnapshotSource` — live or stored snapshot retrieval.
+- `Engine` — rule evaluation against a snapshot.
+
+Unit tests use fakes for each boundary. Store-level tests cover SQLite
+semantics such as dismissal suppression and fix-history persistence.
+
+## Daemon and MCP
+
+The daemon exposes issue operations over JSON-RPC:
+
+- `rules.check`
+- `issues.check`
+- `issues.list`
+- `issues.record`
+- `issues.update`
+- `issues.acknowledge`
+- `issues.dismiss`
+- `issues.fix.record`
+- `issues.fix.list`
+
+The MCP server exposes the same operational surface through the `issues` tool:
+
+- `check`
+- `list`
+- `acknowledge`
+- `dismiss`
+- `record_fix`
+- `fix_history`
+
+## Overrides
+
+Project-local `spectra.yml` files can disable built-in rules or override
+their severity:
+
+```yaml
+rules:
+  disabled:
+    - app-unsigned
+  severity:
+    jvm-eol-version: high
+    library-storage-footprint: low
+```
+
+Unknown rule IDs produce warnings so team configs do not silently drift.

--- a/internal/issues/service.go
+++ b/internal/issues/service.go
@@ -1,0 +1,165 @@
+// Package issues coordinates recommendations findings with persisted issue state.
+package issues
+
+import (
+	"context"
+
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+// Store is the persistence boundary used by Service.
+type Store interface {
+	ListIssues(ctx context.Context, machineUUID string, status store.IssueStatus) ([]store.IssueRow, error)
+	UpdateIssueStatus(ctx context.Context, id string, status store.IssueStatus) error
+	UpsertIssues(ctx context.Context, machineUUID, snapshotID string, findings []store.FindingInput) ([]string, error)
+	RecordAppliedFix(ctx context.Context, fix store.AppliedFixInput) (string, error)
+	ListAppliedFixes(ctx context.Context, issueID string) ([]store.AppliedFixRow, error)
+}
+
+// SnapshotStore persists snapshots captured during a live issue check.
+type SnapshotStore interface {
+	SaveSnapshot(ctx context.Context, snap store.SnapshotInput) error
+	SaveSnapshotProcesses(ctx context.Context, snapshotID string, processes []store.ProcessSnapshotRow) error
+	SaveLoginItems(ctx context.Context, snapshotID string, items []store.LoginItemRow) error
+	SaveGrantedPerms(ctx context.Context, snapshotID string, perms []store.GrantedPermRow) error
+}
+
+// SnapshotSource returns either a live or previously persisted snapshot.
+type SnapshotSource interface {
+	Live(ctx context.Context) (snapshot.Snapshot, error)
+	Stored(ctx context.Context, id string) (snapshot.Snapshot, error)
+}
+
+// Engine evaluates recommendation rules against a snapshot.
+type Engine interface {
+	Evaluate(snapshot.Snapshot) []rules.Finding
+}
+
+// EngineFunc adapts a function into an Engine.
+type EngineFunc func(snapshot.Snapshot) []rules.Finding
+
+// Evaluate implements Engine.
+func (f EngineFunc) Evaluate(snap snapshot.Snapshot) []rules.Finding {
+	return f(snap)
+}
+
+// Service owns issue lifecycle operations.
+type Service struct {
+	Store         Store
+	SnapshotStore SnapshotStore
+	Snapshots     SnapshotSource
+	Engine        Engine
+}
+
+// CheckOptions configures a rule evaluation and persistence pass.
+type CheckOptions struct {
+	SnapshotID string
+}
+
+// CheckResult is the persisted result of a rule evaluation.
+type CheckResult struct {
+	Snapshot    snapshot.Snapshot `json:"snapshot"`
+	MachineUUID string            `json:"machine_uuid"`
+	Findings    []rules.Finding   `json:"findings"`
+	IssueIDs    []string          `json:"issue_ids"`
+}
+
+// Check evaluates rules against a stored or live snapshot and upserts issues.
+func (s Service) Check(ctx context.Context, opts CheckOptions) (CheckResult, error) {
+	var snap snapshot.Snapshot
+	var err error
+	if opts.SnapshotID != "" {
+		snap, err = s.Snapshots.Stored(ctx, opts.SnapshotID)
+	} else {
+		snap, err = s.Snapshots.Live(ctx)
+		if err == nil && s.SnapshotStore != nil {
+			if err = persistSnapshot(ctx, s.SnapshotStore, snap); err != nil {
+				return CheckResult{}, err
+			}
+		}
+	}
+	if err != nil {
+		return CheckResult{}, err
+	}
+
+	findings := s.Engine.Evaluate(snap)
+	ids, err := s.Store.UpsertIssues(ctx, MachineUUID(snap), snap.ID, FindingInputs(findings))
+	if err != nil {
+		return CheckResult{}, err
+	}
+	return CheckResult{
+		Snapshot:    snap,
+		MachineUUID: MachineUUID(snap),
+		Findings:    findings,
+		IssueIDs:    ids,
+	}, nil
+}
+
+// List returns persisted issues for one machine.
+func (s Service) List(ctx context.Context, machineUUID string, status store.IssueStatus) ([]store.IssueRow, error) {
+	return s.Store.ListIssues(ctx, machineUUID, status)
+}
+
+// Update changes issue status.
+func (s Service) Update(ctx context.Context, id string, status store.IssueStatus) error {
+	return s.Store.UpdateIssueStatus(ctx, id, status)
+}
+
+// Acknowledge marks an issue acknowledged.
+func (s Service) Acknowledge(ctx context.Context, id string) error {
+	return s.Update(ctx, id, store.IssueAcknowledged)
+}
+
+// Dismiss marks an issue dismissed.
+func (s Service) Dismiss(ctx context.Context, id string) error {
+	return s.Update(ctx, id, store.IssueDismissed)
+}
+
+// RecordFix appends one fix attempt.
+func (s Service) RecordFix(ctx context.Context, fix store.AppliedFixInput) (string, error) {
+	return s.Store.RecordAppliedFix(ctx, fix)
+}
+
+// FixHistory returns recorded fix attempts for one issue.
+func (s Service) FixHistory(ctx context.Context, issueID string) ([]store.AppliedFixRow, error) {
+	return s.Store.ListAppliedFixes(ctx, issueID)
+}
+
+// FindingInputs converts rule findings to store inputs.
+func FindingInputs(findings []rules.Finding) []store.FindingInput {
+	inputs := make([]store.FindingInput, 0, len(findings))
+	for _, f := range findings {
+		inputs = append(inputs, store.FindingInput{
+			RuleID:   f.RuleID,
+			Subject:  f.Subject,
+			Severity: string(f.Severity),
+			Message:  f.Message,
+			Fix:      f.Fix,
+		})
+	}
+	return inputs
+}
+
+// MachineUUID returns the stable machine identity used for issue matching.
+func MachineUUID(snap snapshot.Snapshot) string {
+	if snap.Host.MachineUUID != "" {
+		return snap.Host.MachineUUID
+	}
+	if snap.Host.Hostname != "" {
+		return snap.Host.Hostname
+	}
+	return "local"
+}
+
+func persistSnapshot(ctx context.Context, dst SnapshotStore, snap snapshot.Snapshot) error {
+	input := store.FromSnapshot(snap)
+	if err := dst.SaveSnapshot(ctx, input); err != nil {
+		return err
+	}
+	_ = dst.SaveSnapshotProcesses(ctx, snap.ID, store.ProcessesFromSnapshot(snap))
+	_ = dst.SaveLoginItems(ctx, snap.ID, store.LoginItemsFromSnapshot(snap))
+	_ = dst.SaveGrantedPerms(ctx, snap.ID, store.GrantedPermsFromSnapshot(snap))
+	return nil
+}

--- a/internal/issues/service_test.go
+++ b/internal/issues/service_test.go
@@ -1,0 +1,240 @@
+package issues
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+type fakeStore struct {
+	listMachine string
+	listStatus  store.IssueStatus
+	listRows    []store.IssueRow
+
+	upsertMachine  string
+	upsertSnapshot string
+	upsertFindings []store.FindingInput
+	upsertIDs      []string
+	upsertErr      error
+
+	updatedID     string
+	updatedStatus store.IssueStatus
+
+	recordedFix store.AppliedFixInput
+	fixID       string
+
+	historyIssueID string
+	historyRows    []store.AppliedFixRow
+}
+
+func (f *fakeStore) ListIssues(_ context.Context, machineUUID string, status store.IssueStatus) ([]store.IssueRow, error) {
+	f.listMachine = machineUUID
+	f.listStatus = status
+	return f.listRows, nil
+}
+
+func (f *fakeStore) UpdateIssueStatus(_ context.Context, id string, status store.IssueStatus) error {
+	f.updatedID = id
+	f.updatedStatus = status
+	return nil
+}
+
+func (f *fakeStore) UpsertIssues(_ context.Context, machineUUID, snapshotID string, findings []store.FindingInput) ([]string, error) {
+	f.upsertMachine = machineUUID
+	f.upsertSnapshot = snapshotID
+	f.upsertFindings = append([]store.FindingInput(nil), findings...)
+	return f.upsertIDs, f.upsertErr
+}
+
+func (f *fakeStore) RecordAppliedFix(_ context.Context, fix store.AppliedFixInput) (string, error) {
+	f.recordedFix = fix
+	return f.fixID, nil
+}
+
+func (f *fakeStore) ListAppliedFixes(_ context.Context, issueID string) ([]store.AppliedFixRow, error) {
+	f.historyIssueID = issueID
+	return f.historyRows, nil
+}
+
+type fakeSnapshots struct {
+	liveCalled   bool
+	storedCalled string
+	live         snapshot.Snapshot
+	stored       snapshot.Snapshot
+	err          error
+}
+
+func (f *fakeSnapshots) Live(context.Context) (snapshot.Snapshot, error) {
+	f.liveCalled = true
+	return f.live, f.err
+}
+
+func (f *fakeSnapshots) Stored(_ context.Context, id string) (snapshot.Snapshot, error) {
+	f.storedCalled = id
+	return f.stored, f.err
+}
+
+type fakeSnapshotStore struct {
+	savedSnapshotID string
+	savedProcesses  bool
+	savedLoginItems bool
+	savedPerms      bool
+	err             error
+}
+
+func (f *fakeSnapshotStore) SaveSnapshot(_ context.Context, snap store.SnapshotInput) error {
+	f.savedSnapshotID = snap.ID
+	return f.err
+}
+
+func (f *fakeSnapshotStore) SaveSnapshotProcesses(context.Context, string, []store.ProcessSnapshotRow) error {
+	f.savedProcesses = true
+	return nil
+}
+
+func (f *fakeSnapshotStore) SaveLoginItems(context.Context, string, []store.LoginItemRow) error {
+	f.savedLoginItems = true
+	return nil
+}
+
+func (f *fakeSnapshotStore) SaveGrantedPerms(context.Context, string, []store.GrantedPermRow) error {
+	f.savedPerms = true
+	return nil
+}
+
+func testSnap() snapshot.Snapshot {
+	return snapshot.Snapshot{
+		ID:      "snap-1",
+		TakenAt: time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		Kind:    snapshot.KindLive,
+		Host: snapshot.HostInfo{
+			MachineUUID: "machine-1",
+			Hostname:    "host-1",
+			OSName:      "macOS",
+			OSVersion:   "15.6",
+		},
+	}
+}
+
+func TestCheckLivePersistsSnapshotAndFindings(t *testing.T) {
+	st := &fakeStore{upsertIDs: []string{"issue-1"}}
+	snapStore := &fakeSnapshotStore{}
+	source := &fakeSnapshots{live: testSnap()}
+	finding := rules.Finding{
+		RuleID:   "rule-1",
+		Subject:  "subject-1",
+		Severity: rules.SeverityHigh,
+		Message:  "message",
+		Fix:      "fix",
+	}
+	svc := Service{
+		Store:         st,
+		SnapshotStore: snapStore,
+		Snapshots:     source,
+		Engine:        EngineFunc(func(snapshot.Snapshot) []rules.Finding { return []rules.Finding{finding} }),
+	}
+
+	got, err := svc.Check(context.Background(), CheckOptions{})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !source.liveCalled {
+		t.Fatal("expected live snapshot source")
+	}
+	if snapStore.savedSnapshotID != "snap-1" || !snapStore.savedProcesses || !snapStore.savedLoginItems || !snapStore.savedPerms {
+		t.Fatalf("snapshot persistence incomplete: %+v", snapStore)
+	}
+	if got.MachineUUID != "machine-1" || got.Snapshot.ID != "snap-1" || !reflect.DeepEqual(got.IssueIDs, []string{"issue-1"}) {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+	wantInputs := []store.FindingInput{{RuleID: "rule-1", Subject: "subject-1", Severity: "high", Message: "message", Fix: "fix"}}
+	if st.upsertMachine != "machine-1" || st.upsertSnapshot != "snap-1" || !reflect.DeepEqual(st.upsertFindings, wantInputs) {
+		t.Fatalf("unexpected upsert: machine=%q snapshot=%q findings=%+v", st.upsertMachine, st.upsertSnapshot, st.upsertFindings)
+	}
+}
+
+func TestCheckStoredDoesNotPersistSnapshot(t *testing.T) {
+	st := &fakeStore{}
+	snapStore := &fakeSnapshotStore{}
+	source := &fakeSnapshots{stored: testSnap()}
+	svc := Service{
+		Store:         st,
+		SnapshotStore: snapStore,
+		Snapshots:     source,
+		Engine:        EngineFunc(func(snapshot.Snapshot) []rules.Finding { return nil }),
+	}
+
+	if _, err := svc.Check(context.Background(), CheckOptions{SnapshotID: "snap-1"}); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if source.storedCalled != "snap-1" {
+		t.Fatalf("stored snapshot id = %q", source.storedCalled)
+	}
+	if snapStore.savedSnapshotID != "" {
+		t.Fatalf("stored check should not save snapshot: %+v", snapStore)
+	}
+}
+
+func TestCheckReturnsUpsertError(t *testing.T) {
+	wantErr := errors.New("upsert failed")
+	svc := Service{
+		Store:     &fakeStore{upsertErr: wantErr},
+		Snapshots: &fakeSnapshots{live: testSnap()},
+		Engine:    EngineFunc(func(snapshot.Snapshot) []rules.Finding { return nil }),
+	}
+	if _, err := svc.Check(context.Background(), CheckOptions{}); !errors.Is(err, wantErr) {
+		t.Fatalf("Check err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestLifecycleMethodsUseStore(t *testing.T) {
+	st := &fakeStore{
+		listRows:    []store.IssueRow{{ID: "issue-1"}},
+		fixID:       "fix-1",
+		historyRows: []store.AppliedFixRow{{ID: "fix-1"}},
+	}
+	svc := Service{Store: st}
+
+	rows, err := svc.List(context.Background(), "machine-1", store.IssueOpen)
+	if err != nil || len(rows) != 1 || st.listMachine != "machine-1" || st.listStatus != store.IssueOpen {
+		t.Fatalf("List rows=%+v err=%v store=%+v", rows, err, st)
+	}
+	if err := svc.Acknowledge(context.Background(), "issue-1"); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+	if st.updatedID != "issue-1" || st.updatedStatus != store.IssueAcknowledged {
+		t.Fatalf("ack update = %q/%q", st.updatedID, st.updatedStatus)
+	}
+	if err := svc.Dismiss(context.Background(), "issue-2"); err != nil {
+		t.Fatalf("Dismiss: %v", err)
+	}
+	if st.updatedID != "issue-2" || st.updatedStatus != store.IssueDismissed {
+		t.Fatalf("dismiss update = %q/%q", st.updatedID, st.updatedStatus)
+	}
+	id, err := svc.RecordFix(context.Background(), store.AppliedFixInput{IssueID: "issue-2", Command: "fix"})
+	if err != nil || id != "fix-1" || st.recordedFix.IssueID != "issue-2" {
+		t.Fatalf("RecordFix id=%q err=%v fix=%+v", id, err, st.recordedFix)
+	}
+	history, err := svc.FixHistory(context.Background(), "issue-2")
+	if err != nil || len(history) != 1 || st.historyIssueID != "issue-2" {
+		t.Fatalf("FixHistory rows=%+v err=%v issue=%q", history, err, st.historyIssueID)
+	}
+}
+
+func TestMachineUUIDFallbacks(t *testing.T) {
+	if got := MachineUUID(snapshot.Snapshot{Host: snapshot.HostInfo{MachineUUID: "uuid", Hostname: "host"}}); got != "uuid" {
+		t.Fatalf("MachineUUID = %q", got)
+	}
+	if got := MachineUUID(snapshot.Snapshot{Host: snapshot.HostInfo{Hostname: "host"}}); got != "host" {
+		t.Fatalf("MachineUUID hostname fallback = %q", got)
+	}
+	if got := MachineUUID(snapshot.Snapshot{}); got != "local" {
+		t.Fatalf("MachineUUID local fallback = %q", got)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -905,7 +905,9 @@ type AppliedFixRow struct {
 // UpsertIssues reconciles a slice of findings against the issues table.
 // For each finding, it looks up an existing open/acknowledged issue by
 // (rule_id, machine_uuid, subject). If found, last_seen_snapshot_id and
-// updated_at are refreshed. If not found, a new open issue is inserted.
+// updated_at are refreshed. Dismissed issues suppress later matching
+// findings. If no active or dismissed issue exists, a new open issue is
+// inserted.
 // Returns the IDs of all touched (inserted or updated) issues.
 func (s *DB) UpsertIssues(ctx context.Context, machineUUID, snapshotID string, findings []FindingInput) ([]string, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -939,6 +941,19 @@ func (s *DB) UpsertIssues(ctx context.Context, machineUUID, snapshotID string, f
 		}
 		if !errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("store: lookup issue: %w", err)
+		}
+		var dismissedID string
+		err = tx.QueryRowContext(ctx, `
+			SELECT id FROM issues
+			WHERE rule_id=? AND machine_uuid=? AND subject=? AND status='dismissed'
+			LIMIT 1`,
+			f.RuleID, machineUUID, f.Subject,
+		).Scan(&dismissedID)
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("store: lookup dismissed issue: %w", err)
 		}
 
 		// New issue.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -442,7 +442,7 @@ func TestRecordAndListAppliedFixes(t *testing.T) {
 	}
 }
 
-func TestUpsertIssuesDoesNotReopenDismissed(t *testing.T) {
+func TestUpsertIssuesDoesNotReopenOrDuplicateDismissed(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()
 	snapID := seedSnapshot(t, db)
@@ -455,13 +455,20 @@ func TestUpsertIssuesDoesNotReopenDismissed(t *testing.T) {
 	// Dismiss the issue.
 	_ = db.UpdateIssueStatus(ctx, ids[0], IssueDismissed)
 
-	// Same finding again — should create a NEW issue because dismissed != open|acknowledged.
+	// Same finding again should stay suppressed after dismissal.
 	ids2, err := db.UpsertIssues(ctx, "TEST-UUID-1234", snapID, findings)
 	if err != nil {
 		t.Fatalf("UpsertIssues after dismiss: %v", err)
 	}
-	if len(ids2) != 1 || ids2[0] == ids[0] {
-		t.Errorf("expected new issue ID after dismiss, got same: %v", ids2)
+	if len(ids2) != 0 {
+		t.Errorf("expected dismissed issue to be suppressed, got touched IDs: %v", ids2)
+	}
+	rows, err := db.ListIssues(ctx, "TEST-UUID-1234", "")
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != ids[0] || rows[0].Status != IssueDismissed {
+		t.Errorf("dismissed issue was duplicated or reopened: %+v", rows)
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Live data sources: inspection/live-data-sources.md
   - Operations:
       - CLI: operations/cli.md
+      - Issues: operations/issues.md
       - Daemon (planned): operations/daemon.md
       - Remote (planned): operations/remote.md
       - Caching (planned): operations/caching.md


### PR DESCRIPTION
## Summary
- add internal/issues Service with Store, SnapshotStore, SnapshotSource, and Engine interfaces
- add fake-backed unit tests for check, lifecycle, fix history, and machine identity behavior
- wire spectra issues check through the service and add CLI fix-history commands
- document the operations/issues workflow and MkDocs nav entry

## Validation
- go test ./... -count=1
- go build ./...
- go vet ./...
- make docs-validate