### PR TITLE
Add daemon artifact policy controls

### DIFF
--- a/cmd/spectra/daemon_install.go
+++ b/cmd/spectra/daemon_install.go
@@ -179,18 +179,25 @@ func parseDaemonAgentOptions(name string, args []string, stderr io.Writer) (daem
 
 func (o daemonAgentOptions) serveArgs() []string {
 	args := []string{"serve"}
+	args = appendServePathArgs(args, o)
+	args = appendServeRemoteArgs(args, o)
+	args = appendServeLogArgs(args, o)
+	return args
+}
+
+func appendServePathArgs(args []string, o daemonAgentOptions) []string {
 	if o.SockPath != "" {
 		args = append(args, "--sock", o.SockPath)
 	}
 	if o.TCPAddr != "" {
 		args = append(args, "--tcp", o.TCPAddr)
 	}
-	if o.AllowRemote {
-		args = append(args, "--allow-remote")
-	}
-	if o.TsnetEnabled {
-		args = append(args, "--tsnet")
-	}
+	return args
+}
+
+func appendServeRemoteArgs(args []string, o daemonAgentOptions) []string {
+	args = appendBoolArg(args, "--allow-remote", o.AllowRemote)
+	args = appendBoolArg(args, "--tsnet", o.TsnetEnabled)
 	if o.TsnetAddr != "" && o.TsnetAddr != serve.DefaultTsnetAddr {
 		args = append(args, "--tsnet-addr", o.TsnetAddr)
 	}
@@ -215,11 +222,19 @@ func (o daemonAgentOptions) serveArgs() []string {
 	if o.ArtifactPolicy != "" {
 		args = append(args, "--artifact-policy", o.ArtifactPolicy)
 	}
+	return args
+}
+
+func appendServeLogArgs(args []string, o daemonAgentOptions) []string {
 	if o.LogFile != "" {
 		args = append(args, "--log-file", o.LogFile)
 	}
-	if o.NoLogFile {
-		args = append(args, "--no-log-file")
+	return appendBoolArg(args, "--no-log-file", o.NoLogFile)
+}
+
+func appendBoolArg(args []string, flag string, enabled bool) []string {
+	if enabled {
+		return append(args, flag)
 	}
 	return args
 }

--- a/cmd/spectra/daemon_install.go
+++ b/cmd/spectra/daemon_install.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/fsutil"
 	"github.com/kaeawc/spectra/internal/serve"
 )
@@ -29,6 +30,7 @@ type daemonAgentOptions struct {
 	TsnetTags        string
 	TsnetAllowLogins string
 	TsnetAllowNodes  string
+	ArtifactPolicy   string
 	LogFile          string
 	NoLogFile        bool
 	NoLoad           bool
@@ -149,6 +151,7 @@ func parseDaemonAgentOptions(name string, args []string, stderr io.Writer) (daem
 	fs.StringVar(&opts.TsnetTags, "tsnet-tags", "", "Comma-separated Tailscale tags to advertise")
 	fs.StringVar(&opts.TsnetAllowLogins, "tsnet-allow-logins", "", "Comma-separated Tailscale login names allowed to connect")
 	fs.StringVar(&opts.TsnetAllowNodes, "tsnet-allow-nodes", "", "Comma-separated Tailscale node names allowed to connect")
+	fs.StringVar(&opts.ArtifactPolicy, "artifact-policy", "confirm", "Daemon artifact policy: confirm, deny, or allow")
 	fs.StringVar(&opts.LogFile, "log-file", "", "JSONL daemon log path")
 	fs.BoolVar(&opts.NoLogFile, "no-log-file", false, "Disable daemon JSONL log file")
 	fs.BoolVar(&opts.NoLoad, "no-load", false, "Write plist but do not bootstrap with launchd")
@@ -156,7 +159,11 @@ func parseDaemonAgentOptions(name string, args []string, stderr io.Writer) (daem
 		return daemonAgentOptions{}, false
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: spectra install-daemon [--sock path] [--tcp addr] [--allow-remote] [--tsnet] [--tsnet-hostname name] [--tsnet-allow-logins users] [--tsnet-allow-nodes nodes] [--log-file path|--no-log-file] [--no-load]")
+		fmt.Fprintln(stderr, "usage: spectra install-daemon [--sock path] [--tcp addr] [--allow-remote] [--tsnet] [--tsnet-hostname name] [--tsnet-allow-logins users] [--tsnet-allow-nodes nodes] [--artifact-policy confirm|deny|allow] [--log-file path|--no-log-file] [--no-load]")
+		return daemonAgentOptions{}, false
+	}
+	if err := (artifact.Policy{Mode: opts.ArtifactPolicy}).Validate(); err != nil {
+		fmt.Fprintln(stderr, err)
 		return daemonAgentOptions{}, false
 	}
 	if opts.LogFile != "" && opts.NoLogFile {
@@ -204,6 +211,9 @@ func (o daemonAgentOptions) serveArgs() []string {
 	}
 	if o.TsnetAllowNodes != "" {
 		args = append(args, "--tsnet-allow-nodes", o.TsnetAllowNodes)
+	}
+	if o.ArtifactPolicy != "" {
+		args = append(args, "--artifact-policy", o.ArtifactPolicy)
 	}
 	if o.LogFile != "" {
 		args = append(args, "--log-file", o.LogFile)

--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/logger"
 	"github.com/kaeawc/spectra/internal/rpc"
@@ -32,6 +33,7 @@ func runServe(args []string) int {
 	tsnetTags := fs.String("tsnet-tags", "", "Comma-separated Tailscale tags to advertise, such as tag:engineer")
 	tsnetAllowLogins := fs.String("tsnet-allow-logins", "", "Comma-separated Tailscale login names allowed to connect")
 	tsnetAllowNodes := fs.String("tsnet-allow-nodes", "", "Comma-separated Tailscale node names allowed to connect")
+	artifactPolicy := fs.String("artifact-policy", "confirm", "Daemon artifact policy: confirm, deny, or allow")
 	logFile := fs.String("log-file", "", "JSONL daemon log path (default: ~/Library/Logs/Spectra/daemon.jsonl)")
 	noLogFile := fs.Bool("no-log-file", false, "Disable the daemon JSONL log file")
 	daemon := fs.Bool("daemon", false, "Start spectra serve in the background and return")
@@ -39,6 +41,11 @@ func runServe(args []string) int {
 		return 2
 	}
 	if err := validateServeListen(*tcpAddr, *allowRemote); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	policy := artifact.Policy{Mode: *artifactPolicy}
+	if err := policy.Validate(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
@@ -86,6 +93,7 @@ func runServe(args []string) int {
 		fmt.Fprintf(os.Stderr, "spectra serve: joining tailnet via tsnet on %s\n", *tsnetAddr)
 		fmt.Fprintln(os.Stderr, "spectra serve: tsnet auth uses existing state or TS_AUTHKEY; first-run login URLs are written to the daemon log or stderr")
 	}
+	fmt.Fprintf(os.Stderr, "spectra serve: artifact policy %s\n", policy.Normalize().Mode)
 
 	var detectStore *cache.ShardedStore
 	if cacheStores != nil {
@@ -104,6 +112,7 @@ func runServe(args []string) int {
 		TsnetAllowNodes:  splitCommaList(*tsnetAllowNodes),
 		SpectraVersion:   version,
 		DetectStore:      detectStore,
+		ArtifactPolicy:   policy,
 		Logger:           daemonLog,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -44,8 +45,8 @@ func runServe(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
-	policy := artifact.Policy{Mode: *artifactPolicy}
-	if err := policy.Validate(); err != nil {
+	policy, err := parseArtifactPolicy(*artifactPolicy)
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
@@ -79,21 +80,15 @@ func runServe(args []string) int {
 	if closeLog != nil {
 		defer closeLog()
 	}
-	fmt.Fprintf(os.Stderr, "spectra serve: listening on %s\n", sock)
-	if resolvedLogPath != "" {
-		fmt.Fprintf(os.Stderr, "spectra serve: logging to %s\n", resolvedLogPath)
-	}
-	if *tcpAddr != "" {
-		if *allowRemote {
-			fmt.Fprintln(os.Stderr, "spectra serve: warning: TCP RPC has no Spectra-layer authentication; rely on SSH/Tailscale/firewall controls")
-		}
-		fmt.Fprintf(os.Stderr, "spectra serve: listening on tcp %s\n", *tcpAddr)
-	}
-	if *tsnetEnabled {
-		fmt.Fprintf(os.Stderr, "spectra serve: joining tailnet via tsnet on %s\n", *tsnetAddr)
-		fmt.Fprintln(os.Stderr, "spectra serve: tsnet auth uses existing state or TS_AUTHKEY; first-run login URLs are written to the daemon log or stderr")
-	}
-	fmt.Fprintf(os.Stderr, "spectra serve: artifact policy %s\n", policy.Normalize().Mode)
+	printServeStartup(os.Stderr, serveStartupStatus{
+		Sock:           sock,
+		LogPath:        resolvedLogPath,
+		TCPAddr:        *tcpAddr,
+		AllowRemote:    *allowRemote,
+		TsnetEnabled:   *tsnetEnabled,
+		TsnetAddr:      *tsnetAddr,
+		ArtifactPolicy: policy,
+	})
 
 	var detectStore *cache.ShardedStore
 	if cacheStores != nil {
@@ -119,6 +114,42 @@ func runServe(args []string) int {
 		return 1
 	}
 	return 0
+}
+
+type serveStartupStatus struct {
+	Sock           string
+	LogPath        string
+	TCPAddr        string
+	AllowRemote    bool
+	TsnetEnabled   bool
+	TsnetAddr      string
+	ArtifactPolicy artifact.Policy
+}
+
+func printServeStartup(w io.Writer, status serveStartupStatus) {
+	fmt.Fprintf(w, "spectra serve: listening on %s\n", status.Sock)
+	if status.LogPath != "" {
+		fmt.Fprintf(w, "spectra serve: logging to %s\n", status.LogPath)
+	}
+	if status.TCPAddr != "" {
+		if status.AllowRemote {
+			fmt.Fprintln(w, "spectra serve: warning: TCP RPC has no Spectra-layer authentication; rely on SSH/Tailscale/firewall controls")
+		}
+		fmt.Fprintf(w, "spectra serve: listening on tcp %s\n", status.TCPAddr)
+	}
+	if status.TsnetEnabled {
+		fmt.Fprintf(w, "spectra serve: joining tailnet via tsnet on %s\n", status.TsnetAddr)
+		fmt.Fprintln(w, "spectra serve: tsnet auth uses existing state or TS_AUTHKEY; first-run login URLs are written to the daemon log or stderr")
+	}
+	fmt.Fprintf(w, "spectra serve: artifact policy %s\n", status.ArtifactPolicy.Normalize().Mode)
+}
+
+func parseArtifactPolicy(mode string) (artifact.Policy, error) {
+	policy := artifact.Policy{Mode: mode}
+	if err := policy.Validate(); err != nil {
+		return artifact.Policy{}, err
+	}
+	return policy, nil
 }
 
 func validateServeListen(tcpAddr string, allowRemote bool) error {

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -393,6 +393,7 @@ user's Unix socket at `~/.spectra/sock`.
 | `--tsnet-tags` | empty | Comma-separated Tailscale tags to advertise |
 | `--tsnet-allow-logins` | empty | Comma-separated Tailscale login names allowed to connect |
 | `--tsnet-allow-nodes` | empty | Comma-separated Tailscale node names allowed to connect |
+| `--artifact-policy` | `confirm` | Artifact write policy: `confirm`, `deny`, or `allow` |
 | `--log-file` | `~/Library/Logs/Spectra/daemon.jsonl` | JSONL daemon log path |
 | `--no-log-file` | false | Disable daemon JSONL logging |
 | `--daemon` | false | Start detached and return |
@@ -404,6 +405,12 @@ enrollment uses existing tsnet state, `TS_AUTHKEY`, or a login URL written
 to the daemon log or stderr. `--tsnet-allow-logins` and
 `--tsnet-allow-nodes` add an optional Spectra-side allowlist on top of
 Tailscale ACLs.
+
+`--artifact-policy=confirm` requires sensitive RPC artifact methods to
+carry `confirm_sensitive: true`. `deny` rejects daemon artifact writes
+entirely, which is useful for shared or unattended remote daemons.
+`allow` keeps auditing enabled but skips the confirmation gate for
+trusted automation.
 
 ### Examples
 
@@ -437,7 +444,7 @@ The install and `print-plist` forms accept the serve-listener flags
 `--sock`, `--tcp`, `--allow-remote`, `--tsnet`, `--tsnet-addr`,
 `--tsnet-hostname`, `--tsnet-state-dir`, `--tsnet-ephemeral`,
 `--tsnet-tags`, `--tsnet-allow-logins`, `--tsnet-allow-nodes`,
-`--log-file`, and `--no-log-file`.
+`--artifact-policy`, `--log-file`, and `--no-log-file`.
 
 ### Examples
 

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -164,7 +164,15 @@ with the remote portal.
   `issues.dismiss`, `issues.fix.record`, `snapshot.prune`, JVM heap/JFR
   capture) are explicit methods. Sensitive artifact writes
   (`jvm.heap_dump`, `jvm.jfr.dump`, `jvm.flamegraph`) also require
-  `confirm_sensitive: true` in the request.
+  `confirm_sensitive: true` in the request under the default
+  `--artifact-policy=confirm` mode. Use `--artifact-policy=deny` to
+  reject daemon artifact writes on shared remote daemons, or
+  `--artifact-policy=allow` for trusted automation that still wants
+  daemon audit records.
+- The `health` and `artifact.policy` RPC methods report the active
+  artifact policy so clients can show the current remote write posture.
+- Successful and denied daemon artifact writes are logged to the JSONL
+  daemon audit log when logging is enabled.
 - The daemon is intended to be a low-privilege observer, not a remote
   shell. Method surface is intentionally narrow; arbitrary
   `exec.Command` is not exposed over RPC.

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -187,7 +187,11 @@ The remote daemon is **read-only by default**. State-changing
 operations (snapshots, heap dumps, JFR recordings) require explicit
 consent on the client side and an audit log entry on the daemon. The
 daemon rejects sensitive artifact writes unless the request includes
-`confirm_sensitive: true`.
+`confirm_sensitive: true` under the default `--artifact-policy=confirm`.
+Operators can start the daemon with `--artifact-policy=deny` to make
+remote artifact capture unavailable, or `--artifact-policy=allow` for
+trusted automation. Clients can read the active setting through
+`health` or `artifact.policy`.
 
 The daemon does not expose:
 - Arbitrary file reads outside Spectra-managed paths.

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -31,6 +31,12 @@ const (
 	SensitivityVeryHigh   = "very-high"
 )
 
+const (
+	PolicyConfirm = "confirm"
+	PolicyDeny    = "deny"
+	PolicyAllow   = "allow"
+)
+
 // Record describes one artifact that Spectra created or learned about.
 type Record struct {
 	ID          string            `json:"id"`
@@ -44,6 +50,51 @@ type Record struct {
 	SizeBytes   int64             `json:"size_bytes,omitempty"`
 	CreatedAt   time.Time         `json:"created_at"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// Policy controls whether daemon RPC methods may create sensitive artifacts.
+type Policy struct {
+	Mode string `json:"mode"`
+}
+
+// Normalize returns p with defaults applied.
+func (p Policy) Normalize() Policy {
+	switch p.Mode {
+	case PolicyDeny, PolicyAllow, PolicyConfirm:
+		return p
+	case "":
+		return Policy{Mode: PolicyConfirm}
+	default:
+		return Policy{Mode: p.Mode}
+	}
+}
+
+// Validate reports invalid policy modes.
+func (p Policy) Validate() error {
+	switch p.Normalize().Mode {
+	case PolicyDeny, PolicyAllow, PolicyConfirm:
+		return nil
+	default:
+		return fmt.Errorf("artifact policy %q must be one of: confirm, deny, allow", p.Mode)
+	}
+}
+
+// Authorize checks whether rec may be created under this policy.
+func (p Policy) Authorize(rec Record, confirmed bool) error {
+	p = p.Normalize()
+	switch p.Mode {
+	case PolicyDeny:
+		return fmt.Errorf("artifact policy denies %s artifacts", rec.Kind)
+	case PolicyAllow:
+		return nil
+	case PolicyConfirm:
+		if confirmed {
+			return nil
+		}
+		return fmt.Errorf("%s requires confirm_sensitive=true under artifact policy %q", rec.Kind, p.Mode)
+	default:
+		return p.Validate()
+	}
 }
 
 // Recorder records artifact lifecycle metadata. Use this interface in

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -94,3 +94,22 @@ func TestFakeRecorder(t *testing.T) {
 		t.Fatal("snapshot exposed internal storage")
 	}
 }
+
+func TestPolicyAuthorize(t *testing.T) {
+	rec := Record{Kind: KindHeapDump}
+	if err := (Policy{}).Authorize(rec, false); err == nil {
+		t.Fatal("default policy allowed unconfirmed artifact")
+	}
+	if err := (Policy{}).Authorize(rec, true); err != nil {
+		t.Fatalf("default policy rejected confirmed artifact: %v", err)
+	}
+	if err := (Policy{Mode: PolicyDeny}).Authorize(rec, true); err == nil {
+		t.Fatal("deny policy allowed artifact")
+	}
+	if err := (Policy{Mode: PolicyAllow}).Authorize(rec, false); err != nil {
+		t.Fatalf("allow policy rejected artifact: %v", err)
+	}
+	if err := (Policy{Mode: "bogus"}).Validate(); err == nil {
+		t.Fatal("invalid policy mode validated")
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -76,6 +76,7 @@ type Options struct {
 	DetectStore      *cache.ShardedStore // nil = no detect caching
 	DetectWriter     *cache.AsyncWriter  // nil = sync writes or daemon-created writer
 	ArtifactRecorder artifact.Recorder   // nil = default per-user manifest
+	ArtifactPolicy   artifact.Policy     // empty = confirm per sensitive artifact
 	Logger           logger.Logger       // nil = discard
 }
 
@@ -205,10 +206,14 @@ func runDaemon(ctx context.Context, log logger.Logger, opts Options, listeners [
 		}
 		artifactRecorder = artifact.NewManager(artifact.NewJSONStore(path), nil)
 	}
+	artifactPolicy := opts.ArtifactPolicy.Normalize()
+	if err := artifactPolicy.Validate(); err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, opts.SpectraVersion, db, collector, history, cacheReg, opts.DetectStore, detectWriter, artifactRecorder, tsnetStatus, tsNode)
-	log.Info("daemon serving", "version", opts.SpectraVersion, "listeners", len(listeners))
+	registerHandlers(d, opts.SpectraVersion, db, collector, history, cacheReg, opts.DetectStore, detectWriter, artifactRecorder, artifactPolicy, log, tsnetStatus, tsNode)
+	log.Info("daemon serving", "version", opts.SpectraVersion, "listeners", len(listeners), "artifact_policy", artifactPolicy.Mode)
 
 	go func() {
 		<-ctx.Done()
@@ -431,13 +436,17 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB, history *li
 // registerHandlers wires all JSON-RPC methods into d.
 //
 //gocyclo:ignore
-func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, history *livehistory.Ring, cacheReg *cache.Registry, detectStore *cache.ShardedStore, detectWriter *cache.AsyncWriter, artifactRecorder artifact.Recorder, tsnetStatus *TsnetStatus, tsnetNode TsnetNode) {
+func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, history *livehistory.Ring, cacheReg *cache.Registry, detectStore *cache.ShardedStore, detectWriter *cache.AsyncWriter, artifactRecorder artifact.Recorder, artifactPolicy artifact.Policy, log logger.Logger, tsnetStatus *TsnetStatus, tsnetNode TsnetNode) {
 	if history == nil {
 		history = livehistory.NewRing(livehistory.DefaultCapacity)
 	}
 	issueSvc := issueflow.Service{Store: db}
+	artifactPolicy = artifactPolicy.Normalize()
+	if log == nil {
+		log = logger.Discard()
+	}
 	d.Register("health", func(_ json.RawMessage) (any, error) {
-		result := map[string]any{"ok": true, "version": version}
+		result := map[string]any{"ok": true, "version": version, "artifact_policy": artifactPolicy}
 		if tsnetStatus != nil {
 			status := *tsnetStatus
 			if tsnetNode != nil {
@@ -452,6 +461,10 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			result["tsnet"] = status
 		}
 		return result, nil
+	})
+
+	d.Register("artifact.policy", func(_ json.RawMessage) (any, error) {
+		return artifactPolicy, nil
 	})
 
 	d.Register("snapshot.list", func(_ json.RawMessage) (any, error) {
@@ -876,19 +889,23 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err := json.Unmarshal(params, &p); err != nil || p.PID == 0 {
 			return nil, fmt.Errorf("jvm.thread_dump requires {\"pid\": <pid>}")
 		}
-		out, err := runThreadDump(p.PID, nil)
-		if err != nil {
-			return nil, fmt.Errorf("thread dump pid %d: %w", p.PID, err)
-		}
-		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+		rec := artifact.Record{
 			Kind:        artifact.KindThreadDump,
 			Sensitivity: artifact.SensitivityMediumHigh,
 			Source:      "daemon-rpc",
 			Command:     "jvm.thread_dump",
 			CacheKind:   cache.KindThreads,
 			PID:         p.PID,
-			SizeBytes:   int64(len(out)),
-		}, map[string]any{"pid": p.PID, "output": string(out)}), nil
+		}
+		if err := authorizeArtifact(log, artifactPolicy, rec, true); err != nil {
+			return nil, err
+		}
+		out, err := runThreadDump(p.PID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("thread dump pid %d: %w", p.PID, err)
+		}
+		rec.SizeBytes = int64(len(out))
+		return recordArtifact(context.Background(), log, artifactRecorder, rec, map[string]any{"pid": p.PID, "output": string(out)}), nil
 	}
 	d.Register("jvm.thread_dump", jvmThreadDump)
 	d.Register("jvm.threadDump", jvmThreadDump)
@@ -1082,15 +1099,7 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if p.Dest == "" {
 			p.Dest = fmt.Sprintf("/tmp/spectra-flamegraph-%d.html", p.PID)
 		}
-		if err := jvm.CaptureFlamegraph(p.PID, jvm.FlamegraphOptions{
-			AsprofPath:      p.AsprofPath,
-			Event:           p.Event,
-			DurationSeconds: p.DurationSeconds,
-			OutputPath:      p.Dest,
-		}); err != nil {
-			return nil, fmt.Errorf("flamegraph pid %d: %w", p.PID, err)
-		}
-		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+		rec := artifact.Record{
 			Kind:        artifact.KindFlamegraph,
 			Sensitivity: artifact.SensitivityMediumHigh,
 			Source:      "daemon-rpc",
@@ -1100,7 +1109,19 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			Metadata: map[string]string{
 				"event": p.Event,
 			},
-		}, map[string]any{"pid": p.PID, "dest": p.Dest}), nil
+		}
+		if err := authorizeArtifact(log, artifactPolicy, rec, p.ConfirmSensitive); err != nil {
+			return nil, err
+		}
+		if err := jvm.CaptureFlamegraph(p.PID, jvm.FlamegraphOptions{
+			AsprofPath:      p.AsprofPath,
+			Event:           p.Event,
+			DurationSeconds: p.DurationSeconds,
+			OutputPath:      p.Dest,
+		}); err != nil {
+			return nil, fmt.Errorf("flamegraph pid %d: %w", p.PID, err)
+		}
+		return recordArtifact(context.Background(), log, artifactRecorder, rec, map[string]any{"pid": p.PID, "dest": p.Dest}), nil
 	})
 
 	// jvm.jfr.start — start a JFR recording on a JVM process.
@@ -1144,10 +1165,7 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if name == "" {
 			name = "spectra"
 		}
-		if err := runJFRDump(p.PID, name, p.Dest, nil); err != nil {
-			return nil, fmt.Errorf("jfr dump pid %d: %w", p.PID, err)
-		}
-		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+		rec := artifact.Record{
 			Kind:        artifact.KindJFRRecording,
 			Sensitivity: artifact.SensitivityMediumHigh,
 			Source:      "daemon-rpc",
@@ -1158,7 +1176,14 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			Metadata: map[string]string{
 				"name": name,
 			},
-		}, map[string]any{"pid": p.PID, "name": name, "dest": p.Dest, "dumped": true}), nil
+		}
+		if err := authorizeArtifact(log, artifactPolicy, rec, p.ConfirmSensitive); err != nil {
+			return nil, err
+		}
+		if err := runJFRDump(p.PID, name, p.Dest, nil); err != nil {
+			return nil, fmt.Errorf("jfr dump pid %d: %w", p.PID, err)
+		}
+		return recordArtifact(context.Background(), log, artifactRecorder, rec, map[string]any{"pid": p.PID, "name": name, "dest": p.Dest, "dumped": true}), nil
 	})
 
 	// jvm.jfr.stop — stop a JFR recording. Optional: {"dest": "/path/to/out.jfr"}.
@@ -1175,6 +1200,24 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if name == "" {
 			name = "spectra"
 		}
+		var rec artifact.Record
+		if p.Dest != "" {
+			rec = artifact.Record{
+				Kind:        artifact.KindJFRRecording,
+				Sensitivity: artifact.SensitivityMediumHigh,
+				Source:      "daemon-rpc",
+				Command:     "jvm.jfr.stop",
+				Path:        p.Dest,
+				CacheKind:   cache.KindJFR,
+				PID:         p.PID,
+				Metadata: map[string]string{
+					"name": name,
+				},
+			}
+			if err := authorizeArtifact(log, artifactPolicy, rec, true); err != nil {
+				return nil, err
+			}
+		}
 		if err := jvm.JFRStop(p.PID, name, p.Dest, nil); err != nil {
 			return nil, fmt.Errorf("jfr stop pid %d: %w", p.PID, err)
 		}
@@ -1182,18 +1225,7 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if p.Dest == "" {
 			return result, nil
 		}
-		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
-			Kind:        artifact.KindJFRRecording,
-			Sensitivity: artifact.SensitivityMediumHigh,
-			Source:      "daemon-rpc",
-			Command:     "jvm.jfr.stop",
-			Path:        p.Dest,
-			CacheKind:   cache.KindJFR,
-			PID:         p.PID,
-			Metadata: map[string]string{
-				"name": name,
-			},
-		}, result), nil
+		return recordArtifact(context.Background(), log, artifactRecorder, rec, result), nil
 	})
 
 	// jvm.jfr.summary — run `jfr summary <path>` and return parsed event counts.
@@ -1244,10 +1276,7 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if p.Dest == "" {
 			p.Dest = fmt.Sprintf("/tmp/spectra-heap-%d.hprof", p.PID)
 		}
-		if err := runHeapDump(p.PID, p.Dest, nil); err != nil {
-			return nil, fmt.Errorf("heap dump pid %d: %w", p.PID, err)
-		}
-		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+		rec := artifact.Record{
 			Kind:        artifact.KindHeapDump,
 			Sensitivity: artifact.SensitivityVeryHigh,
 			Source:      "daemon-rpc",
@@ -1255,7 +1284,14 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			Path:        p.Dest,
 			CacheKind:   cache.KindHprof,
 			PID:         p.PID,
-		}, map[string]any{"pid": p.PID, "dest": p.Dest}), nil
+		}
+		if err := authorizeArtifact(log, artifactPolicy, rec, p.ConfirmSensitive); err != nil {
+			return nil, err
+		}
+		if err := runHeapDump(p.PID, p.Dest, nil); err != nil {
+			return nil, fmt.Errorf("heap dump pid %d: %w", p.PID, err)
+		}
+		return recordArtifact(context.Background(), log, artifactRecorder, rec, map[string]any{"pid": p.PID, "dest": p.Dest}), nil
 	}
 	d.Register("jvm.heap_dump", jvmHeapDump)
 	d.Register("jvm.heapDump", jvmHeapDump)
@@ -1386,23 +1422,27 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if p.Interval == 0 {
 			p.Interval = 10
 		}
-		out, err := runSampleCmd(p.PID, p.Duration, p.Interval)
-		if err != nil {
-			return nil, fmt.Errorf("sample pid %d: %w", p.PID, err)
-		}
-		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
+		rec := artifact.Record{
 			Kind:        artifact.KindProcessSample,
 			Sensitivity: artifact.SensitivityMedium,
 			Source:      "daemon-rpc",
 			Command:     "process.sample",
 			CacheKind:   cache.KindSamples,
 			PID:         p.PID,
-			SizeBytes:   int64(len(out)),
 			Metadata: map[string]string{
 				"duration": fmt.Sprint(p.Duration),
 				"interval": fmt.Sprint(p.Interval),
 			},
-		}, map[string]any{"pid": p.PID, "output": string(out)}), nil
+		}
+		if err := authorizeArtifact(log, artifactPolicy, rec, true); err != nil {
+			return nil, err
+		}
+		out, err := runSampleCmd(p.PID, p.Duration, p.Interval)
+		if err != nil {
+			return nil, fmt.Errorf("sample pid %d: %w", p.PID, err)
+		}
+		rec.SizeBytes = int64(len(out))
+		return recordArtifact(context.Background(), log, artifactRecorder, rec, map[string]any{"pid": p.PID, "output": string(out)}), nil
 	})
 
 	// power.state — battery level, thermal pressure, assertions, and top energy users.
@@ -1542,6 +1582,22 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err := json.Unmarshal(params, &p); err != nil || p.Interface == "" {
 			return nil, fmt.Errorf("helper.net_capture.start requires {\"interface\": \"...\"}")
 		}
+		rec := artifact.Record{
+			Kind:        artifact.KindPacketCapture,
+			Sensitivity: artifact.SensitivityHigh,
+			Source:      "daemon-rpc",
+			Command:     "helper.net_capture.start",
+			CacheKind:   cache.KindNetcap,
+			Metadata: map[string]string{
+				"interface": p.Interface,
+				"proto":     p.Proto,
+				"host":      p.Host,
+				"port":      fmt.Sprint(p.Port),
+			},
+		}
+		if err := authorizeArtifact(log, artifactPolicy, rec, true); err != nil {
+			return nil, err
+		}
 		result, err := hc.NetCaptureStart(p.Interface, p.DurationMS, p.SnapLen, p.Proto, p.Host, p.Port)
 		if err != nil {
 			if helperclient.IsUnavailable(err) {
@@ -1551,21 +1607,9 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		}
 		out, _ := result["output_path"].(string)
 		handle, _ := result["handle"].(string)
-		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
-			Kind:        artifact.KindPacketCapture,
-			Sensitivity: artifact.SensitivityHigh,
-			Source:      "daemon-rpc",
-			Command:     "helper.net_capture.start",
-			Path:        out,
-			CacheKind:   cache.KindNetcap,
-			Metadata: map[string]string{
-				"handle":    handle,
-				"interface": p.Interface,
-				"proto":     p.Proto,
-				"host":      p.Host,
-				"port":      fmt.Sprint(p.Port),
-			},
-		}, result), nil
+		rec.Path = out
+		rec.Metadata["handle"] = handle
+		return recordArtifact(context.Background(), log, artifactRecorder, rec, result), nil
 	})
 
 	d.Register("helper.net_capture.stop", func(params json.RawMessage) (any, error) {
@@ -1575,6 +1619,19 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 		if err := json.Unmarshal(params, &p); err != nil || p.Handle == "" {
 			return nil, fmt.Errorf("helper.net_capture.stop requires {\"handle\": \"...\"}")
 		}
+		rec := artifact.Record{
+			Kind:        artifact.KindPacketCapture,
+			Sensitivity: artifact.SensitivityHigh,
+			Source:      "daemon-rpc",
+			Command:     "helper.net_capture.stop",
+			CacheKind:   cache.KindNetcap,
+			Metadata: map[string]string{
+				"handle": p.Handle,
+			},
+		}
+		if err := authorizeArtifact(log, artifactPolicy, rec, true); err != nil {
+			return nil, err
+		}
 		result, err := hc.NetCaptureStop(p.Handle)
 		if err != nil {
 			if helperclient.IsUnavailable(err) {
@@ -1583,17 +1640,8 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, err
 		}
 		out, _ := result["output_path"].(string)
-		return recordArtifact(context.Background(), artifactRecorder, artifact.Record{
-			Kind:        artifact.KindPacketCapture,
-			Sensitivity: artifact.SensitivityHigh,
-			Source:      "daemon-rpc",
-			Command:     "helper.net_capture.stop",
-			Path:        out,
-			CacheKind:   cache.KindNetcap,
-			Metadata: map[string]string{
-				"handle": p.Handle,
-			},
-		}, result), nil
+		rec.Path = out
+		return recordArtifact(context.Background(), log, artifactRecorder, rec, result), nil
 	})
 
 	d.Register("helper.tcc.system.query", func(params json.RawMessage) (any, error) {
@@ -1617,7 +1665,24 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 	})
 }
 
-func recordArtifact(ctx context.Context, recorder artifact.Recorder, rec artifact.Record, result map[string]any) map[string]any {
+func authorizeArtifact(log logger.Logger, policy artifact.Policy, rec artifact.Record, confirmed bool) error {
+	if err := policy.Authorize(rec, confirmed); err != nil {
+		log.Warn(
+			"daemon artifact denied",
+			"kind", rec.Kind,
+			"sensitivity", rec.Sensitivity,
+			"command", rec.Command,
+			"pid", rec.PID,
+			"path", rec.Path,
+			"policy", policy.Normalize().Mode,
+			"error", err.Error(),
+		)
+		return err
+	}
+	return nil
+}
+
+func recordArtifact(ctx context.Context, log logger.Logger, recorder artifact.Recorder, rec artifact.Record, result map[string]any) map[string]any {
 	if result == nil {
 		result = map[string]any{}
 	}
@@ -1627,10 +1692,21 @@ func recordArtifact(ctx context.Context, recorder artifact.Recorder, rec artifac
 	stored, err := recorder.Record(ctx, rec)
 	if err != nil {
 		result["artifact_error"] = err.Error()
+		log.Warn("daemon artifact record failed", "kind", rec.Kind, "command", rec.Command, "pid", rec.PID, "path", rec.Path, "error", err.Error())
 		return result
 	}
 	result["artifact_id"] = stored.ID
 	result["artifact_kind"] = stored.Kind
+	log.Info(
+		"daemon artifact recorded",
+		"id", stored.ID,
+		"kind", stored.Kind,
+		"sensitivity", stored.Sensitivity,
+		"command", stored.Command,
+		"pid", stored.PID,
+		"path", stored.Path,
+		"size_bytes", stored.SizeBytes,
+	)
 	return result
 }
 

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -78,7 +78,7 @@ func testDaemonWithDB(t *testing.T) (*json.Encoder, *json.Decoder, *store.DB, co
 		collectToolchains = origCollectToolchains
 		collectJDKs = origCollectJDKs
 	})
-	registerHandlers(d, "test-version", db, metrics.NewCollector(), livehistory.NewRing(livehistory.DefaultCapacity), cache.Default, nil, nil, &artifact.FakeRecorder{}, nil, nil)
+	registerHandlers(d, "test-version", db, metrics.NewCollector(), livehistory.NewRing(livehistory.DefaultCapacity), cache.Default, nil, nil, &artifact.FakeRecorder{}, artifact.Policy{}, logger.Discard(), nil, nil)
 
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -1238,7 +1238,7 @@ func TestDaemonJVMHeapDumpRecordsArtifact(t *testing.T) {
 	defer db.Close()
 	fake := &artifact.FakeRecorder{}
 	d := rpc.NewDispatcher()
-	registerHandlers(d, "test-version", db, metrics.NewCollector(), livehistory.NewRing(livehistory.DefaultCapacity), cache.Default, nil, nil, fake, nil, nil)
+	registerHandlers(d, "test-version", db, metrics.NewCollector(), livehistory.NewRing(livehistory.DefaultCapacity), cache.Default, nil, nil, fake, artifact.Policy{}, logger.Discard(), nil, nil)
 	client, server := net.Pipe()
 	defer client.Close()
 	go d.Serve(server)


### PR DESCRIPTION
## Summary
- add daemon artifact policy modes: confirm, deny, and allow
- expose the active policy through health and artifact.policy RPC responses
- audit successful, failed, and denied daemon artifact writes in the JSONL daemon log
- document the remote policy controls for serve and install-daemon

## Validation
- go test ./internal/artifact ./internal/serve ./cmd/spectra -count=1
- go build ./...
- go vet ./...