### PR TITLE
Filter triage findings to the supplied target (#224)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -57,6 +58,7 @@ func triageToolDef() ToolDefinition {
 			"pid":         integerProp("PID."),
 			"bundle_id":   stringProp("Bundle ID."),
 			"symptom":     stringProp("Problem to investigate."),
+			"scope":       enumProp([]string{"target", "global"}, "target"),
 			"network":     boolProp("Scan app URLs."),
 			"include_raw": boolProp("Return raw data."),
 		}, nil),
@@ -211,6 +213,7 @@ type triageParams struct {
 	PID        int    `json:"pid"`
 	BundleID   string `json:"bundle_id"`
 	Symptom    string `json:"symptom"`
+	Scope      string `json:"scope"`
 	Network    bool   `json:"network"`
 	IncludeRaw bool   `json:"include_raw"`
 }
@@ -223,35 +226,54 @@ func (s *Server) collectTriage(p triageParams) ([]string, []string, map[string]i
 		evidence = append(evidence, "symptom: "+p.Symptom)
 	}
 	hasTarget := p.AppPath != "" || p.PID > 0 || p.BundleID != ""
+	var pidProc *process.Info
 	if p.AppPath != "" {
 		evidence, next = s.collectTriageApp(p, evidence, next, rawOut)
 	}
 	if p.PID > 0 {
-		evidence, next = s.collectTriagePID(p.PID, evidence, next, rawOut)
+		evidence, next, pidProc = s.collectTriagePID(p.PID, evidence, next, rawOut)
 	}
 	if p.BundleID != "" {
 		evidence = s.collectTriageBundle(p, evidence, rawOut)
 	}
-	// When triage has no target (pure symptom or empty call), the global
-	// rules pass is the only way to surface anything actionable. With a
-	// target, skip the full snapshot cost — the per-target collectors above
-	// already gathered what was asked for, and global findings would be
-	// noise relative to the explicit target. Direct callers to diagnose
-	// when they want host-wide context.
-	if !hasTarget {
-		findings, err := s.evaluateLiveRules("")
-		if err == nil && len(findings) > 0 {
-			evidence = append(evidence, summarizeFindings(findings, 5)...)
-			rawOut["findings"] = findings
-			next = append(next, "Use diagnose include_raw=true for the full rules output.")
-		}
-	} else {
-		next = append(next, "Use diagnose for host-wide rule findings; this triage was scoped to your target.")
-	}
+	evidence, next = s.appendTriageFindings(p, hasTarget, pidProc, evidence, next, rawOut)
 	if len(next) == 0 {
 		next = append(next, "Use snapshot operation=create store=true to preserve current state for later diffing.")
 	}
 	return evidence, next, rawOut
+}
+
+func (s *Server) appendTriageFindings(p triageParams, hasTarget bool, pidProc *process.Info, evidence, next []string, rawOut map[string]interface{}) ([]string, []string) {
+	scope := strings.ToLower(strings.TrimSpace(p.Scope))
+	if scope == "" {
+		scope = "global"
+		if hasTarget {
+			scope = "target"
+		}
+	}
+	findings, err := s.evaluateLiveRules("")
+	if err != nil {
+		return evidence, next
+	}
+	if !hasTarget || scope == "global" {
+		if len(findings) > 0 {
+			evidence = append(evidence, summarizeFindings(findings, 5)...)
+			rawOut["findings"] = findings
+			next = append(next, "Use diagnose include_raw=true for the full rules output.")
+		}
+		return evidence, next
+	}
+	target := triageTarget(p, pidProc, rawOut)
+	matched := filterFindingsForTarget(findings, target)
+	rawOut["target"] = target
+	if len(matched) > 0 {
+		evidence = append(evidence, summarizeFindings(matched, 5)...)
+		rawOut["findings"] = matched
+	} else {
+		evidence = append(evidence, fmt.Sprintf("no rules matched for %s", target.describe()))
+	}
+	next = append(next, "Use diagnose for host-wide rule findings; this triage was scoped to your target.")
+	return evidence, next
 }
 
 func (s *Server) collectTriageApp(p triageParams, evidence, next []string, rawOut map[string]interface{}) ([]string, []string) {
@@ -277,11 +299,14 @@ func (s *Server) collectTriageApp(p triageParams, evidence, next []string, rawOu
 	return evidence, next
 }
 
-func (s *Server) collectTriagePID(pid int, evidence, next []string, rawOut map[string]interface{}) ([]string, []string) {
+func (s *Server) collectTriagePID(pid int, evidence, next []string, rawOut map[string]interface{}) ([]string, []string, *process.Info) {
 	procs := s.collect.Processes.CollectProcesses(context.Background(), process.CollectOptions{Deep: true})
+	var matched *process.Info
 	if proc, ok := findProcess(procs, pid); ok {
 		evidence = append(evidence, summarizeProcesses([]process.Info{proc}, 1)...)
 		rawOut["process"] = proc
+		p := proc
+		matched = &p
 	} else {
 		evidence = append(evidence, fmt.Sprintf("pid %d not found in process list", pid))
 	}
@@ -290,7 +315,7 @@ func (s *Server) collectTriagePID(pid int, evidence, next []string, rawOut map[s
 		rawOut["jvm"] = info
 		next = append(next, "Use jvm operation=explain for GC/thread/memory interpretation.")
 	}
-	return evidence, next
+	return evidence, next, matched
 }
 
 func (s *Server) collectTriageBundle(p triageParams, evidence []string, rawOut map[string]interface{}) []string {
@@ -303,6 +328,79 @@ func (s *Server) collectTriageBundle(p triageParams, evidence []string, rawOut m
 		}
 	}
 	return evidence
+}
+
+// triageTargetInfo names the resolved identifiers a triage call is scoped to.
+// Subjects on findings are matched against the AppNames set (app-rule
+// subjects use the .app display name) or the PID set (process/JVM-rule
+// subjects embed "PID <n>").
+type triageTargetInfo struct {
+	AppNames []string `json:"app_names,omitempty"`
+	PID      int      `json:"pid,omitempty"`
+	BundleID string   `json:"bundle_id,omitempty"`
+}
+
+func (t triageTargetInfo) describe() string {
+	parts := make([]string, 0, 3)
+	if t.PID > 0 {
+		parts = append(parts, fmt.Sprintf("pid %d", t.PID))
+	}
+	parts = append(parts, t.AppNames...)
+	if t.BundleID != "" {
+		parts = append(parts, t.BundleID)
+	}
+	if len(parts) == 0 {
+		return "target"
+	}
+	return strings.Join(parts, " / ")
+}
+
+func triageTarget(p triageParams, pidProc *process.Info, rawOut map[string]interface{}) triageTargetInfo {
+	t := triageTargetInfo{PID: p.PID, BundleID: p.BundleID}
+	seen := map[string]bool{}
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		t.AppNames = append(t.AppNames, name)
+	}
+	if p.AppPath != "" {
+		add(triageAppNameFromPath(p.AppPath))
+	}
+	if pidProc != nil && pidProc.AppPath != "" {
+		add(triageAppNameFromPath(pidProc.AppPath))
+	}
+	if app, ok := rawOut["matched_app"].(detect.Result); ok && app.Path != "" {
+		add(triageAppNameFromPath(app.Path))
+	}
+	return t
+}
+
+func triageAppNameFromPath(appPath string) string {
+	return strings.TrimSuffix(filepath.Base(appPath), ".app")
+}
+
+func filterFindingsForTarget(findings []rules.Finding, t triageTargetInfo) []rules.Finding {
+	names := map[string]bool{}
+	for _, n := range t.AppNames {
+		names[n] = true
+	}
+	pidToken := ""
+	if t.PID > 0 {
+		pidToken = fmt.Sprintf("PID %d", t.PID)
+	}
+	var out []rules.Finding
+	for _, f := range findings {
+		if names[f.Subject] {
+			out = append(out, f)
+			continue
+		}
+		if pidToken != "" && strings.HasPrefix(f.Subject, pidToken) {
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 func (s *Server) toolInspectApp(raw json.RawMessage) ToolResult {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/snapshot"
 )
 
 func TestWithAgentAttachedSkipsAutoAttachWhenDisabled(t *testing.T) {
@@ -190,6 +191,96 @@ func TestInspectAppDeepUsesInjectedCollectors(t *testing.T) {
 			t.Fatalf("inspect_app deep output missing %q:\n%s", want, text)
 		}
 	}
+}
+
+func TestTriageScopedToTargetFiltersFindings(t *testing.T) {
+	slackPath := "/Applications/Slack.app"
+	apps := []detect.Result{
+		{Path: slackPath, BundleID: "com.tinyspeck.slackmacgap", TeamID: "BQR82RBBHL", HardenedRuntime: true, GatekeeperStatus: "accepted"},
+		{Path: "/Applications/Arbigent.app", BundleID: "com.arbigent", TeamID: "", GatekeeperStatus: "rejected"},
+		{Path: "/Applications/Xcode-26.3.0.app", BundleID: "com.apple.dt.Xcode", TeamID: "APPLECORP", HardenedRuntime: false},
+	}
+	procs := []process.Info{
+		{PID: 96454, PPID: 1, Command: "Slack", AppPath: slackPath, RSSKiB: 4096},
+	}
+
+	s := NewServer(strings.NewReader(""), &strings.Builder{})
+	s.SetCollectors(Collectors{
+		Processes: &fakeProcessCollector{procs: procs},
+		Snapshots: fakeSnapshotCollector{snap: snapshot.Snapshot{Apps: apps}},
+		Clock:     fixedClock{t: time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC)},
+	})
+
+	result := s.toolTriage(json.RawMessage(`{"pid":96454,"include_raw":true}`))
+	if result.IsError {
+		t.Fatalf("triage returned error: %+v", result.Content)
+	}
+	text := result.Content[0].Text
+	for _, bad := range []string{"Arbigent", "Xcode-26.3.0"} {
+		if strings.Contains(text, bad) {
+			t.Fatalf("triage pid=96454 leaked unrelated finding mentioning %q:\n%s", bad, text)
+		}
+	}
+	if !strings.Contains(text, "no rules matched") {
+		t.Fatalf("expected explicit \"no rules matched\" message when target has no findings:\n%s", text)
+	}
+}
+
+func TestTriageScopedKeepsMatchingFindings(t *testing.T) {
+	slackPath := "/Applications/Slack.app"
+	apps := []detect.Result{
+		{Path: slackPath, BundleID: "com.tinyspeck.slackmacgap", TeamID: ""},
+		{Path: "/Applications/Arbigent.app", BundleID: "com.arbigent", TeamID: ""},
+	}
+
+	s := NewServer(strings.NewReader(""), &strings.Builder{})
+	s.SetCollectors(Collectors{
+		Snapshots: fakeSnapshotCollector{snap: snapshot.Snapshot{Apps: apps}},
+		Clock:     fixedClock{t: time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC)},
+	})
+
+	result := s.toolTriage(json.RawMessage(`{"app_path":"/Applications/Slack.app","include_raw":true}`))
+	if result.IsError {
+		t.Fatalf("triage returned error: %+v", result.Content)
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, "Slack") {
+		t.Fatalf("expected Slack finding to be present:\n%s", text)
+	}
+	if strings.Contains(text, "Arbigent") {
+		t.Fatalf("Arbigent must not appear in target-scoped triage:\n%s", text)
+	}
+}
+
+func TestTriageScopeGlobalRestoresHostWideFindings(t *testing.T) {
+	apps := []detect.Result{
+		{Path: "/Applications/Slack.app", BundleID: "com.tinyspeck.slackmacgap", TeamID: "BQR82RBBHL", HardenedRuntime: true, GatekeeperStatus: "accepted"},
+		{Path: "/Applications/Arbigent.app", BundleID: "com.arbigent", TeamID: ""},
+	}
+	procs := []process.Info{{PID: 1, Command: "Slack", AppPath: "/Applications/Slack.app"}}
+
+	s := NewServer(strings.NewReader(""), &strings.Builder{})
+	s.SetCollectors(Collectors{
+		Processes: &fakeProcessCollector{procs: procs},
+		Snapshots: fakeSnapshotCollector{snap: snapshot.Snapshot{Apps: apps}},
+		Clock:     fixedClock{t: time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC)},
+	})
+
+	result := s.toolTriage(json.RawMessage(`{"pid":1,"scope":"global","include_raw":true}`))
+	if result.IsError {
+		t.Fatalf("triage returned error: %+v", result.Content)
+	}
+	if !strings.Contains(result.Content[0].Text, "Arbigent") {
+		t.Fatalf("scope=global must include host-wide findings; got:\n%s", result.Content[0].Text)
+	}
+}
+
+type fakeSnapshotCollector struct {
+	snap snapshot.Snapshot
+}
+
+func (f fakeSnapshotCollector) BuildSnapshot(_ context.Context, _ snapshot.Options) snapshot.Snapshot {
+	return f.snap
 }
 
 type fakeAppInspector struct {


### PR DESCRIPTION
## Summary
- `triage` now scopes rule findings to the supplied `app_path` / `pid` / `bundle_id` instead of returning the global app-rules output regardless of target (#224).
- Resolves the target to a set of .app display names (and a `PID <n>` token for process/JVM-rule subjects), then keeps only findings whose `Subject` matches.
- When no findings match, evidence reads `no rules matched for <target>` rather than substituting host-wide noise.
- New `scope` parameter (`target` default when an identifier is supplied, `global` to opt back into host-wide rules).

## Validation criteria
- `triage pid=<X>` for an app with no rule hits returns `no rules matched for ...` and does **not** mention other apps (`TestTriageScopedToTargetFiltersFindings`).
- `triage app_path=...` for a target that *does* fire a rule keeps that finding and excludes unrelated ones (`TestTriageScopedKeepsMatchingFindings`).
- `triage pid=<X> scope=global` restores the prior host-wide behavior (`TestTriageScopeGlobalRestoresHostWideFindings`).
- Full `go test ./...` passes.

## Test plan
- [x] `go test ./internal/mcp/ -run Triage -count=1`
- [x] `go test ./...`

Closes #224