### PR TITLE
[codex] Add broad live history replay

### DIFF
--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -73,8 +73,8 @@ JSON-RPC 2.0 methods, organized by concern:
 - **Snapshots** — `snapshot.create`, `snapshot.list`, `snapshot.get`,
   `snapshot.diff`, `snapshot.processes`, `snapshot.login_items`,
   `snapshot.granted_perms`, `snapshot.prune`
-- **Live state** — `process.live`, `process.history`, `process.list`,
-  `process.tree`, `process.sample`
+- **Live state** — `live.current`, `live.history`, `process.live`,
+  `process.history`, `process.list`, `process.tree`, `process.sample`
 - **Helper** — `helper.health`, `helper.powermetrics.sample`,
   `helper.tcc.system.query`, `helper.firewall.rules`,
   `helper.fs_usage.start`, `helper.fs_usage.stop`,
@@ -113,6 +113,12 @@ Process-level metrics (CPU%, RSS, virtual size) are sampled at ~1Hz into
 an in-memory ring buffer. The last 30 minutes per process are kept in RAM
 and flushed as 1-minute aggregates to SQLite. `spectra metrics` reads the
 stored rows; the `process.live` RPC returns recent in-memory samples.
+
+Broader live collector replay is kept as a second in-memory ring of daemon
+snapshot captures. `live.current` returns the newest broad live snapshot and
+`live.history` returns recent captures across the host, process, toolchain,
+power, sysctl, and network collectors. At the default 1-minute daemon cadence,
+the in-memory replay window keeps the last 30 captures.
 
 The daemon also captures a host-focused live snapshot every minute and prunes
 live snapshots to the last 100 rows. Apps, storage, and JVMs are skipped in

--- a/internal/livehistory/history.go
+++ b/internal/livehistory/history.go
@@ -1,0 +1,75 @@
+// Package livehistory keeps recent daemon live collector snapshots in memory.
+package livehistory
+
+import (
+	"sync"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+// DefaultCapacity is the daemon's in-memory replay window for broad live
+// collector snapshots. At the current 1-minute cadence this keeps 30 minutes.
+const DefaultCapacity = 30
+
+// Ring stores recent snapshots in chronological order behind a circular buffer.
+type Ring struct {
+	mu        sync.RWMutex
+	snapshots []snapshot.Snapshot
+	head      int
+	count     int
+}
+
+// NewRing returns a Ring that retains at most capacity snapshots.
+func NewRing(capacity int) *Ring {
+	if capacity <= 0 {
+		capacity = DefaultCapacity
+	}
+	return &Ring{snapshots: make([]snapshot.Snapshot, capacity)}
+}
+
+// Add records one snapshot, overwriting the oldest when the ring is full.
+func (r *Ring) Add(s snapshot.Snapshot) {
+	if r == nil || len(r.snapshots) == 0 {
+		return
+	}
+	r.mu.Lock()
+	r.snapshots[r.head] = s
+	r.head = (r.head + 1) % len(r.snapshots)
+	if r.count < len(r.snapshots) {
+		r.count++
+	}
+	r.mu.Unlock()
+}
+
+// Recent returns snapshots in chronological order, capped to the newest limit
+// when limit is positive.
+func (r *Ring) Recent(limit int) []snapshot.Snapshot {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.count == 0 {
+		return nil
+	}
+	all := make([]snapshot.Snapshot, r.count)
+	if r.count < len(r.snapshots) {
+		copy(all, r.snapshots[:r.count])
+	} else {
+		n := copy(all, r.snapshots[r.head:])
+		copy(all[n:], r.snapshots[:r.head])
+	}
+	if limit > 0 && len(all) > limit {
+		return all[len(all)-limit:]
+	}
+	return all
+}
+
+// Latest returns the newest snapshot, if any.
+func (r *Ring) Latest() (snapshot.Snapshot, bool) {
+	recent := r.Recent(1)
+	if len(recent) == 0 {
+		return snapshot.Snapshot{}, false
+	}
+	return recent[0], true
+}

--- a/internal/livehistory/history_test.go
+++ b/internal/livehistory/history_test.go
@@ -1,0 +1,48 @@
+package livehistory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func TestRingRecentKeepsChronologicalOrder(t *testing.T) {
+	r := NewRing(3)
+	base := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		r.Add(snapshot.Snapshot{
+			ID:      string(rune('a' + i)),
+			TakenAt: base.Add(time.Duration(i) * time.Minute),
+		})
+	}
+
+	got := r.Recent(0)
+	if len(got) != 3 {
+		t.Fatalf("Recent len = %d, want 3", len(got))
+	}
+	for i, want := range []string{"c", "d", "e"} {
+		if got[i].ID != want {
+			t.Errorf("Recent[%d].ID = %q, want %q", i, got[i].ID, want)
+		}
+	}
+}
+
+func TestRingLimitAndLatest(t *testing.T) {
+	r := NewRing(4)
+	r.Add(snapshot.Snapshot{ID: "first"})
+	r.Add(snapshot.Snapshot{ID: "second"})
+
+	recent := r.Recent(1)
+	if len(recent) != 1 || recent[0].ID != "second" {
+		t.Fatalf("Recent(1) = %+v, want second", recent)
+	}
+
+	latest, ok := r.Latest()
+	if !ok {
+		t.Fatal("Latest ok = false, want true")
+	}
+	if latest.ID != "second" {
+		t.Errorf("Latest ID = %q, want second", latest.ID)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kaeawc/spectra/internal/diff"
 	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/livehistory"
 	"github.com/kaeawc/spectra/internal/logger"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/netstate"
@@ -179,10 +180,11 @@ func runDaemon(ctx context.Context, log logger.Logger, opts Options, listeners [
 	log.Info("daemon storage ready", "db", dbPath)
 
 	collector := metrics.NewCollector()
+	history := livehistory.NewRing(livehistory.DefaultCapacity)
 	sampler := metrics.NewSampler(collector, time.Second, nil)
 	go sampler.Run(ctx)
 	go flushMetricsLoop(ctx, collector, db)
-	go snapshotLoop(ctx, opts.SpectraVersion, db)
+	go snapshotLoop(ctx, opts.SpectraVersion, db, history)
 
 	cacheReg := opts.CacheRegistry
 	if cacheReg == nil {
@@ -198,7 +200,7 @@ func runDaemon(ctx context.Context, log logger.Logger, opts Options, listeners [
 	}
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, opts.SpectraVersion, db, collector, cacheReg, opts.DetectStore, artifactRecorder, tsnetStatus, tsNode)
+	registerHandlers(d, opts.SpectraVersion, db, collector, history, cacheReg, opts.DetectStore, artifactRecorder, tsnetStatus, tsNode)
 	log.Info("daemon serving", "version", opts.SpectraVersion, "listeners", len(listeners))
 
 	go func() {
@@ -395,7 +397,7 @@ func flushMetricsLoop(ctx context.Context, c *metrics.Collector, db *store.DB) {
 // snapshotLoop captures a live host-only snapshot every minute and prunes the
 // live snapshot history to the last 100 entries. Apps, storage, and JVMs are
 // skipped to keep the per-tick cost low (~50ms vs seconds for a full snapshot).
-func snapshotLoop(ctx context.Context, version string, db *store.DB) {
+func snapshotLoop(ctx context.Context, version string, db *store.DB, history *livehistory.Ring) {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 	for {
@@ -409,6 +411,7 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB) {
 				SkipStorage:    true,
 				SkipJVMs:       true,
 			})
+			history.Add(snap)
 			_ = db.SaveSnapshot(ctx, store.FromSnapshot(snap))
 			_ = db.SaveSnapshotProcesses(ctx, snap.ID, store.ProcessesFromSnapshot(snap))
 			_ = db.SaveLoginItems(ctx, snap.ID, store.LoginItemsFromSnapshot(snap))
@@ -421,7 +424,10 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB) {
 // registerHandlers wires all JSON-RPC methods into d.
 //
 //gocyclo:ignore
-func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, cacheReg *cache.Registry, detectStore *cache.ShardedStore, artifactRecorder artifact.Recorder, tsnetStatus *TsnetStatus, tsnetNode TsnetNode) {
+func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, history *livehistory.Ring, cacheReg *cache.Registry, detectStore *cache.ShardedStore, artifactRecorder artifact.Recorder, tsnetStatus *TsnetStatus, tsnetNode TsnetNode) {
+	if history == nil {
+		history = livehistory.NewRing(livehistory.DefaultCapacity)
+	}
 	d.Register("health", func(_ json.RawMessage) (any, error) {
 		result := map[string]any{"ok": true, "version": version}
 		if tsnetStatus != nil {
@@ -507,6 +513,25 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, fmt.Errorf("process.history requires {\"pid\": <pid>}")
 		}
 		return db.GetProcessMetrics(context.Background(), p.PID, p.Limit)
+	})
+
+	d.Register("live.current", func(_ json.RawMessage) (any, error) {
+		snap, ok := history.Latest()
+		if !ok {
+			return nil, fmt.Errorf("live.current has no samples yet")
+		}
+		return snap, nil
+	})
+
+	d.Register("live.history", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Limit int `json:"limit"`
+		}
+		_ = json.Unmarshal(params, &p)
+		if p.Limit <= 0 {
+			p.Limit = livehistory.DefaultCapacity
+		}
+		return history.Recent(p.Limit), nil
 	})
 
 	d.Register("inspect.app", func(params json.RawMessage) (any, error) {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/livehistory"
 	"github.com/kaeawc/spectra/internal/logger"
 	"github.com/kaeawc/spectra/internal/metrics"
 	"github.com/kaeawc/spectra/internal/rpc"
@@ -77,7 +78,7 @@ func testDaemonWithDB(t *testing.T) (*json.Encoder, *json.Decoder, *store.DB, co
 		collectToolchains = origCollectToolchains
 		collectJDKs = origCollectJDKs
 	})
-	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default, nil, &artifact.FakeRecorder{}, nil, nil)
+	registerHandlers(d, "test-version", db, metrics.NewCollector(), livehistory.NewRing(livehistory.DefaultCapacity), cache.Default, nil, &artifact.FakeRecorder{}, nil, nil)
 
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -1237,7 +1238,7 @@ func TestDaemonJVMHeapDumpRecordsArtifact(t *testing.T) {
 	defer db.Close()
 	fake := &artifact.FakeRecorder{}
 	d := rpc.NewDispatcher()
-	registerHandlers(d, "test-version", db, metrics.NewCollector(), cache.Default, nil, fake, nil, nil)
+	registerHandlers(d, "test-version", db, metrics.NewCollector(), livehistory.NewRing(livehistory.DefaultCapacity), cache.Default, nil, fake, nil, nil)
 	client, server := net.Pipe()
 	defer client.Close()
 	go d.Serve(server)


### PR DESCRIPTION
## Summary

Adds broader live collector replay alongside the existing per-process metrics history. The daemon now keeps recent host-focused live snapshots in an in-memory ring and exposes them through `live.current` and `live.history` RPC methods.

## Why

Process metrics already had a ring/history path, but broader live collector state could only be captured through fresh calls or persisted daemon snapshots. This gives RPC clients a recent replay window for host, process, toolchain, power, sysctl, and network state without re-running collectors.

## Impact

The existing process metrics ring and stored snapshot retention remain unchanged. The new ring stores the existing minute-level daemon snapshot values in memory and defaults to 30 captures at the current daemon cadence.

## Validation

- `go test ./internal/livehistory ./internal/serve ./internal/metrics -count=1`
- `go build ./...`
- `go vet ./...`
