### PR TITLE
Add service installer interfaces

### DIFF
--- a/cmd/spectra/helper.go
+++ b/cmd/spectra/helper.go
@@ -47,6 +47,20 @@ const helperPlistContent = `<?xml version="1.0" encoding="UTF-8"?>
 const helperNewsyslogContent = helperLogPath + `	root:wheel	640	7	1024	*	J
 `
 
+type helperStatusClient interface {
+	Available() bool
+	Health() (map[string]any, error)
+}
+
+type helperInstallDeps struct {
+	executable func() (string, error)
+	stat       func(string) (os.FileInfo, error)
+	getenv     func(string) string
+	runRoot    rootRunner
+	writeTemp  tempTextWriter
+	client     func() helperStatusClient
+}
+
 func runInstallHelper(args []string) int {
 	fs := flag.NewFlagSet("spectra install-helper", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -54,17 +68,22 @@ func runInstallHelper(args []string) int {
 		return 2
 	}
 
-	// Find the spectra-helper binary next to the running spectra binary.
-	self, err := os.Executable()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "install-helper: could not find executable path:", err)
+	if err := installHelper(defaultHelperInstallDeps()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
+	return 0
+}
+
+func installHelper(deps helperInstallDeps) error {
+	// Find the spectra-helper binary next to the running spectra binary.
+	self, err := deps.executable()
+	if err != nil {
+		return fmt.Errorf("install-helper: could not find executable path: %w", err)
+	}
 	helperSrc := filepath.Join(filepath.Dir(self), "spectra-helper")
-	if _, err := os.Stat(helperSrc); err != nil {
-		fmt.Fprintf(os.Stderr, "install-helper: spectra-helper binary not found at %s\n", helperSrc)
-		fmt.Fprintln(os.Stderr, "Build it with: go build ./cmd/spectra-helper")
-		return 1
+	if _, err := deps.stat(helperSrc); err != nil {
+		return fmt.Errorf("install-helper: spectra-helper binary not found at %s\nBuild it with: go build ./cmd/spectra-helper", helperSrc)
 	}
 
 	fmt.Fprintf(os.Stderr, "This requires administrator privilege. You may be prompted for your password.\n\n")
@@ -73,34 +92,36 @@ func runInstallHelper(args []string) int {
 		name string
 		fn   func() error
 	}{
-		{"Create _spectra group", ensureHelperGroup},
+		{"Create _spectra group", func() error {
+			return ensureHelperGroup(deps.runRoot)
+		}},
 		{"Add current user to _spectra group", func() error {
-			user := helperInstallUser(os.Getenv)
+			user := helperInstallUser(deps.getenv)
 			if user == "" || user == "root" {
 				return nil
 			}
-			return sudoRun("dseditgroup", "-o", "edit", "-a", user, "-t", "user", helperGroup)
+			return deps.runRoot("dseditgroup", "-o", "edit", "-a", user, "-t", "user", helperGroup)
 		}},
 		{"Create /Library/PrivilegedHelperTools/", func() error {
-			return sudoRun("mkdir", "-p", "/Library/PrivilegedHelperTools")
+			return deps.runRoot("mkdir", "-p", "/Library/PrivilegedHelperTools")
 		}},
 		{"Copy spectra-helper binary", func() error {
-			return sudoRun("cp", helperSrc, helperBinaryDest)
+			return deps.runRoot("cp", helperSrc, helperBinaryDest)
 		}},
 		{"Set ownership and permissions", func() error {
-			if err := sudoRun("chown", "root:wheel", helperBinaryDest); err != nil {
+			if err := deps.runRoot("chown", "root:wheel", helperBinaryDest); err != nil {
 				return err
 			}
-			return sudoRun("chmod", "755", helperBinaryDest)
+			return deps.runRoot("chmod", "755", helperBinaryDest)
 		}},
 		{"Install LaunchDaemon plist", func() error {
-			return installRootTextFile(helperPlist, helperPlistContent, sudoRun, writeTempText)
+			return installRootTextFile(helperPlist, helperPlistContent, deps.runRoot, deps.writeTemp)
 		}},
 		{"Install helper log rotation", func() error {
-			return installRootTextFile(helperNewsyslogConf, helperNewsyslogContent, sudoRun, writeTempText)
+			return installRootTextFile(helperNewsyslogConf, helperNewsyslogContent, deps.runRoot, deps.writeTemp)
 		}},
 		{"Load LaunchDaemon", func() error {
-			return sudoRun("launchctl", "load", "-w", helperPlist)
+			return deps.runRoot("launchctl", "load", "-w", helperPlist)
 		}},
 	}
 
@@ -108,8 +129,7 @@ func runInstallHelper(args []string) int {
 		fmt.Printf("  • %s… ", step.name)
 		if err := step.fn(); err != nil {
 			fmt.Println("FAILED")
-			fmt.Fprintln(os.Stderr, err)
-			return 1
+			return err
 		}
 		fmt.Println("done")
 	}
@@ -123,14 +143,14 @@ func runInstallHelper(args []string) int {
 	fmt.Println("If this is the first install, log out and back in so group membership is refreshed.")
 	fmt.Println()
 	fmt.Println("Verify with: spectra install-helper --status")
-	return 0
+	return nil
 }
 
-func ensureHelperGroup() error {
-	if err := sudoRun("dseditgroup", "-o", "read", helperGroup); err == nil {
+func ensureHelperGroup(run rootRunner) error {
+	if err := run("dseditgroup", "-o", "read", helperGroup); err == nil {
 		return nil
 	}
-	return sudoRun("dseditgroup", "-o", "create", helperGroup)
+	return run("dseditgroup", "-o", "create", helperGroup)
 }
 
 func helperInstallUser(getenv func(string) string) string {
@@ -180,21 +200,29 @@ func runUninstallHelper(args []string) int {
 		return 2
 	}
 
+	if err := uninstallHelper(defaultHelperInstallDeps()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func uninstallHelper(deps helperInstallDeps) error {
 	steps := []struct {
 		name string
 		fn   func() error
 	}{
 		{"Unload LaunchDaemon", func() error {
-			return sudoRun("launchctl", "unload", "-w", helperPlist)
+			return deps.runRoot("launchctl", "unload", "-w", helperPlist)
 		}},
 		{"Remove plist", func() error {
-			return sudoRun("rm", "-f", helperPlist)
+			return deps.runRoot("rm", "-f", helperPlist)
 		}},
 		{"Remove helper log rotation", func() error {
-			return sudoRun("rm", "-f", helperNewsyslogConf)
+			return deps.runRoot("rm", "-f", helperNewsyslogConf)
 		}},
 		{"Remove binary", func() error {
-			return sudoRun("rm", "-f", helperBinaryDest)
+			return deps.runRoot("rm", "-f", helperBinaryDest)
 		}},
 	}
 
@@ -202,14 +230,13 @@ func runUninstallHelper(args []string) int {
 		fmt.Printf("  • %s… ", step.name)
 		if err := step.fn(); err != nil {
 			fmt.Println("FAILED")
-			fmt.Fprintln(os.Stderr, err)
-			return 1
+			return err
 		}
 		fmt.Println("done")
 	}
 
 	fmt.Println("\nspectra-helper uninstalled.")
-	return 0
+	return nil
 }
 
 func runHelperStatus(args []string) int {
@@ -219,18 +246,41 @@ func runHelperStatus(args []string) int {
 		return 2
 	}
 
-	c := helperclient.New()
+	if err := helperStatus(defaultHelperInstallDeps()); err != nil {
+		if helperclient.IsUnavailable(err) {
+			return 1
+		}
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func helperStatus(deps helperInstallDeps) error {
+	c := deps.client()
 	if !c.Available() {
 		fmt.Println("spectra-helper: not running (socket unreachable)")
-		return 1
+		return helperclient.ErrHelperUnavailable
 	}
 	h, err := c.Health()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "spectra-helper health check failed: %v\n", err)
-		return 1
+		return fmt.Errorf("spectra-helper health check failed: %w", err)
 	}
 	fmt.Printf("spectra-helper: running — %v\n", h)
-	return 0
+	return nil
+}
+
+func defaultHelperInstallDeps() helperInstallDeps {
+	return helperInstallDeps{
+		executable: os.Executable,
+		stat:       os.Stat,
+		getenv:     os.Getenv,
+		runRoot:    sudoRun,
+		writeTemp:  writeTempText,
+		client: func() helperStatusClient {
+			return helperclient.New()
+		},
+	}
 }
 
 func sudoRun(name string, args ...string) error {

--- a/cmd/spectra/helper_test.go
+++ b/cmd/spectra/helper_test.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/kaeawc/spectra/internal/helperclient"
 )
 
 func TestHelperInstallUserPrefersSudoUser(t *testing.T) {
@@ -62,6 +68,119 @@ func TestInstallRootTextFileCopiesTemporaryContent(t *testing.T) {
 	}
 }
 
+func TestInstallHelperRunsExpectedRootOperations(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.env["SUDO_USER"] = "alice"
+	if err := installHelper(fake.deps()); err != nil {
+		t.Fatal(err)
+	}
+
+	helperSrc := filepath.Join(filepath.Dir(fake.executablePath), "spectra-helper")
+	wantRuns := [][]string{
+		{"dseditgroup", "-o", "read", helperGroup},
+		{"dseditgroup", "-o", "edit", "-a", "alice", "-t", "user", helperGroup},
+		{"mkdir", "-p", "/Library/PrivilegedHelperTools"},
+		{"cp", helperSrc, helperBinaryDest},
+		{"chown", "root:wheel", helperBinaryDest},
+		{"chmod", "755", helperBinaryDest},
+		{"cp", "/tmp/spectra-helper-1", helperPlist},
+		{"cp", "/tmp/spectra-helper-2", helperNewsyslogConf},
+		{"launchctl", "load", "-w", helperPlist},
+	}
+	if !reflect.DeepEqual(fake.runs, wantRuns) {
+		t.Fatalf("runs = %v, want %v", fake.runs, wantRuns)
+	}
+	wantTemps := []string{helperPlistContent, helperNewsyslogContent}
+	if !slices.Equal(fake.tempContents, wantTemps) {
+		t.Fatalf("temp contents = %q, want %q", fake.tempContents, wantTemps)
+	}
+	if fake.cleanups != 2 {
+		t.Fatalf("cleanups = %d, want 2", fake.cleanups)
+	}
+}
+
+func TestInstallHelperCreatesMissingGroup(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.runErrs["dseditgroup\x00-o\x00read\x00"+helperGroup] = errors.New("no group")
+	if err := installHelper(fake.deps()); err != nil {
+		t.Fatal(err)
+	}
+	wantPrefix := [][]string{
+		{"dseditgroup", "-o", "read", helperGroup},
+		{"dseditgroup", "-o", "create", helperGroup},
+	}
+	if !reflect.DeepEqual(fake.runs[:2], wantPrefix) {
+		t.Fatalf("runs prefix = %v, want %v", fake.runs[:2], wantPrefix)
+	}
+}
+
+func TestInstallHelperSkipsRootUserGroupEdit(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.env["SUDO_USER"] = "root"
+	if err := installHelper(fake.deps()); err != nil {
+		t.Fatal(err)
+	}
+	for _, run := range fake.runs {
+		if slices.Contains(run, "-a") {
+			t.Fatalf("group edit should be skipped for root user, got runs %v", fake.runs)
+		}
+	}
+}
+
+func TestInstallHelperReportsMissingHelperBinary(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.statErr = os.ErrNotExist
+	err := installHelper(fake.deps())
+	if err == nil {
+		t.Fatal("installHelper succeeded with missing helper binary")
+	}
+	if !strings.Contains(err.Error(), "spectra-helper binary not found") {
+		t.Fatalf("error = %v", err)
+	}
+	if len(fake.runs) != 0 {
+		t.Fatalf("runs = %v, want none", fake.runs)
+	}
+}
+
+func TestUninstallHelperRunsExpectedRootOperations(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	if err := uninstallHelper(fake.deps()); err != nil {
+		t.Fatal(err)
+	}
+	wantRuns := [][]string{
+		{"launchctl", "unload", "-w", helperPlist},
+		{"rm", "-f", helperPlist},
+		{"rm", "-f", helperNewsyslogConf},
+		{"rm", "-f", helperBinaryDest},
+	}
+	if !reflect.DeepEqual(fake.runs, wantRuns) {
+		t.Fatalf("runs = %v, want %v", fake.runs, wantRuns)
+	}
+}
+
+func TestHelperStatusUsesInjectedClient(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.statusClient.available = true
+	fake.statusClient.health = map[string]any{"ok": true}
+	if err := helperStatus(fake.deps()); err != nil {
+		t.Fatal(err)
+	}
+	if !fake.statusClient.healthCalled {
+		t.Fatal("Health was not called")
+	}
+}
+
+func TestHelperStatusUnavailable(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	err := helperStatus(fake.deps())
+	if err == nil {
+		t.Fatal("helperStatus succeeded with unavailable helper")
+	}
+	if !errors.Is(err, helperclient.ErrHelperUnavailable) {
+		t.Fatalf("error = %v, want helper unavailable", err)
+	}
+}
+
 func TestSudoCommandAllowedCoversHelperManagementCommands(t *testing.T) {
 	for _, name := range []string{"chmod", "chown", "cp", "dseditgroup", "launchctl", "mkdir", "rm"} {
 		if !sudoCommandAllowed(name) {
@@ -78,4 +197,71 @@ func TestSudoRunRejectsNonAllowlistedCommand(t *testing.T) {
 	if !strings.Contains(err.Error(), `sudo command "sh" is not allowlisted`) {
 		t.Fatalf("error = %v", err)
 	}
+}
+
+type fakeHelperInstallDeps struct {
+	executablePath string
+	env            map[string]string
+	runs           [][]string
+	runErrs        map[string]error
+	statErr        error
+	tempContents   []string
+	cleanups       int
+	statusClient   *fakeHelperStatusClient
+}
+
+func newFakeHelperInstallDeps(t *testing.T) *fakeHelperInstallDeps {
+	t.Helper()
+	return &fakeHelperInstallDeps{
+		executablePath: filepath.Join(t.TempDir(), "spectra"),
+		env:            map[string]string{"USER": "alice"},
+		runErrs:        map[string]error{},
+		statusClient:   &fakeHelperStatusClient{},
+	}
+}
+
+func (f *fakeHelperInstallDeps) deps() helperInstallDeps {
+	return helperInstallDeps{
+		executable: func() (string, error) {
+			return f.executablePath, nil
+		},
+		stat: func(string) (os.FileInfo, error) {
+			if f.statErr != nil {
+				return nil, f.statErr
+			}
+			return nil, nil
+		},
+		getenv: func(key string) string {
+			return f.env[key]
+		},
+		runRoot: func(name string, args ...string) error {
+			call := append([]string{name}, args...)
+			f.runs = append(f.runs, slices.Clone(call))
+			return f.runErrs[strings.Join(call, "\x00")]
+		},
+		writeTemp: func(_ string, content string) (string, func(), error) {
+			f.tempContents = append(f.tempContents, content)
+			path := "/tmp/spectra-helper-" + string(rune('0'+len(f.tempContents)))
+			return path, func() { f.cleanups++ }, nil
+		},
+		client: func() helperStatusClient {
+			return f.statusClient
+		},
+	}
+}
+
+type fakeHelperStatusClient struct {
+	available    bool
+	health       map[string]any
+	healthErr    error
+	healthCalled bool
+}
+
+func (f *fakeHelperStatusClient) Available() bool {
+	return f.available
+}
+
+func (f *fakeHelperStatusClient) Health() (map[string]any, error) {
+	f.healthCalled = true
+	return f.health, f.healthErr
 }

--- a/docs/operations/install-services.md
+++ b/docs/operations/install-services.md
@@ -1,0 +1,238 @@
+# Install services
+
+Spectra can run two launchd-managed background services:
+
+- `spectra serve` as a per-user LaunchAgent.
+- `spectra-helper` as an optional root LaunchDaemon for root-only telemetry.
+
+Install the daemon first for normal local or remote operation. Install the
+helper only when the machine needs system TCC, `powermetrics`, firewall,
+bounded `fs_usage`, or packet-capture data.
+
+## Service model
+
+| Service | Command | launchd domain | Runs as | Privilege |
+|---|---|---|---|---|
+| User daemon | `spectra install-daemon` | `gui/<uid>` | current user | unprivileged |
+| Privileged helper | `sudo spectra install-helper` | `system` | root | optional elevated telemetry |
+
+The user daemon owns the SQLite database, local Unix socket, optional TCP
+listener, optional `tsnet` listener, and daemon logs. The helper is local
+only. Remote clients never connect to the helper directly; they call the
+user daemon, which proxies the small helper RPC surface when needed.
+
+## Build prerequisites
+
+From a source checkout:
+
+```bash
+make build-all
+./spectra version
+./spectra-helper --version
+```
+
+`spectra install-helper` expects `spectra-helper` to be next to the running
+`spectra` binary. `make build-all` produces that layout in the repo root.
+
+## Install the user daemon
+
+```bash
+spectra install-daemon
+spectra status
+spectra install-daemon status
+```
+
+The installer writes:
+
+| Path | Purpose |
+|---|---|
+| `~/Library/LaunchAgents/dev.spectra.daemon.plist` | Per-user LaunchAgent |
+| `~/Library/Logs/Spectra/daemon.launchd.out.log` | launchd stdout |
+| `~/Library/Logs/Spectra/daemon.launchd.err.log` | launchd stderr |
+| `~/Library/Logs/Spectra/daemon.jsonl` | structured daemon lifecycle log, unless disabled |
+| `~/.spectra/sock` | default local JSON-RPC Unix socket |
+| `~/.spectra/spectra.db` | default SQLite state |
+
+After writing the plist atomically, Spectra runs:
+
+```bash
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/dev.spectra.daemon.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.spectra.daemon.plist
+launchctl enable gui/$(id -u)/dev.spectra.daemon
+launchctl kickstart -k gui/$(id -u)/dev.spectra.daemon
+```
+
+The `bootout` step is best-effort so reinstalling updates the service in
+place. `RunAtLoad` and `KeepAlive` are both enabled, so launchd starts the
+daemon at login and restarts it after unexpected exits.
+
+Use `--no-load` to inspect or deploy the plist without bootstrapping it:
+
+```bash
+spectra install-daemon --no-load
+spectra install-daemon print-plist
+```
+
+## Daemon listener options
+
+Flags passed to `install-daemon` are persisted into the LaunchAgent's
+`ProgramArguments` and passed to `spectra serve` on each launch:
+
+```bash
+spectra install-daemon --sock ~/.spectra/sock
+spectra install-daemon --tcp 127.0.0.1:7878
+spectra install-daemon --tsnet --tsnet-hostname work-mac
+spectra install-daemon --tsnet --tsnet-allow-logins alice@example.com
+spectra install-daemon --log-file ~/Library/Logs/Spectra/daemon.jsonl
+spectra install-daemon --no-log-file
+```
+
+Non-loopback TCP binds require `--allow-remote`:
+
+```bash
+spectra install-daemon --tcp 100.64.0.10:7878 --allow-remote
+```
+
+Prefer `--tsnet` for remote access. Plain TCP has no Spectra-layer
+authentication and should only be exposed over a trusted path.
+
+## Check daemon health
+
+Use the Spectra client path first:
+
+```bash
+spectra status
+spectra connect ~/.spectra/sock
+spectra connect 127.0.0.1:7878
+```
+
+Use launchd when the process did not start or keeps restarting:
+
+```bash
+spectra install-daemon status
+launchctl print gui/$(id -u)/dev.spectra.daemon
+tail -n 50 ~/Library/Logs/Spectra/daemon.launchd.err.log
+tail -n 50 ~/Library/Logs/Spectra/daemon.jsonl
+```
+
+Common failure modes:
+
+| Symptom | Check |
+|---|---|
+| `spectra status` cannot connect | Is `~/.spectra/sock` present and owned by the user? |
+| `launchctl print` reports repeated exits | Read `daemon.launchd.err.log` for flag or path errors. |
+| TCP clients cannot connect | Confirm the plist includes `--tcp`; non-loopback needs `--allow-remote`. |
+| `tsnet` has no IP | Check `daemon.jsonl` for the Tailscale login URL or auth-key errors. |
+
+## Uninstall the user daemon
+
+```bash
+spectra install-daemon uninstall
+```
+
+This runs `launchctl bootout gui/<uid>` for the LaunchAgent and removes the
+plist. It does not remove `~/.spectra/`, the SQLite database, logs, or cache
+data.
+
+## Install the privileged helper
+
+```bash
+make build-all
+sudo spectra install-helper
+spectra install-helper --status
+```
+
+The helper installer performs only fixed administrative operations:
+
+1. Creates the `_spectra` group if needed.
+2. Adds the invoking user to `_spectra`.
+3. Creates `/Library/PrivilegedHelperTools/`.
+4. Copies `spectra-helper` to
+   `/Library/PrivilegedHelperTools/spectra-helper`.
+5. Sets helper ownership to `root:wheel` and mode `0755`.
+6. Writes `/Library/LaunchDaemons/dev.spectra.helper.plist`.
+7. Writes `/etc/newsyslog.d/spectra-helper.conf`.
+8. Loads the LaunchDaemon with `launchctl load -w`.
+
+The installer invokes `sudo` only for an allowlisted command set:
+`chmod`, `chown`, `cp`, `dseditgroup`, `launchctl`, `mkdir`, and `rm`.
+The helper itself exposes structured RPC methods; it is not an arbitrary
+root command runner.
+
+On first install, log out and back in so the user's new `_spectra` group
+membership is visible to shells and long-running processes.
+
+## Helper launchd behavior
+
+The helper plist uses:
+
+- Label: `dev.spectra.helper`
+- Program: `/Library/PrivilegedHelperTools/spectra-helper`
+- `RunAtLoad`: enabled
+- `KeepAlive`: enabled
+- stderr: `/var/log/spectra-helper.log`
+
+At startup the helper creates `/var/run/spectra-helper.sock` as
+`root:_spectra` with `0660` permissions. The unprivileged daemon and CLI
+helper client use that socket for local JSON-RPC. Full Disk Access is still
+required for system TCC database queries:
+
+```text
+System Settings -> Privacy & Security -> Full Disk Access -> add spectra-helper
+```
+
+## Check helper health
+
+```bash
+spectra install-helper --status
+launchctl print system/dev.spectra.helper
+ls -l /var/run/spectra-helper.sock
+tail -n 50 /var/log/spectra-helper.log
+```
+
+The status command checks the helper socket and calls `helper.health`.
+If the socket is unreachable, check the LaunchDaemon state and stderr log.
+If system TCC queries fail but `helper.health` works, verify Full Disk
+Access for the installed helper binary.
+
+## Uninstall the helper
+
+```bash
+sudo spectra install-helper uninstall
+```
+
+This unloads the LaunchDaemon and removes:
+
+- `/Library/LaunchDaemons/dev.spectra.helper.plist`
+- `/etc/newsyslog.d/spectra-helper.conf`
+- `/Library/PrivilegedHelperTools/spectra-helper`
+
+It does not remove the `_spectra` group, group membership, or historical
+`/var/log/spectra-helper.log` rotations.
+
+## Sudo boundary
+
+Only helper installation and uninstallation require administrator
+privilege. The user daemon never runs as root. Normal inspection, local RPC,
+remote `tsnet` access, snapshots, metrics, and cache management stay in the
+user account.
+
+When helper-backed data is requested and the helper is not available,
+Spectra reports that the privileged helper is not running and points to:
+
+```bash
+sudo spectra install-helper
+```
+
+The helper remains additive. Machines without it still support static app
+inspection, user-owned process data, user TCC reads, local daemon storage,
+remote daemon access, and normal CLI workflows.
+
+## Related docs
+
+- [Daemon mode](daemon.md) — RPC surfaces, logs, and daemon behavior.
+- [Remote operation](remote.md) — remote access patterns.
+- [Privileged helper design](../design/privileged-helper.md) — helper RPC,
+  authentication, audit logging, and threat boundary.
+- [Distribution](../design/distribution.md) — source, Homebrew, and future
+  signed packaging plan.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
   - Operations:
       - CLI: operations/cli.md
       - Issues: operations/issues.md
+      - Install services: operations/install-services.md
       - Daemon (planned): operations/daemon.md
       - Remote (planned): operations/remote.md
       - Snapshots and hosts: operations/snapshots-and-hosts.md


### PR DESCRIPTION
## Summary

- Add an operations runbook for installing and checking Spectra's user daemon and privileged helper services.
- Refactor helper installation, uninstallation, and status checks behind injectable dependencies.
- Add fakes and unit tests for helper install order, group handling, missing helper binaries, uninstall, and status behavior.

## Validation

- `go test ./... -count=1`
- `go build ./...`
- `go vet ./...`
- `make docs-validate`
