### PR TITLE
[codex] Add distribution packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-mcp build-helper build-agent agent build-all test vet fmt lint complexity security licenses tidy ci clean all \
+.PHONY: build build-mcp build-helper build-agent agent build-all dist notarize test vet fmt lint complexity security licenses tidy ci clean all \
 	release-check validate-workflows \
 	docs-validate docs-nav docs-lychee docs-build docs-serve docs-install
 
@@ -29,6 +29,12 @@ build-agent:
 agent: build-agent
 
 build-all: build build-mcp build-helper
+
+dist:
+	bash scripts/dist.sh
+
+notarize:
+	bash scripts/notarize-archives.sh
 
 # --- Quality -----------------------------------------------------------------
 
@@ -88,6 +94,6 @@ docs-validate: docs-nav docs-lychee docs-build
 
 clean:
 	rm -f $(BIN) $(MCP_BIN) $(HELPER_BIN) junit-report.xml gosec-report.xml
-	rm -rf site/
+	rm -rf dist/ site/
 
 all: build vet test docs-validate

--- a/docs/design/distribution.md
+++ b/docs/design/distribution.md
@@ -3,8 +3,8 @@
 Each macOS distribution channel imposes a different ceiling on what
 Spectra can do. This page captures the analysis behind the current
 **source build + optional LaunchDaemon helper** distribution path, the
-planned Homebrew/prebuilt release channels, and why the Mac App Store is
-out of scope for the full product.
+release packaging now present in-tree, and why the Mac App Store is out
+of scope for the full product.
 
 Today the supported path is:
 
@@ -26,7 +26,7 @@ sudo ./spectra install-helper
 
 ## Capability vs channel matrix
 
-| Capability | MAS | Source build | Homebrew CLI (planned) | Prebuilt archive/cask (planned) |
+| Capability | MAS | Source build | Homebrew CLI | Prebuilt archive/cask |
 |---|---|---|---|---|
 | Static inspection of `/Applications` | partial | ✓ | ✓ | ✓ |
 | Read other users' app data | ✗ (sandbox) | ✓ | ✓ | ✓ |
@@ -78,7 +78,7 @@ honest while the product surface is still changing quickly:
 This is intentionally less polished than a signed release package, but it
 matches the implemented code path and keeps root installation explicit.
 
-## Why Homebrew is still the planned primary channel
+## Homebrew channel
 
 - Developer-shaped tools live there. Krit, Tailscale CLI, Datadog Agent,
   1Password CLI all use it.
@@ -86,17 +86,17 @@ matches the implemented code path and keeps root installation explicit.
   Users who want root-grade visibility opt in separately.
 - The same formula installs to every Mac in a tailnet — important for the
   cross-host remote portal.
-- Notarization is required only for the cask (.app) variant; the CLI
-  formula can build from source and dodge Gatekeeper.
+- Notarization is required only for prebuilt/cask artifacts; the CLI
+  formula builds from source.
 
 ```bash
-# Planned
 brew install kaeawc/tap/spectra
 ```
 
-The first Homebrew formula should build the unprivileged CLI and helper
-binary, but should not install or start the helper automatically.
-User-daemon lifecycle is available after install through:
+The formula template lives at `packaging/homebrew/spectra.rb`. It builds
+the unprivileged CLI, MCP server, and helper binary, but does not install
+or start the helper automatically. User-daemon lifecycle is available
+after install through:
 
 ```bash
 spectra install-daemon
@@ -107,6 +107,44 @@ Root visibility stays behind the same explicit command:
 ```bash
 sudo spectra install-helper
 ```
+
+Publishing the formula still requires a release tag, source archive
+checksum, and tap repository update.
+
+## Prebuilt archives
+
+Release archives are built by:
+
+```bash
+make dist
+```
+
+This produces arm64 and amd64 macOS tarballs plus SHA-256 checksums under
+`dist/`. The archives contain:
+
+- `bin/spectra`
+- `bin/spectra-mcp`
+- `bin/spectra-helper`
+- the JVM attach agent jar when present
+- the install and distribution docs needed by offline users
+
+Set `CODESIGN_ID` to sign binaries before they are archived:
+
+```bash
+CODESIGN_ID="Developer ID Application: Example Corp (TEAMID)" make dist
+```
+
+Signed archives can be submitted with:
+
+```bash
+NOTARY_PROFILE=spectra-notary make notarize
+```
+
+The repo cannot provide Developer ID credentials or a notary keychain
+profile. Those remain release-owner inputs. A future cask can either
+point at these signed archives or wrap the same binaries in a pkg/app
+container if helper identity verification moves to
+`SMAppService.daemon` or `SMJobBless`.
 
 ## Why an optional sudo helper
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,8 @@
 # Install
 
-Spectra is currently distributed only via source build. Homebrew formula and
-prebuilt binaries are planned (see
+Spectra is currently distributed via source build. The repo also contains
+release packaging for Homebrew and macOS tarball archives, but published
+formulae and signed/notarized binaries are release-owner tasks (see
 [design/distribution.md](design/distribution.md)).
 
 ## From source
@@ -36,8 +37,36 @@ brew install kaeawc/tap/spectra
 spectra /Applications/Slack.app
 ```
 
-The formula is not published yet; source build is the supported path for
-now.
+The formula template lives at `packaging/homebrew/spectra.rb`. It builds
+`spectra`, `spectra-mcp`, and `spectra-helper` from source and does not
+install the privileged helper automatically. Publishing requires replacing
+the placeholder tag and checksum in the template and copying it into the
+tap repository.
+
+## Prebuilt archives
+
+Release owners can build unsigned local archives with:
+
+```bash
+make dist
+```
+
+This writes `dist/spectra_<version>_darwin_arm64.tar.gz`,
+`dist/spectra_<version>_darwin_amd64.tar.gz`, and `dist/checksums.txt`.
+To sign binaries inside the archives:
+
+```bash
+CODESIGN_ID="Developer ID Application: Example Corp (TEAMID)" make dist
+```
+
+To submit built archives to Apple's notary service:
+
+```bash
+NOTARY_PROFILE=spectra-notary make notarize
+```
+
+The notary profile must already exist in the local keychain via
+`xcrun notarytool store-credentials`.
 
 ## Privileged helper
 

--- a/packaging/homebrew/spectra.rb
+++ b/packaging/homebrew/spectra.rb
@@ -1,0 +1,32 @@
+class Spectra < Formula
+  desc "macOS app diagnostics and JVM-aware remote debugging"
+  homepage "https://github.com/kaeawc/spectra"
+  url "https://github.com/kaeawc/spectra/archive/refs/tags/v0.0.0.tar.gz"
+  sha256 "REPLACE_WITH_SOURCE_ARCHIVE_SHA256"
+  license "MIT"
+  head "https://github.com/kaeawc/spectra.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    version_ldflag = "-X main.version=#{version}"
+    system "go", "build", "-trimpath", "-ldflags", "-s -w #{version_ldflag}", "-o", bin/"spectra", "./cmd/spectra"
+    system "go", "build", "-trimpath", "-ldflags", "-s -w #{version_ldflag}", "-o", bin/"spectra-mcp", "./cmd/spectra-mcp"
+    system "go", "build", "-trimpath", "-ldflags", "-s -w #{version_ldflag}", "-o", bin/"spectra-helper", "./cmd/spectra-helper"
+
+    pkgshare.install "agent/spectra-agent.jar" if File.exist?("agent/spectra-agent.jar")
+    doc.install "docs/install.md", "docs/operations/install-services.md", "docs/design/distribution.md"
+  end
+
+  service do
+    run [opt_bin/"spectra", "serve"]
+    keep_alive true
+    log_path var/"log/spectra.log"
+    error_log_path var/"log/spectra.err.log"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/spectra version")
+    assert_match version.to_s, shell_output("#{bin}/spectra-helper --version")
+  end
+end

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build macOS release archives for Spectra.
+#
+# Outputs:
+#   dist/spectra_${VERSION}_darwin_arm64.tar.gz
+#   dist/spectra_${VERSION}_darwin_amd64.tar.gz
+#   dist/checksums.txt
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${DIST_DIR:-$ROOT/dist}"
+VERSION="${VERSION:-$(git -C "$ROOT" describe --tags --always --dirty 2>/dev/null || echo dev)}"
+LDFLAGS="-s -w -X main.version=${VERSION}"
+
+usage() {
+    cat <<EOF
+Usage: VERSION=vX.Y.Z $0
+
+Environment:
+  VERSION       Release version. Defaults to git describe.
+  DIST_DIR      Output directory. Defaults to ./dist.
+  CODESIGN_ID   Optional Developer ID Application identity.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+build_one() {
+    local arch="$1"
+    local stage="$DIST_DIR/stage/spectra_${VERSION}_darwin_${arch}"
+    local archive="$DIST_DIR/spectra_${VERSION}_darwin_${arch}.tar.gz"
+
+    rm -rf "$stage"
+    mkdir -p "$stage/bin" "$stage/docs" "$stage/licenses"
+
+    (
+        cd "$ROOT"
+        GOOS=darwin GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" -o "$stage/bin/spectra" ./cmd/spectra/
+        GOOS=darwin GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" -o "$stage/bin/spectra-mcp" ./cmd/spectra-mcp/
+        GOOS=darwin GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" -o "$stage/bin/spectra-helper" ./cmd/spectra-helper/
+    )
+
+    cp "$ROOT/README.md" "$stage/"
+    cp "$ROOT/LICENSE" "$stage/licenses/LICENSE"
+    cp "$ROOT/docs/install.md" "$stage/docs/install.md"
+    cp "$ROOT/docs/operations/install-services.md" "$stage/docs/install-services.md"
+    cp "$ROOT/docs/design/distribution.md" "$stage/docs/distribution.md"
+    if [[ -f "$ROOT/agent/spectra-agent.jar" ]]; then
+        mkdir -p "$stage/agent"
+        cp "$ROOT/agent/spectra-agent.jar" "$stage/agent/"
+    fi
+
+    if [[ -n "${CODESIGN_ID:-}" ]]; then
+        codesign --force --timestamp --options runtime --sign "$CODESIGN_ID" \
+            "$stage/bin/spectra" "$stage/bin/spectra-mcp" "$stage/bin/spectra-helper"
+    fi
+
+    tar -C "$DIST_DIR/stage" -czf "$archive" "$(basename "$stage")"
+}
+
+rm -rf "$DIST_DIR/stage"
+mkdir -p "$DIST_DIR"
+
+build_one arm64
+build_one amd64
+
+(
+    cd "$DIST_DIR"
+    shasum -a 256 spectra_"${VERSION}"_darwin_*.tar.gz > checksums.txt
+)
+
+rm -rf "$DIST_DIR/stage"
+echo "Wrote release archives to $DIST_DIR"

--- a/scripts/notarize-archives.sh
+++ b/scripts/notarize-archives.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Submit release archives to Apple's notary service and staple the result when
+# stapling is supported for the artifact type.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${DIST_DIR:-$ROOT/dist}"
+PROFILE="${NOTARY_PROFILE:-}"
+
+usage() {
+    cat <<EOF
+Usage: NOTARY_PROFILE=<xcrun-notarytool-profile> $0 [archive ...]
+
+If no archives are passed, all dist/spectra_*_darwin_*.tar.gz files are used.
+Create the profile once with:
+  xcrun notarytool store-credentials <profile> --apple-id <id> --team-id <team> --password <app-password>
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ -z "$PROFILE" ]]; then
+    echo "NOTARY_PROFILE is required." >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ "$#" -gt 0 ]]; then
+    archives=("$@")
+else
+    archives=("$DIST_DIR"/spectra_*_darwin_*.tar.gz)
+fi
+
+for archive in "${archives[@]}"; do
+    if [[ ! -f "$archive" ]]; then
+        echo "archive not found: $archive" >&2
+        exit 1
+    fi
+    xcrun notarytool submit "$archive" --keychain-profile "$PROFILE" --wait
+done

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -47,6 +47,9 @@ echo "Files:"
 check "README.md exists" test -f README.md
 check "LICENSE exists" test -f LICENSE
 check "mkdocs.yml exists" test -f mkdocs.yml
+check "dist script exists" test -x scripts/dist.sh
+check "notarize script exists" test -x scripts/notarize-archives.sh
+check "Homebrew formula template exists" test -f packaging/homebrew/spectra.rb
 
 echo ""
 echo "Git:"


### PR DESCRIPTION
## Summary

Adds the in-tree distribution lane for Spectra beyond source builds:

- adds macOS release archive generation for arm64 and amd64, with optional Developer ID signing and SHA-256 checksums
- adds a notarization helper script driven by a local `notarytool` keychain profile
- adds an unpublished Homebrew formula template for the CLI, MCP server, and helper binary
- updates install/distribution docs and release checks to cover the new packaging files

## Notes

Developer ID credentials, notary profiles, final formula tag/checksum replacement, and tap publication remain release-owner inputs.

## Validation

- `go build ./...`
- `go vet ./...`
- `bash -n scripts/dist.sh scripts/notarize-archives.sh scripts/release-check.sh`
- `VERSION=test make dist`
