### PR TITLE
Add reusable thread inspection analysis

### DIFF
--- a/internal/jvm/jcmd.go
+++ b/internal/jvm/jcmd.go
@@ -3,6 +3,7 @@ package jvm
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/heap"
 )
@@ -169,21 +170,7 @@ func JFRStop(pid int, recordingName, destPath string, run CmdRunner) error {
 	return err
 }
 
-// countThreads counts threads in `jcmd Thread.print` output.
-//
-// Thread entries begin with a line like:
-//
-//	"main" #1 prio=5 os_prio=31 cpu=... elapsed=... tid=... nid=... waiting [...]
-//
-// We count lines that start with `"` followed by a non-whitespace char
-// (thread name in quotes) as one thread entry.
+// countThreads counts parsed thread entries in `jcmd Thread.print` output.
 func countThreads(out string) int {
-	count := 0
-	for _, line := range strings.Split(out, "\n") {
-		// Thread name lines start with a double-quote.
-		if len(line) > 0 && line[0] == '"' {
-			count++
-		}
-	}
-	return count
+	return len(ParseThreadDump(out, time.Time{}).Threads)
 }

--- a/internal/jvm/threads.go
+++ b/internal/jvm/threads.go
@@ -1,0 +1,282 @@
+package jvm
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/threadinspect"
+)
+
+type ThreadState = threadinspect.State
+type WaitCategory = threadinspect.WaitCategory
+type ParsedThreadDump = threadinspect.Snapshot
+type Thread = threadinspect.Thread
+type DeadlockCycle = threadinspect.DeadlockCycle
+type ThreadSummary = threadinspect.Summary
+type ThreadFilter = threadinspect.Filter
+type ThreadDumpDiff = threadinspect.Diff
+type ThreadChange = threadinspect.Change
+type ThreadTimeline = threadinspect.Timeline
+type ThreadTimelinePoint = threadinspect.TimelinePoint
+
+const (
+	ThreadStateUnknown      = threadinspect.StateUnknown
+	ThreadStateRunnable     = threadinspect.StateRunnable
+	ThreadStateBlocked      = threadinspect.StateBlocked
+	ThreadStateWaiting      = threadinspect.StateWaiting
+	ThreadStateTimedWaiting = threadinspect.StateTimedWaiting
+	ThreadStateTerminated   = threadinspect.StateTerminated
+
+	WaitCategoryRunning  = threadinspect.WaitCategoryRunning
+	WaitCategorySleeping = threadinspect.WaitCategorySleeping
+	WaitCategoryWait     = threadinspect.WaitCategoryWait
+	WaitCategoryPark     = threadinspect.WaitCategoryPark
+	WaitCategoryMonitor  = threadinspect.WaitCategoryMonitor
+	WaitCategoryUnknown  = threadinspect.WaitCategoryUnknown
+)
+
+// ThreadDumpParser adapts raw jcmd Thread.print bytes into the runtime-neutral
+// threadinspect.Parser interface.
+type ThreadDumpParser struct{}
+
+// ParseThreads parses raw jcmd Thread.print output.
+func (ThreadDumpParser) ParseThreads(raw []byte, capturedAt time.Time) (threadinspect.Snapshot, error) {
+	return ParseThreadDump(string(raw), capturedAt), nil
+}
+
+// ThreadDumpCapturer adapts jcmd Thread.print into the runtime-neutral
+// threadinspect.Capturer interface.
+type ThreadDumpCapturer struct {
+	Run CmdRunner
+	Now func() time.Time
+}
+
+// CaptureThreads captures and parses a JVM thread dump for pid.
+func (c ThreadDumpCapturer) CaptureThreads(ctx context.Context, pid int) (threadinspect.Snapshot, error) {
+	select {
+	case <-ctx.Done():
+		return threadinspect.Snapshot{}, ctx.Err()
+	default:
+	}
+	raw, err := ThreadDump(pid, c.Run)
+	if err != nil {
+		return threadinspect.Snapshot{}, err
+	}
+	now := time.Now
+	if c.Now != nil {
+		now = c.Now
+	}
+	dump := ParseThreadDump(string(raw), now())
+	dump.PID = pid
+	return dump, nil
+}
+
+var (
+	_ threadinspect.Parser   = ThreadDumpParser{}
+	_ threadinspect.Capturer = ThreadDumpCapturer{}
+
+	threadHeaderRE = regexp.MustCompile(`^"([^"]*)"\s+#([0-9]+)\b(.*)$`)
+	stateLineRE    = regexp.MustCompile(`^\s+java\.lang\.Thread\.State:\s+([A-Z_]+)(?:\s+\(([^)]*)\))?`)
+	lockOwnerRE    = regexp.MustCompile(`owned by "([^"]+)" Id=([0-9]+)`)
+)
+
+// ParseThreadDump parses jcmd Thread.print output.
+func ParseThreadDump(out string, capturedAt time.Time) ParsedThreadDump {
+	var dump ParsedThreadDump
+	dump.Runtime = threadinspect.RuntimeJVM
+	dump.CapturedAt = capturedAt
+	blocks := splitThreadBlocks(out)
+	for _, block := range blocks {
+		thread, ok := parseThreadBlock(block)
+		if ok {
+			dump.Threads = append(dump.Threads, thread)
+		}
+	}
+	dump.Deadlocks = parseDeadlocks(out)
+	return dump
+}
+
+// SummarizeThreads returns reusable aggregate counts for a parsed dump.
+func SummarizeThreads(dump ParsedThreadDump) ThreadSummary {
+	return threadinspect.Summarize(dump)
+}
+
+// FilterThreads returns threads matching filter.
+func FilterThreads(dump ParsedThreadDump, filter ThreadFilter) []Thread {
+	return threadinspect.FilterThreads(dump, filter)
+}
+
+// DiffThreadDumps compares stable thread identities between two dumps.
+func DiffThreadDumps(before, after ParsedThreadDump) ThreadDumpDiff {
+	return threadinspect.DiffSnapshots(before, after)
+}
+
+// BuildThreadTimeline converts repeated parsed dumps into aggregate timeline points.
+func BuildThreadTimeline(dumps []ParsedThreadDump) ThreadTimeline {
+	return threadinspect.BuildTimeline(dumps)
+}
+
+func splitThreadBlocks(out string) []string {
+	var blocks []string
+	var current []string
+	for _, line := range strings.Split(out, "\n") {
+		if isThreadHeader(line) {
+			if len(current) > 0 {
+				blocks = append(blocks, strings.Join(current, "\n"))
+			}
+			current = []string{line}
+			continue
+		}
+		if len(current) > 0 {
+			if strings.TrimSpace(line) == "" {
+				blocks = append(blocks, strings.Join(current, "\n"))
+				current = nil
+				continue
+			}
+			current = append(current, line)
+		}
+	}
+	if len(current) > 0 {
+		blocks = append(blocks, strings.Join(current, "\n"))
+	}
+	return blocks
+}
+
+func parseThreadBlock(block string) (Thread, bool) {
+	lines := strings.Split(block, "\n")
+	if len(lines) == 0 {
+		return Thread{}, false
+	}
+	match := threadHeaderRE.FindStringSubmatch(lines[0])
+	if match == nil {
+		return Thread{}, false
+	}
+	javaID, _ := strconv.Atoi(match[2])
+	thread := Thread{
+		Name:      match[1],
+		RuntimeID: threadinspect.RuntimeIDFromInt(javaID),
+		RawHeader: lines[0],
+		RawBlock:  block,
+	}
+	headerRest := match[3]
+	thread.Daemon = strings.Contains(headerRest, " daemon ")
+	thread.Virtual = strings.Contains(headerRest, " virtual ") || strings.Contains(headerRest, "VirtualThread")
+	thread.NativeID = headerValue(headerRest, "nid=")
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+		if stateMatch := stateLineRE.FindStringSubmatch(line); stateMatch != nil {
+			thread.State = ThreadState(stateMatch[1])
+			if len(stateMatch) > 2 {
+				thread.Detail = stateMatch[2]
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "- ") {
+			parseLockLine(trimmed, &thread)
+			continue
+		}
+		if strings.HasPrefix(trimmed, "at ") && thread.TopFrame == "" {
+			thread.TopFrame = strings.TrimPrefix(trimmed, "at ")
+		}
+		if trimmed != "" {
+			thread.Stack = append(thread.Stack, trimmed)
+		}
+	}
+	if thread.State == "" {
+		thread.State = ThreadStateUnknown
+	}
+	thread.Category = classifyWait(thread)
+	return thread, true
+}
+
+func parseLockLine(line string, thread *Thread) {
+	if strings.Contains(line, "parking to wait for") || strings.Contains(line, "waiting on") || strings.Contains(line, "waiting to lock") || strings.Contains(line, "locked") {
+		if start := strings.Index(line, "<"); start >= 0 {
+			if end := strings.Index(line[start:], ">"); end >= 0 {
+				thread.Lock = line[start : start+end+1]
+			}
+		}
+	}
+	if owner := lockOwnerRE.FindStringSubmatch(line); owner != nil {
+		thread.LockOwner = owner[1]
+		thread.LockOwnerID = owner[2]
+	}
+}
+
+func classifyWait(thread Thread) WaitCategory {
+	detail := strings.ToLower(thread.Detail)
+	block := strings.ToLower(thread.RawBlock)
+	switch thread.State {
+	case ThreadStateRunnable:
+		return WaitCategoryRunning
+	case ThreadStateBlocked:
+		return WaitCategoryMonitor
+	case ThreadStateWaiting, ThreadStateTimedWaiting:
+		if strings.Contains(detail, "sleeping") {
+			return WaitCategorySleeping
+		}
+		if strings.Contains(detail, "parking") || strings.Contains(block, "parking to wait for") {
+			return WaitCategoryPark
+		}
+		if strings.Contains(detail, "on object monitor") || strings.Contains(detail, "in object.wait") || strings.Contains(block, "waiting on") {
+			return WaitCategoryWait
+		}
+		return WaitCategoryWait
+	default:
+		return WaitCategoryUnknown
+	}
+}
+
+func parseDeadlocks(out string) []DeadlockCycle {
+	if !strings.Contains(out, "deadlock") && !strings.Contains(out, "Deadlock") {
+		return nil
+	}
+	var cycles []DeadlockCycle
+	var current DeadlockCycle
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, `"`) {
+			if name, ok := parseDeadlockThreadLine(trimmed); ok {
+				current.Threads = append(current.Threads, name)
+			}
+		}
+		if strings.Contains(trimmed, "waiting to lock monitor") || strings.Contains(trimmed, "waiting for ownable synchronizer") {
+			if start := strings.Index(trimmed, "<"); start >= 0 {
+				if end := strings.Index(trimmed[start:], ">"); end >= 0 {
+					current.Locks = append(current.Locks, trimmed[start:start+end+1])
+				}
+			}
+		}
+	}
+	if len(current.Threads) > 1 {
+		cycles = append(cycles, current)
+	}
+	return cycles
+}
+
+func parseDeadlockThreadLine(line string) (string, bool) {
+	end := strings.Index(line[1:], `"`)
+	if end < 0 {
+		return "", false
+	}
+	return line[1 : end+1], true
+}
+
+func isThreadHeader(line string) bool {
+	return threadHeaderRE.MatchString(line)
+}
+
+func headerValue(header, key string) string {
+	idx := strings.Index(header, key)
+	if idx < 0 {
+		return ""
+	}
+	value := header[idx+len(key):]
+	if end := strings.IndexAny(value, " \t"); end >= 0 {
+		value = value[:end]
+	}
+	return strings.Trim(value, ",")
+}

--- a/internal/jvm/threads_test.go
+++ b/internal/jvm/threads_test.go
@@ -1,0 +1,141 @@
+package jvm
+
+import (
+	"testing"
+	"time"
+)
+
+const sampleThreadDump = `2026-05-07 10:00:00
+Full thread dump OpenJDK 64-Bit Server VM:
+
+"main" #1 prio=5 os_prio=31 cpu=12.34ms elapsed=1.23s tid=0x1 nid=0x101 runnable [0x0]
+   java.lang.Thread.State: RUNNABLE
+	at com.example.Main.run(Main.java:10)
+
+"worker" #7 daemon prio=5 os_prio=31 cpu=1.00ms elapsed=1.23s tid=0x7 nid=0x107 waiting on condition [0x0]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(Native Method)
+	- parking to wait for  <0x0000000700012340> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+
+"blocked" #8 prio=5 os_prio=31 cpu=0.50ms elapsed=1.23s tid=0x8 nid=0x108 waiting for monitor entry [0x0]
+   java.lang.Thread.State: BLOCKED (on object monitor)
+	- waiting to lock <0x00000007000abc00> (a java.lang.Object) owned by "owner" Id=9
+	at com.example.Locked.enter(Locked.java:20)
+
+"virtual-task" #11 virtual prio=5 os_prio=31 cpu=0.10ms elapsed=1.23s tid=0x11 nid=0x111 waiting on condition [0x0]
+   java.lang.Thread.State: WAITING (parking)
+	at java.base/java.lang.VirtualThread.park(VirtualThread.java:582)
+`
+
+func TestParseThreadDumpExtractsReusableThreadSignals(t *testing.T) {
+	capturedAt := time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC)
+	dump := ParseThreadDump(sampleThreadDump, capturedAt)
+	if len(dump.Threads) != 4 {
+		t.Fatalf("threads = %d, want 4", len(dump.Threads))
+	}
+	if !dump.CapturedAt.Equal(capturedAt) {
+		t.Fatalf("capturedAt = %v, want %v", dump.CapturedAt, capturedAt)
+	}
+
+	main := dump.Threads[0]
+	if main.Name != "main" || main.RuntimeID != "1" || main.NativeID != "0x101" {
+		t.Fatalf("unexpected main identity: %#v", main)
+	}
+	if main.State != ThreadStateRunnable || main.Category != WaitCategoryRunning {
+		t.Fatalf("main state/category = %s/%s", main.State, main.Category)
+	}
+	if main.TopFrame != "com.example.Main.run(Main.java:10)" {
+		t.Fatalf("main top frame = %q", main.TopFrame)
+	}
+
+	parked := dump.Threads[1]
+	if parked.Category != WaitCategoryPark || parked.Lock != "<0x0000000700012340>" {
+		t.Fatalf("parked category/lock = %s/%q", parked.Category, parked.Lock)
+	}
+	if !parked.Daemon {
+		t.Fatal("worker should be marked daemon")
+	}
+
+	blocked := dump.Threads[2]
+	if blocked.Category != WaitCategoryMonitor || blocked.LockOwner != "owner" || blocked.LockOwnerID != "9" {
+		t.Fatalf("blocked lock owner fields: %#v", blocked)
+	}
+
+	virtual := dump.Threads[3]
+	if !virtual.Virtual || virtual.Category != WaitCategoryPark {
+		t.Fatalf("virtual thread fields: %#v", virtual)
+	}
+}
+
+func TestSummarizeAndFilterThreads(t *testing.T) {
+	dump := ParseThreadDump(sampleThreadDump, time.Time{})
+	summary := SummarizeThreads(dump)
+	if summary.Total != 4 || summary.Daemon != 1 || summary.Virtual != 1 {
+		t.Fatalf("summary totals: %#v", summary)
+	}
+	if summary.ByCategory[WaitCategoryRunning] != 1 ||
+		summary.ByCategory[WaitCategoryPark] != 2 ||
+		summary.ByCategory[WaitCategoryMonitor] != 1 {
+		t.Fatalf("category counts: %#v", summary.ByCategory)
+	}
+	if summary.MonitorLocks["<0x00000007000abc00>"] != 1 {
+		t.Fatalf("monitor lock counts: %#v", summary.MonitorLocks)
+	}
+
+	virtual := FilterThreads(dump, ThreadFilter{VirtualOnly: true, IncludeDaemon: true})
+	if len(virtual) != 1 || virtual[0].Name != "virtual-task" {
+		t.Fatalf("virtual filter: %#v", virtual)
+	}
+
+	parkedNonDaemon := FilterThreads(dump, ThreadFilter{Categories: []WaitCategory{WaitCategoryPark}})
+	if len(parkedNonDaemon) != 1 || parkedNonDaemon[0].Name != "virtual-task" {
+		t.Fatalf("parked non-daemon filter: %#v", parkedNonDaemon)
+	}
+}
+
+func TestDiffThreadDumpsShowsWhatChanged(t *testing.T) {
+	before := ParseThreadDump(sampleThreadDump, time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC))
+	after := ParseThreadDump(`"main" #1 prio=5 os_prio=31 cpu=12.34ms elapsed=2.23s tid=0x1 nid=0x101 waiting on condition [0x0]
+   java.lang.Thread.State: TIMED_WAITING (sleeping)
+	at java.base/java.lang.Thread.sleep(Native Method)
+
+"new-worker" #12 prio=5 os_prio=31 cpu=0.01ms elapsed=0.10s tid=0x12 nid=0x112 runnable [0x0]
+   java.lang.Thread.State: RUNNABLE
+	at com.example.Work.run(Work.java:1)
+`, time.Date(2026, 5, 7, 10, 0, 5, 0, time.UTC))
+
+	diff := DiffThreadDumps(before, after)
+	if len(diff.Added) != 1 || diff.Added[0].Name != "new-worker" {
+		t.Fatalf("added: %#v", diff.Added)
+	}
+	if len(diff.Removed) != 3 {
+		t.Fatalf("removed = %d, want 3", len(diff.Removed))
+	}
+	if len(diff.StateChanged) != 1 || diff.StateChanged[0].Name != "main" {
+		t.Fatalf("state changed: %#v", diff.StateChanged)
+	}
+	if diff.StateChanged[0].BeforeCat != WaitCategoryRunning || diff.StateChanged[0].AfterCat != WaitCategorySleeping {
+		t.Fatalf("main category change: %#v", diff.StateChanged[0])
+	}
+	if diff.CategoryDelta[WaitCategoryPark] != -2 || diff.CategoryDelta[WaitCategorySleeping] != 1 {
+		t.Fatalf("category delta: %#v", diff.CategoryDelta)
+	}
+}
+
+func TestBuildThreadTimeline(t *testing.T) {
+	first := ParseThreadDump(sampleThreadDump, time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC))
+	second := ParseThreadDump(`"main" #1 prio=5 os_prio=31 cpu=12.34ms elapsed=2.23s tid=0x1 nid=0x101 waiting on condition [0x0]
+   java.lang.Thread.State: TIMED_WAITING (sleeping)
+`, time.Date(2026, 5, 7, 10, 0, 5, 0, time.UTC))
+
+	timeline := BuildThreadTimeline([]ParsedThreadDump{first, second})
+	if len(timeline.Points) != 2 {
+		t.Fatalf("points = %d, want 2", len(timeline.Points))
+	}
+	if timeline.Points[0].ByCategory[WaitCategoryPark] != 2 {
+		t.Fatalf("first point categories: %#v", timeline.Points[0].ByCategory)
+	}
+	if timeline.Points[1].Total != 1 || timeline.Points[1].ByCategory[WaitCategorySleeping] != 1 {
+		t.Fatalf("second point: %#v", timeline.Points[1])
+	}
+}

--- a/internal/threadinspect/threadinspect.go
+++ b/internal/threadinspect/threadinspect.go
@@ -1,0 +1,365 @@
+// Package threadinspect defines runtime-neutral thread inspection models and
+// analysis helpers. Runtime-specific packages adapt their native dump formats
+// into these types.
+package threadinspect
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Runtime identifies the application architecture or runtime that produced a
+// thread snapshot.
+type Runtime string
+
+const (
+	RuntimeUnknown Runtime = "unknown"
+	RuntimeJVM     Runtime = "jvm"
+	RuntimeProcess Runtime = "process"
+	RuntimeGo      Runtime = "go"
+	RuntimeNode    Runtime = "node"
+	RuntimeNative  Runtime = "native"
+)
+
+// Capturer captures a runtime-specific thread snapshot for a process.
+type Capturer interface {
+	CaptureThreads(ctx context.Context, pid int) (Snapshot, error)
+}
+
+// Parser adapts raw runtime-specific thread data into a Snapshot.
+type Parser interface {
+	ParseThreads(raw []byte, capturedAt time.Time) (Snapshot, error)
+}
+
+// State is the normalized thread execution state.
+type State string
+
+const (
+	StateUnknown      State = "UNKNOWN"
+	StateRunnable     State = "RUNNABLE"
+	StateBlocked      State = "BLOCKED"
+	StateWaiting      State = "WAITING"
+	StateTimedWaiting State = "TIMED_WAITING"
+	StateTerminated   State = "TERMINATED"
+)
+
+// WaitCategory groups runtime-specific states into triage views that apply
+// across application architectures.
+type WaitCategory string
+
+const (
+	WaitCategoryRunning  WaitCategory = "running"
+	WaitCategorySleeping WaitCategory = "sleeping"
+	WaitCategoryWait     WaitCategory = "wait"
+	WaitCategoryPark     WaitCategory = "park"
+	WaitCategoryMonitor  WaitCategory = "monitor"
+	WaitCategoryUnknown  WaitCategory = "unknown"
+)
+
+// Snapshot is a structured representation of one thread capture.
+type Snapshot struct {
+	Runtime    Runtime         `json:"runtime,omitempty"`
+	PID        int             `json:"pid,omitempty"`
+	CapturedAt time.Time       `json:"captured_at,omitempty"`
+	Threads    []Thread        `json:"threads"`
+	Deadlocks  []DeadlockCycle `json:"deadlocks,omitempty"`
+}
+
+// Thread is one thread entry from any supported runtime.
+type Thread struct {
+	Name        string       `json:"name"`
+	RuntimeID   string       `json:"runtime_id,omitempty"`
+	NativeID    string       `json:"native_id,omitempty"`
+	Daemon      bool         `json:"daemon,omitempty"`
+	Virtual     bool         `json:"virtual,omitempty"`
+	State       State        `json:"state,omitempty"`
+	Category    WaitCategory `json:"category,omitempty"`
+	Detail      string       `json:"detail,omitempty"`
+	Lock        string       `json:"lock,omitempty"`
+	LockOwner   string       `json:"lock_owner,omitempty"`
+	LockOwnerID string       `json:"lock_owner_id,omitempty"`
+	TopFrame    string       `json:"top_frame,omitempty"`
+	Stack       []string     `json:"stack,omitempty"`
+	RawHeader   string       `json:"raw_header,omitempty"`
+	RawBlock    string       `json:"raw_block,omitempty"`
+}
+
+// DeadlockCycle describes one detected lock cycle.
+type DeadlockCycle struct {
+	Threads []string `json:"threads"`
+	Locks   []string `json:"locks,omitempty"`
+}
+
+// Summary aggregates one parsed thread snapshot.
+type Summary struct {
+	Total        int                  `json:"total"`
+	Daemon       int                  `json:"daemon"`
+	Virtual      int                  `json:"virtual"`
+	ByState      map[State]int        `json:"by_state,omitempty"`
+	ByCategory   map[WaitCategory]int `json:"by_category,omitempty"`
+	ByTopFrame   map[string]int       `json:"by_top_frame,omitempty"`
+	MonitorLocks map[string]int       `json:"monitor_locks,omitempty"`
+	Deadlocks    int                  `json:"deadlocks,omitempty"`
+}
+
+// Filter selects threads from a parsed snapshot. Empty fields do not filter.
+type Filter struct {
+	NameContains     string
+	StackContains    string
+	States           []State
+	Categories       []WaitCategory
+	VirtualOnly      bool
+	IncludeDaemon    bool
+	LockContains     string
+	TopFrameContains string
+}
+
+// Diff compares two parsed snapshots.
+type Diff struct {
+	Added         []Thread             `json:"added,omitempty"`
+	Removed       []Thread             `json:"removed,omitempty"`
+	StateChanged  []Change             `json:"state_changed,omitempty"`
+	CategoryDelta map[WaitCategory]int `json:"category_delta,omitempty"`
+	StateDelta    map[State]int        `json:"state_delta,omitempty"`
+	DeadlockDelta int                  `json:"deadlock_delta,omitempty"`
+}
+
+// Change records a state/category transition for a stable thread.
+type Change struct {
+	Name        string       `json:"name"`
+	RuntimeID   string       `json:"runtime_id,omitempty"`
+	NativeID    string       `json:"native_id,omitempty"`
+	BeforeState State        `json:"before_state,omitempty"`
+	AfterState  State        `json:"after_state,omitempty"`
+	BeforeCat   WaitCategory `json:"before_category,omitempty"`
+	AfterCat    WaitCategory `json:"after_category,omitempty"`
+	BeforeTop   string       `json:"before_top_frame,omitempty"`
+	AfterTop    string       `json:"after_top_frame,omitempty"`
+}
+
+// Timeline is an aggregate state timeline over repeated snapshots.
+type Timeline struct {
+	Points []TimelinePoint `json:"points"`
+}
+
+// TimelinePoint is one aggregate point in a thread timeline.
+type TimelinePoint struct {
+	CapturedAt time.Time            `json:"captured_at,omitempty"`
+	Total      int                  `json:"total"`
+	ByCategory map[WaitCategory]int `json:"by_category,omitempty"`
+	ByState    map[State]int        `json:"by_state,omitempty"`
+	Virtual    int                  `json:"virtual,omitempty"`
+	Deadlocks  int                  `json:"deadlocks,omitempty"`
+}
+
+// Summarize returns reusable aggregate counts for a parsed snapshot.
+func Summarize(snapshot Snapshot) Summary {
+	summary := Summary{
+		Total:        len(snapshot.Threads),
+		ByState:      make(map[State]int),
+		ByCategory:   make(map[WaitCategory]int),
+		ByTopFrame:   make(map[string]int),
+		MonitorLocks: make(map[string]int),
+		Deadlocks:    len(snapshot.Deadlocks),
+	}
+	for _, thread := range snapshot.Threads {
+		if thread.Daemon {
+			summary.Daemon++
+		}
+		if thread.Virtual {
+			summary.Virtual++
+		}
+		summary.ByState[thread.State]++
+		summary.ByCategory[thread.Category]++
+		if thread.TopFrame != "" {
+			summary.ByTopFrame[thread.TopFrame]++
+		}
+		if thread.Category == WaitCategoryMonitor && thread.Lock != "" {
+			summary.MonitorLocks[thread.Lock]++
+		}
+	}
+	return summary
+}
+
+// FilterThreads returns threads matching filter.
+func FilterThreads(snapshot Snapshot, filter Filter) []Thread {
+	var out []Thread
+	for _, thread := range snapshot.Threads {
+		if threadMatches(thread, filter) {
+			out = append(out, thread)
+		}
+	}
+	return out
+}
+
+func threadMatches(thread Thread, filter Filter) bool {
+	return matchesThreadKind(thread, filter) &&
+		matchesThreadText(thread, filter) &&
+		matchesThreadState(thread, filter)
+}
+
+func matchesThreadKind(thread Thread, filter Filter) bool {
+	if !filter.IncludeDaemon && thread.Daemon {
+		return false
+	}
+	return !filter.VirtualOnly || thread.Virtual
+}
+
+func matchesThreadText(thread Thread, filter Filter) bool {
+	if filter.NameContains != "" && !containsFold(thread.Name, filter.NameContains) {
+		return false
+	}
+	if filter.StackContains != "" && !containsFold(strings.Join(thread.Stack, "\n"), filter.StackContains) {
+		return false
+	}
+	if filter.LockContains != "" && !containsFold(thread.Lock, filter.LockContains) {
+		return false
+	}
+	return filter.TopFrameContains == "" || containsFold(thread.TopFrame, filter.TopFrameContains)
+}
+
+func matchesThreadState(thread Thread, filter Filter) bool {
+	if len(filter.States) > 0 && !hasState(filter.States, thread.State) {
+		return false
+	}
+	return len(filter.Categories) == 0 || hasCategory(filter.Categories, thread.Category)
+}
+
+// DiffSnapshots compares stable thread identities between two snapshots.
+func DiffSnapshots(before, after Snapshot) Diff {
+	diff := Diff{
+		CategoryDelta: deltaCategories(before, after),
+		StateDelta:    deltaStates(before, after),
+		DeadlockDelta: len(after.Deadlocks) - len(before.Deadlocks),
+	}
+	beforeByID := indexThreads(before.Threads)
+	afterByID := indexThreads(after.Threads)
+	for key, thread := range afterByID {
+		prev, ok := beforeByID[key]
+		if !ok {
+			diff.Added = append(diff.Added, thread)
+			continue
+		}
+		if prev.State != thread.State || prev.Category != thread.Category || prev.TopFrame != thread.TopFrame {
+			diff.StateChanged = append(diff.StateChanged, Change{
+				Name:        thread.Name,
+				RuntimeID:   thread.RuntimeID,
+				NativeID:    thread.NativeID,
+				BeforeState: prev.State,
+				AfterState:  thread.State,
+				BeforeCat:   prev.Category,
+				AfterCat:    thread.Category,
+				BeforeTop:   prev.TopFrame,
+				AfterTop:    thread.TopFrame,
+			})
+		}
+	}
+	for key, thread := range beforeByID {
+		if _, ok := afterByID[key]; !ok {
+			diff.Removed = append(diff.Removed, thread)
+		}
+	}
+	sortThreads(diff.Added)
+	sortThreads(diff.Removed)
+	sort.Slice(diff.StateChanged, func(i, j int) bool {
+		return diff.StateChanged[i].Name < diff.StateChanged[j].Name
+	})
+	return diff
+}
+
+// BuildTimeline converts repeated parsed snapshots into aggregate timeline points.
+func BuildTimeline(snapshots []Snapshot) Timeline {
+	points := make([]TimelinePoint, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		summary := Summarize(snapshot)
+		points = append(points, TimelinePoint{
+			CapturedAt: snapshot.CapturedAt,
+			Total:      summary.Total,
+			ByCategory: summary.ByCategory,
+			ByState:    summary.ByState,
+			Virtual:    summary.Virtual,
+			Deadlocks:  summary.Deadlocks,
+		})
+	}
+	return Timeline{Points: points}
+}
+
+func containsFold(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}
+
+func hasState(states []State, state State) bool {
+	for _, candidate := range states {
+		if candidate == state {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCategory(categories []WaitCategory, category WaitCategory) bool {
+	for _, candidate := range categories {
+		if candidate == category {
+			return true
+		}
+	}
+	return false
+}
+
+func indexThreads(threads []Thread) map[string]Thread {
+	index := make(map[string]Thread, len(threads))
+	for _, thread := range threads {
+		index[threadKey(thread)] = thread
+	}
+	return index
+}
+
+func threadKey(thread Thread) string {
+	if thread.NativeID != "" {
+		return "native:" + thread.NativeID
+	}
+	if thread.RuntimeID != "" {
+		return "runtime:" + thread.RuntimeID
+	}
+	return "name:" + thread.Name
+}
+
+func deltaCategories(before, after Snapshot) map[WaitCategory]int {
+	out := make(map[WaitCategory]int)
+	for category, count := range Summarize(after).ByCategory {
+		out[category] += count
+	}
+	for category, count := range Summarize(before).ByCategory {
+		out[category] -= count
+	}
+	return out
+}
+
+func deltaStates(before, after Snapshot) map[State]int {
+	out := make(map[State]int)
+	for state, count := range Summarize(after).ByState {
+		out[state] += count
+	}
+	for state, count := range Summarize(before).ByState {
+		out[state] -= count
+	}
+	return out
+}
+
+func sortThreads(threads []Thread) {
+	sort.Slice(threads, func(i, j int) bool {
+		return threadKey(threads[i]) < threadKey(threads[j])
+	})
+}
+
+// RuntimeIDFromInt formats numeric runtime thread IDs for adapters that expose
+// integer IDs.
+func RuntimeIDFromInt(id int) string {
+	if id == 0 {
+		return ""
+	}
+	return strconv.Itoa(id)
+}

--- a/internal/threadinspect/threadinspect_test.go
+++ b/internal/threadinspect/threadinspect_test.go
@@ -1,0 +1,69 @@
+package threadinspect
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRuntimeNeutralSummaryFilterDiffAndTimeline(t *testing.T) {
+	first := Snapshot{
+		Runtime:    RuntimeNative,
+		PID:        42,
+		CapturedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+		Threads: []Thread{
+			{Name: "main", RuntimeID: "1", NativeID: "0x1", State: StateRunnable, Category: WaitCategoryRunning, TopFrame: "main"},
+			{Name: "worker", RuntimeID: "2", NativeID: "0x2", State: StateWaiting, Category: WaitCategoryWait, TopFrame: "wait", Daemon: true},
+			{Name: "fiber", RuntimeID: "3", State: StateWaiting, Category: WaitCategoryPark, Virtual: true, TopFrame: "park"},
+		},
+	}
+	second := Snapshot{
+		Runtime:    RuntimeNative,
+		PID:        42,
+		CapturedAt: time.Date(2026, 5, 7, 10, 0, 5, 0, time.UTC),
+		Threads: []Thread{
+			{Name: "main", RuntimeID: "1", NativeID: "0x1", State: StateTimedWaiting, Category: WaitCategorySleeping, TopFrame: "sleep"},
+			{Name: "new-worker", RuntimeID: "4", NativeID: "0x4", State: StateRunnable, Category: WaitCategoryRunning, TopFrame: "work"},
+		},
+	}
+
+	summary := Summarize(first)
+	if summary.Total != 3 || summary.Daemon != 1 || summary.Virtual != 1 {
+		t.Fatalf("summary totals: %#v", summary)
+	}
+	if summary.ByCategory[WaitCategoryRunning] != 1 || summary.ByCategory[WaitCategoryPark] != 1 {
+		t.Fatalf("summary categories: %#v", summary.ByCategory)
+	}
+
+	virtual := FilterThreads(first, Filter{VirtualOnly: true, IncludeDaemon: true})
+	if len(virtual) != 1 || virtual[0].Name != "fiber" {
+		t.Fatalf("virtual filter: %#v", virtual)
+	}
+
+	diff := DiffSnapshots(first, second)
+	if len(diff.Added) != 1 || diff.Added[0].Name != "new-worker" {
+		t.Fatalf("added: %#v", diff.Added)
+	}
+	if len(diff.Removed) != 2 {
+		t.Fatalf("removed = %d, want 2", len(diff.Removed))
+	}
+	if len(diff.StateChanged) != 1 || diff.StateChanged[0].AfterCat != WaitCategorySleeping {
+		t.Fatalf("state changed: %#v", diff.StateChanged)
+	}
+
+	timeline := BuildTimeline([]Snapshot{first, second})
+	if len(timeline.Points) != 2 {
+		t.Fatalf("timeline points = %d, want 2", len(timeline.Points))
+	}
+	if timeline.Points[1].ByCategory[WaitCategorySleeping] != 1 {
+		t.Fatalf("second point categories: %#v", timeline.Points[1].ByCategory)
+	}
+}
+
+func TestRuntimeIDFromInt(t *testing.T) {
+	if got := RuntimeIDFromInt(17); got != "17" {
+		t.Fatalf("RuntimeIDFromInt(17) = %q", got)
+	}
+	if got := RuntimeIDFromInt(0); got != "" {
+		t.Fatalf("RuntimeIDFromInt(0) = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a runtime-neutral `threadinspect` package for thread snapshots, filters, aggregate summaries, diffs, and timelines.
- Adapt JVM `jcmd Thread.print` parsing onto the shared interfaces while keeping JVM convenience wrappers.
- Reuse the structured parser for JVM thread counting so counting and analysis share one path.

## Why
Spectra inspects all application architectures, not only JVMs. This keeps thread analysis reusable for future native, Go, Node, and other runtime adapters instead of baking the analysis model into JVM-specific code.

## Validation
- `make ci`
