### PR TITLE
Add runtime telemetry snapshot model

### DIFF
--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -98,13 +98,53 @@ JVMInfo {
   vm_args
   vm_flags
   thread_count
+  gc                                  # legacy one-shot jstat -gc counters
   sys_props                            # selected java.* / os.* / user.* keys
 }
 ```
 
-Source: `jps` and `jcmd`. GC snapshots are available through JVM commands
-but are not embedded in the snapshot shape today. See
-[../inspection/jvm.md](../inspection/jvm.md).
+Source: `jps`, `jcmd`, and `jstat`.
+
+## RuntimeTelemetry
+
+Runtime-neutral telemetry for managed and native application architectures:
+
+```
+RuntimeTelemetry {
+  runtime                 # jvm, python, node, go, native, ...
+  pid
+  identity                # runtime-specific identity fields
+  config                  # runtime-specific config and selected properties
+  heap {
+    used_bytes
+    committed_bytes
+    max_bytes
+    native_bytes
+    source
+  }
+  gc {
+    collections
+    collection_time_ms
+    pools[]
+    source
+  }
+  threads {
+    live
+    peak
+    daemon
+    states
+    source
+  }
+  profiles[]              # references to profiling artifacts, not payloads
+  sections[]              # runtime-specific diagnostic sections/errors
+}
+```
+
+JVM telemetry is the first adapter. It maps `jstat -gc`, `jcmd` thread
+counts, optional VM-memory diagnostics, and optional spectra-agent probes into
+this common shape. Other runtimes plug in through the same collector
+interface, so snapshots can grow beyond JVMs without adding one-off top-level
+fields for every architecture. See [../inspection/jvm.md](../inspection/jvm.md).
 
 ## JDKInstall
 

--- a/internal/jvm/telemetry.go
+++ b/internal/jvm/telemetry.go
@@ -1,0 +1,177 @@
+package jvm
+
+import (
+	"context"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/telemetry"
+)
+
+// TelemetryOptions configure JVM runtime telemetry collection.
+type TelemetryOptions struct {
+	CollectOptions
+	// IncludeDiagnostics embeds VM-internal diagnostic sections such as
+	// GC.heap_info and VM.native_memory. These may be verbose, so callers can
+	// keep snapshots lightweight by leaving this false.
+	IncludeDiagnostics bool
+	// AgentClient fetches in-process probes when the spectra agent is attached.
+	// Zero value discovers agent status through jcmd.
+	AgentClient AgentClient
+	// Clock stamps each process telemetry record. Nil means time.Now.
+	Clock func() time.Time
+}
+
+// CollectTelemetry discovers running JVMs and returns runtime-neutral telemetry.
+func CollectTelemetry(ctx context.Context, opts TelemetryOptions) []telemetry.Process {
+	infos := CollectAll(ctx, opts.CollectOptions)
+	if len(infos) == 0 {
+		return nil
+	}
+	out := make([]telemetry.Process, 0, len(infos))
+	for _, info := range infos {
+		out = append(out, TelemetryForInfo(info, opts))
+	}
+	return out
+}
+
+// TelemetryForInfo maps JVM-specific inspection results into the generic
+// runtime telemetry shape used by snapshots.
+func TelemetryForInfo(info Info, opts TelemetryOptions) telemetry.Process {
+	collected := time.Now().UTC()
+	if opts.Clock != nil {
+		collected = opts.Clock().UTC()
+	}
+	proc := telemetry.Process{
+		Runtime:   telemetry.RuntimeJVM,
+		PID:       info.PID,
+		Identity:  jvmTelemetryIdentity(info),
+		Config:    jvmTelemetryConfig(info),
+		Collected: collected,
+	}
+	if info.ThreadCount > 0 {
+		proc.Threads = &telemetry.Threads{Live: info.ThreadCount, Source: "jcmd Thread.print"}
+	}
+	if info.GC != nil {
+		proc.GC = telemetryFromGCStats(*info.GC)
+		proc.Heap = heapFromGCStats(*info.GC)
+	}
+
+	client := opts.AgentClient
+	if client.StatusProvider != nil || client.Transport != nil {
+		applyAgentProbes(&proc, info.PID, client)
+	}
+	if opts.IncludeDiagnostics {
+		applyVMMemoryDiagnostics(&proc, CollectVMMemoryDiagnostics(info.PID, opts.CmdRunner))
+	}
+	return proc
+}
+
+func jvmTelemetryIdentity(info Info) map[string]string {
+	fields := map[string]string{
+		"main_class":     info.MainClass,
+		"java_home":      info.JavaHome,
+		"jdk_vendor":     info.JDKVendor,
+		"jdk_version":    info.JDKVersion,
+		"jdk_install_id": info.JDKInstallID,
+		"jdk_source":     info.JDKSource,
+		"jdk_path":       info.JDKPath,
+	}
+	return compactStringMap(fields)
+}
+
+func jvmTelemetryConfig(info Info) map[string]string {
+	fields := map[string]string{
+		"vm_args":  info.VMArgs,
+		"vm_flags": info.VMFlags,
+	}
+	for k, v := range info.SysProps {
+		if v != "" {
+			fields["sysprop."+k] = v
+		}
+	}
+	return compactStringMap(fields)
+}
+
+func compactStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if v != "" {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func telemetryFromGCStats(gc GCStats) *telemetry.GC {
+	totalCollections := gc.YGC + gc.FGC
+	totalMS := int64((gc.YGCT + gc.FGCT) * 1000)
+	return &telemetry.GC{
+		Collections:      totalCollections,
+		CollectionTimeMS: totalMS,
+		Source:           "jstat -gc",
+		Pools: []telemetry.GCPool{
+			{Name: "survivor0", CapacityBytes: kibToBytes(gc.S0C), UsedBytes: kibToBytes(gc.S0U)},
+			{Name: "survivor1", CapacityBytes: kibToBytes(gc.S1C), UsedBytes: kibToBytes(gc.S1U)},
+			{Name: "eden", CapacityBytes: kibToBytes(gc.EC), UsedBytes: kibToBytes(gc.EU), Collections: gc.YGC, CollectionTime: int64(gc.YGCT * 1000)},
+			{Name: "old", CapacityBytes: kibToBytes(gc.OC), UsedBytes: kibToBytes(gc.OU), Collections: gc.FGC, CollectionTime: int64(gc.FGCT * 1000)},
+			{Name: "metaspace", CapacityBytes: kibToBytes(gc.MC), UsedBytes: kibToBytes(gc.MU)},
+			{Name: "compressed_class_space", CapacityBytes: kibToBytes(gc.CCSC), UsedBytes: kibToBytes(gc.CCSU)},
+		},
+	}
+}
+
+func heapFromGCStats(gc GCStats) *telemetry.Heap {
+	return &telemetry.Heap{
+		UsedBytes:      kibToBytes(gc.S0U + gc.S1U + gc.EU + gc.OU + gc.MU + gc.CCSU),
+		CommittedBytes: kibToBytes(gc.S0C + gc.S1C + gc.EC + gc.OC + gc.MC + gc.CCSC),
+		Source:         "jstat -gc",
+	}
+}
+
+func applyAgentProbes(proc *telemetry.Process, pid int, client AgentClient) {
+	probes, err := client.Probes(pid)
+	if err != nil {
+		proc.Sections = append(proc.Sections, telemetry.Section{Name: "jvm.agent.probes", Error: err.Error()})
+		return
+	}
+	if probes.Runtime.TotalMemory > 0 || probes.Runtime.FreeMemory > 0 || probes.Runtime.MaxMemory > 0 {
+		proc.Heap = &telemetry.Heap{
+			UsedBytes:      probes.Runtime.TotalMemory - probes.Runtime.FreeMemory,
+			CommittedBytes: probes.Runtime.TotalMemory,
+			MaxBytes:       probes.Runtime.MaxMemory,
+			Source:         "spectra-agent probes",
+		}
+	}
+	if probes.Threads.Live > 0 {
+		proc.Threads = &telemetry.Threads{Live: probes.Threads.Live, Source: "spectra-agent probes"}
+	}
+}
+
+func applyVMMemoryDiagnostics(proc *telemetry.Process, diagnostics VMMemoryDiagnostics) {
+	add := func(name string, section DiagnosticSection) {
+		proc.Sections = append(proc.Sections, telemetry.Section{
+			Name:    name,
+			Command: section.Command,
+			Output:  section.Output,
+			Error:   section.Error,
+		})
+	}
+	add("jvm.heap_info", diagnostics.HeapInfo)
+	add("jvm.metaspace", diagnostics.Metaspace)
+	add("jvm.native_memory", diagnostics.NativeMemory)
+	add("jvm.classloader_stats", diagnostics.ClassLoaderStats)
+	add("jvm.code_cache", diagnostics.CodeCache)
+	if len(diagnostics.CodeHeap.Command) > 0 || diagnostics.CodeHeap.Output != "" || diagnostics.CodeHeap.Error != "" {
+		add("jvm.code_heap", diagnostics.CodeHeap)
+	}
+}
+
+func kibToBytes(kib float64) int64 {
+	if kib <= 0 {
+		return 0
+	}
+	return int64(kib * 1024)
+}

--- a/internal/jvm/telemetry_test.go
+++ b/internal/jvm/telemetry_test.go
@@ -1,0 +1,59 @@
+package jvm
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTelemetryForInfoMapsGCHeapThreadsAndIdentity(t *testing.T) {
+	at := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	info := Info{
+		PID:         412,
+		MainClass:   "com.example.Main",
+		JavaHome:    "/Library/Java/JavaVirtualMachines/temurin.jdk/Contents/Home",
+		JDKVendor:   "Eclipse Adoptium",
+		JDKVersion:  "21.0.3",
+		VMArgs:      "-Xmx2g",
+		ThreadCount: 37,
+		SysProps: map[string]string{
+			"java.io.tmpdir": "/tmp",
+		},
+		GC: &GCStats{
+			EC:   1024,
+			EU:   512,
+			OC:   2048,
+			OU:   256,
+			YGC:  7,
+			YGCT: 0.125,
+			FGC:  1,
+			FGCT: 0.250,
+		},
+	}
+
+	got := TelemetryForInfo(info, TelemetryOptions{Clock: func() time.Time { return at }})
+
+	if got.PID != 412 {
+		t.Fatalf("PID = %d, want 412", got.PID)
+	}
+	if got.Identity["main_class"] != "com.example.Main" {
+		t.Fatalf("main_class = %q", got.Identity["main_class"])
+	}
+	if got.Config["vm_args"] != "-Xmx2g" {
+		t.Fatalf("vm_args = %q", got.Config["vm_args"])
+	}
+	if got.Config["sysprop.java.io.tmpdir"] != "/tmp" {
+		t.Fatalf("tmpdir = %q", got.Config["sysprop.java.io.tmpdir"])
+	}
+	if got.Threads == nil || got.Threads.Live != 37 {
+		t.Fatalf("Threads = %#v, want live 37", got.Threads)
+	}
+	if got.GC == nil || got.GC.Collections != 8 || got.GC.CollectionTimeMS != 375 {
+		t.Fatalf("GC = %#v, want 8 collections and 375ms", got.GC)
+	}
+	if got.Heap == nil || got.Heap.UsedBytes != 768*1024 {
+		t.Fatalf("Heap = %#v, want 768KiB used", got.Heap)
+	}
+	if !got.Collected.Equal(at) {
+		t.Fatalf("Collected = %v, want %v", got.Collected, at)
+	}
+}

--- a/internal/snapshot/runtime_telemetry.go
+++ b/internal/snapshot/runtime_telemetry.go
@@ -1,0 +1,64 @@
+package snapshot
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/telemetry"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+func collectRuntimeTelemetry(ctx context.Context, collectors []telemetry.Collector) []telemetry.Process {
+	var out []telemetry.Process
+	for _, collector := range collectors {
+		if collector == nil {
+			continue
+		}
+		out = append(out, collector.CollectRuntimeTelemetry(ctx)...)
+	}
+	return out
+}
+
+func collectJVMTelemetry(_ context.Context, infos []jvm.Info, opts Options) []telemetry.Process {
+	if len(infos) == 0 {
+		return nil
+	}
+	jvmOpts := opts.JVMTelemetryOpts
+	if jvmOpts.CmdRunner == nil {
+		jvmOpts.CmdRunner = opts.JVMOpts.CmdRunner
+	}
+	if len(jvmOpts.JDKs) == 0 {
+		jvmOpts.JDKs = opts.JVMOpts.JDKs
+	}
+	out := make([]telemetry.Process, 0, len(infos))
+	for _, info := range infos {
+		out = append(out, jvm.TelemetryForInfo(info, jvmOpts))
+	}
+	return out
+}
+
+func attributeRuntimeJDKs(processes []telemetry.Process, jdks []toolchain.JDKInstall) {
+	if len(jdks) == 0 {
+		return
+	}
+	for i := range processes {
+		if processes[i].Runtime != telemetry.RuntimeJVM {
+			continue
+		}
+		identity := processes[i].Identity
+		if identity == nil || identity["java_home"] == "" || identity["jdk_install_id"] != "" {
+			continue
+		}
+		javaHome := filepath.Clean(identity["java_home"])
+		for _, install := range jdks {
+			if install.Path == "" || filepath.Clean(install.Path) != javaHome {
+				continue
+			}
+			identity["jdk_install_id"] = install.InstallID
+			identity["jdk_source"] = install.Source
+			identity["jdk_path"] = install.Path
+			break
+		}
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/storagestate"
 	"github.com/kaeawc/spectra/internal/sysinfo"
+	"github.com/kaeawc/spectra/internal/telemetry"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
@@ -43,7 +44,8 @@ type Snapshot struct {
 	Network    netstate.State       `json:"network"`
 	Storage    storagestate.State   `json:"storage"`
 
-	JVMs []jvm.Info `json:"jvms,omitempty"`
+	JVMs             []jvm.Info          `json:"jvms,omitempty"`
+	RuntimeTelemetry []telemetry.Process `json:"runtime_telemetry,omitempty"`
 }
 
 // Options configure a snapshot Build.
@@ -101,6 +103,15 @@ type Options struct {
 	// Zero value uses the real jps/jcmd commands.
 	JVMOpts jvm.CollectOptions
 
+	// JVMTelemetryOpts are forwarded to the JVM telemetry adapter.
+	// Zero value keeps telemetry lightweight and uses JVMOpts for discovery.
+	JVMTelemetryOpts jvm.TelemetryOptions
+
+	// RuntimeTelemetryCollectors can add runtime-neutral telemetry from other
+	// application architectures. JVM telemetry is collected separately unless
+	// SkipJVMs is true.
+	RuntimeTelemetryCollectors []telemetry.Collector
+
 	// SkipJVMs disables JVM process discovery (faster for tests; requires jps
 	// in PATH for real collection).
 	SkipJVMs bool
@@ -146,28 +157,11 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	}
 
 	var wg sync.WaitGroup
-	collectors := 5 // host, toolchains, power, sysctls, network
-	if !opts.SkipApps {
-		collectors++
-	}
-	if !opts.SkipProcesses {
-		collectors++
-	}
-	if !opts.SkipStorage {
-		collectors++
-	}
-	if !opts.SkipJVMs {
-		collectors++
-	}
-	wg.Add(collectors)
+	wg.Add(snapshotCollectorCount(opts))
 
 	go func() {
 		defer wg.Done()
-		hostCollector := opts.HostCollector
-		if hostCollector == nil {
-			hostCollector = LiveHostCollector{}
-		}
-		s.Host = hostCollector.CollectHost(opts.SpectraVersion)
+		s.Host = hostCollectorFor(opts).CollectHost(opts.SpectraVersion)
 	}()
 	if !opts.SkipApps {
 		go func() {
@@ -216,10 +210,47 @@ func Build(ctx context.Context, opts Options) Snapshot {
 			s.JVMs = jvm.CollectAll(ctx, opts.JVMOpts)
 		}()
 	}
+	if len(opts.RuntimeTelemetryCollectors) > 0 {
+		go func() {
+			defer wg.Done()
+			s.RuntimeTelemetry = collectRuntimeTelemetry(ctx, opts.RuntimeTelemetryCollectors)
+		}()
+	}
 
 	wg.Wait()
 	jvm.AttributeJDKs(s.JVMs, s.Toolchains.JDKs)
+	if !opts.SkipJVMs {
+		s.RuntimeTelemetry = append(s.RuntimeTelemetry, collectJVMTelemetry(ctx, s.JVMs, opts)...)
+	}
+	attributeRuntimeJDKs(s.RuntimeTelemetry, s.Toolchains.JDKs)
 	return s
+}
+
+func snapshotCollectorCount(opts Options) int {
+	collectors := 5 // host, toolchains, power, sysctls, network
+	if !opts.SkipApps {
+		collectors++
+	}
+	if !opts.SkipProcesses {
+		collectors++
+	}
+	if !opts.SkipStorage {
+		collectors++
+	}
+	if !opts.SkipJVMs {
+		collectors++
+	}
+	if len(opts.RuntimeTelemetryCollectors) > 0 {
+		collectors++
+	}
+	return collectors
+}
+
+func hostCollectorFor(opts Options) HostCollector {
+	if opts.HostCollector != nil {
+		return opts.HostCollector
+	}
+	return LiveHostCollector{}
 }
 
 func snapshotAppPaths(opts Options) []string {

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kaeawc/spectra/internal/clock"
 	"github.com/kaeawc/spectra/internal/idgen"
 	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/telemetry"
 )
 
 func TestBuildHostOnly(t *testing.T) {
@@ -151,6 +152,37 @@ type fakeHostCollector struct {
 
 func (f fakeHostCollector) CollectHost(string) HostInfo {
 	return f.host
+}
+
+func TestBuildIncludesRuntimeTelemetryCollectors(t *testing.T) {
+	snap := Build(context.Background(), Options{
+		SkipApps:      true,
+		SkipProcesses: true,
+		SkipStorage:   true,
+		SkipJVMs:      true,
+		RuntimeTelemetryCollectors: []telemetry.Collector{
+			fakeRuntimeTelemetryCollector{processes: []telemetry.Process{{
+				Runtime: telemetry.Runtime("python"),
+				PID:     812,
+				Heap:    &telemetry.Heap{UsedBytes: 1024, Source: "test"},
+			}}},
+		},
+	})
+
+	if len(snap.RuntimeTelemetry) != 1 {
+		t.Fatalf("RuntimeTelemetry len = %d, want 1", len(snap.RuntimeTelemetry))
+	}
+	if snap.RuntimeTelemetry[0].Runtime != "python" || snap.RuntimeTelemetry[0].PID != 812 {
+		t.Fatalf("RuntimeTelemetry[0] = %#v", snap.RuntimeTelemetry[0])
+	}
+}
+
+type fakeRuntimeTelemetryCollector struct {
+	processes []telemetry.Process
+}
+
+func (f fakeRuntimeTelemetryCollector) CollectRuntimeTelemetry(context.Context) []telemetry.Process {
+	return f.processes
 }
 
 func TestBuildAttributesProcessesToConfiguredAppPaths(t *testing.T) {

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -1,0 +1,89 @@
+// Package telemetry defines runtime-neutral process telemetry embedded in
+// Spectra snapshots.
+package telemetry
+
+import (
+	"context"
+	"time"
+)
+
+// Runtime names the application architecture that produced telemetry.
+type Runtime string
+
+const (
+	RuntimeJVM Runtime = "jvm"
+)
+
+// Collector gathers runtime-specific telemetry in a runtime-neutral shape.
+// Collectors should return partial process snapshots when individual probes
+// fail instead of failing the entire snapshot.
+type Collector interface {
+	CollectRuntimeTelemetry(context.Context) []Process
+}
+
+// Process is one runtime process observed during a Spectra snapshot.
+type Process struct {
+	Runtime   Runtime           `json:"runtime"`
+	PID       int               `json:"pid"`
+	Identity  map[string]string `json:"identity,omitempty"`
+	Config    map[string]string `json:"config,omitempty"`
+	Heap      *Heap             `json:"heap,omitempty"`
+	GC        *GC               `json:"gc,omitempty"`
+	Threads   *Threads          `json:"threads,omitempty"`
+	Profiles  []Profile         `json:"profiles,omitempty"`
+	Sections  []Section         `json:"sections,omitempty"`
+	Collected time.Time         `json:"collected,omitempty"`
+}
+
+// Heap captures memory counters that are meaningful across managed runtimes.
+type Heap struct {
+	UsedBytes      int64  `json:"used_bytes,omitempty"`
+	CommittedBytes int64  `json:"committed_bytes,omitempty"`
+	MaxBytes       int64  `json:"max_bytes,omitempty"`
+	NativeBytes    int64  `json:"native_bytes,omitempty"`
+	Source         string `json:"source,omitempty"`
+}
+
+// GC captures garbage-collector counters and pool-level details.
+type GC struct {
+	Collections      int64    `json:"collections,omitempty"`
+	CollectionTimeMS int64    `json:"collection_time_ms,omitempty"`
+	Pools            []GCPool `json:"pools,omitempty"`
+	Source           string   `json:"source,omitempty"`
+}
+
+// GCPool is a memory pool observed by a managed runtime collector.
+type GCPool struct {
+	Name           string `json:"name"`
+	CapacityBytes  int64  `json:"capacity_bytes,omitempty"`
+	UsedBytes      int64  `json:"used_bytes,omitempty"`
+	Collections    int64  `json:"collections,omitempty"`
+	CollectionTime int64  `json:"collection_time_ms,omitempty"`
+}
+
+// Threads captures runtime thread counts and optional state breakdowns.
+type Threads struct {
+	Live   int            `json:"live,omitempty"`
+	Peak   int            `json:"peak,omitempty"`
+	Daemon int            `json:"daemon,omitempty"`
+	States map[string]int `json:"states,omitempty"`
+	Source string         `json:"source,omitempty"`
+}
+
+// Profile is metadata for an operator-requested or previously captured
+// profiling artifact. Snapshots keep references, not large artifact payloads.
+type Profile struct {
+	Kind       string `json:"kind"`
+	Event      string `json:"event,omitempty"`
+	ArtifactID string `json:"artifact_id,omitempty"`
+	Path       string `json:"path,omitempty"`
+}
+
+// Section carries runtime-specific diagnostic output without forcing every
+// runtime to share the same schema up front.
+type Section struct {
+	Name    string   `json:"name"`
+	Command []string `json:"command,omitempty"`
+	Output  string   `json:"output,omitempty"`
+	Error   string   `json:"error,omitempty"`
+}


### PR DESCRIPTION
## Summary

Adds a runtime-neutral telemetry model to Spectra snapshots so JVM GC, heap, thread, and diagnostic state can be embedded without making the snapshot architecture JVM-only.

## Changes

- Add `internal/telemetry` with reusable process, heap, GC, thread, profile, and diagnostic section types.
- Add a JVM telemetry adapter that maps existing `jstat`, `jcmd`, and optional spectra-agent probe data into the generic model.
- Extend snapshots with `runtime_telemetry` while preserving the existing `jvms` field.
- Allow non-JVM runtime telemetry collectors to plug into snapshot builds.
- Document the new `RuntimeTelemetry` snapshot shape.

## Validation

- `make ci`
- `make build-all validate-workflows`
- `git diff --check`
- `go mod tidy` produced no `go.mod`/`go.sum` diff
