### PR TITLE
Add reusable profiling architecture

### DIFF
--- a/internal/jvm/profiler.go
+++ b/internal/jvm/profiler.go
@@ -1,6 +1,11 @@
 package jvm
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/profile"
+)
 
 // FlamegraphOptions configures an async-profiler flamegraph capture.
 type FlamegraphOptions struct {
@@ -23,6 +28,19 @@ func CaptureFlamegraph(pid int, opts FlamegraphOptions) error {
 	if opts.OutputPath == "" {
 		return fmt.Errorf("flamegraph output path is required")
 	}
+	session, err := profile.NormalizeSession(profile.SessionSpec{
+		Target: profile.Target{
+			PID:          pid,
+			Architecture: profile.ArchitectureJVM,
+		},
+		Collector: "async-profiler",
+		Event:     opts.Event,
+		Workflow:  profile.WorkflowSampling,
+		Duration:  time.Duration(opts.DurationSeconds) * time.Second,
+	})
+	if err != nil {
+		return err
+	}
 	run := opts.CmdRunner
 	if run == nil {
 		run = DefaultRunner
@@ -31,17 +49,7 @@ func CaptureFlamegraph(pid int, opts FlamegraphOptions) error {
 	if asprof == "" {
 		asprof = "asprof"
 	}
-	event := opts.Event
-	if event == "" {
-		event = "cpu"
-	}
-	duration := opts.DurationSeconds
-	if duration == 0 {
-		duration = 30
-	}
-	if duration < 0 {
-		return fmt.Errorf("flamegraph duration must be greater than zero")
-	}
-	_, err := run(asprof, "-d", fmt.Sprint(duration), "-e", event, "-f", opts.OutputPath, fmt.Sprint(pid))
+	duration := int(session.Duration / time.Second)
+	_, err = run(asprof, "-d", fmt.Sprint(duration), "-e", session.Event, "-f", opts.OutputPath, fmt.Sprint(pid))
 	return err
 }

--- a/internal/profile/collapsed.go
+++ b/internal/profile/collapsed.go
@@ -1,0 +1,152 @@
+package profile
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// StackSample is one weighted stack from a profiler output.
+type StackSample struct {
+	Frames []string `json:"frames"`
+	Value  int64    `json:"value"`
+}
+
+// MethodStat is an inclusive and exclusive method ranking entry.
+type MethodStat struct {
+	Name      string `json:"name"`
+	Inclusive int64  `json:"inclusive"`
+	Exclusive int64  `json:"exclusive"`
+}
+
+// CallTreeNode is a compact call tree node usable by CLI, RPC, and TUI views.
+type CallTreeNode struct {
+	Name     string         `json:"name"`
+	Value    int64          `json:"value"`
+	Self     int64          `json:"self,omitempty"`
+	Children []CallTreeNode `json:"children,omitempty"`
+}
+
+// ParseCollapsedStacks parses lines shaped like "a;b;c 42". Several profilers
+// can emit this folded/collapsed format, including async-profiler and Linux
+// perf tooling, so the parser stays outside runtime-specific packages.
+func ParseCollapsedStacks(r io.Reader) ([]StackSample, error) {
+	var samples []StackSample
+	scanner := bufio.NewScanner(r)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		stack, valueText, ok := strings.Cut(line, " ")
+		if !ok {
+			return nil, fmt.Errorf("collapsed stack line %d missing value", lineNo)
+		}
+		value, err := strconv.ParseInt(strings.TrimSpace(valueText), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("collapsed stack line %d value: %w", lineNo, err)
+		}
+		if value < 0 {
+			return nil, fmt.Errorf("collapsed stack line %d value must be non-negative", lineNo)
+		}
+		frames := splitFrames(stack)
+		if len(frames) == 0 {
+			continue
+		}
+		samples = append(samples, StackSample{Frames: frames, Value: value})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return samples, nil
+}
+
+// HotMethods returns method totals sorted by inclusive value, then name.
+func HotMethods(samples []StackSample) []MethodStat {
+	byName := make(map[string]*MethodStat)
+	for _, sample := range samples {
+		seen := make(map[string]bool, len(sample.Frames))
+		for i, frame := range sample.Frames {
+			stat := byName[frame]
+			if stat == nil {
+				stat = &MethodStat{Name: frame}
+				byName[frame] = stat
+			}
+			if !seen[frame] {
+				stat.Inclusive += sample.Value
+				seen[frame] = true
+			}
+			if i == len(sample.Frames)-1 {
+				stat.Exclusive += sample.Value
+			}
+		}
+	}
+	out := make([]MethodStat, 0, len(byName))
+	for _, stat := range byName {
+		out = append(out, *stat)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Inclusive != out[j].Inclusive {
+			return out[i].Inclusive > out[j].Inclusive
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// BuildCallTree rolls weighted stacks into a deterministic tree.
+func BuildCallTree(samples []StackSample) CallTreeNode {
+	root := treeNode{name: "root", children: make(map[string]*treeNode)}
+	for _, sample := range samples {
+		node := &root
+		node.value += sample.Value
+		for _, frame := range sample.Frames {
+			child := node.children[frame]
+			if child == nil {
+				child = &treeNode{name: frame, children: make(map[string]*treeNode)}
+				node.children[frame] = child
+			}
+			child.value += sample.Value
+			node = child
+		}
+		node.self += sample.Value
+	}
+	return root.export()
+}
+
+type treeNode struct {
+	name     string
+	value    int64
+	self     int64
+	children map[string]*treeNode
+}
+
+func (n *treeNode) export() CallTreeNode {
+	out := CallTreeNode{Name: n.name, Value: n.value, Self: n.self}
+	names := make([]string, 0, len(n.children))
+	for name := range n.children {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		out.Children = append(out.Children, n.children[name].export())
+	}
+	return out
+}
+
+func splitFrames(stack string) []string {
+	raw := strings.Split(stack, ";")
+	frames := raw[:0]
+	for _, frame := range raw {
+		frame = strings.TrimSpace(frame)
+		if frame != "" {
+			frames = append(frames, frame)
+		}
+	}
+	return frames
+}

--- a/internal/profile/collapsed_test.go
+++ b/internal/profile/collapsed_test.go
@@ -1,0 +1,54 @@
+package profile
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseCollapsedStacksAndHotMethods(t *testing.T) {
+	input := strings.NewReader(`
+main;svc.handle;db.query 7
+main;svc.handle;json.encode 3
+main;idle 2
+`)
+	samples, err := ParseCollapsedStacks(input)
+	if err != nil {
+		t.Fatalf("ParseCollapsedStacks: %v", err)
+	}
+	got := HotMethods(samples)
+	if len(got) < 2 {
+		t.Fatalf("hot methods too short: %#v", got)
+	}
+	if got[0].Name != "main" || got[0].Inclusive != 12 || got[0].Exclusive != 0 {
+		t.Fatalf("top method = %#v", got[0])
+	}
+	if got[1].Name != "svc.handle" || got[1].Inclusive != 10 {
+		t.Fatalf("second method = %#v", got[1])
+	}
+}
+
+func TestBuildCallTree(t *testing.T) {
+	samples := []StackSample{
+		{Frames: []string{"main", "svc", "db"}, Value: 7},
+		{Frames: []string{"main", "svc", "json"}, Value: 3},
+	}
+	tree := BuildCallTree(samples)
+	if tree.Value != 10 || len(tree.Children) != 1 {
+		t.Fatalf("root = %#v", tree)
+	}
+	main := tree.Children[0]
+	if main.Name != "main" || main.Value != 10 || len(main.Children) != 1 {
+		t.Fatalf("main = %#v", main)
+	}
+	svc := main.Children[0]
+	if svc.Name != "svc" || svc.Value != 10 || len(svc.Children) != 2 {
+		t.Fatalf("svc = %#v", svc)
+	}
+}
+
+func TestParseCollapsedStacksRejectsBadValue(t *testing.T) {
+	_, err := ParseCollapsedStacks(strings.NewReader("main;work nope\n"))
+	if err == nil {
+		t.Fatal("expected bad value error")
+	}
+}

--- a/internal/profile/session.go
+++ b/internal/profile/session.go
@@ -1,0 +1,209 @@
+package profile
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Architecture describes the kind of application/runtime being profiled.
+type Architecture string
+
+const (
+	ArchitectureUnknown Architecture = "unknown"
+	ArchitectureJVM     Architecture = "jvm"
+	ArchitectureNative  Architecture = "native"
+	ArchitectureNode    Architecture = "node"
+	ArchitecturePython  Architecture = "python"
+	ArchitectureBrowser Architecture = "browser"
+)
+
+// Workflow describes the profiling mechanism used by a session.
+type Workflow string
+
+const (
+	WorkflowSampling        Workflow = "sampling"
+	WorkflowInstrumentation Workflow = "instrumentation"
+)
+
+// View names an analysis view that can be built from captured profile data.
+type View string
+
+const (
+	ViewCallTree           View = "call_tree"
+	ViewHotMethods         View = "hot_methods"
+	ViewAllocationTimeline View = "allocation_timeline"
+	ViewLockContention     View = "lock_contention"
+)
+
+// Target describes the application or runtime a profiler session attaches to.
+// PID is common today, but BundleID, Executable, and RuntimeID let future
+// collectors target app bundles, helper processes, browser renderers, or
+// language runtime identifiers without changing the session contract.
+type Target struct {
+	PID          int               `json:"pid,omitempty"`
+	Architecture Architecture      `json:"architecture,omitempty"`
+	BundleID     string            `json:"bundle_id,omitempty"`
+	Executable   string            `json:"executable,omitempty"`
+	RuntimeID    string            `json:"runtime_id,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+}
+
+// SessionSpec is the reusable planning shape for profiler captures. Frontends
+// can build it before choosing a concrete collector.
+type SessionSpec struct {
+	Target Target `json:"target"`
+	// TargetPID keeps existing callers source-compatible while they migrate to
+	// Target. New application architectures should populate Target directly.
+	TargetPID int           `json:"target_pid"`
+	Collector string        `json:"collector"`
+	Event     string        `json:"event"`
+	Workflow  Workflow      `json:"workflow"`
+	Duration  time.Duration `json:"duration"`
+	Views     []View        `json:"views,omitempty"`
+}
+
+// Artifact is the normalized output from a collector. The bytes may live in a
+// file path, cache key, or inline stream depending on the caller's storage layer.
+type Artifact struct {
+	Kind     string            `json:"kind"`
+	Path     string            `json:"path,omitempty"`
+	MimeType string            `json:"mime_type,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// Collector is implemented by runtime-specific capture adapters such as JFR,
+// async-profiler, sample, DTrace, or future Node/Python collectors.
+type Collector interface {
+	Name() string
+	Supports(Target) bool
+	Capture(context.Context, SessionSpec) (Artifact, error)
+}
+
+// Analyzer turns normalized samples or artifacts into reusable analysis views.
+type Analyzer interface {
+	Views() []View
+	Analyze(context.Context, Artifact) (Analysis, error)
+}
+
+// Analysis is a collector-independent profile view container.
+type Analysis struct {
+	Target     Target                 `json:"target,omitempty"`
+	Event      string                 `json:"event,omitempty"`
+	Views      []View                 `json:"views,omitempty"`
+	CallTree   *CallTreeNode          `json:"call_tree,omitempty"`
+	HotMethods []MethodStat           `json:"hot_methods,omitempty"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// NormalizeSession applies Spectra's profiling defaults and validates fields
+// that are independent of a specific transport or command frontend.
+func NormalizeSession(spec SessionSpec) (SessionSpec, error) {
+	spec.Target = normalizeTarget(spec.Target, spec.TargetPID)
+	spec.Collector = normalizeCollector(spec.Collector, spec.Target.Architecture)
+	spec.Event = normalizeEvent(spec.Event)
+	spec.Workflow = normalizeWorkflow(spec.Workflow, spec.Collector, spec.Event)
+	spec.Duration = normalizeDuration(spec.Duration)
+	if spec.Workflow != WorkflowSampling && spec.Workflow != WorkflowInstrumentation {
+		return SessionSpec{}, fmt.Errorf("unknown profiling workflow %q", spec.Workflow)
+	}
+	if spec.Duration < 0 {
+		return SessionSpec{}, fmt.Errorf("duration must be greater than zero")
+	}
+	if !hasTarget(spec.Target) {
+		return SessionSpec{}, fmt.Errorf("profile target is required")
+	}
+	if len(spec.Views) == 0 {
+		spec.Views = DefaultViews(spec.Event)
+	}
+	spec.TargetPID = spec.Target.PID
+	return spec, nil
+}
+
+func normalizeTarget(target Target, fallbackPID int) Target {
+	if target.PID == 0 && fallbackPID != 0 {
+		target.PID = fallbackPID
+	}
+	if target.Architecture == "" {
+		target.Architecture = ArchitectureUnknown
+	}
+	return target
+}
+
+func hasTarget(target Target) bool {
+	return target.PID > 0 || target.BundleID != "" || target.Executable != "" || target.RuntimeID != ""
+}
+
+func normalizeCollector(collector string, architecture Architecture) string {
+	collector = strings.TrimSpace(collector)
+	if collector == "" {
+		return DefaultCollector(architecture)
+	}
+	return collector
+}
+
+func normalizeEvent(event string) string {
+	event = strings.TrimSpace(event)
+	if event == "" {
+		return "cpu"
+	}
+	return event
+}
+
+func normalizeWorkflow(workflow Workflow, collector, event string) Workflow {
+	if workflow == "" {
+		return defaultWorkflow(collector, event)
+	}
+	return workflow
+}
+
+func normalizeDuration(duration time.Duration) time.Duration {
+	if duration == 0 {
+		return 30 * time.Second
+	}
+	return duration
+}
+
+// DefaultCollector returns a conservative first-choice collector by architecture.
+func DefaultCollector(architecture Architecture) string {
+	switch architecture {
+	case ArchitectureJVM:
+		return "async-profiler"
+	case ArchitectureNative:
+		return "sample"
+	case ArchitectureNode:
+		return "node-profiler"
+	case ArchitecturePython:
+		return "py-spy"
+	case ArchitectureBrowser:
+		return "browser-profiler"
+	default:
+		return "process-sampler"
+	}
+}
+
+// DefaultViews returns analysis views usually useful for a profiler event.
+func DefaultViews(event string) []View {
+	switch strings.ToLower(strings.TrimSpace(event)) {
+	case "alloc", "allocation", "objectallocationinsample", "jdk.objectallocationinsample":
+		return []View{ViewHotMethods, ViewCallTree, ViewAllocationTimeline}
+	case "lock", "monitor-blocked", "jdk.javamonitorenter":
+		return []View{ViewLockContention, ViewHotMethods, ViewCallTree}
+	default:
+		return []View{ViewHotMethods, ViewCallTree}
+	}
+}
+
+func defaultWorkflow(collector, event string) Workflow {
+	switch strings.ToLower(strings.TrimSpace(collector)) {
+	case "jfr":
+		return WorkflowInstrumentation
+	}
+	switch strings.ToLower(strings.TrimSpace(event)) {
+	case "cpu", "wall", "alloc", "lock":
+		return WorkflowSampling
+	default:
+		return WorkflowInstrumentation
+	}
+}

--- a/internal/profile/session_test.go
+++ b/internal/profile/session_test.go
@@ -1,0 +1,86 @@
+package profile
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNormalizeSessionDefaultsCPU(t *testing.T) {
+	got, err := NormalizeSession(SessionSpec{
+		Target: Target{PID: 42, Architecture: ArchitectureJVM},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeSession: %v", err)
+	}
+	if got.Collector != "async-profiler" || got.Event != "cpu" || got.Workflow != WorkflowSampling {
+		t.Fatalf("defaults = %#v", got)
+	}
+	if got.Duration != 30*time.Second {
+		t.Fatalf("duration = %v", got.Duration)
+	}
+	if want := []View{ViewHotMethods, ViewCallTree}; !reflect.DeepEqual(got.Views, want) {
+		t.Fatalf("views = %v, want %v", got.Views, want)
+	}
+}
+
+func TestNormalizeSessionSupportsNonJVMTarget(t *testing.T) {
+	got, err := NormalizeSession(SessionSpec{
+		Target: Target{
+			PID:          42,
+			Architecture: ArchitectureNative,
+			BundleID:     "com.example.NativeApp",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeSession: %v", err)
+	}
+	if got.Collector != "sample" {
+		t.Fatalf("collector = %q, want sample", got.Collector)
+	}
+	if got.TargetPID != 42 {
+		t.Fatalf("target pid compatibility field = %d", got.TargetPID)
+	}
+}
+
+func TestNormalizeSessionSupportsRuntimeTargetWithoutPID(t *testing.T) {
+	got, err := NormalizeSession(SessionSpec{
+		Target: Target{
+			Architecture: ArchitectureBrowser,
+			RuntimeID:    "renderer-7",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeSession: %v", err)
+	}
+	if got.Collector != "browser-profiler" {
+		t.Fatalf("collector = %q, want browser-profiler", got.Collector)
+	}
+}
+
+func TestNormalizeSessionMigratesTargetPID(t *testing.T) {
+	got, err := NormalizeSession(SessionSpec{TargetPID: 42, Collector: "async-profiler"})
+	if err != nil {
+		t.Fatalf("NormalizeSession: %v", err)
+	}
+	if got.Target.PID != 42 || got.Target.Architecture != ArchitectureUnknown {
+		t.Fatalf("target = %#v", got.Target)
+	}
+}
+
+func TestNormalizeSessionDefaultViewsForLock(t *testing.T) {
+	got, err := NormalizeSession(SessionSpec{Target: Target{PID: 42}, Event: "lock"})
+	if err != nil {
+		t.Fatalf("NormalizeSession: %v", err)
+	}
+	want := []View{ViewLockContention, ViewHotMethods, ViewCallTree}
+	if !reflect.DeepEqual(got.Views, want) {
+		t.Fatalf("views = %v, want %v", got.Views, want)
+	}
+}
+
+func TestNormalizeSessionRejectsMissingPID(t *testing.T) {
+	if _, err := NormalizeSession(SessionSpec{}); err == nil {
+		t.Fatal("expected missing pid error")
+	}
+}


### PR DESCRIPTION
## Summary
- add a generic internal/profile package for profiler targets, collectors, analyzers, artifacts, and analysis views
- add collapsed stack parsing plus hot-method and call-tree analysis primitives
- adapt JVM async-profiler capture to use the generic session model while preserving current behavior

## Validation
- make ci
- make build-all
- make validate-workflows