### PR TITLE
[codex] Harden helper signing release path

### DIFF
--- a/cmd/spectra/helper.go
+++ b/cmd/spectra/helper.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/kaeawc/spectra/internal/helperclient"
 )
@@ -56,6 +58,7 @@ type helperInstallDeps struct {
 	executable func() (string, error)
 	stat       func(string) (os.FileInfo, error)
 	getenv     func(string) string
+	runCheck   commandRunner
 	runRoot    rootRunner
 	writeTemp  tempTextWriter
 	client     func() helperStatusClient
@@ -64,18 +67,24 @@ type helperInstallDeps struct {
 func runInstallHelper(args []string) int {
 	fs := flag.NewFlagSet("spectra install-helper", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
+	requireSigned := fs.Bool("require-signed", false, "require spectra-helper to carry a valid Developer ID signature before installing")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	if err := installHelper(defaultHelperInstallDeps()); err != nil {
+	opts := helperInstallOptions{RequireSigned: *requireSigned}
+	if err := installHelper(defaultHelperInstallDeps(), opts); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
 	return 0
 }
 
-func installHelper(deps helperInstallDeps) error {
+type helperInstallOptions struct {
+	RequireSigned bool
+}
+
+func installHelper(deps helperInstallDeps, opts helperInstallOptions) error {
 	// Find the spectra-helper binary next to the running spectra binary.
 	self, err := deps.executable()
 	if err != nil {
@@ -84,6 +93,11 @@ func installHelper(deps helperInstallDeps) error {
 	helperSrc := filepath.Join(filepath.Dir(self), "spectra-helper")
 	if _, err := deps.stat(helperSrc); err != nil {
 		return fmt.Errorf("install-helper: spectra-helper binary not found at %s\nBuild it with: go build ./cmd/spectra-helper", helperSrc)
+	}
+	if opts.RequireSigned || truthyEnv(deps.getenv("SPECTRA_REQUIRE_SIGNED_HELPER")) {
+		if err := verifyHelperSignature(helperSrc, deps.runCheck); err != nil {
+			return err
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "This requires administrator privilege. You may be prompted for your password.\n\n")
@@ -144,6 +158,30 @@ func installHelper(deps helperInstallDeps) error {
 	fmt.Println()
 	fmt.Println("Verify with: spectra install-helper --status")
 	return nil
+}
+
+func verifyHelperSignature(path string, run commandRunner) error {
+	if run == nil {
+		run = runCommand
+	}
+	if out, err := run("codesign", "-dv", "--verbose=4", path); err != nil {
+		return fmt.Errorf("install-helper: %s is not signed with a verifiable Developer ID signature: %w\n%s", path, err, strings.TrimSpace(out))
+	} else if !strings.Contains(out, "Authority=Developer ID Application:") {
+		return fmt.Errorf("install-helper: %s is signed, but not with a Developer ID Application certificate", path)
+	}
+	if out, err := run("codesign", "--verify", "--strict", "--verbose=2", path); err != nil {
+		return fmt.Errorf("install-helper: %s failed strict code-signature verification: %w\n%s", path, err, strings.TrimSpace(out))
+	}
+	return nil
+}
+
+func truthyEnv(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "t", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func ensureHelperGroup(run rootRunner) error {
@@ -275,12 +313,25 @@ func defaultHelperInstallDeps() helperInstallDeps {
 		executable: os.Executable,
 		stat:       os.Stat,
 		getenv:     os.Getenv,
+		runCheck:   runCommand,
 		runRoot:    sudoRun,
 		writeTemp:  writeTempText,
 		client: func() helperStatusClient {
 			return helperclient.New()
 		},
 	}
+}
+
+type commandRunner func(name string, args ...string) (string, error)
+
+func runCommand(name string, args ...string) (string, error) {
+	// #nosec G204 -- command names are fixed at call sites.
+	cmd := exec.Command(name, args...)
+	var combined bytes.Buffer
+	cmd.Stdout = &combined
+	cmd.Stderr = &combined
+	err := cmd.Run()
+	return combined.String(), err
 }
 
 func sudoRun(name string, args ...string) error {

--- a/cmd/spectra/helper_test.go
+++ b/cmd/spectra/helper_test.go
@@ -71,7 +71,7 @@ func TestInstallRootTextFileCopiesTemporaryContent(t *testing.T) {
 func TestInstallHelperRunsExpectedRootOperations(t *testing.T) {
 	fake := newFakeHelperInstallDeps(t)
 	fake.env["SUDO_USER"] = "alice"
-	if err := installHelper(fake.deps()); err != nil {
+	if err := installHelper(fake.deps(), helperInstallOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -102,7 +102,7 @@ func TestInstallHelperRunsExpectedRootOperations(t *testing.T) {
 func TestInstallHelperCreatesMissingGroup(t *testing.T) {
 	fake := newFakeHelperInstallDeps(t)
 	fake.runErrs["dseditgroup\x00-o\x00read\x00"+helperGroup] = errors.New("no group")
-	if err := installHelper(fake.deps()); err != nil {
+	if err := installHelper(fake.deps(), helperInstallOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	wantPrefix := [][]string{
@@ -117,7 +117,7 @@ func TestInstallHelperCreatesMissingGroup(t *testing.T) {
 func TestInstallHelperSkipsRootUserGroupEdit(t *testing.T) {
 	fake := newFakeHelperInstallDeps(t)
 	fake.env["SUDO_USER"] = "root"
-	if err := installHelper(fake.deps()); err != nil {
+	if err := installHelper(fake.deps(), helperInstallOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	for _, run := range fake.runs {
@@ -130,7 +130,7 @@ func TestInstallHelperSkipsRootUserGroupEdit(t *testing.T) {
 func TestInstallHelperReportsMissingHelperBinary(t *testing.T) {
 	fake := newFakeHelperInstallDeps(t)
 	fake.statErr = os.ErrNotExist
-	err := installHelper(fake.deps())
+	err := installHelper(fake.deps(), helperInstallOptions{})
 	if err == nil {
 		t.Fatal("installHelper succeeded with missing helper binary")
 	}
@@ -155,6 +155,48 @@ func TestUninstallHelperRunsExpectedRootOperations(t *testing.T) {
 	}
 	if !reflect.DeepEqual(fake.runs, wantRuns) {
 		t.Fatalf("runs = %v, want %v", fake.runs, wantRuns)
+	}
+}
+
+func TestInstallHelperCanRequireDeveloperIDSignature(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.checkOut["codesign\x00-dv\x00--verbose=4\x00"+fake.helperSrc()] = "Authority=Developer ID Application: Example, Inc. (ABCDE12345)\n"
+	if err := installHelper(fake.deps(), helperInstallOptions{RequireSigned: true}); err != nil {
+		t.Fatal(err)
+	}
+	wantChecks := [][]string{
+		{"codesign", "-dv", "--verbose=4", fake.helperSrc()},
+		{"codesign", "--verify", "--strict", "--verbose=2", fake.helperSrc()},
+	}
+	if !reflect.DeepEqual(fake.checks, wantChecks) {
+		t.Fatalf("checks = %v, want %v", fake.checks, wantChecks)
+	}
+}
+
+func TestInstallHelperRejectsNonDeveloperIDSignature(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.checkOut["codesign\x00-dv\x00--verbose=4\x00"+fake.helperSrc()] = "Authority=Apple Development: Example\n"
+	err := installHelper(fake.deps(), helperInstallOptions{RequireSigned: true})
+	if err == nil {
+		t.Fatal("installHelper accepted non-Developer ID signature")
+	}
+	if !strings.Contains(err.Error(), "not with a Developer ID Application certificate") {
+		t.Fatalf("error = %v", err)
+	}
+	if len(fake.runs) != 0 {
+		t.Fatalf("runs = %v, want none", fake.runs)
+	}
+}
+
+func TestInstallHelperRequireSignedEnv(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.env["SPECTRA_REQUIRE_SIGNED_HELPER"] = "true"
+	fake.checkOut["codesign\x00-dv\x00--verbose=4\x00"+fake.helperSrc()] = "Authority=Developer ID Application: Example, Inc. (ABCDE12345)\n"
+	if err := installHelper(fake.deps(), helperInstallOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.checks) != 2 {
+		t.Fatalf("checks = %v, want codesign checks", fake.checks)
 	}
 }
 
@@ -189,6 +231,19 @@ func TestSudoCommandAllowedCoversHelperManagementCommands(t *testing.T) {
 	}
 }
 
+func TestTruthyEnv(t *testing.T) {
+	for _, v := range []string{"1", "true", "TRUE", "yes", "on"} {
+		if !truthyEnv(v) {
+			t.Fatalf("truthyEnv(%q) = false", v)
+		}
+	}
+	for _, v := range []string{"", "0", "false", "no", "off"} {
+		if truthyEnv(v) {
+			t.Fatalf("truthyEnv(%q) = true", v)
+		}
+	}
+}
+
 func TestSudoRunRejectsNonAllowlistedCommand(t *testing.T) {
 	err := sudoRun("sh", "-c", "echo should-not-run")
 	if err == nil {
@@ -204,6 +259,9 @@ type fakeHelperInstallDeps struct {
 	env            map[string]string
 	runs           [][]string
 	runErrs        map[string]error
+	checks         [][]string
+	checkOut       map[string]string
+	checkErrs      map[string]error
 	statErr        error
 	tempContents   []string
 	cleanups       int
@@ -216,8 +274,14 @@ func newFakeHelperInstallDeps(t *testing.T) *fakeHelperInstallDeps {
 		executablePath: filepath.Join(t.TempDir(), "spectra"),
 		env:            map[string]string{"USER": "alice"},
 		runErrs:        map[string]error{},
+		checkOut:       map[string]string{},
+		checkErrs:      map[string]error{},
 		statusClient:   &fakeHelperStatusClient{},
 	}
+}
+
+func (f *fakeHelperInstallDeps) helperSrc() string {
+	return filepath.Join(filepath.Dir(f.executablePath), "spectra-helper")
 }
 
 func (f *fakeHelperInstallDeps) deps() helperInstallDeps {
@@ -233,6 +297,12 @@ func (f *fakeHelperInstallDeps) deps() helperInstallDeps {
 		},
 		getenv: func(key string) string {
 			return f.env[key]
+		},
+		runCheck: func(name string, args ...string) (string, error) {
+			call := append([]string{name}, args...)
+			f.checks = append(f.checks, slices.Clone(call))
+			key := strings.Join(call, "\x00")
+			return f.checkOut[key], f.checkErrs[key]
 		},
 		runRoot: func(name string, args ...string) error {
 			call := append([]string{name}, args...)

--- a/docs/design/distribution.md
+++ b/docs/design/distribution.md
@@ -72,11 +72,34 @@ honest while the product surface is still changing quickly:
   `/Library/PrivilegedHelperTools/spectra-helper`, writes
   `/Library/LaunchDaemons/dev.spectra.helper.plist`, and loads it with
   `launchctl`.
+- Signed releases can require Developer ID helper verification with
+  `sudo spectra install-helper --require-signed` or
+  `SPECTRA_REQUIRE_SIGNED_HELPER=1`.
 - `spectra install-helper uninstall` unloads the LaunchDaemon and removes
   the installed helper files.
 
 This is intentionally less polished than a signed release package, but it
 matches the implemented code path and keeps root installation explicit.
+
+## Signed release path
+
+`make release-check` remains usable for source-build readiness without Apple
+credentials. When `SPECTRA_SIGN_IDENTITY` is set, it signs `spectra` and
+`spectra-helper` with hardened runtime and verifies the helper's Developer ID
+chain. When notary credentials are also present, it submits the signed binaries
+to Apple notarization:
+
+```bash
+SPECTRA_SIGN_IDENTITY="Developer ID Application: Example, Inc. (TEAMID)" \
+SPECTRA_NOTARY_KEYCHAIN_PROFILE=spectra-notary \
+make release-check
+```
+
+The notary step can also use `SPECTRA_NOTARY_APPLE_ID`,
+`SPECTRA_NOTARY_TEAM_ID`, and `SPECTRA_NOTARY_PASSWORD`. This does not replace
+the current shell installer with `SMAppService.daemon` yet, but it gives the
+release process the signed helper identity that `SMAppService` or
+`SMJobBless` registration will require.
 
 ## Why Homebrew is still the planned primary channel
 
@@ -121,8 +144,10 @@ sudo spectra install-helper
 The current installer uses a LaunchDaemon plist and root-owned helper
 binary. Future signed packaging can move this to `SMAppService.daemon`
 or `SMJobBless` once Spectra has release signing, notarization, and
-helper identity verification in place. The unprivileged CLI/daemon talks
-to the helper over a local Unix socket when it needs root-only data.
+helper identity verification in place. Signed release installs should pass
+`--require-signed` so unsigned or locally ad-hoc helpers are rejected before
+root-owned files are touched. The unprivileged CLI/daemon talks to the helper
+over a local Unix socket when it needs root-only data.
 Users who don't install the helper still get every capability that
 doesn't strictly require root, which is the overwhelming majority of what
 Spectra extracts today.

--- a/docs/design/privileged-helper.md
+++ b/docs/design/privileged-helper.md
@@ -47,8 +47,22 @@ What this does:
 4. Prompts the user to grant Full Disk Access to the helper in System
    Settings → Privacy & Security → Full Disk Access.
 
-`SMAppService.daemon` / `SMJobBless` packaging is future distribution work.
-The current installer is intentionally explicit and shell-based.
+Source builds install unsigned helpers by default. Release builds can require
+Developer ID verification before any privileged copy happens:
+
+```bash
+sudo spectra install-helper --require-signed
+```
+
+The same policy can be enforced non-interactively with
+`SPECTRA_REQUIRE_SIGNED_HELPER=1`. The installer verifies that the helper is
+signed by a Developer ID Application certificate and passes strict
+`codesign --verify` before it creates or modifies any root-owned files.
+
+`SMAppService.daemon` / `SMJobBless` packaging is still future distribution
+work. The current installer remains intentionally explicit and shell-based,
+but the release path now has the signature verification needed before moving
+to signed registration.
 
 ```bash
 sudo spectra uninstall-helper
@@ -192,11 +206,25 @@ rotations and rolls the helper audit log after it reaches 1 MiB.
 
 ## Code signing and notarization
 
-- Release builds should sign the helper with the same Developer ID as
-  the main binary, hardened runtime enabled.
-- Future `SMAppService.daemon` registration should verify the embedded
-  helper's code-signing requirements before loading.
-- Notarization should staple both binaries for end-user distribution.
+Release builds should run:
+
+```bash
+SPECTRA_SIGN_IDENTITY="Developer ID Application: Example, Inc. (TEAMID)" \
+SPECTRA_NOTARY_KEYCHAIN_PROFILE=spectra-notary \
+make release-check
+```
+
+`scripts/release-check.sh` builds both binaries, signs them with hardened
+runtime (`--options runtime --timestamp`), verifies the helper's Developer ID
+chain, and submits a zip to Apple notarization when notary credentials are
+present. The script also accepts direct notary credentials through
+`SPECTRA_NOTARY_APPLE_ID`, `SPECTRA_NOTARY_TEAM_ID`, and
+`SPECTRA_NOTARY_PASSWORD`.
+
+Future `SMAppService.daemon` registration should embed the helper in a signed
+app-style release artifact and register it only after checking the helper
+requirement against the same Team ID. Older macOS support can use the same
+signed helper identity with an `SMJobBless` fallback.
 
 ## Why not a System Extension instead
 

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -6,9 +6,11 @@ set -euo pipefail
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
+YELLOW='\033[0;33m'
 NC='\033[0m'
 PASS=0
 FAIL=0
+SKIP=0
 
 check() {
     local name="$1"
@@ -23,12 +25,70 @@ check() {
     fi
 }
 
+skip() {
+    local name="$1"
+    echo -n "  $name... "
+    echo -e "${YELLOW}SKIP${NC}"
+    SKIP=$((SKIP + 1))
+}
+
+sign_binary() {
+    local path="$1"
+    codesign --force --timestamp --options runtime --sign "$SPECTRA_SIGN_IDENTITY" "$path"
+}
+
+notarize_archive() {
+    local archive="$1"
+    local submit_args=(notarytool submit "$archive" --wait)
+    if [ -n "${SPECTRA_NOTARY_KEYCHAIN_PROFILE:-}" ]; then
+        submit_args+=(--keychain-profile "$SPECTRA_NOTARY_KEYCHAIN_PROFILE")
+    else
+        submit_args+=(--apple-id "$SPECTRA_NOTARY_APPLE_ID" --team-id "$SPECTRA_NOTARY_TEAM_ID" --password "$SPECTRA_NOTARY_PASSWORD")
+    fi
+    xcrun "${submit_args[@]}"
+}
+
+create_notarization_zip() {
+    rm -rf spectra-notary
+    mkdir -p spectra-notary
+    cp spectra spectra-helper spectra-notary/
+    ditto -c -k --keepParent spectra-notary spectra-notary.zip
+}
+
+notary_configured() {
+    if [ -n "${SPECTRA_NOTARY_KEYCHAIN_PROFILE:-}" ]; then
+        return 0
+    fi
+    [ -n "${SPECTRA_NOTARY_APPLE_ID:-}" ] && [ -n "${SPECTRA_NOTARY_TEAM_ID:-}" ] && [ -n "${SPECTRA_NOTARY_PASSWORD:-}" ]
+}
+
 echo "=== Release Checklist ==="
 echo ""
 
 echo "Build:"
 check "spectra binary" go build -ldflags "-s -w" -o spectra ./cmd/spectra/
 check "spectra-helper binary" go build -ldflags "-s -w" -o spectra-helper ./cmd/spectra-helper/
+
+echo ""
+echo "Signing:"
+if [ -n "${SPECTRA_SIGN_IDENTITY:-}" ]; then
+    check "sign spectra" sign_binary spectra
+    check "sign spectra-helper" sign_binary spectra-helper
+    check "spectra signature valid" codesign --verify --strict --verbose=2 spectra
+    check "spectra-helper Developer ID signature" bash -c 'codesign -dv --verbose=4 spectra-helper 2>&1 | grep -q "Authority=Developer ID Application:"'
+    check "spectra-helper signature valid" codesign --verify --strict --verbose=2 spectra-helper
+else
+    skip "codesign binaries (set SPECTRA_SIGN_IDENTITY)"
+fi
+
+echo ""
+echo "Notarization:"
+if [ -n "${SPECTRA_SIGN_IDENTITY:-}" ] && notary_configured; then
+    check "create notarization zip" create_notarization_zip
+    check "submit notarization" notarize_archive spectra-notary.zip
+else
+    skip "notarize binaries (set signing + notary credentials)"
+fi
 
 echo ""
 echo "Quality:"
@@ -56,7 +116,7 @@ check "no untracked Go files" bash -c '[ -z "$(git ls-files --others --exclude-s
 
 echo ""
 echo "================================"
-echo -e "Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+echo -e "Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}, ${YELLOW}${SKIP} skipped${NC}"
 
 if [ "$FAIL" -gt 0 ]; then
     echo ""


### PR DESCRIPTION
## Summary
- add a strict signed-helper install gate via `--require-signed` and `SPECTRA_REQUIRE_SIGNED_HELPER=1`
- verify Developer ID Application signatures before privileged helper installation touches root-owned files
- extend release checks to optionally sign with hardened runtime and submit notarization when Apple credentials are configured
- update helper and distribution docs for the current signed path and remaining SMAppService/SMJobBless work

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `bash -n scripts/release-check.sh`
- `shellcheck scripts/release-check.sh` where available