### PR TITLE
Sample top twice so energy_top reports non-zero impact

### DIFF
--- a/internal/sysinfo/power.go
+++ b/internal/sysinfo/power.go
@@ -69,7 +69,9 @@ func (s CommandPowerSource) Assertions() ([]byte, error) {
 }
 
 func (s CommandPowerSource) EnergyTop() ([]byte, error) {
-	return s.runner()("top", "-l", "1", "-n", "10", "-o", "power", "-stats", "pid,power,command")
+	// Two samples 1s apart: `top` computes the power column as a delta between
+	// consecutive samples, so a single-sample run reports 0.0 for every pid.
+	return s.runner()("top", "-l", "2", "-s", "1", "-n", "10", "-o", "power", "-stats", "pid,power,command")
 }
 
 // PowerCollector turns raw source output into structured power state.
@@ -108,7 +110,10 @@ func (c PowerCollector) Collect() PowerState {
 	return ps
 }
 
-// parseEnergyTop parses `top -l 1 -n 10 -o power -stats pid,power,command` output.
+// parseEnergyTop parses `top -l N -o power -stats pid,power,command` output.
+// When N>1 there are multiple sample blocks; we keep only entries from the
+// last block, since `top` computes the power column as a delta from the
+// previous sample and the first block always reports zeros.
 func parseEnergyTop(out string) []EnergyUser {
 	var result []EnergyUser
 	for _, line := range strings.Split(out, "\n") {
@@ -117,6 +122,7 @@ func parseEnergyTop(out string) []EnergyUser {
 			continue
 		}
 		if fields[0] == "PID" {
+			result = result[:0]
 			continue
 		}
 		pid, err := strconv.Atoi(fields[0])

--- a/internal/sysinfo/power_test.go
+++ b/internal/sysinfo/power_test.go
@@ -224,6 +224,24 @@ func TestParseEnergyTop(t *testing.T) {
 	}
 }
 
+func TestParseEnergyTopKeepsLastSampleBlock(t *testing.T) {
+	// `top -l 2` emits two blocks; first has zero power (no baseline), second has real deltas.
+	const twoSample = `PID    POWER  COMMAND
+99647  0.0    Slack
+412    0.0    com.apple.WebKit
+PID    POWER  COMMAND
+99647  17.4   Slack
+412    4.1    com.apple.WebKit
+`
+	users := parseEnergyTop(twoSample)
+	if len(users) != 2 {
+		t.Fatalf("len = %d, want 2 (only last block)", len(users))
+	}
+	if users[0].EnergyImpact != 17.4 {
+		t.Errorf("EnergyImpact = %v, want 17.4 from second block", users[0].EnergyImpact)
+	}
+}
+
 func TestParseEnergyTopPreservesCommandWithSpaces(t *testing.T) {
 	users := parseEnergyTop(topEnergyOutputWithSpaces)
 	if len(users) != 1 {


### PR DESCRIPTION
## Summary
- `top -l 1 -o power` always emits 0.0 in the power column because the field is a delta against the previous sample and a single-sample run has no baseline. `spectra power` consequently shows every process at impact 0.0.
- Switch to `top -l 2 -s 1` and have `parseEnergyTop` keep only entries from the last sample block (reset on the second `PID    POWER    COMMAND` header row).
- Added a regression test for the two-block parse.

Verified live:

```
energy top users:
  PID      IMPACT    COMMAND
  ----------------------------------------
  407      44.7      WindowServer
  29491    26.7      Google Chrome He
  29193    12.8      Google Chrome
  66123    11.0      com.apple.Virtua
```

This is the first item of a larger Energy Analysis milestone (issues to follow) that adds real per-process joule accounting via `proc_pid_rusage` + IOReport rather than relying on `top`'s heuristic.

## Test plan
- [x] `go test ./internal/sysinfo/...`
- [x] `make ci` (only failure is pre-existing complexity in `internal/rules/jvm_facts.go`)
- [x] Manual: `spectra power` now reports non-zero impact values