### PR TITLE
Add JVM diagnostics compatibility matrix

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/cache"
+	"github.com/kaeawc/spectra/internal/diag"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
@@ -935,12 +936,14 @@ func printJVMDetail(info jvm.Info) {
 	fmt.Printf("Main class    %s\n", strOrDash(info.MainClass))
 	fmt.Printf("JDK vendor    %s\n", strOrDash(info.JDKVendor))
 	fmt.Printf("JDK version   %s\n", strOrDash(info.JDKVersion))
+	fmt.Printf("Posture       %s\n", strOrDash(info.Posture))
 	fmt.Printf("Java home     %s\n", strOrDash(info.JavaHome))
 	fmt.Printf("JDK install   %s\n", strOrDash(info.JDKInstallID))
 	fmt.Printf("JDK source    %s\n", strOrDash(info.JDKSource))
 	fmt.Printf("VM args       %s\n", strOrDash(info.VMArgs))
 	fmt.Printf("VM flags      %s\n", strOrDash(info.VMFlags))
 	fmt.Printf("Threads       %s\n", intOrDash(info.ThreadCount))
+	printJVMDiagnosticCapabilities(info.Diagnostics)
 
 	if len(info.SysProps) > 0 {
 		fmt.Println("\nSystem properties:")
@@ -952,6 +955,20 @@ func printJVMDetail(info jvm.Info) {
 		for _, k := range keys {
 			fmt.Printf("  %-30s  %s\n", k, info.SysProps[k])
 		}
+	}
+}
+
+func printJVMDiagnosticCapabilities(matrix diag.Matrix) {
+	if len(matrix.Capabilities) == 0 {
+		return
+	}
+	fmt.Println("\nDiagnostics:")
+	for _, capability := range matrix.Capabilities {
+		fmt.Printf("  %-28s %-11s", capability.ID, capability.Status)
+		if len(capability.Command) > 0 {
+			fmt.Printf(" %s", strings.Join(capability.Command, " "))
+		}
+		fmt.Println()
 	}
 }
 

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -93,6 +93,7 @@ JDK commands:
 | Process discovery | `jps -l` |
 | JVM args, system props | `jcmd <pid> VM.system_properties`, `VM.command_line` |
 | Live thread dump | `jcmd <pid> Thread.print` |
+| Virtual-thread-aware dump | `jcmd <pid> Thread.dump_to_file -format=json <path>` |
 | GC stats snapshot | `jstat -gc <pid>` |
 | Heap histogram | `jcmd <pid> GC.class_histogram` |
 | Heap dump | `jcmd <pid> GC.heap_dump <path>` |
@@ -124,6 +125,41 @@ run and parse `jfr view` tables for GC pauses, allocation sites, hot methods,
 monitor blocking, file I/O, and socket I/O, then combine those event views with
 `jfr summary` counts into first-pass incident findings. The same structures are
 intended to back future CLI, daemon RPC, MCP, and remote-debugging views.
+
+## Compatibility posture
+
+Every `jvm.Info` JSON object includes a runtime-neutral
+`diagnostics` capability matrix. JVM support is modeled as data so the same
+shape can be reused by future native, Node, Python, and other app-runtime
+collectors through `internal/diag.Provider` without making those systems
+look like JVMs.
+
+| JDK line | Spectra posture | JVM diagnostics baseline |
+|---|---|---|
+| 8 | Legacy supported | `jps`, `jcmd`, `Thread.print`, `jstat`, heap histogram/dump, local JMX, NMT when enabled |
+| 11 | Modern baseline | JDK 8 baseline plus portable JFR control and summary |
+| 17 | LTS baseline | Same shell-tool support as 11; no production virtual threads |
+| 21 | Virtual-thread production baseline | Adds virtual-thread-era diagnostics through `Thread.dump_to_file` and JFR virtual-thread events |
+| 24 | Virtual-thread pinning-improvement line | Same Spectra commands as 21, with JDK-side synchronization/pinning improvements visible through JFR/thread diagnostics |
+| 25 | Current LTS virtual-thread line | Same Spectra commands as 21/24; tracked as a first-class support target for virtual-thread-heavy apps |
+
+The matrix currently exposes these capability IDs:
+
+| Capability ID | Purpose |
+|---|---|
+| `jvm.jcmd` | HotSpot diagnostic-command transport |
+| `jvm.thread_dump.platform` | Traditional platform-thread dump via `Thread.print` |
+| `jvm.thread_dump.virtual` | Virtual-thread-aware dump via `Thread.dump_to_file -format=json` |
+| `jvm.jfr.virtual_threads` | JFR virtual-thread lifecycle and pinning events |
+| `jvm.jstat.gc` | One-shot `jstat -gc` counters |
+| `jvm.jfr.control` | JFR start/dump/stop support |
+| `jvm.native_memory` | Native memory tracking summary when enabled at JVM startup |
+| `jvm.jmx.local` | Local JMX management-agent status/start |
+
+Traditional `Thread.print` remains useful for monitors, platform threads,
+and deadlock clues. It is not treated as the complete support story for
+virtual-thread-heavy applications. The virtual-thread capability is marked
+available for JDK 21+ targets and unavailable before JDK 21.
 
 `spectra jvm vm-memory --json <pid>` returns every memory section with
 its underlying command, output, and per-section error. Native memory

--- a/internal/diag/capability.go
+++ b/internal/diag/capability.go
@@ -1,0 +1,40 @@
+// Package diag defines runtime-neutral diagnostic capability metadata.
+package diag
+
+// CapabilityStatus describes whether a diagnostic capability is available for
+// a target process or runtime.
+type CapabilityStatus string
+
+const (
+	CapabilityAvailable   CapabilityStatus = "available"
+	CapabilityUnavailable CapabilityStatus = "unavailable"
+	CapabilityLimited     CapabilityStatus = "limited"
+	CapabilityUnknown     CapabilityStatus = "unknown"
+)
+
+// Provider is implemented by runtime-specific diagnostic collectors.
+type Provider interface {
+	DiagnosticsMatrix() Matrix
+}
+
+// Capability is one reusable diagnostic action or signal Spectra can collect.
+// Runtime-specific packages attach these to their own process snapshots while
+// keeping the common support vocabulary stable across JVM, native, Node,
+// Python, and future app architectures.
+type Capability struct {
+	ID          string           `json:"id"`
+	Category    string           `json:"category,omitempty"`
+	Status      CapabilityStatus `json:"status"`
+	Since       string           `json:"since,omitempty"`
+	Command     []string         `json:"command,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Limitations string           `json:"limitations,omitempty"`
+}
+
+// Matrix groups capabilities for one runtime family and version.
+type Matrix struct {
+	Architecture string       `json:"architecture"`
+	Runtime      string       `json:"runtime,omitempty"`
+	Version      string       `json:"version,omitempty"`
+	Capabilities []Capability `json:"capabilities,omitempty"`
+}

--- a/internal/jvm/capability.go
+++ b/internal/jvm/capability.go
@@ -1,0 +1,194 @@
+package jvm
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/diag"
+)
+
+// DiagnosticsProvider adapts a JVM version to the runtime-neutral diag.Provider
+// interface.
+type DiagnosticsProvider struct {
+	Version string
+}
+
+// DiagnosticsMatrix returns the diagnostic support matrix for this JVM version.
+func (p DiagnosticsProvider) DiagnosticsMatrix() diag.Matrix {
+	return DiagnosticsMatrix(p.Version)
+}
+
+// DiagnosticsMatrix returns the JVM diagnostic support posture for a runtime.
+// It is data, not control flow: callers can show it in JSON, rules can reason
+// over it, and future runtime packages can expose the same diag.Matrix shape.
+func DiagnosticsMatrix(version string) diag.Matrix {
+	major := parseJavaMajor(version)
+	return diag.Matrix{
+		Architecture: "jvm",
+		Runtime:      "HotSpot-compatible JVM",
+		Version:      version,
+		Capabilities: []diag.Capability{
+			jcmdCapability(major),
+			threadPrintCapability(major),
+			virtualThreadDumpCapability(major),
+			virtualThreadJFRCapability(major),
+			jstatCapability(major),
+			jfrCapability(major),
+			nmtCapability(major),
+			jmxCapability(major),
+		},
+	}
+}
+
+func jcmdCapability(major int) diag.Capability {
+	return diag.Capability{
+		ID:          "jvm.jcmd",
+		Category:    "tooling",
+		Status:      statusSince(major, 8),
+		Since:       "8",
+		Command:     []string{"jcmd", "<pid>", "help"},
+		Description: "HotSpot diagnostic command transport used by most live JVM inspections.",
+	}
+}
+
+func threadPrintCapability(major int) diag.Capability {
+	return diag.Capability{
+		ID:          "jvm.thread_dump.platform",
+		Category:    "threads",
+		Status:      statusSince(major, 8),
+		Since:       "8",
+		Command:     []string{"jcmd", "<pid>", "Thread.print"},
+		Description: "Traditional live thread dump for platform threads, monitors, and deadlock clues.",
+		Limitations: "On virtual-thread-heavy JVMs this is not the preferred full inventory view.",
+	}
+}
+
+func virtualThreadDumpCapability(major int) diag.Capability {
+	status := statusSince(major, 21)
+	limitations := "Requires JDK 21+ target support; output can be large for applications with many virtual threads."
+	if major > 0 && major < 21 {
+		limitations = "Virtual threads are not a production feature before JDK 21."
+	}
+	return diag.Capability{
+		ID:          "jvm.thread_dump.virtual",
+		Category:    "threads",
+		Status:      status,
+		Since:       "21",
+		Command:     []string{"jcmd", "<pid>", "Thread.dump_to_file", "-format=json", "<path>"},
+		Description: "Virtual-thread-aware thread inventory suitable for Loom-era diagnostics.",
+		Limitations: limitations,
+	}
+}
+
+func virtualThreadJFRCapability(major int) diag.Capability {
+	return diag.Capability{
+		ID:          "jvm.jfr.virtual_threads",
+		Category:    "flight_recorder",
+		Status:      statusSince(major, 21),
+		Since:       "21",
+		Command:     []string{"jcmd", "<pid>", "JFR.start", "settings=profile"},
+		Description: "JFR virtual-thread lifecycle and pinning events for post-capture analysis.",
+	}
+}
+
+func jstatCapability(major int) diag.Capability {
+	return diag.Capability{
+		ID:          "jvm.jstat.gc",
+		Category:    "gc",
+		Status:      statusSince(major, 8),
+		Since:       "8",
+		Command:     []string{"jstat", "-gc", "<pid>"},
+		Description: "One-shot GC and memory-pool counters.",
+	}
+}
+
+func jfrCapability(major int) diag.Capability {
+	return diag.Capability{
+		ID:          "jvm.jfr.control",
+		Category:    "flight_recorder",
+		Status:      statusSince(major, 11),
+		Since:       "11",
+		Command:     []string{"jcmd", "<pid>", "JFR.start"},
+		Description: "Start, stop, dump, and summarize Java Flight Recorder recordings.",
+		Limitations: "JFR exists in many JDK 8 vendor builds, but Spectra treats JDK 11+ as the portable baseline.",
+	}
+}
+
+func nmtCapability(major int) diag.Capability {
+	return diag.Capability{
+		ID:          "jvm.native_memory",
+		Category:    "memory",
+		Status:      statusSince(major, 8),
+		Since:       "8",
+		Command:     []string{"jcmd", "<pid>", "VM.native_memory", "summary"},
+		Description: "Native memory tracking category summary.",
+		Limitations: "Requires the target JVM to have started with NativeMemoryTracking enabled.",
+	}
+}
+
+func jmxCapability(major int) diag.Capability {
+	return diag.Capability{
+		ID:          "jvm.jmx.local",
+		Category:    "management",
+		Status:      statusSince(major, 8),
+		Since:       "8",
+		Command:     []string{"jcmd", "<pid>", "ManagementAgent.status"},
+		Description: "Local JMX management-agent discovery and startup.",
+	}
+}
+
+func statusSince(major, since int) diag.CapabilityStatus {
+	if major == 0 {
+		return diag.CapabilityUnknown
+	}
+	if major < since {
+		return diag.CapabilityUnavailable
+	}
+	return diag.CapabilityAvailable
+}
+
+func parseJavaMajor(version string) int {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return 0
+	}
+	if strings.HasPrefix(version, "1.") {
+		parts := strings.Split(version, ".")
+		if len(parts) >= 2 {
+			n, _ := strconv.Atoi(parts[1])
+			return n
+		}
+	}
+	var b strings.Builder
+	for _, r := range version {
+		if r < '0' || r > '9' {
+			break
+		}
+		b.WriteRune(r)
+	}
+	if b.Len() == 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(b.String())
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func virtualThreadEra(version string) string {
+	major := parseJavaMajor(version)
+	switch {
+	case major == 0:
+		return "unknown"
+	case major < 21:
+		return "pre-virtual-thread-production"
+	case major < 24:
+		return "virtual-thread-production-baseline"
+	case major < 25:
+		return "jdk24-virtual-thread-pinning-improvements"
+	default:
+		return fmt.Sprintf("jdk%d-virtual-thread-era", major)
+	}
+}

--- a/internal/jvm/capability_test.go
+++ b/internal/jvm/capability_test.go
@@ -1,0 +1,74 @@
+package jvm
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/diag"
+)
+
+func TestDiagnosticsMatrixJDK25VirtualThreadCapabilities(t *testing.T) {
+	matrix := DiagnosticsMatrix("25.0.2")
+
+	if matrix.Architecture != "jvm" {
+		t.Fatalf("Architecture = %q, want jvm", matrix.Architecture)
+	}
+	got := capabilityByID(matrix.Capabilities, "jvm.thread_dump.virtual")
+	if got == nil {
+		t.Fatal("virtual-thread dump capability missing")
+	}
+	if got.Status != diag.CapabilityAvailable {
+		t.Fatalf("virtual-thread dump status = %q, want available", got.Status)
+	}
+	if len(got.Command) < 4 || got.Command[2] != "Thread.dump_to_file" {
+		t.Fatalf("virtual-thread dump command = %v", got.Command)
+	}
+
+	jfr := capabilityByID(matrix.Capabilities, "jvm.jfr.virtual_threads")
+	if jfr == nil || jfr.Status != diag.CapabilityAvailable {
+		t.Fatalf("JFR virtual-thread capability = %#v, want available", jfr)
+	}
+}
+
+func TestDiagnosticsProviderImplementsGenericInterface(t *testing.T) {
+	var provider diag.Provider = DiagnosticsProvider{Version: "24.0.2"}
+	matrix := provider.DiagnosticsMatrix()
+	if matrix.Architecture != "jvm" || matrix.Version != "24.0.2" {
+		t.Fatalf("matrix = %#v", matrix)
+	}
+}
+
+func TestDiagnosticsMatrixPreJDK21VirtualThreadsUnavailable(t *testing.T) {
+	matrix := DiagnosticsMatrix("17.0.10")
+	got := capabilityByID(matrix.Capabilities, "jvm.thread_dump.virtual")
+	if got == nil {
+		t.Fatal("virtual-thread dump capability missing")
+	}
+	if got.Status != diag.CapabilityUnavailable {
+		t.Fatalf("virtual-thread dump status = %q, want unavailable", got.Status)
+	}
+}
+
+func TestParseJavaMajor(t *testing.T) {
+	tests := map[string]int{
+		"1.8.0_402":    8,
+		"21.0.6+7-LTS": 21,
+		"24":           24,
+		"25.0.2":       25,
+		"bad-version":  0,
+		"":             0,
+	}
+	for version, want := range tests {
+		if got := parseJavaMajor(version); got != want {
+			t.Fatalf("parseJavaMajor(%q) = %d, want %d", version, got, want)
+		}
+	}
+}
+
+func capabilityByID(capabilities []diag.Capability, id string) *diag.Capability {
+	for i := range capabilities {
+		if capabilities[i].ID == id {
+			return &capabilities[i]
+		}
+	}
+	return nil
+}

--- a/internal/jvm/collect.go
+++ b/internal/jvm/collect.go
@@ -85,6 +85,8 @@ func collectOne(_ context.Context, pid int, main string, run CmdRunner, jdks []t
 		info.JDKVendor = props["java.vendor"]
 		info.JDKVersion = props["java.version"]
 	}
+	info.Posture = virtualThreadEra(info.JDKVersion)
+	info.Diagnostics = DiagnosticsMatrix(info.JDKVersion)
 
 	info.VMFlags, info.VMArgs = collectCommandLine(pid, run)
 	info.ThreadCount = collectThreadCount(pid, run)

--- a/internal/jvm/jvm_test.go
+++ b/internal/jvm/jvm_test.go
@@ -465,6 +465,12 @@ java_command: com.example.Server
 	if info.JDKVersion != "21.0.6" {
 		t.Errorf("JDKVersion = %q", info.JDKVersion)
 	}
+	if info.Posture != "virtual-thread-production-baseline" {
+		t.Errorf("Posture = %q", info.Posture)
+	}
+	if len(info.Diagnostics.Capabilities) == 0 {
+		t.Fatal("Diagnostics capabilities are missing")
+	}
 	if info.VMArgs != "-Xmx2g" {
 		t.Errorf("VMArgs = %q", info.VMArgs)
 	}

--- a/internal/jvm/types.go
+++ b/internal/jvm/types.go
@@ -4,6 +4,8 @@
 // See docs/inspection/jvm.md for the full design.
 package jvm
 
+import "github.com/kaeawc/spectra/internal/diag"
+
 // CmdRunner abstracts shell-out for testability.
 type CmdRunner func(name string, args ...string) ([]byte, error)
 
@@ -17,11 +19,13 @@ type Info struct {
 	JDKInstallID string            `json:"jdk_install_id,omitempty"`
 	JDKSource    string            `json:"jdk_source,omitempty"`
 	JDKPath      string            `json:"jdk_path,omitempty"`
+	Posture      string            `json:"posture,omitempty"`
 	VMArgs       string            `json:"vm_args,omitempty"`  // from jcmd VM.command_line
 	VMFlags      string            `json:"vm_flags,omitempty"` // JVM flags (XX: flags)
 	ThreadCount  int               `json:"thread_count,omitempty"`
 	GC           *GCStats          `json:"gc,omitempty"`        // one-shot jstat -gc counters
 	SysProps     map[string]string `json:"sys_props,omitempty"` // selected system properties
+	Diagnostics  diag.Matrix       `json:"diagnostics"`
 }
 
 // selectedProps is the allowlist of java system properties captured in SysProps.


### PR DESCRIPTION
## Summary

Adds a reusable runtime-neutral diagnostics capability model and wires the JVM collector into it so Spectra can expose an explicit compatibility posture for JDK 8/11/17/21/24/25 without making future non-JVM collectors inherit JVM assumptions.

## Changes

- Added `internal/diag` capability metadata and provider interface for runtime-specific collectors.
- Added a JVM diagnostics matrix with JDK 21+ virtual-thread dump and JFR virtual-thread capability reporting.
- Included JVM posture and diagnostics in `jvm.Info` JSON and CLI detail output.
- Documented the JDK compatibility matrix and virtual-thread-era support story.

## Validation

- `make ci` passed.
- `make build-all` passed.
- `make validate-workflows` passed.
- `make agent` passed; generated artifacts were not included.
- `go test ./internal/cache -run TestAsyncWriterQueueFull -count=20` passed.
- `go test ./internal/cache -count=1` passed.

Note: a subsequent `make all` run hit a transient `internal/cache` `TestAsyncWriterQueueFull` failure after prior full-suite success via `make ci`; focused reruns passed immediately and repeatedly.
