### PR TITLE
Add reusable heap analysis interfaces

### DIFF
--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -11,6 +11,16 @@ installed-JDK inventory when `java.home` matches a discovered JDK path.
 The optional in-process `spectra-agent.jar` adds direct MBean enumeration
 and lightweight in-process probes after an explicit attach step.
 
+Heap forensics beyond capture is intentionally split into reusable
+application-runtime interfaces before it grows a command surface.
+`internal/heap` defines generic heap records, snapshots, parsers, and
+analyzers that JVM, native, Node, Python, WebKit, and future collectors can
+adapt to. The JVM adapter parses `jcmd GC.class_histogram` output into
+structured rows, compares histogram snapshots, and ranks shallow-size and
+growth suspects. It does not parse `.hprof` object graphs yet, so dominator
+trees, retained sizes, paths-to-GC-roots, object queries, and heap-dump
+diffing remain future work.
+
 Spectra is intended to **supplant VisualVM** for the day-to-day
 "what's this Java process doing" question. JVM inspection is a
 first-class subsystem alongside the app scanner, not a bolt-on.

--- a/internal/heap/analysis.go
+++ b/internal/heap/analysis.go
@@ -1,0 +1,193 @@
+package heap
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Runtime identifies the application/runtime architecture that produced heap
+// evidence. New collectors should add runtime-specific adapters that return
+// generic heap records through this package's interfaces.
+type Runtime string
+
+const (
+	RuntimeUnknown Runtime = "unknown"
+	RuntimeJVM     Runtime = "jvm"
+	RuntimeNative  Runtime = "native"
+	RuntimeNode    Runtime = "node"
+	RuntimePython  Runtime = "python"
+	RuntimeWebKit  Runtime = "webkit"
+)
+
+// Record is the smallest common shape shared by heap-like object summaries.
+// JVM classes, native allocation sites, JavaScript constructors, Python types,
+// and WebKit object groups can all map onto this interface.
+type Record interface {
+	Identity() string
+	DisplayName() string
+	LiveCount() int64
+	ShallowBytes() int64
+}
+
+// Snapshot is a runtime-neutral heap observation.
+type Snapshot interface {
+	Runtime() Runtime
+	Source() string
+	Records() []Record
+	TotalShallowBytes() int64
+}
+
+// Parser turns runtime-specific heap evidence into a generic snapshot.
+type Parser interface {
+	Runtime() Runtime
+	ParseSnapshot([]byte) (Snapshot, error)
+}
+
+// Analyzer is the reusable heap-analysis contract for all app runtimes.
+type Analyzer interface {
+	Compare(before, after Snapshot) ([]Delta, error)
+	RankLargest(snapshot Snapshot, limit int) []AnalysisSuspect
+	RankGrowth(before, after Snapshot, limit int) ([]AnalysisSuspect, error)
+}
+
+// DefaultAnalyzer implements runtime-neutral shallow-size analysis.
+type DefaultAnalyzer struct{}
+
+// Delta is one record-level difference between two generic heap snapshots.
+type Delta struct {
+	Identity    string  `json:"identity"`
+	DisplayName string  `json:"display_name"`
+	Runtime     Runtime `json:"runtime"`
+	BeforeCount int64   `json:"before_count"`
+	AfterCount  int64   `json:"after_count"`
+	DeltaCount  int64   `json:"delta_count"`
+	BeforeBytes int64   `json:"before_bytes"`
+	AfterBytes  int64   `json:"after_bytes"`
+	DeltaBytes  int64   `json:"delta_bytes"`
+}
+
+// AnalysisSuspect describes a runtime-neutral record worth inspecting.
+type AnalysisSuspect struct {
+	Identity   string  `json:"identity"`
+	Name       string  `json:"name"`
+	Runtime    Runtime `json:"runtime"`
+	Reason     string  `json:"reason"`
+	Count      int64   `json:"count"`
+	Bytes      int64   `json:"bytes"`
+	DeltaCount int64   `json:"delta_count,omitempty"`
+	DeltaBytes int64   `json:"delta_bytes,omitempty"`
+}
+
+// Compare computes record-level changes from before to after.
+func (DefaultAnalyzer) Compare(before, after Snapshot) ([]Delta, error) {
+	if before == nil || after == nil {
+		return nil, fmt.Errorf("compare heap snapshots: nil snapshot")
+	}
+	type pair struct {
+		before Record
+		after  Record
+	}
+	byID := make(map[string]pair, len(before.Records())+len(after.Records()))
+	for _, r := range before.Records() {
+		p := byID[r.Identity()]
+		p.before = r
+		byID[r.Identity()] = p
+	}
+	for _, r := range after.Records() {
+		p := byID[r.Identity()]
+		p.after = r
+		byID[r.Identity()] = p
+	}
+
+	deltas := make([]Delta, 0, len(byID))
+	for id, p := range byID {
+		d := Delta{Identity: id, Runtime: after.Runtime()}
+		if p.before != nil {
+			d.DisplayName = p.before.DisplayName()
+			d.BeforeCount = p.before.LiveCount()
+			d.BeforeBytes = p.before.ShallowBytes()
+		}
+		if p.after != nil {
+			d.DisplayName = p.after.DisplayName()
+			d.AfterCount = p.after.LiveCount()
+			d.AfterBytes = p.after.ShallowBytes()
+		}
+		d.DeltaCount = d.AfterCount - d.BeforeCount
+		d.DeltaBytes = d.AfterBytes - d.BeforeBytes
+		deltas = append(deltas, d)
+	}
+	sortDeltas(deltas)
+	return deltas, nil
+}
+
+// RankLargest returns the largest shallow-size records in one snapshot.
+func (DefaultAnalyzer) RankLargest(snapshot Snapshot, limit int) []AnalysisSuspect {
+	if snapshot == nil || limit <= 0 {
+		return nil
+	}
+	records := append([]Record(nil), snapshot.Records()...)
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].ShallowBytes() != records[j].ShallowBytes() {
+			return records[i].ShallowBytes() > records[j].ShallowBytes()
+		}
+		return records[i].Identity() < records[j].Identity()
+	})
+	if len(records) > limit {
+		records = records[:limit]
+	}
+	suspects := make([]AnalysisSuspect, 0, len(records))
+	for _, r := range records {
+		suspects = append(suspects, AnalysisSuspect{
+			Identity: r.Identity(),
+			Name:     r.DisplayName(),
+			Runtime:  snapshot.Runtime(),
+			Reason:   "largest live shallow size in heap snapshot",
+			Count:    r.LiveCount(),
+			Bytes:    r.ShallowBytes(),
+		})
+	}
+	return suspects
+}
+
+// RankGrowth returns the largest positive shallow-size growth between snapshots.
+func (a DefaultAnalyzer) RankGrowth(before, after Snapshot, limit int) ([]AnalysisSuspect, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	deltas, err := a.Compare(before, after)
+	if err != nil {
+		return nil, err
+	}
+	suspects := make([]AnalysisSuspect, 0, limit)
+	for _, d := range deltas {
+		if d.DeltaBytes <= 0 {
+			continue
+		}
+		suspects = append(suspects, AnalysisSuspect{
+			Identity:   d.Identity,
+			Name:       d.DisplayName,
+			Runtime:    d.Runtime,
+			Reason:     "largest positive shallow-size growth between heap snapshots",
+			Count:      d.AfterCount,
+			Bytes:      d.AfterBytes,
+			DeltaCount: d.DeltaCount,
+			DeltaBytes: d.DeltaBytes,
+		})
+		if len(suspects) == limit {
+			break
+		}
+	}
+	return suspects, nil
+}
+
+func sortDeltas(deltas []Delta) {
+	sort.Slice(deltas, func(i, j int) bool {
+		if deltas[i].DeltaBytes != deltas[j].DeltaBytes {
+			return deltas[i].DeltaBytes > deltas[j].DeltaBytes
+		}
+		if deltas[i].AfterBytes != deltas[j].AfterBytes {
+			return deltas[i].AfterBytes > deltas[j].AfterBytes
+		}
+		return deltas[i].Identity < deltas[j].Identity
+	})
+}

--- a/internal/heap/analysis_test.go
+++ b/internal/heap/analysis_test.go
@@ -1,0 +1,78 @@
+package heap
+
+import "testing"
+
+type testRecord struct {
+	id    string
+	name  string
+	count int64
+	bytes int64
+}
+
+func (r testRecord) Identity() string    { return r.id }
+func (r testRecord) DisplayName() string { return r.name }
+func (r testRecord) LiveCount() int64    { return r.count }
+func (r testRecord) ShallowBytes() int64 { return r.bytes }
+
+type testSnapshot struct {
+	runtime Runtime
+	source  string
+	records []Record
+	total   int64
+}
+
+func (s testSnapshot) Runtime() Runtime         { return s.runtime }
+func (s testSnapshot) Source() string           { return s.source }
+func (s testSnapshot) Records() []Record        { return s.records }
+func (s testSnapshot) TotalShallowBytes() int64 { return s.total }
+
+func TestDefaultAnalyzerWorksAcrossRuntimeRecords(t *testing.T) {
+	before := testSnapshot{
+		runtime: RuntimeNative,
+		source:  "malloc-history",
+		records: []Record{
+			testRecord{id: "alloc:cache", name: "Cache allocations", count: 10, bytes: 1024},
+			testRecord{id: "alloc:old", name: "Old allocations", count: 1, bytes: 512},
+		},
+	}
+	after := testSnapshot{
+		runtime: RuntimeNative,
+		source:  "malloc-history",
+		records: []Record{
+			testRecord{id: "alloc:cache", name: "Cache allocations", count: 14, bytes: 4096},
+			testRecord{id: "alloc:new", name: "New allocations", count: 2, bytes: 2048},
+		},
+	}
+
+	analyzer := DefaultAnalyzer{}
+	deltas, err := analyzer.Compare(before, after)
+	if err != nil {
+		t.Fatalf("Compare: %v", err)
+	}
+	if len(deltas) != 3 {
+		t.Fatalf("deltas = %d, want 3: %#v", len(deltas), deltas)
+	}
+	if deltas[0].Identity != "alloc:cache" || deltas[0].Runtime != RuntimeNative || deltas[0].DeltaBytes != 3072 {
+		t.Fatalf("first delta = %#v", deltas[0])
+	}
+
+	largest := analyzer.RankLargest(after, 1)
+	if len(largest) != 1 || largest[0].Identity != "alloc:cache" {
+		t.Fatalf("largest = %#v", largest)
+	}
+
+	growth, err := analyzer.RankGrowth(before, after, 2)
+	if err != nil {
+		t.Fatalf("RankGrowth: %v", err)
+	}
+	if len(growth) != 2 || growth[0].Identity != "alloc:cache" || growth[1].Identity != "alloc:new" {
+		t.Fatalf("growth = %#v", growth)
+	}
+}
+
+func TestDefaultAnalyzerRejectsNilSnapshots(t *testing.T) {
+	_, err := DefaultAnalyzer{}.Compare(nil, testSnapshot{})
+	if err == nil {
+		t.Fatal("expected nil snapshot error")
+	}
+}

--- a/internal/heap/histogram.go
+++ b/internal/heap/histogram.go
@@ -1,0 +1,244 @@
+// Package heap contains reusable app heap-analysis building blocks.
+package heap
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ClassEntry is one row from a JVM class histogram.
+type ClassEntry struct {
+	Rank      int    `json:"rank"`
+	Instances int64  `json:"instances"`
+	Bytes     int64  `json:"bytes"`
+	ClassName string `json:"class_name"`
+	Module    string `json:"module,omitempty"`
+}
+
+// Identity returns the stable record key used by generic heap analysis.
+func (e ClassEntry) Identity() string {
+	if e.Module == "" {
+		return e.ClassName
+	}
+	return e.Module + ":" + e.ClassName
+}
+
+// DisplayName returns the human-readable record name.
+func (e ClassEntry) DisplayName() string {
+	return e.ClassName
+}
+
+// LiveCount returns the live instance count for this class.
+func (e ClassEntry) LiveCount() int64 {
+	return e.Instances
+}
+
+// ShallowBytes returns the shallow bytes for this class.
+func (e ClassEntry) ShallowBytes() int64 {
+	return e.Bytes
+}
+
+// Histogram is a structured view of jcmd GC.class_histogram output.
+type Histogram struct {
+	Entries []ClassEntry `json:"entries"`
+	Total   ClassEntry   `json:"total"`
+	Skipped []string     `json:"skipped,omitempty"`
+}
+
+// Runtime returns the source runtime for this heap snapshot.
+func (Histogram) Runtime() Runtime {
+	return RuntimeJVM
+}
+
+// Source returns the collector output that produced this snapshot.
+func (Histogram) Source() string {
+	return "jcmd GC.class_histogram"
+}
+
+// Records returns generic heap records for runtime-neutral analysis.
+func (h Histogram) Records() []Record {
+	records := make([]Record, 0, len(h.Entries))
+	for i := range h.Entries {
+		records = append(records, h.Entries[i])
+	}
+	return records
+}
+
+// TotalShallowBytes returns the total shallow bytes reported by the collector.
+func (h Histogram) TotalShallowBytes() int64 {
+	return h.Total.Bytes
+}
+
+// JVMHistogramParser parses jcmd GC.class_histogram output.
+type JVMHistogramParser struct{}
+
+// Runtime returns the parser's supported runtime.
+func (JVMHistogramParser) Runtime() Runtime {
+	return RuntimeJVM
+}
+
+// ParseSnapshot parses a JVM class histogram into a generic heap snapshot.
+func (JVMHistogramParser) ParseSnapshot(out []byte) (Snapshot, error) {
+	return ParseHistogram(string(out))
+}
+
+// ParseHistogram parses the text emitted by jcmd GC.class_histogram.
+func ParseHistogram(out string) (Histogram, error) {
+	var h Histogram
+	for _, raw := range strings.Split(out, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "num ") || strings.HasPrefix(line, "-") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 3 && fields[0] == "Total" {
+			instances, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				return h, fmt.Errorf("parse histogram total instances: %w", err)
+			}
+			bytes, err := strconv.ParseInt(fields[2], 10, 64)
+			if err != nil {
+				return h, fmt.Errorf("parse histogram total bytes: %w", err)
+			}
+			h.Total = ClassEntry{Instances: instances, Bytes: bytes, ClassName: "Total"}
+			continue
+		}
+		if len(fields) < 4 {
+			h.Skipped = append(h.Skipped, raw)
+			continue
+		}
+		rankText := strings.TrimSuffix(fields[0], ":")
+		rank, err := strconv.Atoi(rankText)
+		if err != nil {
+			h.Skipped = append(h.Skipped, raw)
+			continue
+		}
+		instances, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return h, fmt.Errorf("parse histogram instances on rank %d: %w", rank, err)
+		}
+		bytes, err := strconv.ParseInt(fields[2], 10, 64)
+		if err != nil {
+			return h, fmt.Errorf("parse histogram bytes on rank %d: %w", rank, err)
+		}
+		name, module := splitClassAndModule(strings.Join(fields[3:], " "))
+		entry := ClassEntry{
+			Rank:      rank,
+			Instances: instances,
+			Bytes:     bytes,
+			ClassName: name,
+			Module:    module,
+		}
+		h.Entries = append(h.Entries, entry)
+	}
+	return h, nil
+}
+
+func splitClassAndModule(s string) (className, module string) {
+	s = strings.TrimSpace(s)
+	if i := strings.LastIndex(s, " ("); i > 0 && strings.HasSuffix(s, ")") {
+		return strings.TrimSpace(s[:i]), strings.TrimSuffix(s[i+2:], ")")
+	}
+	return s, ""
+}
+
+// HistogramDelta is the class-level difference between two histograms.
+type HistogramDelta struct {
+	ClassName    string `json:"class_name"`
+	BeforeCount  int64  `json:"before_count"`
+	AfterCount   int64  `json:"after_count"`
+	DeltaCount   int64  `json:"delta_count"`
+	BeforeBytes  int64  `json:"before_bytes"`
+	AfterBytes   int64  `json:"after_bytes"`
+	DeltaBytes   int64  `json:"delta_bytes"`
+	BeforeRank   int    `json:"before_rank,omitempty"`
+	AfterRank    int    `json:"after_rank,omitempty"`
+	BeforeModule string `json:"before_module,omitempty"`
+	AfterModule  string `json:"after_module,omitempty"`
+}
+
+// CompareHistograms computes class-level changes from before to after.
+func CompareHistograms(before, after Histogram) []HistogramDelta {
+	generic, err := DefaultAnalyzer{}.Compare(before, after)
+	if err != nil {
+		return nil
+	}
+	deltas := make([]HistogramDelta, 0, len(generic))
+	beforeByID := histogramEntriesByID(before)
+	afterByID := histogramEntriesByID(after)
+	for _, gd := range generic {
+		d := HistogramDelta{
+			ClassName:   gd.DisplayName,
+			BeforeCount: gd.BeforeCount,
+			AfterCount:  gd.AfterCount,
+			DeltaCount:  gd.DeltaCount,
+			BeforeBytes: gd.BeforeBytes,
+			AfterBytes:  gd.AfterBytes,
+			DeltaBytes:  gd.DeltaBytes,
+		}
+		if e, ok := beforeByID[gd.Identity]; ok {
+			d.BeforeRank = e.Rank
+			d.BeforeModule = e.Module
+		}
+		if e, ok := afterByID[gd.Identity]; ok {
+			d.AfterRank = e.Rank
+			d.AfterModule = e.Module
+		}
+		deltas = append(deltas, d)
+	}
+	return deltas
+}
+
+func histogramEntriesByID(h Histogram) map[string]ClassEntry {
+	entries := make(map[string]ClassEntry, len(h.Entries))
+	for _, e := range h.Entries {
+		entries[e.Identity()] = e
+	}
+	return entries
+}
+
+// Suspect describes a class worth inspecting in a heap-forensics workflow.
+type Suspect struct {
+	ClassName  string `json:"class_name"`
+	Reason     string `json:"reason"`
+	Instances  int64  `json:"instances"`
+	Bytes      int64  `json:"bytes"`
+	DeltaCount int64  `json:"delta_count,omitempty"`
+	DeltaBytes int64  `json:"delta_bytes,omitempty"`
+}
+
+// RankHistogramSuspects returns the largest classes in one histogram.
+func RankHistogramSuspects(h Histogram, limit int) []Suspect {
+	generic := DefaultAnalyzer{}.RankLargest(h, limit)
+	suspects := make([]Suspect, 0, len(generic))
+	for _, s := range generic {
+		suspects = append(suspects, Suspect{
+			ClassName: s.Name,
+			Reason:    "largest live shallow size in class histogram",
+			Instances: s.Count,
+			Bytes:     s.Bytes,
+		})
+	}
+	return suspects
+}
+
+// RankGrowthSuspects returns the largest positive class growth between two histograms.
+func RankGrowthSuspects(before, after Histogram, limit int) []Suspect {
+	generic, err := DefaultAnalyzer{}.RankGrowth(before, after, limit)
+	if err != nil {
+		return nil
+	}
+	suspects := make([]Suspect, 0, len(generic))
+	for _, s := range generic {
+		suspects = append(suspects, Suspect{
+			ClassName:  s.Name,
+			Reason:     "largest positive shallow-size growth between histograms",
+			Instances:  s.Count,
+			Bytes:      s.Bytes,
+			DeltaCount: s.DeltaCount,
+			DeltaBytes: s.DeltaBytes,
+		})
+	}
+	return suspects
+}

--- a/internal/heap/histogram_test.go
+++ b/internal/heap/histogram_test.go
@@ -1,0 +1,117 @@
+package heap
+
+import "testing"
+
+func TestParseHistogram(t *testing.T) {
+	input := ` num     #instances         #bytes  class name (module)
+-------------------------------------------------------
+   1:          321       1048576  [B (java.base@21.0.2)
+   2:           12          4096  java.lang.String (java.base@21.0.2)
+   3:            7          2048  com.example.Cache$Entry
+Total          340       1054720
+`
+	got, err := ParseHistogram(input)
+	if err != nil {
+		t.Fatalf("ParseHistogram: %v", err)
+	}
+	if len(got.Entries) != 3 {
+		t.Fatalf("entries = %d, want 3: %#v", len(got.Entries), got.Entries)
+	}
+	first := got.Entries[0]
+	if first.Rank != 1 || first.Instances != 321 || first.Bytes != 1048576 || first.ClassName != "[B" || first.Module != "java.base@21.0.2" {
+		t.Fatalf("first entry = %#v", first)
+	}
+	if got.Total.Instances != 340 || got.Total.Bytes != 1054720 {
+		t.Fatalf("total = %#v", got.Total)
+	}
+	if len(got.Skipped) != 0 {
+		t.Fatalf("skipped = %#v", got.Skipped)
+	}
+}
+
+func TestJVMHistogramImplementsGenericSnapshot(t *testing.T) {
+	snapshot, err := JVMHistogramParser{}.ParseSnapshot([]byte(` num     #instances         #bytes  class name
+   1:            2            64  java.lang.Object
+Total            2            64
+`))
+	if err != nil {
+		t.Fatalf("ParseSnapshot: %v", err)
+	}
+	if snapshot.Runtime() != RuntimeJVM || snapshot.Source() != "jcmd GC.class_histogram" {
+		t.Fatalf("snapshot metadata = %s %q", snapshot.Runtime(), snapshot.Source())
+	}
+	records := snapshot.Records()
+	if len(records) != 1 || records[0].Identity() != "java.lang.Object" || records[0].ShallowBytes() != 64 {
+		t.Fatalf("records = %#v", records)
+	}
+	if snapshot.TotalShallowBytes() != 64 {
+		t.Fatalf("total = %d, want 64", snapshot.TotalShallowBytes())
+	}
+}
+
+func TestParseHistogramSkipsNonRows(t *testing.T) {
+	input := `before full gc
+ num     #instances         #bytes  class name
+not a row
+   1:            2            64  java.lang.Object
+`
+	got, err := ParseHistogram(input)
+	if err != nil {
+		t.Fatalf("ParseHistogram: %v", err)
+	}
+	if len(got.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(got.Entries))
+	}
+	if len(got.Skipped) != 2 {
+		t.Fatalf("skipped = %d, want 2: %#v", len(got.Skipped), got.Skipped)
+	}
+}
+
+func TestCompareHistogramsSortsGrowthFirst(t *testing.T) {
+	before, err := ParseHistogram(` num     #instances         #bytes  class name
+   1:           10          1000  com.example.Stable
+   2:            5           500  com.example.Grow
+   3:            2           200  com.example.Gone
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := ParseHistogram(` num     #instances         #bytes  class name
+   1:           20          2500  com.example.Grow
+   2:           10          1000  com.example.Stable
+   3:            1            64  com.example.New
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := CompareHistograms(before, after)
+	if len(got) != 4 {
+		t.Fatalf("deltas = %d, want 4: %#v", len(got), got)
+	}
+	if got[0].ClassName != "com.example.Grow" || got[0].DeltaBytes != 2000 || got[0].DeltaCount != 15 {
+		t.Fatalf("first delta = %#v", got[0])
+	}
+	if got[len(got)-1].ClassName != "com.example.Gone" || got[len(got)-1].DeltaBytes != -200 {
+		t.Fatalf("last delta = %#v", got[len(got)-1])
+	}
+}
+
+func TestRankSuspects(t *testing.T) {
+	before, _ := ParseHistogram(` num     #instances         #bytes  class name
+   1:           10          1000  a.Big
+   2:            5           500  b.Small
+`)
+	after, _ := ParseHistogram(` num     #instances         #bytes  class name
+   1:           20          3000  a.Big
+   2:           80          1600  c.Growing
+   3:            1             8  b.Small
+`)
+	largest := RankHistogramSuspects(after, 2)
+	if len(largest) != 2 || largest[0].ClassName != "a.Big" || largest[1].ClassName != "c.Growing" {
+		t.Fatalf("largest = %#v", largest)
+	}
+	growth := RankGrowthSuspects(before, after, 2)
+	if len(growth) != 2 || growth[0].ClassName != "a.Big" || growth[0].DeltaBytes != 2000 || growth[1].ClassName != "c.Growing" {
+		t.Fatalf("growth = %#v", growth)
+	}
+}

--- a/internal/jvm/jcmd.go
+++ b/internal/jvm/jcmd.go
@@ -3,6 +3,8 @@ package jvm
 import (
 	"fmt"
 	"strings"
+
+	"github.com/kaeawc/spectra/internal/heap"
 )
 
 // collectSysProps runs `jcmd <pid> VM.system_properties` and returns the
@@ -109,6 +111,16 @@ func HeapHistogram(pid int, run CmdRunner) ([]byte, error) {
 		run = DefaultRunner
 	}
 	return run("jcmd", fmt.Sprint(pid), "GC.class_histogram")
+}
+
+// HeapHistogramSnapshot runs GC.class_histogram and parses it into structured
+// rows for reusable heap-analysis workflows.
+func HeapHistogramSnapshot(pid int, run CmdRunner) (heap.Histogram, error) {
+	out, err := HeapHistogram(pid, run)
+	if err != nil {
+		return heap.Histogram{}, err
+	}
+	return heap.ParseHistogram(string(out))
 }
 
 // HeapDump runs `jcmd <pid> GC.heap_dump <destPath>` to write a .hprof file.

--- a/internal/jvm/jvm_test.go
+++ b/internal/jvm/jvm_test.go
@@ -167,6 +167,22 @@ func TestHeapHistogramFakeRunner(t *testing.T) {
 	}
 }
 
+func TestHeapHistogramSnapshotFakeRunner(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		if name == "jcmd" && len(args) == 2 && args[1] == "GC.class_histogram" {
+			return []byte(" num     #instances         #bytes  class name\n   1:          1234       9876543  [B\nTotal         1234       9876543\n"), nil
+		}
+		return nil, fmt.Errorf("unexpected: %s %v", name, args)
+	}
+	got, err := HeapHistogramSnapshot(42, run)
+	if err != nil {
+		t.Fatalf("HeapHistogramSnapshot: %v", err)
+	}
+	if len(got.Entries) != 1 || got.Entries[0].ClassName != "[B" || got.Total.Bytes != 9876543 {
+		t.Fatalf("snapshot = %#v", got)
+	}
+}
+
 func TestHeapDumpFakeRunner(t *testing.T) {
 	var capturedArgs []string
 	run := func(name string, args ...string) ([]byte, error) {


### PR DESCRIPTION
## Summary

- add runtime-neutral heap Record, Snapshot, Parser, and Analyzer interfaces
- implement DefaultAnalyzer for shallow-size ranking and snapshot growth comparison
- adapt JVM class histograms into the generic heap-analysis model
- document the app-runtime extensibility boundary for future native, Node, Python, and WebKit collectors

## Validation

- make ci
- make all
