### PR TITLE
Add core file inspection analyzers

### DIFF
--- a/cmd/spectra/core.go
+++ b/cmd/spectra/core.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/corefile"
+)
+
+func runCore(args []string) int {
+	if len(args) > 0 && args[0] == "inspect" {
+		return runCoreInspect(args[1:])
+	}
+	fmt.Fprintln(os.Stderr, "usage: spectra core inspect [--json] [--exe <path>] <core-file>")
+	return 2
+}
+
+func runCoreInspect(args []string) int {
+	fs := flag.NewFlagSet("spectra core inspect", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	exePath := fs.String("exe", "", "Executable path for the crashed process")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra core inspect [--json] [--exe <path>] <core-file>")
+		return 2
+	}
+
+	inspector := corefile.Inspector{Analyzers: []corefile.Analyzer{
+		corefile.JVMAnalyzer{},
+	}}
+	report, err := inspector.Inspect(context.Background(), fs.Arg(0), *exePath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+		return 0
+	}
+	printCoreReport(report)
+	return 0
+}
+
+func printCoreReport(report corefile.Report) {
+	fmt.Printf("core:          %s\n", report.Artifact.Path)
+	if report.Artifact.ExecutablePath != "" {
+		fmt.Printf("executable:    %s\n", report.Artifact.ExecutablePath)
+	}
+	fmt.Printf("format:        %s\n", valueOrUnknown(report.Artifact.Format))
+	if report.Artifact.Architecture != "" {
+		fmt.Printf("architecture:  %s\n", report.Artifact.Architecture)
+	}
+	fmt.Printf("size:          %d bytes\n", report.Artifact.SizeBytes)
+	if report.Runtime != "" {
+		fmt.Printf("runtime:       %s\n", report.Runtime)
+	}
+	if len(report.Analyzers) > 0 {
+		fmt.Printf("analyzers:     %s\n", strings.Join(report.Analyzers, ", "))
+	}
+	for _, obs := range report.Observations {
+		fmt.Printf("%s: %s\n", obs.Key, obs.Value)
+	}
+	if len(report.Commands) == 0 {
+		return
+	}
+	fmt.Println("")
+	fmt.Println("Suggested commands:")
+	for _, cmd := range report.Commands {
+		fmt.Printf("  %s %s\n", cmd.Tool, strings.Join(shellQuoteArgs(cmd.Args), " "))
+		if cmd.Purpose != "" {
+			fmt.Printf("    %s\n", cmd.Purpose)
+		}
+	}
+}
+
+func shellQuoteArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i, arg := range args {
+		out[i] = shellQuote(arg)
+	}
+	return out
+}
+
+func shellQuote(arg string) string {
+	if strings.IndexFunc(arg, func(r rune) bool {
+		return r != '/' && r != '.' && r != '-' && r != '_' && r != '=' && r != ':' &&
+			r != '<' && r != '>' &&
+			(r < '0' || r > '9') &&
+			(r < 'A' || r > 'Z') &&
+			(r < 'a' || r > 'z')
+	}) == -1 {
+		return arg
+	}
+	return strconv.Quote(arg)
+}
+
+func valueOrUnknown(value string) string {
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -57,6 +57,7 @@ func subcommandList() []subcommand {
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},
 		{"install-daemon", "Install the user LaunchAgent for spectra serve", runInstallDaemonCmd},
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
+		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -23,6 +23,7 @@ const (
 	KindProcessSample = "process_sample"
 	KindPacketCapture = "packet_capture"
 	KindFlamegraph    = "flamegraph"
+	KindCoreDump      = "core_dump"
 
 	SensitivityLow        = "low"
 	SensitivityMedium     = "medium"
@@ -150,7 +151,7 @@ func (m *Manager) Record(ctx context.Context, rec Record) (Record, error) {
 
 func defaultSensitivity(kind string) string {
 	switch kind {
-	case KindHeapDump:
+	case KindHeapDump, KindCoreDump:
 		return SensitivityVeryHigh
 	case KindPacketCapture:
 		return SensitivityHigh

--- a/internal/corefile/inspect.go
+++ b/internal/corefile/inspect.go
@@ -1,0 +1,116 @@
+package corefile
+
+import (
+	"context"
+	"debug/macho"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const defaultProbeBytes = 1 << 20
+
+const machOTypeCore macho.Type = 4
+
+// Inspector coordinates runtime-neutral artifact probing with pluggable analyzers.
+type Inspector struct {
+	Analyzers []Analyzer
+	ReadProbe func(path string, limit int64) ([]byte, error)
+}
+
+// Inspect probes path and runs every analyzer that supports the artifact.
+func (i Inspector) Inspect(ctx context.Context, path, executablePath string) (Report, error) {
+	artifact, probe, err := i.describe(path, executablePath)
+	if err != nil {
+		return Report{}, err
+	}
+	report := Report{Artifact: artifact}
+	for _, analyzer := range i.Analyzers {
+		if analyzer == nil || !analyzer.Supports(ctx, artifact, probe) {
+			continue
+		}
+		next, err := analyzer.Analyze(ctx, artifact, probe)
+		if err != nil {
+			return Report{}, fmt.Errorf("%s analyzer: %w", analyzer.Name(), err)
+		}
+		report.Analyzers = append(report.Analyzers, analyzer.Name())
+		if report.Runtime == "" {
+			report.Runtime = next.Runtime
+		}
+		report.Observations = append(report.Observations, next.Observations...)
+		report.Commands = append(report.Commands, next.Commands...)
+	}
+	return report, nil
+}
+
+func (i Inspector) describe(path, executablePath string) (Artifact, []byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Artifact{}, nil, fmt.Errorf("stat core file: %w", err)
+	}
+	if info.IsDir() {
+		return Artifact{}, nil, fmt.Errorf("core file %q is a directory", path)
+	}
+	readProbe := i.ReadProbe
+	if readProbe == nil {
+		readProbe = readPrefix
+	}
+	probe, err := readProbe(path, defaultProbeBytes)
+	if err != nil {
+		return Artifact{}, nil, fmt.Errorf("read core probe: %w", err)
+	}
+	artifact := Artifact{
+		Path:           path,
+		ExecutablePath: executablePath,
+		SizeBytes:      info.Size(),
+	}
+	artifact.Format, artifact.Architecture = identifyMachO(path)
+	if artifact.Format == "" {
+		artifact.Format = identifyProbe(probe)
+	}
+	return artifact, probe, nil
+}
+
+func readPrefix(path string, limit int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	buf := make([]byte, limit)
+	n, err := f.Read(buf)
+	if err != nil && n == 0 {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+func identifyMachO(path string) (format, arch string) {
+	if f, err := macho.Open(path); err == nil {
+		defer f.Close()
+		if f.Type == machOTypeCore {
+			return "mach-o-core", f.Cpu.String()
+		}
+		return "mach-o-" + strings.ToLower(f.Type.String()), f.Cpu.String()
+	}
+	if fat, err := macho.OpenFat(path); err == nil {
+		defer fat.Close()
+		for _, arch := range fat.Arches {
+			if arch.Type == machOTypeCore {
+				return "fat-mach-o-core", arch.Cpu.String()
+			}
+		}
+		return "fat-mach-o", ""
+	}
+	return "", ""
+}
+
+func identifyProbe(probe []byte) string {
+	if len(probe) >= 4 && string(probe[:4]) == "\x7fELF" {
+		return "elf"
+	}
+	if len(probe) == 0 {
+		return "unknown"
+	}
+	return "unknown"
+}

--- a/internal/corefile/inspect_test.go
+++ b/internal/corefile/inspect_test.go
@@ -1,0 +1,52 @@
+package corefile
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInspectorRunsSupportingAnalyzers(t *testing.T) {
+	dir := t.TempDir()
+	corePath := filepath.Join(dir, "java.core")
+	if err := os.WriteFile(corePath, []byte("prefix HotSpot java.lang.Thread suffix"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := (Inspector{Analyzers: []Analyzer{JVMAnalyzer{}}}).Inspect(context.Background(), corePath, "/Library/Java/JavaVirtualMachines/temurin.jdk/Contents/Home/bin/java")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Artifact.Path != corePath {
+		t.Fatalf("path = %q, want %q", report.Artifact.Path, corePath)
+	}
+	if report.Runtime != "jvm" {
+		t.Fatalf("runtime = %q, want jvm", report.Runtime)
+	}
+	if len(report.Commands) != 3 {
+		t.Fatalf("commands len = %d, want 3", len(report.Commands))
+	}
+	if report.Commands[0].Tool != "jhsdb" {
+		t.Fatalf("first tool = %q, want jhsdb", report.Commands[0].Tool)
+	}
+}
+
+func TestJVMAnalyzerNeedsExecutableForCommands(t *testing.T) {
+	report, err := (JVMAnalyzer{}).Analyze(context.Background(), Artifact{Path: "/tmp/core"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Commands) != 0 {
+		t.Fatalf("commands len = %d, want 0", len(report.Commands))
+	}
+	if len(report.Observations) == 0 {
+		t.Fatal("expected executable-path observation")
+	}
+}
+
+func TestJVMAnalyzerDoesNotOwnUnknownCore(t *testing.T) {
+	if (JVMAnalyzer{}).Supports(context.Background(), Artifact{Path: "/tmp/core"}, []byte("plain native crash")) {
+		t.Fatal("JVM analyzer claimed an unknown core")
+	}
+}

--- a/internal/corefile/jvm.go
+++ b/internal/corefile/jvm.go
@@ -1,0 +1,75 @@
+package corefile
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/artifact"
+)
+
+// JVMAnalyzer contributes HotSpot Serviceability Agent commands for JVM cores.
+type JVMAnalyzer struct{}
+
+func (JVMAnalyzer) Name() string { return "jvm-serviceability-agent" }
+
+func (JVMAnalyzer) Supports(_ context.Context, a Artifact, probe []byte) bool {
+	exe := filepath.Base(a.ExecutablePath)
+	if exe == "java" || exe == "java.exe" {
+		return true
+	}
+	lowerExe := strings.ToLower(a.ExecutablePath)
+	if strings.Contains(lowerExe, "/jre/") || strings.Contains(lowerExe, "/jdk") {
+		return true
+	}
+	for _, marker := range [][]byte{
+		[]byte("HotSpot"),
+		[]byte("OpenJDK"),
+		[]byte("Java HotSpot(TM)"),
+		[]byte("java.lang.Thread"),
+	} {
+		if bytes.Contains(probe, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func (JVMAnalyzer) Analyze(_ context.Context, a Artifact, _ []byte) (Report, error) {
+	report := Report{
+		Artifact: a,
+		Runtime:  "jvm",
+		Observations: []Observation{
+			{Key: "serviceability_agent", Value: "offline JVM inspection requires a matching JDK for the crashed JVM"},
+		},
+	}
+	if a.ExecutablePath == "" {
+		report.Observations = append(report.Observations, Observation{
+			Key:   "executable_path",
+			Value: "missing; pass --exe so jhsdb can resolve VM symbols",
+		})
+		return report, nil
+	}
+	report.Commands = append(report.Commands,
+		Command{
+			Tool:        "jhsdb",
+			Args:        []string{"jstack", "--exe", a.ExecutablePath, "--core", a.Path},
+			Purpose:     "Extract Java and native thread state from a crashed JVM core",
+			Sensitivity: artifact.SensitivityMediumHigh,
+		},
+		Command{
+			Tool:        "jhsdb",
+			Args:        []string{"jmap", "--histo", "--exe", a.ExecutablePath, "--core", a.Path},
+			Purpose:     "Extract a heap class histogram from a crashed JVM core",
+			Sensitivity: artifact.SensitivityVeryHigh,
+		},
+		Command{
+			Tool:        "jhsdb",
+			Args:        []string{"jmap", "--binaryheap", "--dumpfile", "<heap.hprof>", "--exe", a.ExecutablePath, "--core", a.Path},
+			Purpose:     "Write an HPROF heap dump from a crashed JVM core",
+			Sensitivity: artifact.SensitivityVeryHigh,
+		},
+	)
+	return report, nil
+}

--- a/internal/corefile/types.go
+++ b/internal/corefile/types.go
@@ -1,0 +1,48 @@
+// Package corefile describes and inspects crashed-process core files.
+//
+// The package is runtime-neutral: analyzers declare whether they support a
+// core artifact and contribute commands or summaries for that application
+// architecture. JVM Serviceability Agent support is one analyzer, not the
+// package boundary.
+package corefile
+
+import "context"
+
+// Artifact describes a crashed-process image and optional executable.
+type Artifact struct {
+	Path           string `json:"path"`
+	ExecutablePath string `json:"executable_path,omitempty"`
+	Format         string `json:"format,omitempty"`
+	Architecture   string `json:"architecture,omitempty"`
+	SizeBytes      int64  `json:"size_bytes,omitempty"`
+}
+
+// Command is a suggested offline inspection command for an artifact.
+type Command struct {
+	Tool        string   `json:"tool"`
+	Args        []string `json:"args,omitempty"`
+	Purpose     string   `json:"purpose,omitempty"`
+	Sensitivity string   `json:"sensitivity,omitempty"`
+}
+
+// Observation is a small finding produced while inspecting an artifact.
+type Observation struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// Report is the combined output from all analyzers that support an artifact.
+type Report struct {
+	Artifact     Artifact      `json:"artifact"`
+	Runtime      string        `json:"runtime,omitempty"`
+	Analyzers    []string      `json:"analyzers,omitempty"`
+	Observations []Observation `json:"observations,omitempty"`
+	Commands     []Command     `json:"commands,omitempty"`
+}
+
+// Analyzer contributes runtime-specific offline analysis for a core artifact.
+type Analyzer interface {
+	Name() string
+	Supports(ctx context.Context, artifact Artifact, probe []byte) bool
+	Analyze(ctx context.Context, artifact Artifact, probe []byte) (Report, error)
+}


### PR DESCRIPTION
## Summary

Adds a runtime-neutral core-file inspection foundation for crashed-process artifacts, with JVM Serviceability Agent support implemented as one analyzer adapter.

## Details

- Introduces `internal/corefile` with generic artifact metadata, analyzer interfaces, and inspector orchestration.
- Adds a JVM Serviceability Agent analyzer that recognizes likely HotSpot/OpenJDK cores and suggests offline `jhsdb` thread, heap histogram, and heap dump commands.
- Adds `spectra core inspect [--json] [--exe <path>] <core-file>` for local use without folding core-file analysis into the live JVM command path.
- Registers `core_dump` as a very-high sensitivity artifact kind.

## Validation

- `go test ./internal/cache -run TestAsyncWriterQueueFull -count=20`
- `make ci`

Note: an earlier full `make ci` pass hit a transient `golangci-lint` parallel lock, and a subsequent run hit a non-reproducing cache test failure. After rerunning the focused cache test 20 times, the final `make ci` passed end to end.
