### PR TITLE
Add artifact lifecycle manifest

### DIFF
--- a/cmd/spectra/artifact.go
+++ b/cmd/spectra/artifact.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/kaeawc/spectra/internal/artifact"
+)
+
+var artifactRecorder artifact.Recorder
+
+func initArtifactRecorder() {
+	path, err := artifact.DefaultManifestPath()
+	if err != nil {
+		return
+	}
+	artifactRecorder = artifact.NewManager(artifact.NewJSONStore(path), nil)
+}
+
+func recordArtifactCLI(rec artifact.Record) {
+	if artifactRecorder == nil {
+		return
+	}
+	_, err := artifactRecorder.Record(context.Background(), rec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "artifact manifest: %v\n", err)
+		return
+	}
+}

--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/toolchain"
@@ -121,6 +122,15 @@ func runJVMThreadDump(args []string) int {
 			fmt.Fprintf(os.Stderr, "cached as threads/%x\n", key[:4])
 		}
 	}
+	recordArtifactCLI(artifact.Record{
+		Kind:        artifact.KindThreadDump,
+		Sensitivity: artifact.SensitivityMediumHigh,
+		Source:      "cli",
+		Command:     "spectra jvm thread-dump",
+		CacheKind:   cache.KindThreads,
+		PID:         pid,
+		SizeBytes:   int64(len(data)),
+	})
 
 	os.Stdout.Write(data)
 	return 0
@@ -189,6 +199,15 @@ func runJVMHeapDump(args []string) int {
 		fmt.Fprintf(os.Stderr, "heap-dump failed for PID %d: %v\n", pid, err)
 		return 1
 	}
+	recordArtifactCLI(artifact.Record{
+		Kind:        artifact.KindHeapDump,
+		Sensitivity: artifact.SensitivityVeryHigh,
+		Source:      "cli",
+		Command:     "spectra jvm heap-dump",
+		Path:        destPath,
+		CacheKind:   cache.KindHprof,
+		PID:         pid,
+	})
 	fmt.Println(destPath)
 	return 0
 }
@@ -355,6 +374,17 @@ func runJVMFlamegraph(args []string) int {
 		fmt.Fprintf(os.Stderr, "flamegraph failed for PID %d: %v\n", pid, err)
 		return 1
 	}
+	recordArtifactCLI(artifact.Record{
+		Kind:        artifact.KindFlamegraph,
+		Sensitivity: artifact.SensitivityMediumHigh,
+		Source:      "cli",
+		Command:     "spectra jvm flamegraph",
+		Path:        dest,
+		PID:         pid,
+		Metadata: map[string]string{
+			"event": *event,
+		},
+	})
 	fmt.Println(dest)
 	return 0
 }
@@ -503,6 +533,18 @@ func runJFRDump(pid int, name, dest string) int {
 		return 1
 	}
 	cacheJFRDump(pid, dest)
+	recordArtifactCLI(artifact.Record{
+		Kind:        artifact.KindJFRRecording,
+		Sensitivity: artifact.SensitivityMediumHigh,
+		Source:      "cli",
+		Command:     "spectra jvm jfr dump",
+		Path:        dest,
+		CacheKind:   cache.KindJFR,
+		PID:         pid,
+		Metadata: map[string]string{
+			"name": name,
+		},
+	})
 	fmt.Println(dest)
 	return 0
 }
@@ -552,6 +594,18 @@ func runJFRStop(pid int, name, dest string) int {
 	}
 	fmt.Fprintf(os.Stdout, "JFR recording %q stopped on PID %d\n", name, pid)
 	if dest != "" {
+		recordArtifactCLI(artifact.Record{
+			Kind:        artifact.KindJFRRecording,
+			Sensitivity: artifact.SensitivityMediumHigh,
+			Source:      "cli",
+			Command:     "spectra jvm jfr stop",
+			Path:        dest,
+			CacheKind:   cache.KindJFR,
+			PID:         pid,
+			Metadata: map[string]string{
+				"name": name,
+			},
+		})
 		fmt.Println(dest)
 	}
 	return 0

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -63,6 +63,7 @@ func subcommandList() []subcommand {
 
 func main() {
 	initCacheStores()
+	initArtifactRecorder()
 	os.Exit(dispatch(os.Args[1:]))
 }
 

--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/artifact"
+	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/netcap"
 	"github.com/kaeawc/spectra/internal/netdiag"
@@ -294,6 +296,12 @@ func runNetworkCaptureStart(args []string) int {
 		fmt.Fprintf(os.Stderr, "network capture start: %v\n", err)
 		return 1
 	}
+	recordNetworkCaptureArtifact("spectra network capture start", result, map[string]string{
+		"interface": *iface,
+		"proto":     *proto,
+		"host":      *host,
+		"port":      strconv.Itoa(*port),
+	})
 	return printNetworkCaptureResult(result, *asJSON, "capture started")
 }
 
@@ -319,6 +327,9 @@ func runNetworkCaptureStop(args []string) int {
 		fmt.Fprintf(os.Stderr, "network capture stop: %v\n", err)
 		return 1
 	}
+	recordNetworkCaptureArtifact("spectra network capture stop", result, map[string]string{
+		"handle": fs.Arg(0),
+	})
 	if *summarize {
 		path, _ := result["output_path"].(string)
 		if path == "" {
@@ -341,6 +352,23 @@ func runNetworkCaptureStop(args []string) int {
 		return 0
 	}
 	return printNetworkCaptureResult(result, *asJSON, "capture stopped")
+}
+
+func recordNetworkCaptureArtifact(command string, result map[string]any, metadata map[string]string) {
+	path, _ := result["output_path"].(string)
+	handle, _ := result["handle"].(string)
+	if handle != "" {
+		metadata["handle"] = handle
+	}
+	recordArtifactCLI(artifact.Record{
+		Kind:        artifact.KindPacketCapture,
+		Sensitivity: artifact.SensitivityHigh,
+		Source:      "cli",
+		Command:     command,
+		Path:        path,
+		CacheKind:   cache.KindNetcap,
+		Metadata:    metadata,
+	})
 }
 
 func runNetworkCaptureSummarize(args []string) int {

--- a/cmd/spectra/sample.go
+++ b/cmd/spectra/sample.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/cache"
 )
 
@@ -51,6 +52,19 @@ func runSample(args []string) int {
 			fmt.Fprintf(os.Stderr, "cached as samples/%x\n", key[:4])
 		}
 	}
+	recordArtifactCLI(artifact.Record{
+		Kind:        artifact.KindProcessSample,
+		Sensitivity: artifact.SensitivityMedium,
+		Source:      "cli",
+		Command:     "spectra sample",
+		CacheKind:   cache.KindSamples,
+		PID:         pid,
+		SizeBytes:   int64(len(data)),
+		Metadata: map[string]string{
+			"duration": strconv.Itoa(*duration),
+			"interval": strconv.Itoa(*interval),
+		},
+	})
 
 	os.Stdout.Write(data)
 	return 0

--- a/docs/design/threat-model.md
+++ b/docs/design/threat-model.md
@@ -255,3 +255,5 @@ for the current reporting process.
 - [privileged-helper.md](privileged-helper.md) — protocol + boundary
 - [distribution.md](distribution.md) — code-signing context
 - [remote-portal.md](remote-portal.md) — tailnet exposure model
+- [Artifact lifecycle](../operations/artifacts.md) — retention, sharing,
+  and deletion guidance for sensitive artifacts

--- a/docs/operations/artifacts.md
+++ b/docs/operations/artifacts.md
@@ -1,0 +1,220 @@
+# Artifact lifecycle
+
+Spectra can collect diagnostic artifacts that are more sensitive than
+ordinary inspection output. Heap dumps, JFR recordings, thread dumps,
+process samples, and packet captures can contain credentials, customer
+data, source paths, hostnames, private URLs, request payloads, or other
+material that should not be shared casually.
+
+This page defines the user-facing lifecycle for those artifacts: when
+they are created, where they live, how long they stay around, how to
+share them, and how to remove them.
+
+## Artifact classes
+
+| Class | Examples | Sensitivity | Default location |
+|---|---|---|---|
+| Heap dumps | `.hprof` from `spectra jvm heap-dump` | very high | `~/.spectra/` plus `hprof` cache entries |
+| JFR recordings | `.jfr` from `spectra jvm jfr dump` / `stop` | medium-high | `~/.spectra/` plus `jfr` cache entries |
+| Thread dumps | `jcmd Thread.print` output | medium-high | `threads` cache entries |
+| Process samples | `sample <pid>` output | medium | `samples` cache entries |
+| Packet captures | `.pcap` from `spectra network capture` | high | helper-owned capture path; future `netcap` cache entries |
+| Detection cache | app detection results | low-medium | `detect` cache entries |
+
+Heap dumps are the most sensitive class because they are full process
+memory snapshots. Treat them as equivalent to access to the target
+process. JFR files and thread dumps are smaller, but they may still
+contain stack frames, class names, file paths, query text, system
+properties, environment-derived values, and business identifiers.
+Packet captures may include DNS names, IPs, headers, and payload bytes
+depending on the protocol and capture filter.
+
+## Creation
+
+Artifacts are created only by explicit diagnostic commands or daemon RPC
+methods. Routine app inspection does not create heap dumps, JFR
+recordings, or packet captures.
+
+```bash
+spectra jvm thread-dump <pid>
+spectra jvm heap-dump [--out <path>] <pid>
+spectra jvm jfr start <pid> [--name spectra]
+spectra jvm jfr dump <pid> [--name spectra] [--out <path>]
+spectra jvm jfr stop <pid> [--name spectra] [--out <path>]
+spectra sample [--no-cache] [--duration <s>] [--interval <ms>] <pid>
+spectra network capture start ...
+spectra network capture stop ...
+```
+
+For local CLI commands, the person running the command is responsible
+for choosing whether the target process may be inspected. For daemon RPC
+calls, sensitive write methods require an explicit consent parameter
+such as `confirm_sensitive: true`; callers should surface that consent
+in their own UI instead of hiding it behind a default.
+
+## Storage
+
+Spectra uses two storage roots:
+
+- `~/.spectra/` for user-visible output paths such as default heap-dump
+  and JFR destinations, plus the artifact manifest at
+  `~/.spectra/artifacts.json`.
+- `~/.cache/spectra/v1/` for content-addressed cache entries managed by
+  `spectra cache`.
+
+Both roots are per-user. Spectra does not write shared system-wide
+artifact stores for normal CLI or daemon operation. The privileged
+helper may create root-only packet-capture files while a capture is
+active; those are bounded by helper validation and should be treated as
+high-sensitivity artifacts once returned to the user.
+
+The cache layout and implementation details are documented in
+[Caching](caching.md). The important operational point is that cache
+entries are local files. Filesystem permissions are the primary access
+control, and a user who can read the Spectra user's home can read that
+user's artifacts.
+
+The manifest records metadata only: artifact kind, sensitivity, source,
+command, path, cache kind, PID, size when known, creation time, and small
+capture-specific fields such as a JFR recording name or packet-capture
+handle. It does not copy artifact contents into the manifest.
+
+## Retention
+
+There is no automatic artifact expiration in the current v1 cache.
+Artifacts remain until the user removes them or clears the relevant
+cache kind.
+
+Use cache stats before and after long investigations:
+
+```bash
+spectra cache stats
+spectra cache clear --kind hprof
+spectra cache clear --kind jfr
+spectra cache clear --kind threads
+spectra cache clear --kind samples
+spectra cache clear --kind netcap
+spectra cache clear
+```
+
+Manually chosen output files under `~/.spectra/` or another `--out`
+path are not removed by `spectra cache clear`; delete those files
+directly when the investigation is done.
+
+Recommended retention defaults:
+
+| Artifact | Recommended maximum |
+|---|---|
+| Heap dumps | delete as soon as analysis is complete |
+| Packet captures | delete as soon as analysis is complete |
+| JFR recordings | keep only for the active incident or performance investigation |
+| Thread dumps / samples | keep only while the corresponding issue is open |
+| Detection cache | safe to keep; clear when troubleshooting cache behavior |
+
+## Sharing
+
+Share artifacts only through channels approved for the data they may
+contain. Do not attach heap dumps, packet captures, or JFR files to
+public issues, public pull requests, chat rooms, or unencrypted email.
+
+Before sharing, prefer a derived summary over the raw artifact:
+
+- `spectra jvm heap-histogram <pid>` instead of a full heap dump.
+- `spectra jvm jfr summary <recording.jfr>` instead of the full JFR.
+- `spectra network capture summarize <pcap-path>` instead of the raw
+  PCAP.
+- A short excerpt from a thread dump instead of the full dump.
+
+If a raw artifact is necessary, record:
+
+- who requested it,
+- which process or interface was captured,
+- when it was captured,
+- where it was sent,
+- when it should be deleted.
+
+The future remote portal should expose this as an artifact manifest
+rather than relying on ad hoc notes. The daemon and CLI already write
+local manifest records; portal UI and policy controls should build on
+that record instead of inventing a second lifecycle model.
+
+## Deletion
+
+For cached artifacts, use `spectra cache clear --kind <kind>` when the
+artifact class is no longer needed. For explicit output files, delete
+the path printed by the command.
+
+Suggested cleanup after a sensitive JVM investigation:
+
+```bash
+spectra cache clear --kind hprof
+spectra cache clear --kind jfr
+spectra cache clear --kind threads
+rm -f ~/.spectra/*.hprof ~/.spectra/*.jfr
+spectra cache stats
+```
+
+Suggested cleanup after packet capture work:
+
+```bash
+spectra cache clear --kind netcap
+rm -f /var/tmp/spectra-netcap/*/*.pcap
+spectra cache stats
+```
+
+Only remove packet captures from helper-managed paths that belong to
+your investigation. On shared systems, coordinate with the machine owner
+before removing files under `/var/tmp/spectra-netcap/`.
+
+## Redaction limits
+
+Spectra summaries are designed to avoid retaining packet payload bodies
+and full artifact contents, but summaries are not guaranteed to be
+anonymous. Hostnames, URLs, class names, bundle IDs, process names, stack
+frames, and file paths can all identify systems or users.
+
+Do not assume that a derived summary is safe for public posting without
+review.
+
+## Remote access
+
+Remote debugging over TCP or Tailscale delegates meaningful diagnostic
+power to the peer. A peer who can request heap dumps, JFR dumps, process
+samples, or packet captures may obtain sensitive data from the machine.
+
+Remote clients should:
+
+- require explicit consent for each high-sensitivity artifact,
+- show the destination path and estimated scope before capture,
+- avoid serving raw artifacts by default,
+- prefer summaries and bounded excerpts,
+- record artifact creation in the daemon audit log or future artifact
+  manifest.
+
+This complements the security posture in the
+[Threat model](../design/threat-model.md).
+
+## Incident handling
+
+If a sensitive artifact was shared with the wrong audience:
+
+1. Remove the artifact from the shared location.
+2. Clear the relevant Spectra cache kind.
+3. Delete explicit output files under `~/.spectra/` or the supplied
+   `--out` path.
+4. Rotate credentials that may have been present in process memory,
+   command output, network traffic, or system properties.
+5. Preserve only the minimum metadata needed to investigate the leak:
+   timestamp, command, process, destination, and recipient list.
+
+Heap-dump exposure should be treated as possible secret exposure for the
+target process.
+
+## See also
+
+- [Caching](caching.md) — cache layout, stats, and clear commands.
+- [JVM inspection](../inspection/jvm.md) — JVM artifact commands.
+- [Live data sources](../inspection/live-data-sources.md) — command
+  inventory and capture cost.
+- [Threat model](../design/threat-model.md) — sensitive assets and
+  remote-debugging risk.

--- a/docs/operations/caching.md
+++ b/docs/operations/caching.md
@@ -4,6 +4,9 @@ Spectra uses a versioned, hash-sharded blob cache for expensive or
 large artifacts. The CLI initializes all cache stores at startup and
 exposes shared `stats` / `clear` commands through a registry.
 
+For user-facing retention, sharing, and deletion guidance, see
+[Artifact lifecycle](artifacts.md).
+
 The cache layout follows the patterns proven out in
 [krit](https://github.com/kaeawc/krit). See
 [../design/storage.md](../design/storage.md) for the full storage stack.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -20,7 +20,8 @@ to live-snapshot retention.
 JFR recordings, thread dumps) that don't belong in
 [*SQLite*](#sqlite). Two-level hash-sharded layout under
 `~/.cache/spectra/v1/{kind}/{hash[:2]}/{hash[2:]}.bin`. See
-[../design/storage.md](../design/storage.md).
+[../design/storage.md](../design/storage.md) and
+[../operations/artifacts.md](../operations/artifacts.md).
 
 **Catalog.** The set of [*rules*](#rule) the
 [*recommendations engine*](#recommendations-engine) evaluates. Ships

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -1,0 +1,177 @@
+// Package artifact records the lifecycle metadata for sensitive diagnostic
+// artifacts such as heap dumps, JFR recordings, process samples, and pcaps.
+package artifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/clock"
+)
+
+const (
+	KindHeapDump      = "heap_dump"
+	KindJFRRecording  = "jfr"
+	KindThreadDump    = "thread_dump"
+	KindProcessSample = "process_sample"
+	KindPacketCapture = "packet_capture"
+	KindFlamegraph    = "flamegraph"
+
+	SensitivityLow        = "low"
+	SensitivityMedium     = "medium"
+	SensitivityMediumHigh = "medium-high"
+	SensitivityHigh       = "high"
+	SensitivityVeryHigh   = "very-high"
+)
+
+// Record describes one artifact that Spectra created or learned about.
+type Record struct {
+	ID          string            `json:"id"`
+	Kind        string            `json:"kind"`
+	Sensitivity string            `json:"sensitivity"`
+	Source      string            `json:"source,omitempty"`
+	Command     string            `json:"command,omitempty"`
+	Path        string            `json:"path,omitempty"`
+	CacheKind   string            `json:"cache_kind,omitempty"`
+	PID         int               `json:"pid,omitempty"`
+	SizeBytes   int64             `json:"size_bytes,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// Recorder records artifact lifecycle metadata. Use this interface in
+// packages that create artifacts so tests can substitute a fake.
+type Recorder interface {
+	Record(ctx context.Context, rec Record) (Record, error)
+}
+
+// Store persists and retrieves artifact records.
+type Store interface {
+	Append(ctx context.Context, rec Record) error
+	List(ctx context.Context) ([]Record, error)
+}
+
+// Manager stamps records with time, stable IDs, and best-effort file sizes.
+type Manager struct {
+	store Store
+	clock clock.Clock
+}
+
+// NewManager returns a Recorder backed by store.
+func NewManager(store Store, clk clock.Clock) *Manager {
+	if clk == nil {
+		clk = clock.Default
+	}
+	return &Manager{store: store, clock: clk}
+}
+
+// Record validates and persists rec.
+func (m *Manager) Record(ctx context.Context, rec Record) (Record, error) {
+	if rec.Kind == "" {
+		return Record{}, fmt.Errorf("artifact: kind is required")
+	}
+	if rec.Sensitivity == "" {
+		rec.Sensitivity = defaultSensitivity(rec.Kind)
+	}
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = m.clock.Now().UTC()
+	}
+	if rec.SizeBytes == 0 && rec.Path != "" {
+		if info, err := os.Stat(rec.Path); err == nil && !info.IsDir() {
+			rec.SizeBytes = info.Size()
+		}
+	}
+	if rec.ID == "" {
+		rec.ID = stableID(rec)
+	}
+	if err := m.store.Append(ctx, rec); err != nil {
+		return Record{}, err
+	}
+	return rec, nil
+}
+
+func defaultSensitivity(kind string) string {
+	switch kind {
+	case KindHeapDump:
+		return SensitivityVeryHigh
+	case KindPacketCapture:
+		return SensitivityHigh
+	case KindJFRRecording, KindThreadDump, KindFlamegraph:
+		return SensitivityMediumHigh
+	case KindProcessSample:
+		return SensitivityMedium
+	default:
+		return SensitivityMedium
+	}
+}
+
+func stableID(rec Record) string {
+	h := sha256.New()
+	write := func(s string) {
+		_, _ = h.Write([]byte(s))
+		_, _ = h.Write([]byte{0})
+	}
+	write(rec.Kind)
+	write(rec.Source)
+	write(rec.Command)
+	write(rec.Path)
+	write(rec.CacheKind)
+	write(fmt.Sprint(rec.PID))
+	write(rec.CreatedAt.UTC().Format(time.RFC3339Nano))
+	if len(rec.Metadata) > 0 {
+		keys := make([]string, 0, len(rec.Metadata))
+		for k := range rec.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			write(k)
+			write(rec.Metadata[k])
+		}
+	}
+	sum := h.Sum(nil)
+	return "art-" + hex.EncodeToString(sum[:8])
+}
+
+// DefaultManifestPath returns the per-user artifact manifest path.
+func DefaultManifestPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".spectra", "artifacts.json"), nil
+}
+
+// FakeRecorder is an in-memory Recorder for tests.
+type FakeRecorder struct {
+	mu      sync.Mutex
+	Records []Record
+	Err     error
+}
+
+// Record stores rec in memory unless Err is set.
+func (f *FakeRecorder) Record(_ context.Context, rec Record) (Record, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.Err != nil {
+		return Record{}, f.Err
+	}
+	f.Records = append(f.Records, rec)
+	return rec, nil
+}
+
+// Snapshot returns a copy of recorded entries.
+func (f *FakeRecorder) Snapshot() []Record {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Record, len(f.Records))
+	copy(out, f.Records)
+	return out
+}

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -1,0 +1,96 @@
+package artifact
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/clock"
+)
+
+func TestManagerRecordDefaultsAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	blob := filepath.Join(dir, "heap.hprof")
+	if err := os.WriteFile(blob, []byte("heap"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := NewJSONStore(filepath.Join(dir, "artifacts.json"))
+	now := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	mgr := NewManager(store, clock.NewFake(now))
+
+	rec, err := mgr.Record(context.Background(), Record{
+		Kind:    KindHeapDump,
+		Source:  "cli",
+		Command: "spectra jvm heap-dump",
+		Path:    blob,
+		PID:     42,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.ID == "" {
+		t.Fatal("expected generated id")
+	}
+	if rec.Sensitivity != SensitivityVeryHigh {
+		t.Fatalf("sensitivity = %q, want %q", rec.Sensitivity, SensitivityVeryHigh)
+	}
+	if rec.SizeBytes != 4 {
+		t.Fatalf("size = %d, want 4", rec.SizeBytes)
+	}
+	if !rec.CreatedAt.Equal(now) {
+		t.Fatalf("created_at = %s, want %s", rec.CreatedAt, now)
+	}
+
+	records, err := store.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	if records[0].ID != rec.ID {
+		t.Fatalf("stored id = %q, want %q", records[0].ID, rec.ID)
+	}
+}
+
+func TestJSONStoreAppendPreservesExistingRecords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "artifacts.json")
+	store := NewJSONStore(path)
+
+	for _, rec := range []Record{
+		{ID: "one", Kind: KindJFRRecording, CreatedAt: time.Unix(1, 0).UTC()},
+		{ID: "two", Kind: KindProcessSample, CreatedAt: time.Unix(2, 0).UTC()},
+	} {
+		if err := store.Append(context.Background(), rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	records, err := store.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records = %d, want 2", len(records))
+	}
+	if records[0].ID != "one" || records[1].ID != "two" {
+		t.Fatalf("records out of order: %#v", records)
+	}
+}
+
+func TestFakeRecorder(t *testing.T) {
+	fake := &FakeRecorder{}
+	if _, err := fake.Record(context.Background(), Record{Kind: KindPacketCapture}); err != nil {
+		t.Fatal(err)
+	}
+	got := fake.Snapshot()
+	if len(got) != 1 || got[0].Kind != KindPacketCapture {
+		t.Fatalf("snapshot = %#v", got)
+	}
+	got[0].Kind = "mutated"
+	if fake.Snapshot()[0].Kind != KindPacketCapture {
+		t.Fatal("snapshot exposed internal storage")
+	}
+}

--- a/internal/artifact/json_store.go
+++ b/internal/artifact/json_store.go
@@ -1,0 +1,84 @@
+package artifact
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/kaeawc/spectra/internal/fsutil"
+)
+
+// JSONStore persists the manifest as a single atomically-rewritten JSON file.
+type JSONStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewJSONStore returns a JSON-backed Store at path.
+func NewJSONStore(path string) *JSONStore {
+	return &JSONStore{path: path}
+}
+
+// Append adds rec to the manifest.
+func (s *JSONStore) Append(ctx context.Context, rec Record) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	records, err := s.readLocked()
+	if err != nil {
+		return err
+	}
+	records = append(records, rec)
+	return s.writeLocked(records)
+}
+
+// List returns the manifest records in insertion order.
+func (s *JSONStore) List(ctx context.Context) ([]Record, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.readLocked()
+}
+
+func (s *JSONStore) readLocked() ([]Record, error) {
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("artifact manifest read: %w", err)
+	}
+	var records []Record
+	if len(data) == 0 {
+		return nil, nil
+	}
+	if err := json.Unmarshal(data, &records); err != nil {
+		return nil, fmt.Errorf("artifact manifest decode: %w", err)
+	}
+	return records, nil
+}
+
+func (s *JSONStore) writeLocked(records []Record) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("artifact manifest mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(records, "", "  ")
+	if err != nil {
+		return fmt.Errorf("artifact manifest encode: %w", err)
+	}
+	data = append(data, '\n')
+	if err := fsutil.WriteFileAtomic(s.path, data, 0o600); err != nil {
+		return fmt.Errorf("artifact manifest write: %w", err)
+	}
+	return nil
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/bundleid"
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/detect"
@@ -39,6 +40,8 @@ import (
 var (
 	collectToolchains = toolchain.Collect
 	collectJDKs       = toolchain.CollectJDKs
+	runHeapDump       = jvm.HeapDump
+	runThreadDump     = jvm.ThreadDump
 	runJFRDump        = jvm.JFRDump
 	runJFRSummary     = jvm.SummarizeJFR
 )
@@ -69,6 +72,7 @@ type Options struct {
 	DBPath           string              // empty = store.DefaultPath()
 	CacheRegistry    *cache.Registry     // nil = cache.Default
 	DetectStore      *cache.ShardedStore // nil = no detect caching
+	ArtifactRecorder artifact.Recorder   // nil = default per-user manifest
 	Logger           logger.Logger       // nil = discard
 }
 
@@ -184,9 +188,17 @@ func runDaemon(ctx context.Context, log logger.Logger, opts Options, listeners [
 	if cacheReg == nil {
 		cacheReg = cache.Default
 	}
+	artifactRecorder := opts.ArtifactRecorder
+	if artifactRecorder == nil {
+		path, err := artifact.DefaultManifestPath()
+		if err != nil {
+			return fmt.Errorf("serve: resolve artifact manifest path: %w", err)
+		}
+		artifactRecorder = artifact.NewManager(artifact.NewJSONStore(path), nil)
+	}
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, opts.SpectraVersion, db, collector, cacheReg, opts.DetectStore, tsnetStatus, tsNode)
+	registerHandlers(d, opts.SpectraVersion, db, collector, cacheReg, opts.DetectStore, artifactRecorder, tsnetStatus, tsNode)
 	log.Info("daemon serving", "version", opts.SpectraVersion, "listeners", len(listeners))
 
 	go func() {
@@ -409,7 +421,7 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB) {
 // registerHandlers wires all JSON-RPC methods into d.
 //
 //gocyclo:ignore
-func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, cacheReg *cache.Registry, detectStore *cache.ShardedStore, tsnetStatus *TsnetStatus, tsnetNode TsnetNode) {
+func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, cacheReg *cache.Registry, detectStore *cache.ShardedStore, artifactRecorder artifact.Recorder, tsnetStatus *TsnetStatus, tsnetNode TsnetNode) {
 	d.Register("health", func(_ json.RawMessage) (any, error) {
 		result := map[string]any{"ok": true, "version": version}
 		if tsnetStatus != nil {
@@ -828,11 +840,19 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err := json.Unmarshal(params, &p); err != nil || p.PID == 0 {
 			return nil, fmt.Errorf("jvm.thread_dump requires {\"pid\": <pid>}")
 		}
-		out, err := jvm.ThreadDump(p.PID, nil)
+		out, err := runThreadDump(p.PID, nil)
 		if err != nil {
 			return nil, fmt.Errorf("thread dump pid %d: %w", p.PID, err)
 		}
-		return map[string]any{"pid": p.PID, "output": string(out)}, nil
+		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+			Kind:        artifact.KindThreadDump,
+			Sensitivity: artifact.SensitivityMediumHigh,
+			Source:      "daemon-rpc",
+			Command:     "jvm.thread_dump",
+			CacheKind:   cache.KindThreads,
+			PID:         p.PID,
+			SizeBytes:   int64(len(out)),
+		}, map[string]any{"pid": p.PID, "output": string(out)}), nil
 	}
 	d.Register("jvm.thread_dump", jvmThreadDump)
 	d.Register("jvm.threadDump", jvmThreadDump)
@@ -970,7 +990,17 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		}); err != nil {
 			return nil, fmt.Errorf("flamegraph pid %d: %w", p.PID, err)
 		}
-		return map[string]any{"pid": p.PID, "dest": p.Dest}, nil
+		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+			Kind:        artifact.KindFlamegraph,
+			Sensitivity: artifact.SensitivityMediumHigh,
+			Source:      "daemon-rpc",
+			Command:     "jvm.flamegraph",
+			Path:        p.Dest,
+			PID:         p.PID,
+			Metadata: map[string]string{
+				"event": p.Event,
+			},
+		}, map[string]any{"pid": p.PID, "dest": p.Dest}), nil
 	})
 
 	// jvm.jfr.start — start a JFR recording on a JVM process.
@@ -1017,7 +1047,18 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err := runJFRDump(p.PID, name, p.Dest, nil); err != nil {
 			return nil, fmt.Errorf("jfr dump pid %d: %w", p.PID, err)
 		}
-		return map[string]any{"pid": p.PID, "name": name, "dest": p.Dest, "dumped": true}, nil
+		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+			Kind:        artifact.KindJFRRecording,
+			Sensitivity: artifact.SensitivityMediumHigh,
+			Source:      "daemon-rpc",
+			Command:     "jvm.jfr.dump",
+			Path:        p.Dest,
+			CacheKind:   cache.KindJFR,
+			PID:         p.PID,
+			Metadata: map[string]string{
+				"name": name,
+			},
+		}, map[string]any{"pid": p.PID, "name": name, "dest": p.Dest, "dumped": true}), nil
 	})
 
 	// jvm.jfr.stop — stop a JFR recording. Optional: {"dest": "/path/to/out.jfr"}.
@@ -1037,7 +1078,22 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err := jvm.JFRStop(p.PID, name, p.Dest, nil); err != nil {
 			return nil, fmt.Errorf("jfr stop pid %d: %w", p.PID, err)
 		}
-		return map[string]any{"pid": p.PID, "name": name, "dest": p.Dest, "stopped": true}, nil
+		result := map[string]any{"pid": p.PID, "name": name, "dest": p.Dest, "stopped": true}
+		if p.Dest == "" {
+			return result, nil
+		}
+		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+			Kind:        artifact.KindJFRRecording,
+			Sensitivity: artifact.SensitivityMediumHigh,
+			Source:      "daemon-rpc",
+			Command:     "jvm.jfr.stop",
+			Path:        p.Dest,
+			CacheKind:   cache.KindJFR,
+			PID:         p.PID,
+			Metadata: map[string]string{
+				"name": name,
+			},
+		}, result), nil
 	})
 
 	// jvm.jfr.summary — run `jfr summary <path>` and return parsed event counts.
@@ -1088,10 +1144,18 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if p.Dest == "" {
 			p.Dest = fmt.Sprintf("/tmp/spectra-heap-%d.hprof", p.PID)
 		}
-		if err := jvm.HeapDump(p.PID, p.Dest, nil); err != nil {
+		if err := runHeapDump(p.PID, p.Dest, nil); err != nil {
 			return nil, fmt.Errorf("heap dump pid %d: %w", p.PID, err)
 		}
-		return map[string]any{"pid": p.PID, "dest": p.Dest}, nil
+		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+			Kind:        artifact.KindHeapDump,
+			Sensitivity: artifact.SensitivityVeryHigh,
+			Source:      "daemon-rpc",
+			Command:     "jvm.heap_dump",
+			Path:        p.Dest,
+			CacheKind:   cache.KindHprof,
+			PID:         p.PID,
+		}, map[string]any{"pid": p.PID, "dest": p.Dest}), nil
 	}
 	d.Register("jvm.heap_dump", jvmHeapDump)
 	d.Register("jvm.heapDump", jvmHeapDump)
@@ -1226,7 +1290,19 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err != nil {
 			return nil, fmt.Errorf("sample pid %d: %w", p.PID, err)
 		}
-		return map[string]any{"pid": p.PID, "output": string(out)}, nil
+		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+			Kind:        artifact.KindProcessSample,
+			Sensitivity: artifact.SensitivityMedium,
+			Source:      "daemon-rpc",
+			Command:     "process.sample",
+			CacheKind:   cache.KindSamples,
+			PID:         p.PID,
+			SizeBytes:   int64(len(out)),
+			Metadata: map[string]string{
+				"duration": fmt.Sprint(p.Duration),
+				"interval": fmt.Sprint(p.Interval),
+			},
+		}, map[string]any{"pid": p.PID, "output": string(out)}), nil
 	})
 
 	// power.state — battery level, thermal pressure, assertions, and top energy users.
@@ -1373,7 +1449,23 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			}
 			return nil, err
 		}
-		return result, nil
+		out, _ := result["output_path"].(string)
+		handle, _ := result["handle"].(string)
+		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+			Kind:        artifact.KindPacketCapture,
+			Sensitivity: artifact.SensitivityHigh,
+			Source:      "daemon-rpc",
+			Command:     "helper.net_capture.start",
+			Path:        out,
+			CacheKind:   cache.KindNetcap,
+			Metadata: map[string]string{
+				"handle":    handle,
+				"interface": p.Interface,
+				"proto":     p.Proto,
+				"host":      p.Host,
+				"port":      fmt.Sprint(p.Port),
+			},
+		}, result), nil
 	})
 
 	d.Register("helper.net_capture.stop", func(params json.RawMessage) (any, error) {
@@ -1390,7 +1482,18 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			}
 			return nil, err
 		}
-		return result, nil
+		out, _ := result["output_path"].(string)
+		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+			Kind:        artifact.KindPacketCapture,
+			Sensitivity: artifact.SensitivityHigh,
+			Source:      "daemon-rpc",
+			Command:     "helper.net_capture.stop",
+			Path:        out,
+			CacheKind:   cache.KindNetcap,
+			Metadata: map[string]string{
+				"handle": p.Handle,
+			},
+		}, result), nil
 	})
 
 	d.Register("helper.tcc.system.query", func(params json.RawMessage) (any, error) {
@@ -1412,6 +1515,23 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		}
 		return result, nil
 	})
+}
+
+func recordArtifact(ctx context.Context, recorder artifact.Recorder, rec artifact.Record, result map[string]any) map[string]any {
+	if result == nil {
+		result = map[string]any{}
+	}
+	if recorder == nil {
+		return result
+	}
+	stored, err := recorder.Record(ctx, rec)
+	if err != nil {
+		result["artifact_error"] = err.Error()
+		return result
+	}
+	result["artifact_id"] = stored.ID
+	result["artifact_kind"] = stored.Kind
+	return result
 }
 
 func daemonJVMOptions() jvm.CollectOptions {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/logger"
@@ -76,7 +77,7 @@ func testDaemonWithDB(t *testing.T) (*json.Encoder, *json.Decoder, *store.DB, co
 		collectToolchains = origCollectToolchains
 		collectJDKs = origCollectJDKs
 	})
-	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default, nil, nil, nil)
+	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default, nil, &artifact.FakeRecorder{}, nil, nil)
 
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -1215,6 +1216,51 @@ func TestDaemonJVMHeapDumpRequiresSensitiveConfirmation(t *testing.T) {
 	resp := rpcCall(t, enc, dec, 152, "jvm.heap_dump", `{"pid":42}`)
 	if resp.Error == nil {
 		t.Error("expected error when confirm_sensitive is missing")
+	}
+}
+
+func TestDaemonJVMHeapDumpRecordsArtifact(t *testing.T) {
+	orig := runHeapDump
+	var gotPID int
+	var gotDest string
+	runHeapDump = func(pid int, dest string, _ jvm.CmdRunner) error {
+		gotPID = pid
+		gotDest = dest
+		return os.WriteFile(dest, []byte("heap"), 0o600)
+	}
+	t.Cleanup(func() { runHeapDump = orig })
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	fake := &artifact.FakeRecorder{}
+	d := rpc.NewDispatcher()
+	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default, nil, fake, nil, nil)
+	client, server := net.Pipe()
+	defer client.Close()
+	go d.Serve(server)
+	enc := json.NewEncoder(client)
+	dec := json.NewDecoder(client)
+
+	dest := filepath.Join(t.TempDir(), "heap.hprof")
+	resp := rpcCall(t, enc, dec, 1, "jvm.heap_dump", `{"pid":42,"dest":"`+dest+`","confirm_sensitive":true}`)
+	if resp.Error != nil {
+		t.Fatalf("jvm.heap_dump: %v", resp.Error)
+	}
+	if gotPID != 42 || gotDest != dest {
+		t.Fatalf("heap dump args = (%d, %q), want (42, %q)", gotPID, gotDest, dest)
+	}
+	records := fake.Snapshot()
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	if records[0].Kind != artifact.KindHeapDump || records[0].Sensitivity != artifact.SensitivityVeryHigh {
+		t.Fatalf("record = %#v", records[0])
+	}
+	if records[0].Path != dest || records[0].PID != 42 || records[0].CacheKind != cache.KindHprof {
+		t.Fatalf("record target = %#v", records[0])
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Daemon (planned): operations/daemon.md
       - Remote (planned): operations/remote.md
       - Caching (planned): operations/caching.md
+      - Artifact lifecycle: operations/artifacts.md
   - Reference:
       - Result schema: reference/result-schema.md
       - Glossary: reference/glossary.md


### PR DESCRIPTION
## Summary

Adds a first-pass artifact lifecycle implementation for sensitive diagnostic outputs. The new `internal/artifact` package defines the record model, recorder/store interfaces, a JSON manifest store backed by atomic writes, and a fake recorder for unit tests.

The CLI and daemon now record metadata for heap dumps, JFR recordings, thread dumps, process samples, flamegraphs, and packet captures without copying artifact contents into the manifest. The manifest lives at `~/.spectra/artifacts.json` by default.

Also adds the user-facing artifact lifecycle operations doc and links it from caching, the threat model, the glossary, and MkDocs navigation.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
