### PR TITLE
Add diagnostic playbooks

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -42,6 +42,7 @@ func subcommandList() []subcommand {
 		{"power", "Show current battery and thermal state", runPower},
 		{"storage", "Show disk volumes and ~/Library footprint", runStorage},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
+		{"playbook", "Show diagnostic playbooks and command plans", runPlaybook},
 		{"diff", "Diff two stored snapshots (alias for snapshot diff)", runSnapshotDiff},
 		{"rules", "Evaluate recommendations rules against a snapshot", runRules},
 		{"issues", "List, check, or update persisted issues from the recommendations engine", runIssues},

--- a/cmd/spectra/playbook.go
+++ b/cmd/spectra/playbook.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/playbook"
+)
+
+type playbookCatalog interface {
+	List() []playbook.Playbook
+	Get(id string) (playbook.Playbook, bool)
+}
+
+func runPlaybook(args []string) int {
+	return runPlaybookWith(args, os.Stdout, os.Stderr, playbook.MustDefaultCatalog())
+}
+
+func runPlaybookWith(args []string, stdout io.Writer, stderr io.Writer, catalog playbookCatalog) int {
+	fs := flag.NewFlagSet("spectra playbook", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of human output")
+	commandsOnly := fs.Bool("commands", false, "Show only command plan for a playbook")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	rest := fs.Args()
+	if len(rest) == 0 || rest[0] == "list" {
+		return runPlaybookList(stdout, stderr, catalog, *asJSON)
+	}
+	id := rest[0]
+	pb, ok := catalog.Get(id)
+	if !ok {
+		fmt.Fprintf(stderr, "unknown playbook %q\n", id)
+		printPlaybookUsage(stderr)
+		return 2
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(pb); err != nil {
+			fmt.Fprintf(stderr, "encode playbook: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if *commandsOnly {
+		printPlaybookCommands(stdout, pb)
+		return 0
+	}
+	printPlaybook(stdout, pb)
+	return 0
+}
+
+func runPlaybookList(stdout io.Writer, stderr io.Writer, catalog playbookCatalog, asJSON bool) int {
+	rows := catalog.List()
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rows); err != nil {
+			fmt.Fprintf(stderr, "encode playbooks: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(stderr, "no playbooks registered")
+		return 0
+	}
+	fmt.Fprintf(stdout, "%-18s  %-22s  %s\n", "ID", "TITLE", "SYMPTOM")
+	fmt.Fprintln(stdout, strings.Repeat("-", 78))
+	for _, pb := range rows {
+		fmt.Fprintf(stdout, "%-18s  %-22s  %s\n", pb.ID, truncate(pb.Title, 22), truncate(pb.Symptom, 34))
+	}
+	return 0
+}
+
+func printPlaybook(w io.Writer, pb playbook.Playbook) {
+	fmt.Fprintf(w, "# %s\n\n", pb.Title)
+	fmt.Fprintf(w, "id:      %s\n", pb.ID)
+	fmt.Fprintf(w, "symptom: %s\n", pb.Symptom)
+	if pb.Description != "" {
+		fmt.Fprintf(w, "\n%s\n", pb.Description)
+	}
+	for i, step := range pb.Steps {
+		fmt.Fprintf(w, "\n%d. %s\n", i+1, step.Title)
+		if step.Purpose != "" {
+			fmt.Fprintf(w, "   %s\n", step.Purpose)
+		}
+		for _, cmd := range step.Commands {
+			fmt.Fprintf(w, "   $ spectra %s", strings.Join(cmd.Args, " "))
+			if cmd.Remote {
+				fmt.Fprint(w, "  # remote")
+			}
+			if cmd.Destructive {
+				fmt.Fprint(w, "  # capture/pausing action")
+			}
+			if cmd.Description != "" {
+				fmt.Fprintf(w, "\n     %s", cmd.Description)
+			}
+			fmt.Fprintln(w)
+		}
+		for _, sig := range step.Signals {
+			fmt.Fprintf(w, "   - %s: %s\n", sig.Name, sig.Meaning)
+		}
+	}
+	if len(pb.References) > 0 {
+		fmt.Fprintln(w, "\nReferences:")
+		for _, ref := range pb.References {
+			fmt.Fprintf(w, "  - %s: %s\n", ref.Title, ref.Path)
+		}
+	}
+}
+
+func printPlaybookCommands(w io.Writer, pb playbook.Playbook) {
+	for _, step := range pb.Steps {
+		for _, cmd := range step.Commands {
+			fmt.Fprintf(w, "spectra %s\n", strings.Join(cmd.Args, " "))
+		}
+	}
+}
+
+func printPlaybookUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: spectra playbook [--json] [list|<id>]")
+	fmt.Fprintln(w, "   or: spectra playbook --commands <id>")
+}

--- a/cmd/spectra/playbook_test.go
+++ b/cmd/spectra/playbook_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/playbook"
+)
+
+type fakePlaybookCatalog struct {
+	rows []playbook.Playbook
+}
+
+func (f fakePlaybookCatalog) List() []playbook.Playbook {
+	return f.rows
+}
+
+func (f fakePlaybookCatalog) Get(id string) (playbook.Playbook, bool) {
+	for _, row := range f.rows {
+		if row.ID == id {
+			return row, true
+		}
+	}
+	return playbook.Playbook{}, false
+}
+
+func TestRunPlaybookList(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPlaybookWith(nil, &stdout, &stderr, fakePlaybookCatalog{rows: []playbook.Playbook{
+		testPlaybook(),
+	}})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "jvm-memory") || !strings.Contains(out, "JVM memory") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestRunPlaybookShow(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPlaybookWith([]string{"jvm-memory"}, &stdout, &stderr, fakePlaybookCatalog{rows: []playbook.Playbook{
+		testPlaybook(),
+	}})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "# JVM memory") || !strings.Contains(out, "$ spectra jvm <pid>") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestRunPlaybookCommandsOnly(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPlaybookWith([]string{"--commands", "jvm-memory"}, &stdout, &stderr, fakePlaybookCatalog{rows: []playbook.Playbook{
+		testPlaybook(),
+	}})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	got := strings.TrimSpace(stdout.String())
+	if got != "spectra jvm <pid>" {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRunPlaybookJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPlaybookWith([]string{"--json", "jvm-memory"}, &stdout, &stderr, fakePlaybookCatalog{rows: []playbook.Playbook{
+		testPlaybook(),
+	}})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	var pb playbook.Playbook
+	if err := json.Unmarshal(stdout.Bytes(), &pb); err != nil {
+		t.Fatal(err)
+	}
+	if pb.ID != "jvm-memory" {
+		t.Fatalf("playbook = %+v", pb)
+	}
+}
+
+func TestRunPlaybookUnknown(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPlaybookWith([]string{"missing"}, &stdout, &stderr, fakePlaybookCatalog{})
+	if code != 2 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown playbook") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestSubcommandListIncludesPlaybook(t *testing.T) {
+	for _, sc := range subcommandList() {
+		if sc.name == "playbook" {
+			return
+		}
+	}
+	t.Fatal("subcommandList missing playbook")
+}
+
+func testPlaybook() playbook.Playbook {
+	return playbook.Playbook{
+		ID:      "jvm-memory",
+		Title:   "JVM memory",
+		Symptom: "Java app slow",
+		Steps: []playbook.Step{
+			{
+				ID:      "inspect",
+				Title:   "Inspect",
+				Purpose: "Inspect JVM",
+				Commands: []playbook.Command{
+					{Args: []string{"jvm", "<pid>"}, Description: "Inspect one JVM"},
+				},
+			},
+		},
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -29,6 +29,7 @@ spectra [flags] <App.app>...     # routes to `inspect` (default)
 | `power` | Show current battery and thermal state |
 | `storage` | Show disk volumes and `~/Library` footprint |
 | `process` | List running processes sorted by memory |
+| `playbook` | Show diagnostic playbooks and command plans |
 | `serve` | Run the local Unix-socket JSON-RPC daemon |
 | `connect` | Call a Spectra daemon over Unix socket or TCP JSON-RPC |
 | `fan` | Run one daemon RPC call against multiple explicit targets |
@@ -327,6 +328,19 @@ spectra network capture stop --summarize netcap-1
 spectra network capture summarize --json /var/tmp/spectra-netcap/501/netcap-1.pcap
 spectra network firewall
 spectra network firewall --json
+```
+
+## `spectra playbook`
+
+Shows problem-first diagnostic workflows over existing collectors. Use it
+to list playbooks, inspect one workflow, emit a command-only plan, or return
+the playbook definition as JSON.
+
+```bash
+spectra playbook
+spectra playbook jvm-memory
+spectra playbook --commands network-failure
+spectra playbook --json storage-bloat
 ```
 
 ## `spectra serve`

--- a/docs/playbooks/index.md
+++ b/docs/playbooks/index.md
@@ -1,0 +1,29 @@
+# Diagnostic playbooks
+
+Spectra's collectors are useful on their own, but incident work usually
+starts from a symptom. These playbooks group the app, process, JVM,
+network, storage, toolchain, snapshot, and remote collectors into repeatable
+diagnostic flows.
+
+Use them when the question is operational:
+
+| Symptom | Playbook |
+|---|---|
+| Java app is slow or memory-heavy | [JVM memory](jvm-memory.md) |
+| App cannot reach a service or endpoint | [Network failure](network-failure.md) |
+| Disk is filling up or an app is unexpectedly large | [Storage bloat](storage-bloat.md) |
+| Another Mac is behaving differently | [Remote triage](remote-triage.md) |
+| Builds or tools differ across machines | [Toolchain drift](toolchain-drift.md) |
+
+The collector reference remains under [Inspection](../inspection/). The
+playbooks link back to those pages when the next step is to understand a
+specific data source or JSON field.
+
+The CLI can also render the same workflow definitions:
+
+```bash
+spectra playbook
+spectra playbook jvm-memory
+spectra playbook --commands network-failure
+spectra playbook --json storage-bloat
+```

--- a/docs/playbooks/jvm-memory.md
+++ b/docs/playbooks/jvm-memory.md
@@ -1,0 +1,86 @@
+# JVM memory
+
+Use this when a Java process is slow, memory-heavy, GC-bound, or suspected
+of leaking classloaders, heap, metaspace, direct buffers, or JIT code cache.
+
+## Start local
+
+List running JVMs and identify the target PID:
+
+```bash
+spectra jvm
+spectra jvm --json
+```
+
+Inspect the target and ask Spectra for interpreted findings:
+
+```bash
+spectra jvm <pid>
+spectra jvm explain <pid>
+```
+
+If the symptom is memory pressure, collect the VM-internal view next:
+
+```bash
+spectra jvm gc-stats <pid>
+spectra jvm vm-memory <pid>
+spectra jvm heap-histogram <pid>
+```
+
+## Read the result
+
+Check these signals first:
+
+| Signal | Meaning |
+|---|---|
+| Heap used near max | Java objects are pressuring `-Xmx`; compare with heap histogram |
+| High GC count or long GC time | Allocation rate or heap sizing is a likely contributor |
+| Metaspace or classloader growth | Plugin reloads, dynamic proxies, or classloader leaks are possible |
+| Native memory tracking unavailable | The JVM was not started with NMT; other VM sections still matter |
+| Code cache pressure | JIT compilation may be constrained or deoptimizing hot paths |
+
+One snapshot can show pressure, not a leak. Take repeated samples when the
+claim depends on growth:
+
+```bash
+spectra jvm explain --samples 5 --interval 10s <pid>
+```
+
+## Capture deeper evidence
+
+Use a heap dump only when the target can tolerate the pause and the file
+size:
+
+```bash
+spectra jvm heap-dump --out ~/Desktop/app.hprof <pid>
+```
+
+Use JFR or a flamegraph when the symptom is throughput, CPU, allocation
+rate, lock contention, or thread scheduling:
+
+```bash
+spectra jvm jfr start <pid> --name incident
+spectra jvm jfr dump <pid> --name incident --out ~/Desktop/incident.jfr
+spectra jvm jfr stop <pid> --name incident
+spectra jvm jfr summary ~/Desktop/incident.jfr
+
+spectra jvm flamegraph --event cpu --duration 30 --out ~/Desktop/cpu.html <pid>
+```
+
+## Remote target
+
+Run the same flow against a daemon target when the sick JVM is on another
+Mac:
+
+```bash
+spectra connect work-mac jvm
+spectra connect work-mac jvm-explain <pid>
+spectra connect work-mac jvm-vm-memory <pid>
+spectra connect work-mac jvm-threads <pid>
+```
+
+## References
+
+- [JVM inspection](../inspection/jvm.md)
+- [Toolchains](../inspection/toolchains.md)
+- [Remote operations](../operations/remote.md)

--- a/docs/playbooks/network-failure.md
+++ b/docs/playbooks/network-failure.md
@@ -1,0 +1,79 @@
+# Network failure
+
+Use this when an app cannot reach a service, connects to the wrong host,
+is affected by VPN/proxy/DNS state, or appears to be moving unexpected
+traffic.
+
+## Start with the machine
+
+Capture the local network state before focusing on one app:
+
+```bash
+spectra network
+spectra network --json
+```
+
+Look for the default route, active VPN, DNS resolvers, proxy settings,
+listening ports, and per-process throughput.
+
+## Focus on the app
+
+Diagnose a running app, PID, or explicit endpoint:
+
+```bash
+spectra network diagnose --app /Applications/Slack.app
+spectra network diagnose --pid <pid>
+spectra network diagnose --app /Applications/Slack.app --ports 443 api.example.com
+```
+
+Use static endpoint extraction when the question is "what hosts does this
+bundle reference?" rather than "what sockets are live right now?":
+
+```bash
+spectra -v --network /Applications/Slack.app
+```
+
+## Read the result
+
+| Signal | Next step |
+|---|---|
+| DNS fails or resolves differently than expected | Compare `scutil --dns` context and explicit probe host |
+| TCP connect fails | Check route, VPN, firewall, and endpoint port |
+| TLS connects but issuer/subject is unexpected | Inspect proxy or interception policy |
+| App has no live sockets | Confirm the app is exercising the failing workflow |
+| Static hosts differ from live sockets | Separate bundled configuration from runtime behavior |
+
+## Capture bounded packet evidence
+
+Use the privileged helper only for explicit, bounded captures. Keep filters
+narrow enough to avoid collecting unrelated traffic:
+
+```bash
+spectra network capture start --interface en0 --duration 30s --proto tcp --host api.example.com --port 443
+spectra network capture stop --summarize netcap-1
+spectra network capture summarize --json /var/tmp/spectra-netcap/501/netcap-1.pcap
+```
+
+Check firewall rules when local packet policy is in scope:
+
+```bash
+spectra network firewall
+spectra network firewall --json
+```
+
+## Remote target
+
+Network failures are often machine-specific. Compare the sick host with a
+known-good host:
+
+```bash
+spectra connect work-mac network
+spectra connect work-mac network-by-app /Applications/Slack.app
+spectra fan --hosts work-mac,known-good call network.connections
+```
+
+## References
+
+- [Network endpoints](../inspection/network-endpoints.md)
+- [Live data sources](../inspection/live-data-sources.md)
+- [CLI network commands](../operations/cli.md#spectra-network)

--- a/docs/playbooks/remote-triage.md
+++ b/docs/playbooks/remote-triage.md
@@ -1,0 +1,71 @@
+# Remote triage
+
+Use this when a teammate's Mac is slow, failing a workflow, or behaving
+differently from a known-good machine. Spectra's remote surface is explicit:
+the target must run a daemon and the network path must be trusted.
+
+## Establish the target
+
+On the target Mac, run the daemon in the intended mode:
+
+```bash
+spectra serve --tcp 127.0.0.1:7878
+spectra serve --tsnet
+```
+
+From the client:
+
+```bash
+spectra connect work-mac
+spectra connect work-mac snapshot
+```
+
+Use loopback TCP for local testing, SSH/Tailscale for trusted remote access,
+or the tsnet daemon mode when the host should appear directly on the tailnet.
+
+## First pass
+
+Collect the broad view before chasing one subsystem:
+
+```bash
+spectra connect work-mac processes
+spectra connect work-mac network
+spectra connect work-mac storage
+spectra connect work-mac toolchains
+spectra connect work-mac jvm
+```
+
+This separates machine-wide symptoms from app-specific symptoms.
+
+## Compare against a baseline
+
+Use snapshots and diffs when "works on my machine" is the problem:
+
+```bash
+spectra snapshot --baseline local-good
+spectra connect work-mac snapshot
+spectra diff local-good work-mac
+```
+
+For team-wide checks:
+
+```bash
+spectra fan --hosts alice-laptop,bob-laptop snapshot
+spectra fan --hosts alice-laptop,bob-laptop toolchains
+```
+
+## Narrow by symptom
+
+| Symptom | Remote command |
+|---|---|
+| Java app slow | `spectra connect work-mac jvm-explain <pid>` |
+| Endpoint failing | `spectra connect work-mac network-by-app /Applications/App.app` |
+| Disk full | `spectra connect work-mac storage /Applications/App.app` |
+| Build differs | `spectra connect work-mac toolchains` |
+| App differs | `spectra diff local-good work-mac --filter app=AppName` |
+
+## References
+
+- [Remote operations](../operations/remote.md)
+- [Daemon operations](../operations/daemon.md)
+- [Threat model](../design/threat-model.md)

--- a/docs/playbooks/storage-bloat.md
+++ b/docs/playbooks/storage-bloat.md
@@ -1,0 +1,73 @@
+# Storage bloat
+
+Use this when disk is filling up, an app is unexpectedly large, or an app's
+state is spread across `~/Library` locations that Activity Monitor does not
+attribute clearly.
+
+## Start with one app
+
+Inspect the app and its per-location storage footprint:
+
+```bash
+spectra -v /Applications/Docker.app
+spectra -v /Applications/Slack.app
+```
+
+For structured output:
+
+```bash
+spectra --json /Applications/Docker.app | jq '.[0].Storage'
+```
+
+## Check system storage
+
+Use the storage command when the question is broader than one bundle:
+
+```bash
+spectra storage
+spectra storage --json
+```
+
+If a baseline exists, compare before and after the incident:
+
+```bash
+spectra snapshot --baseline pre-incident
+spectra diff baseline pre-incident live
+```
+
+## Read the result
+
+| Location | Interpretation |
+|---|---|
+| `appsupport` | Durable application state, indexes, projects, downloaded models |
+| `caches` | Usually disposable, but check app-specific cache safety first |
+| `containers` | Sandboxed app state; may include everything for App Sandbox apps |
+| `group containers` | Shared state between app, helpers, extensions, and login items |
+| `http` / `webkit` | Web content state, cookies, HSTS, WebKit local storage |
+| `logs` | Useful for incident evidence but can grow without rotation |
+
+Sparse files are reported by allocated disk blocks on macOS, so virtual
+disk images and similar files should not be inflated to their apparent size.
+
+## Correlate with runtime
+
+If the app is currently running, connect storage growth to live process
+state:
+
+```bash
+spectra process
+spectra -v /Applications/Docker.app
+```
+
+For remote machines:
+
+```bash
+spectra connect work-mac storage
+spectra connect work-mac storage /Applications/Docker.app
+```
+
+## References
+
+- [Storage footprint](../inspection/storage-footprint.md)
+- [Storage design](../design/storage.md)
+- [CLI storage commands](../operations/cli.md)

--- a/docs/playbooks/toolchain-drift.md
+++ b/docs/playbooks/toolchain-drift.md
@@ -1,0 +1,62 @@
+# Toolchain drift
+
+Use this when a build, test, JVM, package manager, or language runtime works
+on one Mac but fails on another.
+
+## Start local
+
+Collect the toolchain inventory:
+
+```bash
+spectra toolchain
+spectra toolchain --json
+spectra toolchain brew --json
+spectra toolchain jdks --json
+```
+
+Pay attention to version, vendor, install path, manager, and `$PATH` order.
+The same version at a different path may be harmless; a different vendor,
+major version, or shadowed binary is more likely to explain drift.
+
+## Compare machines
+
+Use fan-out when the question spans multiple Macs:
+
+```bash
+spectra fan --hosts alice-laptop,bob-laptop toolchains
+spectra fan --hosts alice-laptop,bob-laptop jdk
+```
+
+Use snapshots and diffs when the drift is temporal:
+
+```bash
+spectra snapshot --baseline before-upgrade
+spectra diff baseline before-upgrade live
+```
+
+## Read the result
+
+| Signal | Meaning |
+|---|---|
+| JDK vendor or major version differs | JVM behavior, compiler flags, TLS roots, and GC defaults may differ |
+| `$PATH` order differs | A different binary may be selected even when both machines have the tool |
+| Brew formula version changed | Check release notes or pinning for changed behavior |
+| Runtime manager differs | `mise`, `asdf`, `sdkman`, `jenv`, and shell init can select different runtimes |
+| Xcode or Command Line Tools differ | Native builds and signing behavior may diverge |
+
+## Link back to app symptoms
+
+Toolchain drift often explains a higher-level failure. After finding drift,
+return to the symptom-specific playbook:
+
+```bash
+spectra jvm explain <pid>
+spectra network diagnose --app /Applications/App.app
+spectra -v /Applications/App.app
+```
+
+## References
+
+- [Toolchains](../inspection/toolchains.md)
+- [System inventory](../design/system-inventory.md)
+- [CLI toolchain commands](../operations/cli.md)

--- a/internal/playbook/defaults.go
+++ b/internal/playbook/defaults.go
@@ -1,0 +1,260 @@
+package playbook
+
+func defaultPlaybooks() []Playbook {
+	return []Playbook{
+		jvmMemory(),
+		networkFailure(),
+		storageBloat(),
+		remoteTriage(),
+		toolchainDrift(),
+	}
+}
+
+func jvmMemory() Playbook {
+	return Playbook{
+		ID:          "jvm-memory",
+		Title:       "JVM memory",
+		Symptom:     "Java app is slow, memory-heavy, GC-bound, or suspected of leaking heap, metaspace, or classloaders.",
+		Description: "Start with process discovery, move to interpreted JVM findings, then collect heap, VM memory, JFR, or flamegraph evidence only when the target can tolerate it.",
+		Steps: []Step{
+			{
+				ID:      "identify",
+				Title:   "Identify the target JVM",
+				Purpose: "Find the PID and basic JVM metadata before collecting heavier diagnostics.",
+				Commands: []Command{
+					{Args: []string{"jvm"}, Description: "List running JVMs"},
+					{Args: []string{"jvm", "--json"}, Description: "List running JVMs as structured data"},
+				},
+				Signals: []Signal{
+					{Name: "Missing JVM", Meaning: "The app may not be Java-based, may be running under another user, or may require helper visibility."},
+				},
+			},
+			{
+				ID:      "explain",
+				Title:   "Interpret memory pressure",
+				Purpose: "Join JVM args, GC counters, heap, metaspace, classloader, and code cache sections into findings.",
+				Commands: []Command{
+					{Args: []string{"jvm", "<pid>"}, Description: "Inspect one JVM"},
+					{Args: []string{"jvm", "explain", "<pid>"}, Description: "Generate interpreted findings"},
+					{Args: []string{"jvm", "explain", "--samples", "5", "--interval", "10s", "<pid>"}, Description: "Sample repeatedly when growth matters"},
+				},
+				Signals: []Signal{
+					{Name: "Heap used near max", Meaning: "Java objects are pressuring -Xmx; compare with heap histogram."},
+					{Name: "Metaspace or classloader growth", Meaning: "Plugin reloads, dynamic proxies, or classloader leaks are possible."},
+					{Name: "NMT unavailable", Meaning: "The JVM was not started with Native Memory Tracking; other VM sections still matter."},
+				},
+			},
+			{
+				ID:      "capture",
+				Title:   "Capture deeper evidence",
+				Purpose: "Collect targeted artifacts for throughput, allocation, lock, or object-retention analysis.",
+				Commands: []Command{
+					{Args: []string{"jvm", "heap-histogram", "<pid>"}, Description: "Summarize live object counts"},
+					{Args: []string{"jvm", "vm-memory", "<pid>"}, Description: "Inspect VM-internal memory sections"},
+					{Args: []string{"jvm", "jfr", "start", "<pid>", "--name", "incident"}, Description: "Start a JFR recording"},
+					{Args: []string{"jvm", "flamegraph", "--event", "cpu", "--duration", "30", "--out", "~/Desktop/cpu.html", "<pid>"}, Description: "Capture an async-profiler flamegraph"},
+					{Args: []string{"jvm", "heap-dump", "--out", "~/Desktop/app.hprof", "<pid>"}, Description: "Capture a heap dump", Destructive: true},
+				},
+			},
+		},
+		References: []Reference{
+			{Title: "JVM inspection", Path: "docs/inspection/jvm.md"},
+			{Title: "Toolchains", Path: "docs/inspection/toolchains.md"},
+			{Title: "Remote operations", Path: "docs/operations/remote.md"},
+		},
+	}
+}
+
+func networkFailure() Playbook {
+	return Playbook{
+		ID:          "network-failure",
+		Title:       "Network failure",
+		Symptom:     "An app cannot reach a service, connects to the wrong host, or is affected by VPN, proxy, DNS, or firewall state.",
+		Description: "Capture machine network state, narrow to one running app or endpoint, then use bounded packet evidence only when needed.",
+		Steps: []Step{
+			{
+				ID:      "machine",
+				Title:   "Capture machine network state",
+				Purpose: "Record routes, DNS, VPN, proxies, listening ports, and per-process throughput.",
+				Commands: []Command{
+					{Args: []string{"network"}, Description: "Show current network state"},
+					{Args: []string{"network", "--json"}, Description: "Emit current network state as JSON"},
+				},
+				Signals: []Signal{
+					{Name: "Unexpected DNS or proxy", Meaning: "Name resolution or interception may explain the symptom before app-level probing."},
+				},
+			},
+			{
+				ID:      "app",
+				Title:   "Diagnose the app or endpoint",
+				Purpose: "Join live sockets, throughput, DNS, route, proxy, TCP/TLS probes, and traceroute output.",
+				Commands: []Command{
+					{Args: []string{"network", "diagnose", "--app", "/Applications/App.app"}, Description: "Diagnose one app bundle"},
+					{Args: []string{"network", "diagnose", "--pid", "<pid>"}, Description: "Diagnose one process"},
+					{Args: []string{"network", "diagnose", "--app", "/Applications/App.app", "--ports", "443", "api.example.com"}, Description: "Probe a narrowed endpoint set"},
+					{Args: []string{"--network", "-v", "/Applications/App.app"}, Description: "Extract static endpoint references from an app bundle"},
+				},
+				Signals: []Signal{
+					{Name: "TCP connect fails", Meaning: "Check route, VPN, firewall, and endpoint port."},
+					{Name: "TLS issuer is unexpected", Meaning: "Inspect proxy or interception policy."},
+					{Name: "No live sockets", Meaning: "Confirm the app is exercising the failing workflow."},
+				},
+			},
+			{
+				ID:      "capture",
+				Title:   "Capture bounded packet evidence",
+				Purpose: "Use helper-backed tcpdump captures with narrow filters.",
+				Commands: []Command{
+					{Args: []string{"network", "capture", "start", "--interface", "en0", "--duration", "30s", "--proto", "tcp", "--host", "api.example.com", "--port", "443"}, Description: "Start a bounded packet capture"},
+					{Args: []string{"network", "capture", "stop", "--summarize", "netcap-1"}, Description: "Stop and summarize a capture"},
+					{Args: []string{"network", "firewall"}, Description: "Show firewall rules"},
+				},
+			},
+		},
+		References: []Reference{
+			{Title: "Network endpoints", Path: "docs/inspection/network-endpoints.md"},
+			{Title: "Live data sources", Path: "docs/inspection/live-data-sources.md"},
+			{Title: "CLI network commands", Path: "docs/operations/cli.md#spectra-network"},
+		},
+	}
+}
+
+func storageBloat() Playbook {
+	return Playbook{
+		ID:          "storage-bloat",
+		Title:       "Storage bloat",
+		Symptom:     "Disk is filling up, an app is unexpectedly large, or state is spread across Library locations.",
+		Description: "Start with per-app storage, expand to system storage, and compare snapshots when the question is temporal.",
+		Steps: []Step{
+			{
+				ID:      "app",
+				Title:   "Inspect one app",
+				Purpose: "Attribute app storage across Application Support, Caches, Containers, Group Containers, HTTPStorages, WebKit, Logs, and Preferences.",
+				Commands: []Command{
+					{Args: []string{"-v", "/Applications/App.app"}, Description: "Inspect one app with storage footprint"},
+					{Args: []string{"--json", "/Applications/App.app"}, Description: "Emit app result as JSON"},
+				},
+				Signals: []Signal{
+					{Name: "Containers dominates", Meaning: "The app is likely sandboxed or stores most state inside its sandbox container."},
+					{Name: "Caches dominates", Meaning: "Data may be disposable, but app-specific cache safety still matters."},
+				},
+			},
+			{
+				ID:      "system",
+				Title:   "Check system storage",
+				Purpose: "Find volume pressure, user Library totals, and largest app bundles.",
+				Commands: []Command{
+					{Args: []string{"storage"}, Description: "Show disk volumes and Library footprint"},
+					{Args: []string{"storage", "--json"}, Description: "Emit storage state as JSON"},
+					{Args: []string{"snapshot", "--baseline", "pre-incident"}, Description: "Save a baseline snapshot"},
+					{Args: []string{"diff", "baseline", "pre-incident", "live"}, Description: "Compare baseline with live state"},
+				},
+			},
+			{
+				ID:      "runtime",
+				Title:   "Correlate with runtime",
+				Purpose: "Connect growth to currently running processes.",
+				Commands: []Command{
+					{Args: []string{"process"}, Description: "List running processes sorted by RSS"},
+					{Args: []string{"connect", "work-mac", "storage", "/Applications/App.app"}, Description: "Inspect app storage on a remote Mac", Remote: true},
+				},
+			},
+		},
+		References: []Reference{
+			{Title: "Storage footprint", Path: "docs/inspection/storage-footprint.md"},
+			{Title: "Storage design", Path: "docs/design/storage.md"},
+			{Title: "CLI storage commands", Path: "docs/operations/cli.md"},
+		},
+	}
+}
+
+func remoteTriage() Playbook {
+	return Playbook{
+		ID:          "remote-triage",
+		Title:       "Remote triage",
+		Symptom:     "A teammate's Mac is slow, failing a workflow, or behaving differently from a known-good machine.",
+		Description: "Establish an explicit daemon target, collect a broad first pass, then narrow by symptom or compare snapshots.",
+		Steps: []Step{
+			{
+				ID:      "target",
+				Title:   "Establish the target",
+				Purpose: "Confirm the daemon is reachable over a trusted local, SSH, TCP, or tsnet path.",
+				Commands: []Command{
+					{Args: []string{"serve", "--tcp", "127.0.0.1:7878"}, Description: "Run a local loopback daemon"},
+					{Args: []string{"serve", "--tsnet"}, Description: "Run a daemon that joins the tailnet"},
+					{Args: []string{"connect", "work-mac"}, Description: "Health check a remote target", Remote: true},
+					{Args: []string{"connect", "work-mac", "snapshot"}, Description: "Capture a remote snapshot", Remote: true},
+				},
+			},
+			{
+				ID:      "first-pass",
+				Title:   "Collect the broad view",
+				Purpose: "Separate machine-wide symptoms from app-specific symptoms.",
+				Commands: []Command{
+					{Args: []string{"connect", "work-mac", "processes"}, Description: "List remote processes", Remote: true},
+					{Args: []string{"connect", "work-mac", "network"}, Description: "Show remote network state", Remote: true},
+					{Args: []string{"connect", "work-mac", "storage"}, Description: "Show remote storage state", Remote: true},
+					{Args: []string{"connect", "work-mac", "toolchains"}, Description: "Show remote toolchain inventory", Remote: true},
+					{Args: []string{"connect", "work-mac", "jvm"}, Description: "List remote JVMs", Remote: true},
+				},
+			},
+			{
+				ID:      "compare",
+				Title:   "Compare against a baseline",
+				Purpose: "Turn works-on-my-machine claims into snapshot diffs.",
+				Commands: []Command{
+					{Args: []string{"snapshot", "--baseline", "local-good"}, Description: "Save a local known-good baseline"},
+					{Args: []string{"diff", "local-good", "work-mac"}, Description: "Diff two snapshots"},
+					{Args: []string{"fan", "--hosts", "alice-laptop,bob-laptop", "snapshot"}, Description: "Capture snapshots across multiple targets", Remote: true},
+				},
+			},
+		},
+		References: []Reference{
+			{Title: "Remote operations", Path: "docs/operations/remote.md"},
+			{Title: "Daemon operations", Path: "docs/operations/daemon.md"},
+			{Title: "Threat model", Path: "docs/design/threat-model.md"},
+		},
+	}
+}
+
+func toolchainDrift() Playbook {
+	return Playbook{
+		ID:          "toolchain-drift",
+		Title:       "Toolchain drift",
+		Symptom:     "A build, test, JVM, package manager, or language runtime works on one Mac but fails on another.",
+		Description: "Collect local inventory, compare remote hosts or snapshots, and interpret version, vendor, manager, and PATH differences.",
+		Steps: []Step{
+			{
+				ID:      "local",
+				Title:   "Collect local inventory",
+				Purpose: "Record language runtimes, JDKs, build tools, Homebrew, managers, and environment paths.",
+				Commands: []Command{
+					{Args: []string{"toolchain"}, Description: "Show full toolchain inventory"},
+					{Args: []string{"toolchain", "--json"}, Description: "Emit full toolchain inventory as JSON"},
+					{Args: []string{"toolchain", "brew", "--json"}, Description: "Emit Homebrew inventory as JSON"},
+					{Args: []string{"toolchain", "jdks", "--json"}, Description: "Emit JDK inventory as JSON"},
+				},
+				Signals: []Signal{
+					{Name: "PATH order differs", Meaning: "A different binary may be selected even when both machines have the tool."},
+					{Name: "JDK vendor differs", Meaning: "Compiler, TLS, GC, and runtime behavior may diverge."},
+				},
+			},
+			{
+				ID:      "compare",
+				Title:   "Compare machines",
+				Purpose: "Use fan-out or snapshots when drift spans hosts or time.",
+				Commands: []Command{
+					{Args: []string{"fan", "--hosts", "alice-laptop,bob-laptop", "toolchains"}, Description: "Collect toolchains across hosts", Remote: true},
+					{Args: []string{"fan", "--hosts", "alice-laptop,bob-laptop", "jdk"}, Description: "Collect JDKs across hosts", Remote: true},
+					{Args: []string{"snapshot", "--baseline", "before-upgrade"}, Description: "Save a pre-change baseline"},
+					{Args: []string{"diff", "baseline", "before-upgrade", "live"}, Description: "Compare a baseline with live state"},
+				},
+			},
+		},
+		References: []Reference{
+			{Title: "Toolchains", Path: "docs/inspection/toolchains.md"},
+			{Title: "System inventory", Path: "docs/design/system-inventory.md"},
+			{Title: "CLI toolchain commands", Path: "docs/operations/cli.md"},
+		},
+	}
+}

--- a/internal/playbook/playbook.go
+++ b/internal/playbook/playbook.go
@@ -1,0 +1,139 @@
+// Package playbook defines diagnostic workflows over Spectra collectors.
+package playbook
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Catalog provides named diagnostic playbooks.
+type Catalog interface {
+	List() []Playbook
+	Get(id string) (Playbook, bool)
+}
+
+// Playbook is a problem-first diagnostic workflow.
+type Playbook struct {
+	ID          string
+	Title       string
+	Symptom     string
+	Description string
+	Steps       []Step
+	References  []Reference
+}
+
+// Step is one diagnostic action in a playbook.
+type Step struct {
+	ID       string
+	Title    string
+	Purpose  string
+	Commands []Command
+	Signals  []Signal
+}
+
+// Command is a Spectra command template. Args intentionally excludes
+// the leading "spectra" binary name so callers can render commands for
+// local, remote, or embedded usage.
+type Command struct {
+	Args        []string
+	Description string
+	Remote      bool
+	Destructive bool
+}
+
+// Signal explains how to interpret a step result.
+type Signal struct {
+	Name    string
+	Meaning string
+}
+
+// Reference links a playbook back to collector documentation.
+type Reference struct {
+	Title string
+	Path  string
+}
+
+// StaticCatalog is an in-memory playbook catalog.
+type StaticCatalog struct {
+	byID map[string]Playbook
+	list []Playbook
+}
+
+// NewStaticCatalog returns a catalog from playbooks. IDs must be unique.
+func NewStaticCatalog(playbooks []Playbook) (*StaticCatalog, error) {
+	byID := make(map[string]Playbook, len(playbooks))
+	list := make([]Playbook, 0, len(playbooks))
+	for _, pb := range playbooks {
+		if err := Validate(pb); err != nil {
+			return nil, err
+		}
+		if _, exists := byID[pb.ID]; exists {
+			return nil, fmt.Errorf("duplicate playbook id %q", pb.ID)
+		}
+		byID[pb.ID] = pb
+		list = append(list, pb)
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].ID < list[j].ID
+	})
+	return &StaticCatalog{byID: byID, list: list}, nil
+}
+
+// List returns playbooks sorted by ID.
+func (c *StaticCatalog) List() []Playbook {
+	out := make([]Playbook, len(c.list))
+	copy(out, c.list)
+	return out
+}
+
+// Get returns a playbook by ID.
+func (c *StaticCatalog) Get(id string) (Playbook, bool) {
+	pb, ok := c.byID[id]
+	return pb, ok
+}
+
+// Validate checks a playbook for fields required by renderers and callers.
+func Validate(pb Playbook) error {
+	if strings.TrimSpace(pb.ID) == "" {
+		return fmt.Errorf("playbook id is required")
+	}
+	if strings.TrimSpace(pb.Title) == "" {
+		return fmt.Errorf("playbook %q title is required", pb.ID)
+	}
+	if strings.TrimSpace(pb.Symptom) == "" {
+		return fmt.Errorf("playbook %q symptom is required", pb.ID)
+	}
+	if len(pb.Steps) == 0 {
+		return fmt.Errorf("playbook %q must have at least one step", pb.ID)
+	}
+	stepIDs := make(map[string]struct{}, len(pb.Steps))
+	for _, step := range pb.Steps {
+		if strings.TrimSpace(step.ID) == "" {
+			return fmt.Errorf("playbook %q has a step without an id", pb.ID)
+		}
+		if _, exists := stepIDs[step.ID]; exists {
+			return fmt.Errorf("playbook %q has duplicate step id %q", pb.ID, step.ID)
+		}
+		stepIDs[step.ID] = struct{}{}
+		if strings.TrimSpace(step.Title) == "" {
+			return fmt.Errorf("playbook %q step %q title is required", pb.ID, step.ID)
+		}
+		for _, cmd := range step.Commands {
+			if len(cmd.Args) == 0 {
+				return fmt.Errorf("playbook %q step %q has an empty command", pb.ID, step.ID)
+			}
+		}
+	}
+	return nil
+}
+
+// MustDefaultCatalog returns the built-in playbook catalog and panics if
+// static definitions are invalid.
+func MustDefaultCatalog() *StaticCatalog {
+	c, err := NewStaticCatalog(defaultPlaybooks())
+	if err != nil {
+		panic(err)
+	}
+	return c
+}

--- a/internal/playbook/playbook_test.go
+++ b/internal/playbook/playbook_test.go
@@ -1,0 +1,90 @@
+package playbook
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultCatalogContainsExpectedPlaybooks(t *testing.T) {
+	c := MustDefaultCatalog()
+	want := []string{"jvm-memory", "network-failure", "remote-triage", "storage-bloat", "toolchain-drift"}
+	got := c.List()
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Fatalf("playbook %d = %q, want %q", i, got[i].ID, id)
+		}
+	}
+}
+
+func TestDefaultCatalogDefinitionsValidate(t *testing.T) {
+	for _, pb := range MustDefaultCatalog().List() {
+		if err := Validate(pb); err != nil {
+			t.Fatalf("Validate(%s): %v", pb.ID, err)
+		}
+		if len(pb.References) == 0 {
+			t.Fatalf("%s has no references", pb.ID)
+		}
+		hasCommand := false
+		for _, step := range pb.Steps {
+			if len(step.Commands) > 0 {
+				hasCommand = true
+			}
+		}
+		if !hasCommand {
+			t.Fatalf("%s has no commands", pb.ID)
+		}
+	}
+}
+
+func TestStaticCatalogRejectsDuplicateIDs(t *testing.T) {
+	_, err := NewStaticCatalog([]Playbook{
+		validPlaybook("same"),
+		validPlaybook("same"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate playbook id") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestValidateRejectsEmptyCommand(t *testing.T) {
+	pb := validPlaybook("bad")
+	pb.Steps[0].Commands = []Command{{}}
+	err := Validate(pb)
+	if err == nil || !strings.Contains(err.Error(), "empty command") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCatalogReturnsCopies(t *testing.T) {
+	c, err := NewStaticCatalog([]Playbook{validPlaybook("one")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := c.List()
+	rows[0].ID = "mutated"
+	got, ok := c.Get("one")
+	if !ok {
+		t.Fatal("missing playbook one")
+	}
+	if got.ID != "one" {
+		t.Fatalf("catalog was mutated: %+v", got)
+	}
+}
+
+func validPlaybook(id string) Playbook {
+	return Playbook{
+		ID:      id,
+		Title:   "Title",
+		Symptom: "Symptom",
+		Steps: []Step{
+			{
+				ID:       "step",
+				Title:    "Step",
+				Commands: []Command{{Args: []string{"jvm"}}},
+			},
+		},
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,13 @@ nav:
       - Toolchains (planned): inspection/toolchains.md
       - JVM (planned): inspection/jvm.md
       - Live data sources: inspection/live-data-sources.md
+  - Playbooks:
+      - Overview: playbooks/index.md
+      - JVM memory: playbooks/jvm-memory.md
+      - Network failure: playbooks/network-failure.md
+      - Storage bloat: playbooks/storage-bloat.md
+      - Remote triage: playbooks/remote-triage.md
+      - Toolchain drift: playbooks/toolchain-drift.md
   - Operations:
       - CLI: operations/cli.md
       - Daemon (planned): operations/daemon.md


### PR DESCRIPTION
## Summary

Adds first-class diagnostic playbooks for symptom-driven Spectra workflows.

- adds `internal/playbook` with typed playbook definitions, catalog interface, validation, and unit tests
- adds `spectra playbook` for listing playbooks, showing command plans, and emitting JSON definitions
- adds docs under `docs/playbooks/` and wires the section into MkDocs navigation and CLI docs

## Validation

- `go test ./internal/playbook ./cmd/spectra -run 'Test(DefaultCatalog|StaticCatalog|Validate|CatalogReturns|RunPlaybook|SubcommandListIncludesPlaybook)' -count=1`
- `go build ./...`
- `go vet ./...`
- `make docs-validate`
- `go test ./... -count=1`
