### PR TITLE
Correct docs for implemented Spectra features

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,20 +39,22 @@ also extracts every URL host referenced in the binary and `app.asar`.
 
 ## Status
 
-Today: a single-binary CLI that does deep, single-host static inspection
-of `.app` bundles. 17 tests, ~10s to scan all 100 apps in `/Applications`.
+Today: a Go CLI plus optional daemon and privileged helper. Spectra does
+deep `.app` inspection, live process/network/storage/power inventory,
+JVM and toolchain diagnostics, SQLite-backed snapshots and diffs,
+recommendation rules, issue tracking, JSON-RPC over Unix socket or
+explicit TCP, and optional Tailscale `tsnet` daemon exposure.
 
-Heading toward: a daemon-with-clients architecture that exposes the same
-inspection over JSON-RPC, talks to peers over Tailscale via `tsnet`,
-adds VisualVM-class JVM introspection, and runs a CEL-based
-recommendations engine over snapshots stored in SQLite.
+Implemented code with passing tests is treated as complete in the docs.
+Code whose tests are failing or absent is documented as partial until the
+test suite catches up.
 
 ## Documentation
 
 Full living docs at [`docs/`](docs/index.md):
 
 - [Quickstart](docs/quickstart.md) — common commands and outputs
-- [Architecture](docs/design/architecture.md) — where this is heading
+- [Architecture](docs/design/architecture.md) — daemon, helper, and clients
 - [Distribution](docs/design/distribution.md) — why MAS is out, why Homebrew
 - [Storage stack](docs/design/storage.md) — SQLite + sharded blob store
 - [Detection model](docs/detection/overview.md) — the three-layer classifier

--- a/docs/design/remote-portal.md
+++ b/docs/design/remote-portal.md
@@ -44,19 +44,21 @@ Three options, ranked by simplicity:
    time, client stores it. More work, but works off-tailnet too.
 3. **mTLS via Tailscale-issued certs.** Cleanest but more code.
 
-V1 will be Tailscale-ACL-only.
+The implemented `tsnet` mode uses Tailscale identity and ACLs, with
+optional Spectra-side allowlists for login names and node names. Per-host
+tokens remain future work for non-Tailscale remote exposure.
 
 ## The killer feature: cross-host correlation
 
 Once each Mac is running the daemon, queries can fan out. Explicit-host
-fan-out is implemented today; tailnet discovery is the planned next step:
+fan-out and Tailscale daemon probing are implemented:
 
 ```bash
 spectra fan --hosts laptop,work-mac inspect /Applications/Slack.app
 # both daemons inspect Slack and return one JSON envelope
 ```
 
-The intended discovered-host workflow remains:
+The broader grouped-inventory workflow remains planned:
 
 ```bash
 spectra list --all-hosts
@@ -74,23 +76,18 @@ spectra diff laptop work-mac
 Activity Monitor cannot tell either of those stories because it's
 per-machine by construction.
 
-## Open architecture questions
+## Architecture decisions
 
-These will get pinned down before the first daemon commit:
-
-1. **Authentication model.** Pure Tailscale ACL is leaning, but per-host
-   tokens may be needed for non-Tailscale SSH usage.
-2. **On-demand vs always-on collection.** If `spectra connect host` only
-   spins up data collection when a client connects, idle cost is ~zero.
-   If the daemon keeps a ring buffer of the last hour, scrollback and
-   replay become possible. The latter requires real persistence —
-   already covered by [storage.md](storage.md).
-3. **What runs where.** Does the daemon do all analysis (binary
-   scanning, rules engine evaluation), or does it stream raw observations
-   and the client computes? Daemon-side keeps clients dumb and lets
-   results cache across multiple connecting clients. Almost certainly
-   daemon-side, lazy, with a small in-memory LRU of recent `Detect()`
-   results.
+1. **Authentication model.** Tailscale ACLs are the primary remote access
+   control in `tsnet` mode, with optional `WhoIs`-based allowlists. Explicit
+   TCP still relies on the trusted network path.
+2. **On-demand plus ring-buffer collection.** Most collectors run on demand
+   for RPC calls. The daemon also keeps a short process metrics ring buffer
+   and writes aggregate history to SQLite, as covered by
+   [storage.md](storage.md).
+3. **Daemon-side analysis.** Binary scanning, snapshot creation, rules
+   evaluation, issue persistence, and helper mediation happen daemon-side.
+   Clients render typed responses or call raw JSON-RPC methods.
 4. **Privileged helper coupling.** The unprivileged daemon talks to the
    privileged helper over a local Unix socket when it needs root-only
    data. The remote client never talks to the helper directly — the
@@ -108,12 +105,16 @@ These will get pinned down before the first daemon commit:
    network path.**
 4. Add explicit-host `spectra fan --hosts ...` fan-out over the typed
    connect surface. **Implemented.**
-5. Add stored `spectra hosts` listing for machines seen through snapshots.
-   **Implemented; live daemon discovery is still planned.**
+5. Add stored `spectra hosts` listing for machines seen through snapshots
+   plus Tailscale daemon probing through `--discover-daemons`.
+   **Implemented.**
 6. Add `tsnet` integration. Daemon becomes a tailnet node. **Implemented.**
 7. TUI client. Bubble Tea, talks to local-or-remote daemon identically.
+   **Planned.**
 8. Privileged helper as `spectra install-helper` subcommand. Same binary
    ships the helper; SMAppService-registered LaunchDaemon.
+   **Implemented.**
 9. Ring buffer + history for replay (requires SQLite from
    [storage.md](storage.md)).
-10. Native GUI after the TUI proves the data model.
+   **Implemented for process metrics.**
+10. Native GUI after the TUI proves the data model. **Planned.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,8 @@ TCP daemon. See
 [detection/overview.md](detection/overview.md) for the framework detection
 model, [inspection/metadata.md](inspection/metadata.md) for what we
 extract from each bundle, and
-[design/architecture.md](design/architecture.md) for where this is heading.
+[design/architecture.md](design/architecture.md) for the daemon, helper,
+and client model.
 
 ```
 ./spectra /Applications/Slack.app           # one app, terse table
@@ -41,21 +42,23 @@ extract from each bundle, and
 ./spectra connect 127.0.0.1:7878            # health check over RPC
 ```
 
-## What's Planned
+## Implemented And Planned
 
-- **tsnet remote portal** — `spectra connect work-mac` from your laptop to
-  inspect a teammate's machine over the tailnet without manually exposing a
-  TCP listener. See
+- **tsnet remote portal** — `spectra serve --tsnet` exposes a managed
+  tailnet daemon, and `spectra connect work-mac` can inspect it through
+  MagicDNS without manually exposing a TCP listener. See
   [design/remote-portal.md](design/remote-portal.md).
 - **Remote fan-out** — `spectra fan --hosts ...` runs one typed remote
   call across multiple explicit daemon targets; `spectra hosts` lists
-  locally known hosts from snapshots while automatic discovery is still
-  planned.
+  locally known hosts from snapshots and `--discover-daemons` probes
+  reachable Spectra daemons discovered through Tailscale.
 - **TUI client** — Bubble Tea UI against the same local-or-remote daemon
   RPC surface.
 - **Release packaging** — the user LaunchAgent installer exists;
   Homebrew formula, prebuilt binaries, signing, and notarization are
-  still planned.
+  still planned. See [operations/daemon.md](operations/daemon.md) and
+  [operations/remote.md](operations/remote.md) for implemented service
+  and remote operation details.
 
 ## Distribution
 

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -236,7 +236,7 @@ beyond JMX-over-RMI port forwarding. Spectra's JVM subsystem is
 purpose-built for the workflow that exists today:
 
 - **Remote-by-default.** Same `spectra connect work-mac` portal as the
-  rest of Spectra once the remote portal lands
+  rest of Spectra over explicit TCP or managed `tsnet`
   ([../design/remote-portal.md](../design/remote-portal.md)).
 - **Persistent.** Thread dumps and JFR recordings can be stored in the blob
   cache; heap dumps are written as explicit `.hprof` artifacts.

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -69,8 +69,9 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
 `nettop`, and `/etc/hosts`. `lsof` is also where current socket owner
 attribution comes from; its visibility is limited to what the invoking user can
-see unless a future helper-backed collector is used. Raw packet capture is
-reserved for explicit future live workflows.
+see unless the privileged helper is installed and the caller uses a
+helper-backed collector. Raw packet capture is reserved for explicit live
+capture workflows.
 
 `internal/netproto` contains protocol parsers that capture collectors use to
 summarize packet metadata without storing request or response bodies. The

--- a/docs/operations/caching.md
+++ b/docs/operations/caching.md
@@ -46,7 +46,7 @@ The cache layout follows the patterns proven out in
 | `jfr` | content hash of recording | Java Flight Recorder file |
 | `threads` | hash of `(pid, timestamp)` | Thread dump text |
 | `samples` | hash of `(pid, timestamp)` | `sample <pid>` output |
-| `netcap` | hash of capture metadata | Future: pcap recordings |
+| `netcap` | hash of capture metadata | pcap recordings and summaries |
 
 ## Eviction
 
@@ -65,10 +65,12 @@ these commands automatically without touching CLI code.
 
 ## Async writer
 
-Cache writes don't block the collector. A bounded queue (workers +
-queueSize) flushes blobs in the background; if the queue is full, the
-caller falls back to a synchronous write rather than dropping data.
-Counters track queued / completed / failed / bytes.
+Cache writes normally don't block the collector. A bounded queue
+(workers + queueSize) flushes blobs in the background; if the queue is
+full, the caller falls back to a synchronous write rather than dropping
+data. Callers can also choose synchronous writes when the artifact must
+exist before the operation returns. Counters track queued / completed /
+failed / bytes.
 
 The async writer is implemented in `internal/cache/async_writer.go`.
 Callers can still write synchronously when they need the artifact to be

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -205,8 +205,8 @@ type PythonApp struct {
 ## Stability
 
 Field names and JSON tag shape are intended to be stable. Adding new
-fields is non-breaking; renaming fields will go through a deprecation
-window in the daemon RPC schema once that lands.
+fields is non-breaking; renaming fields should go through a deprecation
+window in the implemented daemon RPC schema.
 
 ## See also
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,8 +94,8 @@ nav:
       - Power and thermal: inspection/power-thermal.md
       - Python-based apps: inspection/python-apps.md
       - Rust-based apps: inspection/rust-based-apps.md
-      - Toolchains (planned): inspection/toolchains.md
-      - JVM (planned): inspection/jvm.md
+      - Toolchains: inspection/toolchains.md
+      - JVM: inspection/jvm.md
       - Live data sources: inspection/live-data-sources.md
   - Playbooks:
       - Overview: playbooks/index.md
@@ -108,10 +108,10 @@ nav:
       - CLI: operations/cli.md
       - Issues: operations/issues.md
       - Install services: operations/install-services.md
-      - Daemon (planned): operations/daemon.md
-      - Remote (planned): operations/remote.md
+      - Daemon: operations/daemon.md
+      - Remote: operations/remote.md
       - Snapshots and hosts: operations/snapshots-and-hosts.md
-      - Caching (planned): operations/caching.md
+      - Caching: operations/caching.md
       - Artifact lifecycle: operations/artifacts.md
   - Reference:
       - Result schema: reference/result-schema.md


### PR DESCRIPTION
## Summary
- remove stale planned labels for implemented JVM, toolchain, daemon, remote, and cache docs
- update README and home docs to match current daemon/helper/tsnet/snapshot/rules capabilities
- align remote portal, JVM, live source, cache, and schema language with implemented behavior

## Validation
- make docs-validate
- go build ./... && go vet ./...
- go test ./... -count=1