### PR TITLE
Add reusable recording analysis interfaces

### DIFF
--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -95,6 +95,7 @@ JDK commands:
 | Flamegraph capture | `asprof -d <seconds> -e <event> -f <path> <pid>` |
 | JFR start / stop / dump | `jcmd <pid> JFR.start`, `JFR.dump` |
 | JFR summary | `jfr summary <recording.jfr>` |
+| JFR event views | `jfr view <view> <recording.jfr>` |
 
 `spectra jvm` and `spectra jvm <pid>` parse output into structured JSON
 when `--json` is passed. `spectra jvm jfr summary --json <file>` returns
@@ -103,6 +104,16 @@ and JFR dump files are copied into the
 [sharded blob store](../design/storage.md) when the cache stores are
 initialized. Heap dumps are written to the requested path or to
 `~/.spectra/<pid>-<timestamp>.hprof`.
+
+Recording analysis is split behind reusable internals before it is exposed as
+new user-facing commands. `internal/recording` defines runtime-neutral artifact,
+view, table, finding, analyzer, and analyzer-registry interfaces so Spectra can
+adapt the same architecture to JVM, native, Electron, Python, network, or other
+application recordings. `internal/jvm` implements that interface for JFR: it can
+run and parse `jfr view` tables for GC pauses, allocation sites, hot methods,
+monitor blocking, file I/O, and socket I/O, then combine those event views with
+`jfr summary` counts into first-pass incident findings. The same structures are
+intended to back future CLI, daemon RPC, MCP, and remote-debugging views.
 
 `spectra jvm vm-memory --json <pid>` returns every memory section with
 its underlying command, output, and per-section error. Native memory

--- a/internal/jvm/jfr_events.go
+++ b/internal/jvm/jfr_events.go
@@ -1,0 +1,282 @@
+package jvm
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/recording"
+)
+
+const (
+	JFRViewGCPauses       = "gc-pauses"
+	JFRViewAllocationSite = "allocation-by-site"
+	JFRViewHotMethods     = "hot-methods"
+	JFRViewMonitorBlocked = "monitor-blocked"
+	JFRViewFileIO         = "file-io"
+	JFRViewSocketIO       = "socket-io"
+)
+
+var jfrColumnSplit = regexp.MustCompile(`\s{2,}`)
+
+// JFRViewTable is one tabular section emitted by `jfr view`.
+type JFRViewTable = recording.Table
+
+// JFRViewTableRow is one row from a `jfr view` table.
+type JFRViewTableRow = recording.Row
+
+// JFRViewResult is the structured form of one `jfr view <view> <recording>`.
+type JFRViewResult = recording.View
+
+// JFRAnalysisOptions controls which reusable JFR event views are collected.
+type JFRAnalysisOptions struct {
+	Views []string
+}
+
+// JFRAnalysis combines summary data, event-view tables, and derived incident notes.
+type JFRAnalysis = recording.Analysis
+
+// JFRFinding is a human-oriented observation derived from a recording.
+type JFRFinding = recording.Finding
+
+// JFRAnalyzer implements recording.Analyzer for Java Flight Recorder files.
+type JFRAnalyzer struct {
+	Run   CmdRunner
+	Views []string
+}
+
+// ViewJFR runs `jfr view` for one event view and parses tabular output.
+func ViewJFR(path, view string, run CmdRunner) (JFRViewResult, error) {
+	if run == nil {
+		run = DefaultRunner
+	}
+	out, err := run("jfr", "view", view, path)
+	if err != nil {
+		return JFRViewResult{}, err
+	}
+	result := ParseJFRView(path, view, string(out))
+	return result, nil
+}
+
+// AnalyzeRecording implements recording.Analyzer for JFR recordings.
+func (a JFRAnalyzer) AnalyzeRecording(path string, opts recording.Options) (recording.Analysis, error) {
+	views := opts.Views
+	if len(views) == 0 {
+		views = a.Views
+	}
+	return AnalyzeJFR(path, JFRAnalysisOptions{Views: views}, a.Run)
+}
+
+// AnalyzeJFR collects reusable event views and derives first-pass incident notes.
+func AnalyzeJFR(path string, opts JFRAnalysisOptions, run CmdRunner) (JFRAnalysis, error) {
+	if run == nil {
+		run = DefaultRunner
+	}
+	views := opts.Views
+	if len(views) == 0 {
+		views = defaultJFRAnalysisViews()
+	}
+	summary, err := SummarizeJFR(path, run)
+	if err != nil {
+		return JFRAnalysis{}, fmt.Errorf("summarize jfr: %w", err)
+	}
+	analysis := JFRAnalysis{
+		Artifact: recording.Artifact{
+			Path:         path,
+			Kind:         "jfr",
+			Runtime:      "jvm",
+			Architecture: "java",
+		},
+		Summary: summary,
+	}
+	for _, view := range views {
+		result, err := ViewJFR(path, view, run)
+		if err != nil {
+			return JFRAnalysis{}, fmt.Errorf("view %s: %w", view, err)
+		}
+		analysis.Views = append(analysis.Views, result)
+	}
+	analysis.Narrative = BuildJFRNarrative(summary, analysis.Views)
+	return analysis, nil
+}
+
+// ParseJFRView parses the text tables emitted by `jfr view`.
+func ParseJFRView(path, view, out string) JFRViewResult {
+	result := JFRViewResult{
+		Path: path,
+		View: view,
+		Raw:  out,
+	}
+	lines := strings.Split(out, "\n")
+	var title string
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if isJFRSeparator(line) && i > 0 {
+			header := strings.TrimSpace(lines[i-1])
+			columns := splitJFRColumns(header)
+			if len(columns) < 2 {
+				continue
+			}
+			table := JFRViewTable{
+				Title:   title,
+				Columns: columns,
+			}
+			for j := i + 1; j < len(lines); j++ {
+				rowLine := strings.TrimSpace(lines[j])
+				if rowLine == "" {
+					i = j
+					break
+				}
+				if isJFRSeparator(rowLine) {
+					i = j - 1
+					break
+				}
+				values := splitJFRColumns(rowLine)
+				if len(values) == 0 {
+					continue
+				}
+				row := make(JFRViewTableRow)
+				for idx, column := range columns {
+					if idx >= len(values) {
+						break
+					}
+					row[column] = values[idx]
+				}
+				if len(row) > 0 {
+					table.Rows = append(table.Rows, row)
+				}
+				if j == len(lines)-1 {
+					i = j
+				}
+			}
+			result.Tables = append(result.Tables, table)
+			title = ""
+			continue
+		}
+		if !isLikelyJFRHeader(line) {
+			title = line
+		}
+	}
+	return result
+}
+
+// BuildJFRNarrative turns event-counts and parsed views into reusable incident notes.
+func BuildJFRNarrative(summary JFRSummary, views []JFRViewResult) []JFRFinding {
+	var findings []JFRFinding
+	counts := jfrEventCounts(summary.Events)
+	if counts["jdk.GarbageCollection"] > 0 || counts["jdk.GCPhasePause"] > 0 {
+		findings = append(findings, JFRFinding{
+			Area:     "gc",
+			Severity: "info",
+			Summary:  "GC pause events are present in the recording.",
+			Detail:   fmt.Sprintf("GarbageCollection=%d GCPhasePause=%d", counts["jdk.GarbageCollection"], counts["jdk.GCPhasePause"]),
+		})
+	}
+	if counts["jdk.ObjectAllocationInNewTLAB"] > 0 || counts["jdk.ObjectAllocationOutsideTLAB"] > 0 {
+		findings = append(findings, JFRFinding{
+			Area:     "allocation",
+			Severity: "info",
+			Summary:  "Allocation events are present and can be correlated with pause windows.",
+			Detail:   fmt.Sprintf("ObjectAllocationInNewTLAB=%d ObjectAllocationOutsideTLAB=%d", counts["jdk.ObjectAllocationInNewTLAB"], counts["jdk.ObjectAllocationOutsideTLAB"]),
+		})
+	}
+	for _, view := range views {
+		top := firstJFRRow(view)
+		if top == nil {
+			continue
+		}
+		switch view.View {
+		case JFRViewGCPauses:
+			findings = append(findings, findingFromRow("gc", "info", "Top GC pause view has entries.", top))
+		case JFRViewAllocationSite:
+			findings = append(findings, findingFromRow("allocation", "info", "Top allocation site view has entries.", top))
+		case JFRViewHotMethods:
+			findings = append(findings, findingFromRow("methods", "info", "Method profiling samples are present.", top))
+		case JFRViewMonitorBlocked:
+			findings = append(findings, findingFromRow("locks", "warning", "Monitor blocking events are present.", top))
+		case JFRViewFileIO:
+			findings = append(findings, findingFromRow("file-io", "info", "File I/O events are present.", top))
+		case JFRViewSocketIO:
+			findings = append(findings, findingFromRow("socket-io", "info", "Socket I/O events are present.", top))
+		}
+	}
+	return findings
+}
+
+func defaultJFRAnalysisViews() []string {
+	return []string{
+		JFRViewGCPauses,
+		JFRViewAllocationSite,
+		JFRViewHotMethods,
+		JFRViewMonitorBlocked,
+		JFRViewFileIO,
+		JFRViewSocketIO,
+	}
+}
+
+func splitJFRColumns(line string) []string {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil
+	}
+	return jfrColumnSplit.Split(line, -1)
+}
+
+func isJFRSeparator(line string) bool {
+	if line == "" {
+		return false
+	}
+	for _, r := range line {
+		if r != '-' && r != ' ' {
+			return false
+		}
+	}
+	return strings.Contains(line, "---")
+}
+
+func isLikelyJFRHeader(line string) bool {
+	return len(splitJFRColumns(line)) > 1
+}
+
+func jfrEventCounts(events []JFREventSummary) map[string]int64 {
+	counts := make(map[string]int64, len(events))
+	for _, event := range events {
+		counts[event.Type] = event.Count
+	}
+	return counts
+}
+
+func firstJFRRow(view JFRViewResult) JFRViewTableRow {
+	for _, table := range view.Tables {
+		if len(table.Rows) > 0 {
+			return table.Rows[0]
+		}
+	}
+	return nil
+}
+
+func findingFromRow(area, severity, summary string, row JFRViewTableRow) JFRFinding {
+	return JFRFinding{
+		Area:     area,
+		Severity: severity,
+		Summary:  summary,
+		Detail:   formatJFRRow(row),
+	}
+}
+
+func formatJFRRow(row JFRViewTableRow) string {
+	keys := make([]string, 0, len(row))
+	for key := range row {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+row[key])
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/jvm/jfr_events_test.go
+++ b/internal/jvm/jfr_events_test.go
@@ -1,0 +1,130 @@
+package jvm
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/recording"
+)
+
+func TestParseJFRViewTable(t *testing.T) {
+	out := `
+Longest GC Pauses
+
+Start Time                 Duration  GC Cause
+------------------------------------------------
+21:00:01.123               45.1 ms   Allocation Failure
+21:00:15.002               12.3 ms   Metadata GC Threshold
+`
+	got := ParseJFRView("/tmp/test.jfr", JFRViewGCPauses, out)
+	if got.Path != "/tmp/test.jfr" || got.View != JFRViewGCPauses {
+		t.Fatalf("identity = (%q, %q)", got.Path, got.View)
+	}
+	if len(got.Tables) != 1 {
+		t.Fatalf("tables = %d, want 1: %+v", len(got.Tables), got.Tables)
+	}
+	table := got.Tables[0]
+	if table.Title != "Longest GC Pauses" {
+		t.Fatalf("title = %q", table.Title)
+	}
+	wantColumns := []string{"Start Time", "Duration", "GC Cause"}
+	if !reflect.DeepEqual(table.Columns, wantColumns) {
+		t.Fatalf("columns = %#v, want %#v", table.Columns, wantColumns)
+	}
+	if len(table.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(table.Rows))
+	}
+	if table.Rows[0]["Duration"] != "45.1 ms" || table.Rows[0]["GC Cause"] != "Allocation Failure" {
+		t.Fatalf("row[0] = %+v", table.Rows[0])
+	}
+}
+
+func TestViewJFRFakeRunner(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	run := func(name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = args
+		return []byte("Method  Samples\n---------------\nmain    10\n"), nil
+	}
+	got, err := ViewJFR("/tmp/test.jfr", JFRViewHotMethods, run)
+	if err != nil {
+		t.Fatalf("ViewJFR: %v", err)
+	}
+	wantArgs := []string{"view", JFRViewHotMethods, "/tmp/test.jfr"}
+	if gotName != "jfr" || !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("command = %s %v, want jfr %v", gotName, gotArgs, wantArgs)
+	}
+	if len(got.Tables) != 1 || got.Tables[0].Rows[0]["Method"] != "main" {
+		t.Fatalf("tables = %+v", got.Tables)
+	}
+}
+
+func TestAnalyzeJFRCollectsViewsAndNarrative(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		if name != "jfr" {
+			return nil, fmt.Errorf("unexpected command %s", name)
+		}
+		switch args[0] {
+		case "summary":
+			return []byte(`Version: 2.1
+jdk.GarbageCollection 2 64
+jdk.ObjectAllocationInNewTLAB 50 800
+`), nil
+		case "view":
+			switch args[1] {
+			case JFRViewGCPauses:
+				return []byte("Start Time  Duration\n--------------------\n21:00:01    45 ms\n"), nil
+			case JFRViewAllocationSite:
+				return []byte("Class  Bytes\n------------\nbyte[]  1024\n"), nil
+			}
+		}
+		return nil, fmt.Errorf("unexpected args %v", args)
+	}
+	got, err := AnalyzeJFR("/tmp/test.jfr", JFRAnalysisOptions{Views: []string{JFRViewGCPauses, JFRViewAllocationSite}}, run)
+	if err != nil {
+		t.Fatalf("AnalyzeJFR: %v", err)
+	}
+	if len(got.Views) != 2 {
+		t.Fatalf("views = %d, want 2", len(got.Views))
+	}
+	if got.Artifact.Kind != "jfr" || got.Artifact.Runtime != "jvm" || got.Artifact.Architecture != "java" {
+		t.Fatalf("artifact = %+v", got.Artifact)
+	}
+	if len(got.Narrative) < 4 {
+		t.Fatalf("narrative = %+v, want summary and view findings", got.Narrative)
+	}
+}
+
+func TestJFRAnalyzerImplementsRecordingAnalyzer(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		switch args[0] {
+		case "summary":
+			return []byte("Version: 2.1\n"), nil
+		case "view":
+			return []byte("Method  Samples\n---------------\nmain    10\n"), nil
+		}
+		return nil, fmt.Errorf("unexpected args %v", args)
+	}
+	var analyzer recording.Analyzer = JFRAnalyzer{Run: run}
+	got, err := analyzer.AnalyzeRecording("/tmp/test.jfr", recording.Options{Views: []string{JFRViewHotMethods}})
+	if err != nil {
+		t.Fatalf("AnalyzeRecording: %v", err)
+	}
+	if got.Artifact.Kind != "jfr" || len(got.Views) != 1 || got.Views[0].View != JFRViewHotMethods {
+		t.Fatalf("analysis = %+v", got)
+	}
+}
+
+func TestAnalyzeJFRPropagatesViewError(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		if args[0] == "summary" {
+			return []byte("Version: 2.1\n"), nil
+		}
+		return nil, fmt.Errorf("view failed")
+	}
+	if _, err := AnalyzeJFR("/tmp/test.jfr", JFRAnalysisOptions{Views: []string{JFRViewGCPauses}}, run); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/recording/recording.go
+++ b/internal/recording/recording.go
@@ -1,0 +1,95 @@
+// Package recording defines reusable analysis contracts for diagnostic
+// recordings captured from applications and their supporting runtimes.
+package recording
+
+import "fmt"
+
+// Artifact describes a recording without assuming a specific runtime.
+type Artifact struct {
+	Path         string `json:"path,omitempty"`
+	Kind         string `json:"kind,omitempty"`
+	Runtime      string `json:"runtime,omitempty"`
+	Architecture string `json:"architecture,omitempty"`
+}
+
+// Options carries analyzer-independent knobs for selecting event views.
+type Options struct {
+	Views []string `json:"views,omitempty"`
+}
+
+// Analyzer turns one diagnostic recording into structured views and findings.
+type Analyzer interface {
+	AnalyzeRecording(path string, opts Options) (Analysis, error)
+}
+
+// AnalyzerFunc adapts a function into an Analyzer.
+type AnalyzerFunc func(path string, opts Options) (Analysis, error)
+
+// AnalyzeRecording implements Analyzer.
+func (f AnalyzerFunc) AnalyzeRecording(path string, opts Options) (Analysis, error) {
+	return f(path, opts)
+}
+
+// Registry dispatches recording analysis by artifact kind.
+type Registry struct {
+	analyzers map[string]Analyzer
+}
+
+// NewRegistry returns an empty analyzer registry.
+func NewRegistry() *Registry {
+	return &Registry{analyzers: make(map[string]Analyzer)}
+}
+
+// Register binds an analyzer to a recording kind.
+func (r *Registry) Register(kind string, analyzer Analyzer) {
+	if r.analyzers == nil {
+		r.analyzers = make(map[string]Analyzer)
+	}
+	r.analyzers[kind] = analyzer
+}
+
+// Analyze finds the analyzer for kind and runs it.
+func (r *Registry) Analyze(kind, path string, opts Options) (Analysis, error) {
+	if r == nil {
+		return Analysis{}, fmt.Errorf("recording analyzer registry is nil")
+	}
+	analyzer, ok := r.analyzers[kind]
+	if !ok || analyzer == nil {
+		return Analysis{}, fmt.Errorf("no recording analyzer registered for %q", kind)
+	}
+	return analyzer.AnalyzeRecording(path, opts)
+}
+
+// Analysis combines runtime-specific metadata, parsed event views, and findings.
+type Analysis struct {
+	Artifact  Artifact  `json:"artifact"`
+	Summary   any       `json:"summary,omitempty"`
+	Views     []View    `json:"views,omitempty"`
+	Narrative []Finding `json:"narrative,omitempty"`
+}
+
+// View is one named perspective over a recording's event stream.
+type View struct {
+	Path   string  `json:"path,omitempty"`
+	View   string  `json:"view"`
+	Tables []Table `json:"tables,omitempty"`
+	Raw    string  `json:"raw,omitempty"`
+}
+
+// Table is one tabular section emitted by an analyzer backend.
+type Table struct {
+	Title   string   `json:"title,omitempty"`
+	Columns []string `json:"columns,omitempty"`
+	Rows    []Row    `json:"rows,omitempty"`
+}
+
+// Row is one structured event-view row.
+type Row map[string]string
+
+// Finding is a human-oriented observation derived from a recording.
+type Finding struct {
+	Area     string `json:"area"`
+	Severity string `json:"severity"`
+	Summary  string `json:"summary"`
+	Detail   string `json:"detail,omitempty"`
+}

--- a/internal/recording/recording_test.go
+++ b/internal/recording/recording_test.go
@@ -1,0 +1,31 @@
+package recording
+
+import "testing"
+
+func TestRegistryDispatchesAnalyzerByKind(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register("sample", AnalyzerFunc(func(path string, opts Options) (Analysis, error) {
+		return Analysis{
+			Artifact: Artifact{Path: path, Kind: "sample", Runtime: "native"},
+			Views:    []View{{View: opts.Views[0]}},
+		}, nil
+	}))
+
+	got, err := registry.Analyze("sample", "/tmp/app.trace", Options{Views: []string{"latency"}})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if got.Artifact.Kind != "sample" || got.Artifact.Runtime != "native" {
+		t.Fatalf("artifact = %+v", got.Artifact)
+	}
+	if len(got.Views) != 1 || got.Views[0].View != "latency" {
+		t.Fatalf("views = %+v", got.Views)
+	}
+}
+
+func TestRegistryReportsMissingAnalyzer(t *testing.T) {
+	registry := NewRegistry()
+	if _, err := registry.Analyze("missing", "/tmp/app.trace", Options{}); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- add runtime-neutral recording analysis contracts and analyzer registry
- implement JFR as the first recording analyzer with `jfr view` parsing and narrative findings
- document the reusable architecture for non-JVM app recordings

## Validation
- `make ci`
- `make all`
