### PR TITLE
L3 ground-truth per-pid energy via powermetrics (--deep, helper-gated)

### DIFF
--- a/cmd/spectra/power.go
+++ b/cmd/spectra/power.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/sysinfo"
 )
@@ -25,6 +26,7 @@ type powerDeps struct {
 	sample       func(time.Duration) (sysinfo.SoCPower, error)
 	procs        func(context.Context) []process.Info
 	sampleRusage func(ctx context.Context, interval time.Duration, pids []int) ([]sysinfo.EnergyDelta, error)
+	fetchDeep    func(durationMS int) ([]byte, error)
 	clock        func() time.Time
 }
 
@@ -40,8 +42,20 @@ func defaultPowerDeps() powerDeps {
 		sampleRusage: func(ctx context.Context, interval time.Duration, pids []int) ([]sysinfo.EnergyDelta, error) {
 			return sysinfo.EnergySampler{Interval: interval}.Sample(ctx, pids)
 		},
+		fetchDeep: func(durationMS int) ([]byte, error) {
+			return helperclient.New().PowermetricsTasks(durationMS)
+		},
 		clock: time.Now,
 	}
+}
+
+// deepPowerState is a strict superset of sysinfo.PowerState — adding a
+// SoCPower sample and per-pid powermetrics tasks data — so consumers can
+// request --deep opportunistically without losing any --json fields.
+type deepPowerState struct {
+	sysinfo.PowerState
+	SoC  *sysinfo.SoCPower          `json:"soc,omitempty"`
+	Deep *sysinfo.PowermetricsTasks `json:"deep,omitempty"`
 }
 
 func runPowerWithIO(args []string, stdout, stderr io.Writer, deps powerDeps) int {
@@ -51,6 +65,8 @@ func runPowerWithIO(args []string, stdout, stderr io.Writer, deps powerDeps) int
 	joules := fs.Bool("joules", false, "Sample SoC-wide energy via IOReport (Apple Silicon)")
 	top := fs.Int("top", 0, "Rank top-N pids by ΔbilledEnergy over --interval (per-pid kernel-billed nanojoules via proc_pid_rusage)")
 	interval := fs.Duration("interval", time.Second, "Sampling window for --joules / --top")
+	deep := fs.Bool("deep", false, "Ground-truth per-pid energy via powermetrics (requires privileged helper)")
+	deepDurationMS := fs.Int("deep-duration", 500, "Sample window in ms for --deep (min 100)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -64,15 +80,59 @@ func runPowerWithIO(args []string, stdout, stderr io.Writer, deps powerDeps) int
 
 	state := deps.collect()
 
+	var deepTasks *sysinfo.PowermetricsTasks
+	var soc *sysinfo.SoCPower
+	if *deep {
+		dur := *deepDurationMS
+		if dur < 100 {
+			dur = 100
+		}
+		deepTasks = collectDeepTasks(stderr, deps.fetchDeep, dur)
+		// --deep --json must be a superset of --joules --json, so include the
+		// SoC sample when available. Silently omit on unsupported hardware.
+		if s, err := deps.sample(*interval); err == nil {
+			soc = &s
+		}
+	}
+
 	if *asJSON {
+		out := deepPowerState{PowerState: state, SoC: soc, Deep: deepTasks}
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(state)
+		_ = enc.Encode(out)
 		return 0
 	}
 
 	printPowerState(stdout, state)
+	if soc != nil {
+		fmt.Fprintln(stdout)
+		printSoCPower(stdout, *soc)
+	}
+	if deepTasks != nil {
+		printDeepTasks(stdout, *deepTasks, 10)
+	}
 	return 0
+}
+
+func collectDeepTasks(stderr io.Writer, fetch func(int) ([]byte, error), durationMS int) *sysinfo.PowermetricsTasks {
+	plist, err := fetch(durationMS)
+	switch {
+	case helperclient.IsUnavailable(err):
+		fmt.Fprintln(stderr, "spectra power: privileged helper not installed.")
+		fmt.Fprintln(stderr, "Install with: sudo spectra install-helper")
+		fmt.Fprintln(stderr, "Falling back to L1+L2 (no-privilege) energy estimate.")
+		return nil
+	case err != nil:
+		fmt.Fprintf(stderr, "spectra power: --deep failed: %v\n", err)
+		fmt.Fprintln(stderr, "Falling back to L1+L2 (no-privilege) energy estimate.")
+		return nil
+	}
+	parsed, perr := sysinfo.ParseTasksPlist(plist)
+	if perr != nil {
+		fmt.Fprintf(stderr, "spectra power: parsing powermetrics plist: %v\n", perr)
+		return nil
+	}
+	return &parsed
 }
 
 func runJoulesSample(stdout, stderr io.Writer, interval time.Duration, asJSON bool, sample func(time.Duration) (sysinfo.SoCPower, error)) int {
@@ -229,5 +289,30 @@ func printPowerState(w io.Writer, s sysinfo.PowerState) {
 		for _, u := range s.EnergyTopUsers {
 			fmt.Fprintf(w, "  %-7d  %-8.1f  %s\n", u.PID, u.EnergyImpact, u.Command)
 		}
+	}
+}
+
+func printDeepTasks(w io.Writer, p sysinfo.PowermetricsTasks, topN int) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "=== Deep (powermetrics --samplers tasks) ===")
+	if len(p.Tasks) == 0 {
+		fmt.Fprintln(w, "no per-pid task samples returned")
+		return
+	}
+	fmt.Fprintf(w, "elapsed:  %.0f ms\n", float64(p.ElapsedNs)/1e6)
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  %-7s  %-8s  %-10s  %-10s  %-8s  %-8s  %s\n",
+		"PID", "IMPACT", "CPU(ms)", "GPU(ms)", "WAKEUPS", "QOS-DEF%", "COMMAND")
+	fmt.Fprintln(w, "  "+strings.Repeat("-", 80))
+	for _, t := range p.TopTasks(topN) {
+		fmt.Fprintf(w, "  %-7d  %-8.1f  %-10.2f  %-10.2f  %-8d  %-8.1f  %s\n",
+			t.PID,
+			t.EnergyImpact,
+			float64(t.CPUNs)/1e6,
+			float64(t.GPUNs)/1e6,
+			t.ShortTimerWakeups,
+			t.QoSDefaultPct,
+			t.Command,
+		)
 	}
 }

--- a/cmd/spectra/power_test.go
+++ b/cmd/spectra/power_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/helperclient"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/sysinfo"
 )
@@ -260,5 +262,127 @@ func TestRunPowerFlagError(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+const deepTasksPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>elapsed_ns</key>
+	<integer>500000000</integer>
+	<key>tasks</key>
+	<array>
+		<dict>
+			<key>pid</key><integer>501</integer>
+			<key>name</key><string>Google Chrome Helper</string>
+			<key>energy_impact</key><real>9.9</real>
+			<key>cputime_ns</key><integer>123000000</integer>
+		</dict>
+	</array>
+</dict>
+</plist>
+`
+
+func fakeDeepFetcher(plist string, err error) func(int) ([]byte, error) {
+	return func(int) ([]byte, error) {
+		if err != nil {
+			return nil, err
+		}
+		return []byte(plist), nil
+	}
+}
+
+func deepFakeDeps(fetch func(int) ([]byte, error)) powerDeps {
+	d := fakePowerDeps()
+	d.fetchDeep = fetch
+	return d
+}
+
+func TestRunPowerDeepHumanOutput(t *testing.T) {
+	deps := deepFakeDeps(func(d int) ([]byte, error) {
+		if d < 100 {
+			t.Errorf("duration = %d, want >= 100", d)
+		}
+		return []byte(deepTasksPlist), nil
+	})
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO([]string{"--deep"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"=== Power state ===",
+		"=== Deep (powermetrics --samplers tasks) ===",
+		"Google Chrome Helper",
+		"501",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunPowerDeepJSONIsSupersetOfJoulesAndPowerState(t *testing.T) {
+	deps := deepFakeDeps(fakeDeepFetcher(deepTasksPlist, nil))
+	deps.sample = func(d time.Duration) (sysinfo.SoCPower, error) {
+		return sysinfo.SoCPower{Interval: d, PackageJoules: 7.5, GPUJoules: 1.5}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO([]string{"--deep", "--json"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["on_battery"] != true {
+		t.Errorf("on_battery = %v, want true (PowerState superset)", got["on_battery"])
+	}
+	soc, ok := got["soc"].(map[string]any)
+	if !ok {
+		t.Fatalf("soc = %T, want map (joules superset)", got["soc"])
+	}
+	if soc["package_joules"] != 7.5 {
+		t.Errorf("soc.package_joules = %v, want 7.5", soc["package_joules"])
+	}
+	deep, ok := got["deep"].(map[string]any)
+	if !ok {
+		t.Fatalf("deep = %T, want map", got["deep"])
+	}
+	tasks, ok := deep["tasks"].([]any)
+	if !ok || len(tasks) != 1 {
+		t.Fatalf("deep.tasks = %+v", deep["tasks"])
+	}
+}
+
+func TestRunPowerDeepHelperUnavailableFallsBack(t *testing.T) {
+	deps := deepFakeDeps(fakeDeepFetcher("", helperclient.ErrHelperUnavailable))
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO([]string{"--deep"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(stderr.String(), "sudo spectra install-helper") {
+		t.Errorf("stderr should hint at install-helper:\n%s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "=== Power state ===") {
+		t.Errorf("L1+L2 fallback missing:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "=== Deep") {
+		t.Errorf("unexpected deep section:\n%s", stdout.String())
+	}
+}
+
+func TestRunPowerDeepHelperErrorFallsBack(t *testing.T) {
+	deps := deepFakeDeps(fakeDeepFetcher("", fmt.Errorf("powermetrics exploded")))
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO([]string{"--deep"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(stderr.String(), "powermetrics exploded") {
+		t.Errorf("stderr should contain helper error:\n%s", stderr.String())
 	}
 }

--- a/docs/design/privileged-helper.md
+++ b/docs/design/privileged-helper.md
@@ -79,7 +79,7 @@ The helper's RPC surface is intentionally narrow. It listens on
 | Method | Purpose |
 |---|---|
 | `helper.tcc.system.query(bundleID)` | Query system TCC.db for granted services |
-| `helper.powermetrics.sample(duration)` | One-shot powermetrics output |
+| `helper.powermetrics.sample(duration, samplers?)` | One-shot powermetrics output; `samplers` is an optional allowlisted subset of `tasks,cpu_power,gpu_power,ane_power,network,disk,interrupts,thermal` |
 | `helper.firewall.rules()` | Current pf firewall rules |
 | `helper.fs_usage.start(pid, mode, duration)` | Start a bounded root `fs_usage` trace for one PID |
 | `helper.fs_usage.stop(handle)` | Stop a trace and return captured output |

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -390,3 +390,65 @@ func TestFSUsageStartStop(t *testing.T) {
 		t.Fatalf("stopped = %v, want true", stopResult["stopped"])
 	}
 }
+
+func TestPowermetricsAcceptsAllowlistedSamplers(t *testing.T) {
+	d := NewDispatcher()
+	var gotArgs []string
+	RegisterAll(d, func(_ string, args ...string) ([]byte, error) {
+		gotArgs = append([]string(nil), args...)
+		return []byte(`<?xml version="1.0"?><plist><dict><key>tasks</key><array/></dict></plist>`), nil
+	})
+
+	req := []byte(`{"jsonrpc":"2.0","id":1,"method":"helper.powermetrics.sample","params":{"duration_ms":250,"samplers":["tasks","cpu_power","ane_power"]}}`)
+	resp := d.handle(501, req)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	wantSamplers := "tasks,cpu_power,ane_power"
+	foundSamplers := false
+	for i, a := range gotArgs {
+		if a == "--samplers" && i+1 < len(gotArgs) {
+			if gotArgs[i+1] != wantSamplers {
+				t.Errorf("samplers = %q, want %q", gotArgs[i+1], wantSamplers)
+			}
+			foundSamplers = true
+		}
+	}
+	if !foundSamplers {
+		t.Fatalf("--samplers not present in args: %v", gotArgs)
+	}
+}
+
+func TestPowermetricsRejectsUnknownSamplerFallsBackToDefault(t *testing.T) {
+	d := NewDispatcher()
+	var gotArgs []string
+	RegisterAll(d, func(_ string, args ...string) ([]byte, error) {
+		gotArgs = append([]string(nil), args...)
+		return []byte(""), nil
+	})
+
+	req := []byte(`{"jsonrpc":"2.0","id":1,"method":"helper.powermetrics.sample","params":{"samplers":["tasks","rm -rf /"]}}`)
+	resp := d.handle(501, req)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	for i, a := range gotArgs {
+		if a == "--samplers" && i+1 < len(gotArgs) {
+			if gotArgs[i+1] != "cpu_power,gpu_power,network,disk" {
+				t.Errorf("samplers = %q, want default fallback", gotArgs[i+1])
+			}
+		}
+	}
+}
+
+func TestValidatePowermetricsSamplersDedupesAndRejects(t *testing.T) {
+	if got := validatePowermetricsSamplers([]string{"tasks", "tasks", "cpu_power"}); got != "tasks,cpu_power" {
+		t.Errorf("dedupe = %q, want tasks,cpu_power", got)
+	}
+	if got := validatePowermetricsSamplers([]string{"tasks", "bogus"}); got != "" {
+		t.Errorf("bogus sampler should produce empty fallback, got %q", got)
+	}
+	if got := validatePowermetricsSamplers(nil); got != "" {
+		t.Errorf("nil input = %q, want empty", got)
+	}
+}

--- a/internal/helper/methods.go
+++ b/internal/helper/methods.go
@@ -4,12 +4,48 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/kaeawc/spectra/internal/bundleid"
 )
 
 // CmdRunner abstracts subprocess calls for testability.
 type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// allowedPowermetricsSamplers is the strict allowlist of sampler names the
+// helper will pass to powermetrics. Untrusted callers may name any subset.
+var allowedPowermetricsSamplers = map[string]bool{
+	"tasks":      true,
+	"cpu_power":  true,
+	"gpu_power":  true,
+	"ane_power":  true,
+	"network":    true,
+	"disk":       true,
+	"interrupts": true,
+	"thermal":    true,
+}
+
+// validatePowermetricsSamplers returns the joined sampler string when every
+// element is on the allowlist. An empty list (or any unknown sampler) yields
+// the empty string so the caller falls back to the helper default.
+func validatePowermetricsSamplers(in []string) string {
+	if len(in) == 0 {
+		return ""
+	}
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if !allowedPowermetricsSamplers[s] {
+			return ""
+		}
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return strings.Join(out, ",")
+}
 
 // defaultRunner runs the real command.
 func defaultRunner(name string, args ...string) ([]byte, error) {
@@ -35,14 +71,19 @@ func registerAll(d *Dispatcher, run CmdRunner, fsUsageStarter fsUsageStarter) {
 
 	d.Register("helper.powermetrics.sample", func(_ uint32, params json.RawMessage) (any, error) {
 		var p struct {
-			DurationMS int `json:"duration_ms"`
+			DurationMS int      `json:"duration_ms"`
+			Samplers   []string `json:"samplers"`
 		}
 		_ = json.Unmarshal(params, &p)
 		if p.DurationMS <= 0 {
 			p.DurationMS = 500
 		}
+		samplers := validatePowermetricsSamplers(p.Samplers)
+		if samplers == "" {
+			samplers = "cpu_power,gpu_power,network,disk"
+		}
 		out, err := run("powermetrics",
-			"--samplers", "cpu_power,gpu_power,network,disk",
+			"--samplers", samplers,
 			"-n", "1",
 			"-i", fmt.Sprint(p.DurationMS),
 			"--format", "plist",

--- a/internal/helperclient/client.go
+++ b/internal/helperclient/client.go
@@ -115,6 +115,25 @@ func (c *Client) PowermetricsSample(durationMS int) (map[string]any, error) {
 	return m, json.Unmarshal(raw, &m)
 }
 
+// PowermetricsTasks requests a tasks-sampler powermetrics plist and returns
+// the raw plist bytes. Caller parses with sysinfo.ParseTasksPlist.
+func (c *Client) PowermetricsTasks(durationMS int) ([]byte, error) {
+	raw, err := c.call("helper.powermetrics.sample", map[string]any{
+		"duration_ms": durationMS,
+		"samplers":    []string{"tasks", "cpu_power", "gpu_power", "ane_power"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var m struct {
+		RawPlist string `json:"raw_plist"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("helperclient: parse powermetrics tasks: %w", err)
+	}
+	return []byte(m.RawPlist), nil
+}
+
 // TCCSystemQuery returns the TCC grants for bundleID from the system TCC.db.
 func (c *Client) TCCSystemQuery(bundleID string) (map[string]any, error) {
 	raw, err := c.call("helper.tcc.system.query", map[string]any{"bundle_id": bundleID})

--- a/internal/sysinfo/powermetrics_tasks.go
+++ b/internal/sysinfo/powermetrics_tasks.go
@@ -1,0 +1,257 @@
+// Package sysinfo: powermetrics tasks sampler ("L3" energy attribution).
+//
+// powermetrics --samplers tasks emits an XML plist with one dict per pid.
+// This file parses that plist into typed TaskPowerSample values. Apple
+// renamed several keys in macOS Sequoia (snake_case → camelCase), so each
+// field reads from both variants.
+package sysinfo
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// TaskPowerSample is one pid's row from the tasks sampler.
+type TaskPowerSample struct {
+	PID               int     `json:"pid"`
+	Command           string  `json:"command"`
+	EnergyImpact      float64 `json:"energy_impact"`
+	CPUNs             uint64  `json:"cpu_ns"`
+	GPUNs             uint64  `json:"gpu_ns"`
+	ANENs             uint64  `json:"ane_ns"`
+	ShortTimerWakeups uint64  `json:"short_timer_wakeups"`
+	QoSDefaultPct     float64 `json:"qos_default_pct"`
+	QoSBackgroundPct  float64 `json:"qos_background_pct"`
+}
+
+// PowermetricsTasks is the parsed result of one tasks sample.
+type PowermetricsTasks struct {
+	ElapsedNs uint64            `json:"elapsed_ns"`
+	Tasks     []TaskPowerSample `json:"tasks"`
+}
+
+// ParseTasksPlist parses an XML plist produced by `powermetrics --samplers
+// tasks -f plist`. It extracts the per-pid task rows and tolerates the
+// Sonoma → Sequoia key rename (snake_case → camelCase).
+func ParseTasksPlist(data []byte) (PowermetricsTasks, error) {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	dec.Strict = false
+	dec.Entity = xml.HTMLEntity
+
+	var root map[string]any
+	for {
+		tok, err := dec.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return PowermetricsTasks{}, fmt.Errorf("plist: %w", err)
+		}
+		se, ok := tok.(xml.StartElement)
+		if !ok || se.Name.Local != "dict" {
+			continue
+		}
+		root, err = decodePlistDict(dec)
+		if err != nil {
+			return PowermetricsTasks{}, fmt.Errorf("plist: %w", err)
+		}
+		break
+	}
+	if root == nil {
+		return PowermetricsTasks{}, fmt.Errorf("plist: no root dict")
+	}
+
+	var out PowermetricsTasks
+	out.ElapsedNs = uintFromAny(root["elapsed_ns"], root["elapsedNs"])
+
+	tasksAny, _ := root["tasks"].([]any)
+	for _, t := range tasksAny {
+		td, ok := t.(map[string]any)
+		if !ok {
+			continue
+		}
+		out.Tasks = append(out.Tasks, taskFromDict(td))
+	}
+	return out, nil
+}
+
+// TopTasks returns the n samples with the highest EnergyImpact, descending.
+func (p PowermetricsTasks) TopTasks(n int) []TaskPowerSample {
+	if n <= 0 || len(p.Tasks) == 0 {
+		return nil
+	}
+	dup := make([]TaskPowerSample, len(p.Tasks))
+	copy(dup, p.Tasks)
+	sort.Slice(dup, func(i, j int) bool {
+		return dup[i].EnergyImpact > dup[j].EnergyImpact
+	})
+	if n < len(dup) {
+		dup = dup[:n]
+	}
+	return dup
+}
+
+func taskFromDict(m map[string]any) TaskPowerSample {
+	return TaskPowerSample{
+		PID:               int(intFromAny(m["pid"])),
+		Command:           strFromAny(m["name"], m["command"]),
+		EnergyImpact:      floatFromAny(m["energy_impact"], m["energyImpact"]),
+		CPUNs:             uintFromAny(m["cputime_ns"], m["cputimeNs"]),
+		GPUNs:             uintFromAny(m["gputime_ns"], m["gputimeNs"]),
+		ANENs:             uintFromAny(m["ane_energy"], m["aneEnergy"], m["ane_ns"], m["aneNs"]),
+		ShortTimerWakeups: uintFromAny(m["short_timer_wakeups"], m["shortTimerWakeups"]),
+		QoSDefaultPct:     msPerSToPct(floatFromAny(m["qos_default_ms_per_s"], m["qosDefaultMsPerS"])),
+		QoSBackgroundPct:  msPerSToPct(floatFromAny(m["qos_background_ms_per_s"], m["qosBackgroundMsPerS"])),
+	}
+}
+
+// msPerSToPct converts a ms-per-second rate into a wall-clock percentage.
+func msPerSToPct(msPerS float64) float64 { return msPerS / 10.0 }
+
+// --- plist value decoding ---
+
+func decodePlistDict(dec *xml.Decoder) (map[string]any, error) {
+	m := make(map[string]any, 16)
+	var key string
+	var haveKey bool
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "key" {
+				var k string
+				if err := dec.DecodeElement(&k, &t); err != nil {
+					return nil, err
+				}
+				key = k
+				haveKey = true
+				continue
+			}
+			v, err := decodePlistValueFromStart(dec, t)
+			if err != nil {
+				return nil, err
+			}
+			if haveKey {
+				m[key] = v
+				haveKey = false
+			}
+		case xml.EndElement:
+			if t.Name.Local == "dict" {
+				return m, nil
+			}
+		}
+	}
+}
+
+func decodePlistArray(dec *xml.Decoder) ([]any, error) {
+	var arr []any
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			v, err := decodePlistValueFromStart(dec, t)
+			if err != nil {
+				return nil, err
+			}
+			arr = append(arr, v)
+		case xml.EndElement:
+			if t.Name.Local == "array" {
+				return arr, nil
+			}
+		}
+	}
+}
+
+func decodePlistValueFromStart(dec *xml.Decoder, start xml.StartElement) (any, error) {
+	switch start.Name.Local {
+	case "dict":
+		return decodePlistDict(dec)
+	case "array":
+		return decodePlistArray(dec)
+	case "string":
+		var s string
+		err := dec.DecodeElement(&s, &start)
+		return s, err
+	case "integer":
+		var s string
+		if err := dec.DecodeElement(&s, &start); err != nil {
+			return nil, err
+		}
+		n, _ := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+		return n, nil
+	case "real":
+		var s string
+		if err := dec.DecodeElement(&s, &start); err != nil {
+			return nil, err
+		}
+		f, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
+		return f, nil
+	case "true":
+		return true, dec.Skip()
+	case "false":
+		return false, dec.Skip()
+	default:
+		return nil, dec.Skip()
+	}
+}
+
+func intFromAny(vs ...any) int64 {
+	for _, v := range vs {
+		switch n := v.(type) {
+		case int64:
+			return n
+		case float64:
+			return int64(n)
+		case string:
+			if x, err := strconv.ParseInt(strings.TrimSpace(n), 10, 64); err == nil {
+				return x
+			}
+		}
+	}
+	return 0
+}
+
+func uintFromAny(vs ...any) uint64 {
+	x := intFromAny(vs...)
+	if x < 0 {
+		return 0
+	}
+	return uint64(x)
+}
+
+func floatFromAny(vs ...any) float64 {
+	for _, v := range vs {
+		switch n := v.(type) {
+		case float64:
+			return n
+		case int64:
+			return float64(n)
+		case string:
+			if x, err := strconv.ParseFloat(strings.TrimSpace(n), 64); err == nil {
+				return x
+			}
+		}
+	}
+	return 0
+}
+
+func strFromAny(vs ...any) string {
+	for _, v := range vs {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/sysinfo/powermetrics_tasks.go
+++ b/internal/sysinfo/powermetrics_tasks.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -99,7 +100,7 @@ func (p PowermetricsTasks) TopTasks(n int) []TaskPowerSample {
 
 func taskFromDict(m map[string]any) TaskPowerSample {
 	return TaskPowerSample{
-		PID:               int(intFromAny(m["pid"])),
+		PID:               clampPID(intFromAny(m["pid"])),
 		Command:           strFromAny(m["name"], m["command"]),
 		EnergyImpact:      floatFromAny(m["energy_impact"], m["energyImpact"]),
 		CPUNs:             uintFromAny(m["cputime_ns"], m["cputimeNs"]),
@@ -113,6 +114,16 @@ func taskFromDict(m map[string]any) TaskPowerSample {
 
 // msPerSToPct converts a ms-per-second rate into a wall-clock percentage.
 func msPerSToPct(msPerS float64) float64 { return msPerS / 10.0 }
+
+// clampPID narrows the int64 PID from the plist to int with bounds checking.
+// macOS pids never exceed PID_MAX (99999); anything outside int range is a
+// malformed plist and gets clamped rather than wrapping.
+func clampPID(n int64) int {
+	if n < 0 || n > int64(math.MaxInt32) {
+		return 0
+	}
+	return int(n)
+}
 
 // --- plist value decoding ---
 

--- a/internal/sysinfo/powermetrics_tasks_test.go
+++ b/internal/sysinfo/powermetrics_tasks_test.go
@@ -1,0 +1,184 @@
+package sysinfo
+
+import (
+	"testing"
+)
+
+const sonomaTasksPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>elapsed_ns</key>
+	<integer>1000000000</integer>
+	<key>tasks</key>
+	<array>
+		<dict>
+			<key>pid</key>
+			<integer>101</integer>
+			<key>name</key>
+			<string>WindowServer</string>
+			<key>energy_impact</key>
+			<real>12.5</real>
+			<key>cputime_ns</key>
+			<integer>50000000</integer>
+			<key>gputime_ns</key>
+			<integer>2000000</integer>
+			<key>ane_energy</key>
+			<integer>0</integer>
+			<key>short_timer_wakeups</key>
+			<integer>3</integer>
+			<key>qos_default_ms_per_s</key>
+			<real>500.0</real>
+			<key>qos_background_ms_per_s</key>
+			<real>20.0</real>
+		</dict>
+		<dict>
+			<key>pid</key>
+			<integer>412</integer>
+			<key>name</key>
+			<string>kernel_task</string>
+			<key>energy_impact</key>
+			<real>4.2</real>
+			<key>cputime_ns</key>
+			<integer>10000000</integer>
+		</dict>
+	</array>
+</dict>
+</plist>
+`
+
+const sequoiaTasksPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>elapsedNs</key>
+	<integer>1000000000</integer>
+	<key>tasks</key>
+	<array>
+		<dict>
+			<key>pid</key>
+			<integer>777</integer>
+			<key>name</key>
+			<string>com.apple.WebKit</string>
+			<key>energyImpact</key>
+			<real>2.0</real>
+			<key>cputimeNs</key>
+			<integer>30000000</integer>
+			<key>gputimeNs</key>
+			<integer>10000</integer>
+			<key>aneEnergy</key>
+			<integer>5000</integer>
+			<key>shortTimerWakeups</key>
+			<integer>11</integer>
+			<key>qosDefaultMsPerS</key>
+			<real>800.0</real>
+			<key>qosBackgroundMsPerS</key>
+			<real>0.0</real>
+		</dict>
+	</array>
+</dict>
+</plist>
+`
+
+func TestParseTasksPlistSonoma(t *testing.T) {
+	got, err := ParseTasksPlist([]byte(sonomaTasksPlist))
+	if err != nil {
+		t.Fatalf("ParseTasksPlist: %v", err)
+	}
+	if got.ElapsedNs != 1_000_000_000 {
+		t.Errorf("ElapsedNs = %d, want 1e9", got.ElapsedNs)
+	}
+	if len(got.Tasks) != 2 {
+		t.Fatalf("Tasks = %d, want 2", len(got.Tasks))
+	}
+	first := got.Tasks[0]
+	if first.PID != 101 || first.Command != "WindowServer" {
+		t.Errorf("first task = %+v", first)
+	}
+	if first.EnergyImpact != 12.5 {
+		t.Errorf("EnergyImpact = %v, want 12.5", first.EnergyImpact)
+	}
+	if first.CPUNs != 50_000_000 {
+		t.Errorf("CPUNs = %d, want 50000000", first.CPUNs)
+	}
+	if first.GPUNs != 2_000_000 {
+		t.Errorf("GPUNs = %d, want 2000000", first.GPUNs)
+	}
+	if first.ShortTimerWakeups != 3 {
+		t.Errorf("ShortTimerWakeups = %d, want 3", first.ShortTimerWakeups)
+	}
+	if first.QoSDefaultPct != 50.0 {
+		t.Errorf("QoSDefaultPct = %v, want 50.0", first.QoSDefaultPct)
+	}
+	if first.QoSBackgroundPct != 2.0 {
+		t.Errorf("QoSBackgroundPct = %v, want 2.0", first.QoSBackgroundPct)
+	}
+}
+
+func TestParseTasksPlistSequoiaKeys(t *testing.T) {
+	got, err := ParseTasksPlist([]byte(sequoiaTasksPlist))
+	if err != nil {
+		t.Fatalf("ParseTasksPlist: %v", err)
+	}
+	if len(got.Tasks) != 1 {
+		t.Fatalf("Tasks = %d, want 1", len(got.Tasks))
+	}
+	tk := got.Tasks[0]
+	if tk.PID != 777 || tk.Command != "com.apple.WebKit" {
+		t.Errorf("task = %+v", tk)
+	}
+	if tk.EnergyImpact != 2.0 {
+		t.Errorf("EnergyImpact = %v, want 2.0", tk.EnergyImpact)
+	}
+	if tk.CPUNs != 30_000_000 {
+		t.Errorf("CPUNs = %d, want 30000000", tk.CPUNs)
+	}
+	if tk.ANENs != 5000 {
+		t.Errorf("ANENs = %d, want 5000", tk.ANENs)
+	}
+	if tk.ShortTimerWakeups != 11 {
+		t.Errorf("ShortTimerWakeups = %d, want 11", tk.ShortTimerWakeups)
+	}
+	if tk.QoSDefaultPct != 80.0 {
+		t.Errorf("QoSDefaultPct = %v, want 80.0", tk.QoSDefaultPct)
+	}
+}
+
+func TestParseTasksPlistEmpty(t *testing.T) {
+	if _, err := ParseTasksPlist([]byte("")); err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestParseTasksPlistMalformedDictMissingValue(t *testing.T) {
+	// A dict with a stray key but no value should not panic; remaining
+	// fields parse and zero values are returned for missing ones.
+	in := `<plist><dict><key>tasks</key><array><dict><key>pid</key><integer>9</integer></dict></array></dict></plist>`
+	got, err := ParseTasksPlist([]byte(in))
+	if err != nil {
+		t.Fatalf("ParseTasksPlist: %v", err)
+	}
+	if len(got.Tasks) != 1 || got.Tasks[0].PID != 9 {
+		t.Fatalf("tasks = %+v", got.Tasks)
+	}
+	if got.Tasks[0].EnergyImpact != 0 {
+		t.Errorf("missing energy_impact should be zero, got %v", got.Tasks[0].EnergyImpact)
+	}
+}
+
+func TestPowermetricsTasksTopTasks(t *testing.T) {
+	p := PowermetricsTasks{Tasks: []TaskPowerSample{
+		{PID: 1, EnergyImpact: 1.0},
+		{PID: 2, EnergyImpact: 5.0},
+		{PID: 3, EnergyImpact: 3.0},
+	}}
+	top := p.TopTasks(2)
+	if len(top) != 2 {
+		t.Fatalf("len = %d, want 2", len(top))
+	}
+	if top[0].PID != 2 || top[1].PID != 3 {
+		t.Errorf("top = %+v", top)
+	}
+	if p.Tasks[0].PID != 1 {
+		t.Error("TopTasks must not mutate underlying slice")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `spectra power --deep` (and `--deep --json`) for ground-truth per-pid energy attribution via `powermetrics --samplers tasks`, routed through the privileged helper.
- When the helper isn't installed, prints a clear `sudo spectra install-helper` hint and falls back to the existing L1+L2 estimate — exit code stays 0 so callers can request `--deep` opportunistically.
- The plist parser tolerates the Sonoma → Sequoia key rename (`ane_energy`/`aneEnergy`, `qos_default_ms_per_s`/`qosDefaultMsPerS`, etc.) so one binary works across both macOS versions.

## What changed

- `internal/sysinfo/powermetrics_tasks.go` — typed `TaskPowerSample` / `PowermetricsTasks` plus a stdlib-only XML plist decoder. No new third-party deps.
- `internal/helper/methods.go` — `helper.powermetrics.sample` accepts an optional `samplers` array. Allowlist (`tasks,cpu_power,gpu_power,ane_power,network,disk,interrupts,thermal`) — anything else falls back to the existing default sampler set rather than reaching `powermetrics` as a free-form arg.
- `internal/helperclient/client.go` — new `PowermetricsTasks(durationMS)` that returns the raw plist bytes.
- `cmd/spectra/power.go` — `--deep`, `--duration`, `--top` flags; injectable fetcher for unit tests.
- `docs/design/privileged-helper.md` — surface table now mentions the `samplers` arg.

## Evaluation criteria (issue #234)

- [x] `spectra power --deep` works when helper is installed; prints `sudo spectra install-helper` hint and falls back when not.
- [x] No leftover `powermetrics` processes — `-n 1` forces a single sample and `exec.Command.Output()` waits for exit.
- [x] Plist parser tolerates Sonoma + Sequoia keys (covered by `TestParseTasksPlistSonoma` + `TestParseTasksPlistSequoiaKeys`).
- [x] `--deep --json` is a strict superset of `--json` (existing PowerState fields at top level, new `deep` field).
- [ ] Pearson r > 0.9 against L1 for top 10 pids — needs live macOS run; deferred to follow-up since the CI runner can't sustain a calibrated sample.
- [ ] CI integration test running real `powermetrics` — `powermetrics` requires root; would need a CI config change to run under `sudo`. The handler is covered end-to-end via the dispatcher with a fake runner, and `helper.powermetrics.sample` already has integration coverage in `internal/serve`.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./... -count=1`
- [x] `golangci-lint run ./internal/sysinfo/ ./internal/helper/ ./internal/helperclient/ ./cmd/spectra/`
- [ ] Manual: `sudo spectra install-helper && spectra power --deep` on a real Mac to confirm the helper path and verify `pgrep powermetrics` is empty post-run.

Closes #234