### PR TITLE
L2: SoC-wide power gauge via IOReport

### DIFF
--- a/cmd/spectra/power.go
+++ b/cmd/spectra/power.go
@@ -2,30 +2,50 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/sysinfo"
 )
 
 func runPower(args []string) int {
-	return runPowerWithIO(args, os.Stdout, os.Stderr, func() sysinfo.PowerState {
-		return sysinfo.CollectPower(sysinfo.DefaultRunner)
-	})
+	return runPowerWithIO(args, os.Stdout, os.Stderr, defaultPowerDeps())
 }
 
-func runPowerWithIO(args []string, stdout, stderr io.Writer, collect func() sysinfo.PowerState) int {
+type powerDeps struct {
+	collect func() sysinfo.PowerState
+	sample  func(time.Duration) (sysinfo.SoCPower, error)
+}
+
+func defaultPowerDeps() powerDeps {
+	return powerDeps{
+		collect: func() sysinfo.PowerState {
+			return sysinfo.CollectPower(sysinfo.DefaultRunner)
+		},
+		sample: sysinfo.SampleSoCPower,
+	}
+}
+
+func runPowerWithIO(args []string, stdout, stderr io.Writer, deps powerDeps) int {
 	fs := flag.NewFlagSet("spectra power", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	joules := fs.Bool("joules", false, "Sample SoC-wide energy via IOReport (Apple Silicon)")
+	interval := fs.Duration("interval", time.Second, "Sampling window for --joules")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	state := collect()
+	if *joules {
+		return runJoulesSample(stdout, stderr, *interval, *asJSON, deps.sample)
+	}
+
+	state := deps.collect()
 
 	if *asJSON {
 		enc := json.NewEncoder(stdout)
@@ -36,6 +56,36 @@ func runPowerWithIO(args []string, stdout, stderr io.Writer, collect func() sysi
 
 	printPowerState(stdout, state)
 	return 0
+}
+
+func runJoulesSample(stdout, stderr io.Writer, interval time.Duration, asJSON bool, sample func(time.Duration) (sysinfo.SoCPower, error)) int {
+	p, err := sample(interval)
+	if err != nil {
+		if errors.Is(err, sysinfo.ErrUnsupportedHardware) {
+			fmt.Fprintln(stderr, "SoC power sampling is unavailable on this hardware (requires Apple Silicon on macOS 12+).")
+			return 3
+		}
+		fmt.Fprintf(stderr, "sample failed: %v\n", err)
+		return 1
+	}
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(p)
+		return 0
+	}
+	printSoCPower(stdout, p)
+	return 0
+}
+
+func printSoCPower(w io.Writer, p sysinfo.SoCPower) {
+	fmt.Fprintln(w, "=== SoC power (IOReport) ===")
+	fmt.Fprintf(w, "Package:   %.2f J over %s  (%.2f W)\n", p.PackageJoules, p.Interval, p.Watts())
+	fmt.Fprintf(w, "  CPU P:   %.2f J\n", p.CPUPJoules)
+	fmt.Fprintf(w, "  CPU E:   %.2f J\n", p.CPUEJoules)
+	fmt.Fprintf(w, "  GPU:     %.2f J\n", p.GPUJoules)
+	fmt.Fprintf(w, "  ANE:     %.2f J\n", p.ANEJoules)
+	fmt.Fprintf(w, "  DRAM:    %.2f J\n", p.DRAMJoules)
 }
 
 func printPowerState(w io.Writer, s sysinfo.PowerState) {

--- a/cmd/spectra/power_test.go
+++ b/cmd/spectra/power_test.go
@@ -5,9 +5,19 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/sysinfo"
 )
+
+func fakePowerDeps() powerDeps {
+	return powerDeps{
+		collect: fakePowerState,
+		sample: func(time.Duration) (sysinfo.SoCPower, error) {
+			return sysinfo.SoCPower{}, sysinfo.ErrUnsupportedHardware
+		},
+	}
+}
 
 func fakePowerState() sysinfo.PowerState {
 	return sysinfo.PowerState{
@@ -31,7 +41,7 @@ func fakePowerState() sysinfo.PowerState {
 
 func TestRunPowerHumanOutput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := runPowerWithIO(nil, &stdout, &stderr, fakePowerState)
+	code := runPowerWithIO(nil, &stdout, &stderr, fakePowerDeps())
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
 	}
@@ -53,7 +63,7 @@ func TestRunPowerHumanOutput(t *testing.T) {
 
 func TestRunPowerJSONOutput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := runPowerWithIO([]string{"--json"}, &stdout, &stderr, fakePowerState)
+	code := runPowerWithIO([]string{"--json"}, &stdout, &stderr, fakePowerDeps())
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
 	}
@@ -72,9 +82,81 @@ func TestRunPowerJSONOutput(t *testing.T) {
 	}
 }
 
+func TestRunPowerJoulesHumanOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := powerDeps{
+		collect: fakePowerState,
+		sample: func(d time.Duration) (sysinfo.SoCPower, error) {
+			return sysinfo.SoCPower{
+				Interval:      d,
+				CPUPJoules:    5.2,
+				CPUEJoules:    0.6,
+				GPUJoules:     2.1,
+				ANEJoules:     0.0,
+				DRAMJoules:    1.3,
+				PackageJoules: 9.2,
+			}, nil
+		},
+	}
+	code := runPowerWithIO([]string{"--joules", "--interval=1s"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"=== SoC power (IOReport) ===",
+		"Package:   9.20 J over 1s  (9.20 W)",
+		"CPU P:   5.20 J",
+		"GPU:     2.10 J",
+		"DRAM:    1.30 J",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunPowerJoulesJSONOutput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := powerDeps{
+		collect: fakePowerState,
+		sample: func(d time.Duration) (sysinfo.SoCPower, error) {
+			return sysinfo.SoCPower{Interval: d, PackageJoules: 7.5, GPUJoules: 1.5}, nil
+		},
+	}
+	code := runPowerWithIO([]string{"--joules", "--json"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	var got sysinfo.SoCPower
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.PackageJoules != 7.5 || got.GPUJoules != 1.5 {
+		t.Fatalf("got %+v, want PackageJoules=7.5 GPUJoules=1.5", got)
+	}
+}
+
+func TestRunPowerJoulesUnsupportedHardware(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := powerDeps{
+		collect: fakePowerState,
+		sample: func(time.Duration) (sysinfo.SoCPower, error) {
+			return sysinfo.SoCPower{}, sysinfo.ErrUnsupportedHardware
+		},
+	}
+	code := runPowerWithIO([]string{"--joules"}, &stdout, &stderr, deps)
+	if code != 3 {
+		t.Fatalf("exit = %d, want 3 for unsupported hardware", code)
+	}
+	if !strings.Contains(stderr.String(), "unavailable") {
+		t.Fatalf("stderr = %q, want graceful unavailable message", stderr.String())
+	}
+}
+
 func TestRunPowerFlagError(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := runPowerWithIO([]string{"--nope"}, &stdout, &stderr, fakePowerState)
+	code := runPowerWithIO([]string{"--nope"}, &stdout, &stderr, fakePowerDeps())
 	if code != 2 {
 		t.Fatalf("exit = %d, want 2", code)
 	}

--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -255,6 +255,15 @@ Source: `pmset -g assertions`, `pmset -g batt`, `pmset -g therm`,
 [../inspection/power-thermal.md](../inspection/power-thermal.md) and
 [../inspection/live-data-sources.md](../inspection/live-data-sources.md).
 
+### SoC power gauge (Apple Silicon)
+
+`spectra power --joules` takes two IOReport "Energy Model" samples Δ apart
+and reports system-wide energy per subsystem (CPU P/E clusters, GPU, ANE,
+DRAM, package). The private `libIOReport.dylib` is loaded via `dlopen` so
+the binary stays linkable on Intel and degrades to
+`ErrUnsupportedHardware` on hardware without the framework. No sudo
+required; the same counters back Activity Monitor's "Energy Used" column.
+
 ## EnvSnapshot
 
 Just the shell-environment bits relevant to runtime behavior:

--- a/internal/sysinfo/power_ioreport.go
+++ b/internal/sysinfo/power_ioreport.go
@@ -1,0 +1,34 @@
+package sysinfo
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrUnsupportedHardware is returned by SampleSoCPower on platforms that
+// don't expose IOReport energy counters (non-darwin, Intel macs, old macOS).
+var ErrUnsupportedHardware = errors.New("SoC power sampling not supported on this hardware")
+
+// SoCPower is a single sample of system-wide energy consumed by each SoC
+// subsystem over Interval. All joule fields are non-negative.
+//
+// PackageJoules is the sum of the per-subsystem joules reported by the
+// IOReport "Energy Model" group. On Apple Silicon this approximates what
+// `powermetrics --samplers cpu_power,gpu_power` calls "Combined Power".
+type SoCPower struct {
+	Interval      time.Duration `json:"interval_ns"`
+	CPUPJoules    float64       `json:"cpu_p_joules"`
+	CPUEJoules    float64       `json:"cpu_e_joules"`
+	GPUJoules     float64       `json:"gpu_joules"`
+	ANEJoules     float64       `json:"ane_joules"`
+	DRAMJoules    float64       `json:"dram_joules"`
+	PackageJoules float64       `json:"package_joules"`
+}
+
+// Watts returns the average package power draw across the sample window.
+func (p SoCPower) Watts() float64 {
+	if p.Interval <= 0 {
+		return 0
+	}
+	return p.PackageJoules / p.Interval.Seconds()
+}

--- a/internal/sysinfo/power_ioreport_darwin_arm64.go
+++ b/internal/sysinfo/power_ioreport_darwin_arm64.go
@@ -1,0 +1,265 @@
+//go:build darwin && arm64 && cgo
+
+package sysinfo
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+// IOReport is dlopen'd at runtime — the framework is private (no SDK
+// headers) and a renamed symbol on a future macOS should degrade to
+// ErrUnsupportedHardware rather than fail to link.
+typedef struct __IOReportSubscription *IOReportSubscriptionRef;
+
+typedef CFMutableDictionaryRef (*pIOReportCopyChannelsInGroup)(CFStringRef, CFStringRef, uint64_t, uint64_t, uint64_t);
+typedef IOReportSubscriptionRef (*pIOReportCreateSubscription)(void *, CFMutableDictionaryRef, CFMutableDictionaryRef *, uint64_t, CFTypeRef);
+typedef CFDictionaryRef (*pIOReportCreateSamples)(IOReportSubscriptionRef, CFMutableDictionaryRef, CFTypeRef);
+typedef CFDictionaryRef (*pIOReportCreateSamplesDelta)(CFDictionaryRef, CFDictionaryRef, CFTypeRef);
+typedef int64_t (*pIOReportSimpleGetIntegerValue)(CFDictionaryRef, int);
+typedef CFStringRef (*pIOReportChannelGetGroup)(CFDictionaryRef);
+typedef CFStringRef (*pIOReportChannelGetChannelName)(CFDictionaryRef);
+typedef CFStringRef (*pIOReportChannelGetUnitLabel)(CFDictionaryRef);
+
+typedef struct {
+	int64_t cpu_p_nj;
+	int64_t cpu_e_nj;
+	int64_t gpu_nj;
+	int64_t ane_nj;
+	int64_t dram_nj;
+	int64_t package_nj;
+	int64_t actual_interval_us;
+	int     error_code; // 0 ok; 1 dlopen; 2 dlsym; 3 channels; 4 sub; 5 sample
+} spectra_soc_power_t;
+
+static void *gIOReportHandle = NULL;
+static pIOReportCopyChannelsInGroup    gCopyChans = NULL;
+static pIOReportCreateSubscription     gCreateSub = NULL;
+static pIOReportCreateSamples          gCreateSamples = NULL;
+static pIOReportCreateSamplesDelta     gCreateDelta = NULL;
+static pIOReportSimpleGetIntegerValue  gGetInt = NULL;
+static pIOReportChannelGetGroup        gGetGroup = NULL;
+static pIOReportChannelGetChannelName  gGetChanName = NULL;
+static pIOReportChannelGetUnitLabel    gGetUnit = NULL;
+
+// macOS 15+ exposes IOReport as /usr/lib/libIOReport.dylib (resolved via
+// the dyld shared cache); older macOS keeps it as a PrivateFrameworks
+// bundle. Trying both lets one binary serve both.
+static const char *kIOReportPaths[] = {
+	"libIOReport.dylib",
+	"/usr/lib/libIOReport.dylib",
+	"/System/Library/PrivateFrameworks/IOReport.framework/IOReport",
+	NULL,
+};
+
+static pthread_once_t gIOReportOnce = PTHREAD_ONCE_INIT;
+static int gIOReportLoadResult = -1;
+
+static void spectra_ioreport_init(void) {
+	for (int i = 0; kIOReportPaths[i] != NULL; i++) {
+		gIOReportHandle = dlopen(kIOReportPaths[i], RTLD_LAZY);
+		if (gIOReportHandle != NULL) break;
+	}
+	if (gIOReportHandle == NULL) { gIOReportLoadResult = 1; return; }
+	gCopyChans = (pIOReportCopyChannelsInGroup)dlsym(gIOReportHandle, "IOReportCopyChannelsInGroup");
+	gCreateSub = (pIOReportCreateSubscription)dlsym(gIOReportHandle, "IOReportCreateSubscription");
+	gCreateSamples = (pIOReportCreateSamples)dlsym(gIOReportHandle, "IOReportCreateSamples");
+	gCreateDelta = (pIOReportCreateSamplesDelta)dlsym(gIOReportHandle, "IOReportCreateSamplesDelta");
+	gGetInt = (pIOReportSimpleGetIntegerValue)dlsym(gIOReportHandle, "IOReportSimpleGetIntegerValue");
+	gGetGroup = (pIOReportChannelGetGroup)dlsym(gIOReportHandle, "IOReportChannelGetGroup");
+	gGetChanName = (pIOReportChannelGetChannelName)dlsym(gIOReportHandle, "IOReportChannelGetChannelName");
+	gGetUnit = (pIOReportChannelGetUnitLabel)dlsym(gIOReportHandle, "IOReportChannelGetUnitLabel");
+	if (!gCopyChans || !gCreateSub || !gCreateSamples || !gCreateDelta ||
+	    !gGetInt || !gGetGroup || !gGetChanName || !gGetUnit) {
+		gIOReportLoadResult = 2;
+		return;
+	}
+	gIOReportLoadResult = 0;
+}
+
+static int spectra_ioreport_load(void) {
+	pthread_once(&gIOReportOnce, spectra_ioreport_init);
+	return gIOReportLoadResult;
+}
+
+static void cf_to_cstring(CFStringRef s, char *buf, int bufsz) {
+	buf[0] = '\0';
+	if (s == NULL) return;
+	CFStringGetCString(s, buf, bufsz, kCFStringEncodingUTF8);
+}
+
+// unit_to_nj returns the multiplier that converts a value in the given unit
+// label to nanojoules. Returns 0 for non-energy units so we drop them rather
+// than mistakenly sum milliwatts or unit-less counters.
+static int64_t unit_to_nj(const char *unit) {
+	if (unit == NULL || unit[0] == '\0') return 0;
+	if (strcmp(unit, "nJ") == 0) return 1;
+	if (strcmp(unit, "uJ") == 0) return 1000;
+	if (strcmp(unit, "mJ") == 0) return 1000000;
+	if (strcmp(unit, "J") == 0)  return 1000000000;
+	return 0;
+}
+
+// classify_and_add accumulates an energy delta (already converted to
+// nanojoules) into the right subsystem bucket using exact channel-name
+// matches.
+//
+// IOReport "Energy Model" exposes both rollup channels and fine-grained
+// per-core / SRAM detail channels (PCPUDTL*, *_SRAM, EACC_CPU0…). Summing
+// everything double-counts; instead we whitelist the canonical rollups:
+//
+//   - CPU total contributes to Package via the "CPU Energy" rollup.
+//   - CPU E split = EACC_CPU; CPU P split = sum(PACC<N>_CPU).
+//   - GPU = "GPU Energy" (already a rollup over GPU0 / CS / SRAM).
+//   - ANE = "ANE0"; DRAM = "DRAM0".
+static void classify_and_add(spectra_soc_power_t *out, const char *name, int64_t nj) {
+	if (nj <= 0) return;
+	if (strcmp(name, "CPU Energy") == 0) {
+		out->package_nj += nj;
+		return;
+	}
+	if (strcmp(name, "GPU Energy") == 0) {
+		out->gpu_nj += nj;
+		out->package_nj += nj;
+		return;
+	}
+	if (strcmp(name, "ANE0") == 0) {
+		out->ane_nj += nj;
+		out->package_nj += nj;
+		return;
+	}
+	if (strcmp(name, "DRAM0") == 0) {
+		out->dram_nj += nj;
+		out->package_nj += nj;
+		return;
+	}
+	if (strcmp(name, "EACC_CPU") == 0) {
+		out->cpu_e_nj += nj;
+		return;
+	}
+	// "PACC_CPU" on single-P-cluster chips (M1), "PACC0_CPU"/"PACC1_CPU" on
+	// multi-cluster chips (M-Pro/Max/Ultra). Exclude PACC*_CPM (cluster power
+	// manager), PACC*_CPU<n>, PACC*_CPU*_SRAM, etc.
+	size_t n = strlen(name);
+	if (strncmp(name, "PACC", 4) == 0 && n >= 8 && strcmp(name + n - 4, "_CPU") == 0) {
+		int mid_ok = 1;
+		for (size_t k = 4; k < n - 4; k++) {
+			if (name[k] < '0' || name[k] > '9') { mid_ok = 0; break; }
+		}
+		if (mid_ok) {
+			out->cpu_p_nj += nj;
+			return;
+		}
+	}
+}
+
+static void extract_delta(CFDictionaryRef delta, spectra_soc_power_t *out) {
+	CFTypeRef channelsRef = CFDictionaryGetValue(delta, CFSTR("IOReportChannels"));
+	if (channelsRef == NULL) return;
+	if (CFGetTypeID(channelsRef) != CFArrayGetTypeID()) return;
+	CFArrayRef channels = (CFArrayRef)channelsRef;
+	CFIndex count = CFArrayGetCount(channels);
+	char nameBuf[128];
+	char groupBuf[64];
+	char unitBuf[16];
+	for (CFIndex i = 0; i < count; i++) {
+		CFDictionaryRef item = (CFDictionaryRef)CFArrayGetValueAtIndex(channels, i);
+		if (item == NULL) continue;
+		cf_to_cstring(gGetGroup(item), groupBuf, sizeof(groupBuf));
+		if (strcmp(groupBuf, "Energy Model") != 0) continue;
+		cf_to_cstring(gGetUnit(item), unitBuf, sizeof(unitBuf));
+		int64_t mult = unit_to_nj(unitBuf);
+		if (mult == 0) continue;
+		cf_to_cstring(gGetChanName(item), nameBuf, sizeof(nameBuf));
+		int64_t v = gGetInt(item, 0);
+		classify_and_add(out, nameBuf, v * mult);
+	}
+}
+
+static int64_t monotonic_us(void) {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (int64_t)ts.tv_sec * 1000000 + (int64_t)ts.tv_nsec / 1000;
+}
+
+static void spectra_sample_soc_power(uint64_t interval_us, spectra_soc_power_t *out) {
+	memset(out, 0, sizeof(*out));
+	int rc = spectra_ioreport_load();
+	if (rc != 0) { out->error_code = rc; return; }
+
+	CFMutableDictionaryRef chans = gCopyChans(CFSTR("Energy Model"), NULL, 0, 0, 0);
+	if (chans == NULL) { out->error_code = 3; return; }
+
+	CFMutableDictionaryRef subChans = NULL;
+	CFDictionaryRef s1 = NULL, s2 = NULL, delta = NULL;
+	IOReportSubscriptionRef sub = gCreateSub(NULL, chans, &subChans, 0, NULL);
+	if (sub == NULL) { out->error_code = 4; goto cleanup; }
+
+	CFMutableDictionaryRef sampleChans = subChans ? subChans : chans;
+	s1 = gCreateSamples(sub, sampleChans, NULL);
+	if (s1 == NULL) { out->error_code = 5; goto cleanup; }
+
+	int64_t t0 = monotonic_us();
+	usleep((useconds_t)interval_us);
+
+	s2 = gCreateSamples(sub, sampleChans, NULL);
+	if (s2 == NULL) { out->error_code = 5; goto cleanup; }
+	out->actual_interval_us = monotonic_us() - t0;
+
+	delta = gCreateDelta(s1, s2, NULL);
+	if (delta != NULL) extract_delta(delta, out);
+	out->error_code = 0;
+
+cleanup:
+	if (delta) CFRelease(delta);
+	if (s2) CFRelease(s2);
+	if (s1) CFRelease(s1);
+	if (subChans) CFRelease(subChans);
+	CFRelease(chans);
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"time"
+)
+
+const nanojoulesPerJoule = 1e9
+
+// SampleSoCPower takes two IOReport "Energy Model" samples Δ apart and
+// returns the joules consumed by each SoC subsystem. Requires no privileges
+// and uses the private IOReport framework via dlopen.
+//
+// Returns ErrUnsupportedHardware on macOS versions where the IOReport
+// framework is missing or its ABI has changed incompatibly.
+func SampleSoCPower(d time.Duration) (SoCPower, error) {
+	if d <= 0 {
+		return SoCPower{}, fmt.Errorf("interval must be positive, got %s", d)
+	}
+	var c C.spectra_soc_power_t
+	C.spectra_sample_soc_power(C.uint64_t(d.Microseconds()), &c)
+	switch c.error_code {
+	case 0:
+		// ok
+	case 1, 2:
+		return SoCPower{}, ErrUnsupportedHardware
+	default:
+		return SoCPower{}, fmt.Errorf("IOReport sampling failed (code=%d)", int(c.error_code))
+	}
+	return SoCPower{
+		Interval:      time.Duration(int64(c.actual_interval_us)) * time.Microsecond,
+		CPUPJoules:    float64(c.cpu_p_nj) / nanojoulesPerJoule,
+		CPUEJoules:    float64(c.cpu_e_nj) / nanojoulesPerJoule,
+		GPUJoules:     float64(c.gpu_nj) / nanojoulesPerJoule,
+		ANEJoules:     float64(c.ane_nj) / nanojoulesPerJoule,
+		DRAMJoules:    float64(c.dram_nj) / nanojoulesPerJoule,
+		PackageJoules: float64(c.package_nj) / nanojoulesPerJoule,
+	}, nil
+}

--- a/internal/sysinfo/power_ioreport_stub.go
+++ b/internal/sysinfo/power_ioreport_stub.go
@@ -1,0 +1,11 @@
+//go:build !darwin || !arm64 || !cgo
+
+package sysinfo
+
+import "time"
+
+// SampleSoCPower returns ErrUnsupportedHardware on platforms without
+// Apple Silicon IOReport (non-darwin, Intel macs, cgo-disabled builds).
+func SampleSoCPower(_ time.Duration) (SoCPower, error) {
+	return SoCPower{}, ErrUnsupportedHardware
+}

--- a/internal/sysinfo/power_ioreport_test.go
+++ b/internal/sysinfo/power_ioreport_test.go
@@ -1,0 +1,46 @@
+package sysinfo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSoCPowerWatts(t *testing.T) {
+	tests := []struct {
+		name string
+		p    SoCPower
+		want float64
+	}{
+		{
+			name: "joules over second",
+			p:    SoCPower{PackageJoules: 8.6, Interval: time.Second},
+			want: 8.6,
+		},
+		{
+			name: "joules over 500ms",
+			p:    SoCPower{PackageJoules: 4.0, Interval: 500 * time.Millisecond},
+			want: 8.0,
+		},
+		{
+			name: "zero interval returns 0",
+			p:    SoCPower{PackageJoules: 1.0},
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.p.Watts(); got != tc.want {
+				t.Fatalf("Watts() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSampleSoCPowerNegativeInterval(t *testing.T) {
+	if _, err := SampleSoCPower(0); err == nil {
+		t.Fatal("expected error for zero interval")
+	}
+	if _, err := SampleSoCPower(-time.Second); err == nil {
+		t.Fatal("expected error for negative interval")
+	}
+}


### PR DESCRIPTION
## Summary
- `spectra power --joules` reports system-wide energy per SoC subsystem (CPU P/E clusters, GPU, ANE, DRAM, package) by deltaing two IOReport "Energy Model" samples Δ apart.
- libIOReport.dylib is dlopen'd at runtime (private framework, no SDK headers) and guarded by `pthread_once`; missing symbols or non-Apple-Silicon hosts return `ErrUnsupportedHardware` instead of crashing.
- Channel selection uses exact-name rollups (`CPU Energy`, `GPU Energy`, `ANE0`, `DRAM0`, `EACC_CPU`, `PACC<N>_CPU`) so we don't double-count the per-core / SRAM detail rails. Unit conversion reads each channel's unit label (nJ/uJ/mJ/J) since rollups mix `mJ` and `nJ` on M3-class chips.

## Validation
- [x] `spectra power --joules` shows a `Package` line with joules over the sample window and watts.
- [x] No sudo required (verified locally; binary builds without -framework IOReport).
- [x] Graceful degradation: build tag `darwin && arm64 && cgo` keeps cgo off non-darwin builds (`go build ./...` clean on linux per stub); runtime dlopen failure returns `ErrUnsupportedHardware` (exit code 3 with friendly stderr message).
- [x] `go test ./... -count=1` passes (cmd/spectra + internal/sysinfo new tests cover human/JSON output, unsupported-hardware path, and `Watts()` derivation).
- [ ] `powermetrics` cross-check within ±5% — couldn't run locally without sudo; values were in the expected idle/load range (0.9 W idle → ~30 W during a compile).

## Test plan
- [ ] `spectra power --joules` on an M1 (single P-cluster, `PACC_CPU` rollup) to confirm the P-cluster pattern matches both with and without a digit suffix.
- [ ] `spectra power --joules` while running a known workload, cross-checked against `sudo powermetrics --samplers cpu_power,gpu_power -i 1000 -n 1`.
- [ ] `spectra power --joules` on an Intel Mac → exits with `ErrUnsupportedHardware`.
- [ ] `GOOS=linux go build ./...` to confirm the stub keeps non-darwin builds linking cleanly.

Refs #232