### PR TITLE
Add thermal throttling insights

### DIFF
--- a/cmd/spectra/power.go
+++ b/cmd/spectra/power.go
@@ -53,6 +53,20 @@ func printPowerState(w io.Writer, s sysinfo.PowerState) {
 	if s.ThermalPressure != "" {
 		fmt.Fprintf(w, "thermal:   %s\n", s.ThermalPressure)
 	}
+	if s.CPUSpeedLimitPct > 0 {
+		fmt.Fprintf(w, "cpu limit: %d%%\n", s.CPUSpeedLimitPct)
+	}
+	if s.ThermalThrottled {
+		fmt.Fprintf(w, "throttled: yes")
+		if len(s.CPUSpeedLimitSamples) > 1 {
+			fmt.Fprintf(w, " (lowest %d%%, average %d%%, %d%% of samples)",
+				s.LowestCPUSpeedLimitPct,
+				s.AverageCPUSpeedLimitPct,
+				s.PercentThermalThrottled,
+			)
+		}
+		fmt.Fprintln(w)
+	}
 
 	if len(s.Assertions) > 0 {
 		fmt.Fprintln(w)

--- a/cmd/spectra/power_test.go
+++ b/cmd/spectra/power_test.go
@@ -11,9 +11,15 @@ import (
 
 func fakePowerState() sysinfo.PowerState {
 	return sysinfo.PowerState{
-		OnBattery:       true,
-		BatteryPct:      85,
-		ThermalPressure: "serious",
+		OnBattery:               true,
+		BatteryPct:              85,
+		ThermalPressure:         "serious",
+		ThermalThrottled:        true,
+		CPUSpeedLimitPct:        92,
+		LowestCPUSpeedLimitPct:  90,
+		AverageCPUSpeedLimitPct: 94,
+		PercentThermalThrottled: 66,
+		CPUSpeedLimitSamples:    []int{90, 92, 100},
 		Assertions: []sysinfo.PowerAssertion{
 			{Type: "PreventUserIdleSleep", PID: 412, Name: "playing audio"},
 		},
@@ -34,6 +40,8 @@ func TestRunPowerHumanOutput(t *testing.T) {
 		"=== Power state ===",
 		"source:    battery (85%)",
 		"thermal:   serious",
+		"cpu limit: 92%",
+		"throttled: yes (lowest 90%, average 94%, 66% of samples)",
 		"PreventUserIdleSleep",
 		"Google Chrome Helper",
 	} {
@@ -55,6 +63,9 @@ func TestRunPowerJSONOutput(t *testing.T) {
 	}
 	if !got.OnBattery || got.BatteryPct != 85 || got.ThermalPressure != "serious" {
 		t.Fatalf("state = %+v, want fake power state", got)
+	}
+	if !got.ThermalThrottled || got.CPUSpeedLimitPct != 92 {
+		t.Fatalf("thermal state = %+v, want throttled with 92%% CPU limit", got)
 	}
 	if len(got.EnergyTopUsers) != 1 || got.EnergyTopUsers[0].Command != "Google Chrome Helper" {
 		t.Fatalf("energy users = %+v, want Google Chrome Helper", got.EnergyTopUsers)

--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -197,6 +197,12 @@ reports actual allocation rather than the multi-TB virtual disk size.
 PowerState {
   on_battery, battery_pct
   thermal_pressure ∈ {nominal, fair, serious, critical}
+  thermal_throttled
+  cpu_speed_limit_pct
+  lowest_cpu_speed_limit_pct
+  average_cpu_speed_limit_pct
+  percent_thermal_throttled
+  cpu_speed_limit_samples []
   assertions []{
     type, pid, name
   }

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -86,7 +86,7 @@ sends them in cleartext; it cannot decrypt HTTPS traffic.
 |---|---|---|---|---|
 | `pmset -g assertions` | active wake/sleep assertions | user | <10ms | `power.active_assertions` |
 | `pmset -g batt` | battery state | user | <10ms | `power.on_battery` |
-| `pmset -g therm` | thermal state | user | <10ms | `power.thermal_pressure` |
+| `pmset -g therm` | thermal state and CPU speed-limit percentage | user | <10ms | `power.thermal_pressure`, `power.thermal_throttled`, `power.cpu_speed_limit_pct` |
 | `powermetrics --samplers cpu_power,gpu_power,network,disk -n 1` | deeper energy attribution | helper-only | ~1s | `helper.powermetrics.sample` |
 | `top -l 1 -n 10 -o power -stats pid,power,command` | flat per-process power column | user | ~200ms | `power.energy_top_users` |
 

--- a/docs/inspection/power-thermal.md
+++ b/docs/inspection/power-thermal.md
@@ -26,11 +26,17 @@ query, or tune hardware fans.
 
 ```go
 type PowerState struct {
-    OnBattery       bool             `json:"on_battery"`
-    BatteryPct      int              `json:"battery_pct"`
-    ThermalPressure string           `json:"thermal_pressure,omitempty"`
-    Assertions      []PowerAssertion `json:"assertions,omitempty"`
-    EnergyTopUsers  []EnergyUser     `json:"energy_top_users,omitempty"`
+    OnBattery               bool  `json:"on_battery"`
+    BatteryPct              int   `json:"battery_pct"`
+    ThermalPressure         string `json:"thermal_pressure,omitempty"`
+    ThermalThrottled        bool   `json:"thermal_throttled"`
+    CPUSpeedLimitPct        int    `json:"cpu_speed_limit_pct,omitempty"`
+    LowestCPUSpeedLimitPct  int    `json:"lowest_cpu_speed_limit_pct,omitempty"`
+    AverageCPUSpeedLimitPct int    `json:"average_cpu_speed_limit_pct,omitempty"`
+    PercentThermalThrottled int    `json:"percent_thermal_throttled,omitempty"`
+    CPUSpeedLimitSamples    []int  `json:"cpu_speed_limit_samples,omitempty"`
+    Assertions              []PowerAssertion `json:"assertions,omitempty"`
+    EnergyTopUsers          []EnergyUser     `json:"energy_top_users,omitempty"`
 }
 ```
 
@@ -41,6 +47,12 @@ The JSON fields are:
 | `on_battery` | Whether macOS reports the current power source as battery |
 | `battery_pct` | Current battery percentage when reported by `pmset` |
 | `thermal_pressure` | macOS thermal state such as `nominal`, `fair`, `serious`, or `critical` |
+| `thermal_throttled` | Whether any observed CPU speed-limit sample is below 100% |
+| `cpu_speed_limit_pct` | Latest CPU speed-limit percentage reported by macOS |
+| `lowest_cpu_speed_limit_pct` | Lowest CPU speed-limit percentage in the parsed thermal sample |
+| `average_cpu_speed_limit_pct` | Average CPU speed-limit percentage in the parsed thermal sample |
+| `percent_thermal_throttled` | Percentage of parsed CPU speed-limit samples below 100% |
+| `cpu_speed_limit_samples` | Raw CPU speed-limit percentages parsed from the thermal source |
 | `assertions` | Active sleep/display assertions attributed to owning PIDs |
 | `energy_top_users` | A short `top` sample sorted by the macOS power column |
 
@@ -51,7 +63,7 @@ The unprivileged collector uses only built-in macOS tools:
 | Source | Output | Privilege | Used for |
 |---|---|---|---|
 | `pmset -g batt` | Current AC/battery source and battery percentage | user | `on_battery`, `battery_pct` |
-| `pmset -g therm` | Current thermal pressure state | user | `thermal_pressure` |
+| `pmset -g therm` | Current thermal pressure and CPU speed-limit state | user | `thermal_pressure`, `thermal_throttled`, CPU limit fields |
 | `pmset -g assertions` | Wake, sleep, and display assertions by process | user | `assertions` |
 | `top -l 1 -n 10 -o power -stats pid,power,command` | One-shot process energy-impact list | user | `energy_top_users` |
 
@@ -72,6 +84,8 @@ Human output is optimized for a quick terminal read:
 === Power state ===
 source:    battery (85%)
 thermal:   nominal
+cpu limit: 92%
+throttled: yes (lowest 90%, average 94%, 66% of samples)
 
 assertions (1):
   pid 412      PreventUserIdleSleep          "playing audio"

--- a/internal/sysinfo/power.go
+++ b/internal/sysinfo/power.go
@@ -9,11 +9,17 @@ import (
 // PowerState captures battery and thermal facts.
 // See docs/design/system-inventory.md#powerstate.
 type PowerState struct {
-	OnBattery       bool             `json:"on_battery"`
-	BatteryPct      int              `json:"battery_pct"`
-	ThermalPressure string           `json:"thermal_pressure,omitempty"` // "nominal", "fair", "serious", "critical"
-	Assertions      []PowerAssertion `json:"assertions,omitempty"`
-	EnergyTopUsers  []EnergyUser     `json:"energy_top_users,omitempty"`
+	OnBattery               bool             `json:"on_battery"`
+	BatteryPct              int              `json:"battery_pct"`
+	ThermalPressure         string           `json:"thermal_pressure,omitempty"` // "nominal", "fair", "serious", "critical"
+	ThermalThrottled        bool             `json:"thermal_throttled"`
+	CPUSpeedLimitPct        int              `json:"cpu_speed_limit_pct,omitempty"`
+	LowestCPUSpeedLimitPct  int              `json:"lowest_cpu_speed_limit_pct,omitempty"`
+	AverageCPUSpeedLimitPct int              `json:"average_cpu_speed_limit_pct,omitempty"`
+	PercentThermalThrottled int              `json:"percent_thermal_throttled,omitempty"`
+	CPUSpeedLimitSamples    []int            `json:"cpu_speed_limit_samples,omitempty"`
+	Assertions              []PowerAssertion `json:"assertions,omitempty"`
+	EnergyTopUsers          []EnergyUser     `json:"energy_top_users,omitempty"`
 }
 
 // EnergyUser is one entry from `top -l 1 -o power`.
@@ -160,14 +166,56 @@ func parseTherm(out string, ps *PowerState) {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "System thermal state:") {
 			ps.ThermalPressure = strings.TrimSpace(strings.TrimPrefix(line, "System thermal state:"))
-			return
+			continue
 		}
 		// Fallback: some macOS versions print "thermal state: X"
 		if strings.HasPrefix(line, "thermal state:") {
 			ps.ThermalPressure = strings.TrimSpace(strings.TrimPrefix(line, "thermal state:"))
-			return
+			continue
+		}
+		if strings.Contains(line, "CPU_Speed_Limit") {
+			if limit, ok := parseDiagnosticInt(line); ok {
+				ps.CPUSpeedLimitSamples = append(ps.CPUSpeedLimitSamples, limit)
+			}
 		}
 	}
+	summarizeCPUSpeedLimits(ps)
+}
+
+func parseDiagnosticInt(line string) (int, bool) {
+	_, value, ok := strings.Cut(line, "=")
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func summarizeCPUSpeedLimits(ps *PowerState) {
+	if len(ps.CPUSpeedLimitSamples) == 0 {
+		return
+	}
+	latest := ps.CPUSpeedLimitSamples[len(ps.CPUSpeedLimitSamples)-1]
+	lowest := ps.CPUSpeedLimitSamples[0]
+	sum := 0
+	throttled := 0
+	for _, limit := range ps.CPUSpeedLimitSamples {
+		sum += limit
+		if limit < lowest {
+			lowest = limit
+		}
+		if limit < 100 {
+			throttled++
+		}
+	}
+	ps.CPUSpeedLimitPct = latest
+	ps.LowestCPUSpeedLimitPct = lowest
+	ps.AverageCPUSpeedLimitPct = sum / len(ps.CPUSpeedLimitSamples)
+	ps.PercentThermalThrottled = (throttled * 100) / len(ps.CPUSpeedLimitSamples)
+	ps.ThermalThrottled = throttled > 0
 }
 
 // parseAssertions extracts active assertions from `pmset -g assertions`.

--- a/internal/sysinfo/power_test.go
+++ b/internal/sysinfo/power_test.go
@@ -21,6 +21,32 @@ const thermSerious = `System thermal state: serious
 CPU_Speed_Limit	= 60
 `
 
+const thermLogThrottled = `2021-07-07 12:32:50 -0400 CPU Power notify
+	CPU_Scheduler_Limit 	= 100
+	CPU_Available_CPUs 	= 8
+	CPU_Speed_Limit 	= 90
+2021-07-07 12:32:51 -0400 CPU Power notify
+	CPU_Scheduler_Limit 	= 100
+	CPU_Available_CPUs 	= 8
+	CPU_Speed_Limit 	= 92
+
+2021-07-07 12:32:52 -0400 CPU Power notify
+	CPU_Scheduler_Limit 	= 100
+	CPU_Available_CPUs 	= 8
+	CPU_Speed_Limit 	= 100
+`
+
+const thermLogWithGarbage = `2021-07-07 12:32:50 -0400 CPU Power notify
+	CPU_Scheduler_Limit 	= 100
+	CPU_Available_CPUs 	= 8
+	CPU_Speed_Limit 	= 90
+2021-07-07 12:32:51 -0400 not a complete record
+	CPU_Speed_Limit 	= nope
+2021-07-07 12:32:52 -0400 CPU Power notify
+	CPU_Available_CPUs 	= 8
+	CPU_Speed_Limit 	= 100
+`
+
 const assertionsOutput = `Assertion status system-wide:
    BackgroundTask                 0
    PreventUserIdleSleep           1
@@ -140,6 +166,15 @@ func TestCollectPowerThermal(t *testing.T) {
 	if ps.ThermalPressure != "serious" {
 		t.Errorf("ThermalPressure = %q, want serious", ps.ThermalPressure)
 	}
+	if !ps.ThermalThrottled {
+		t.Error("ThermalThrottled = false, want true")
+	}
+	if ps.CPUSpeedLimitPct != 60 {
+		t.Errorf("CPUSpeedLimitPct = %d, want 60", ps.CPUSpeedLimitPct)
+	}
+	if ps.PercentThermalThrottled != 100 {
+		t.Errorf("PercentThermalThrottled = %d, want 100", ps.PercentThermalThrottled)
+	}
 }
 
 func TestCollectPowerAssertions(t *testing.T) {
@@ -196,6 +231,46 @@ func TestParseEnergyTopPreservesCommandWithSpaces(t *testing.T) {
 	}
 	if users[0].Command != "Google Chrome Helper" {
 		t.Errorf("Command = %q, want Google Chrome Helper", users[0].Command)
+	}
+}
+
+func TestParseThermAggregatesSpeedLimits(t *testing.T) {
+	var ps PowerState
+	parseTherm(thermLogThrottled, &ps)
+	if !ps.ThermalThrottled {
+		t.Error("ThermalThrottled = false, want true")
+	}
+	if ps.CPUSpeedLimitPct != 100 {
+		t.Errorf("CPUSpeedLimitPct = %d, want latest 100", ps.CPUSpeedLimitPct)
+	}
+	if ps.LowestCPUSpeedLimitPct != 90 {
+		t.Errorf("LowestCPUSpeedLimitPct = %d, want 90", ps.LowestCPUSpeedLimitPct)
+	}
+	if ps.AverageCPUSpeedLimitPct != 94 {
+		t.Errorf("AverageCPUSpeedLimitPct = %d, want 94", ps.AverageCPUSpeedLimitPct)
+	}
+	if ps.PercentThermalThrottled != 66 {
+		t.Errorf("PercentThermalThrottled = %d, want 66", ps.PercentThermalThrottled)
+	}
+	wantSamples := []int{90, 92, 100}
+	if len(ps.CPUSpeedLimitSamples) != len(wantSamples) {
+		t.Fatalf("samples = %v, want %v", ps.CPUSpeedLimitSamples, wantSamples)
+	}
+	for i := range wantSamples {
+		if ps.CPUSpeedLimitSamples[i] != wantSamples[i] {
+			t.Fatalf("samples = %v, want %v", ps.CPUSpeedLimitSamples, wantSamples)
+		}
+	}
+}
+
+func TestParseThermSkipsInvalidSpeedLimits(t *testing.T) {
+	var ps PowerState
+	parseTherm(thermLogWithGarbage, &ps)
+	if len(ps.CPUSpeedLimitSamples) != 2 {
+		t.Fatalf("samples = %v, want two valid samples", ps.CPUSpeedLimitSamples)
+	}
+	if ps.LowestCPUSpeedLimitPct != 90 {
+		t.Errorf("LowestCPUSpeedLimitPct = %d, want 90", ps.LowestCPUSpeedLimitPct)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added CPU speed-limit and thermal throttling fields to `sysinfo.PowerState`.
- Parse `CPU_Speed_Limit` values from `pmset -g therm` output, including Foundry-style thermlog snippets.
- Summarize latest, lowest, average, sample list, and percent throttled values.
- Show CPU speed limit and throttling summary in `spectra power` human output.
- Updated power/thermal docs and system inventory docs for the new JSON shape.

## Why

Foundry's thermal logging showed that `CPU_Speed_Limit < 100` is the direct macOS signal for thermal throttling. Spectra now captures that signal in the lightweight power collector without adding dependencies or starting a long-running thermlog process.

## Validation

- `go test ./internal/sysinfo ./cmd/spectra -count=1`
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
