### PR TITLE
Compute documented per-pid energy impact with explainable breakdown

### DIFF
--- a/cmd/spectra/impact.go
+++ b/cmd/spectra/impact.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kaeawc/spectra/internal/sysinfo"
+)
+
+func runImpact(args []string) int {
+	return runImpactWithIO(args, os.Stdin, os.Stdout, os.Stderr, os.Getenv, defaultAssertions)
+}
+
+func defaultAssertions() []sysinfo.PowerAssertion {
+	return sysinfo.CollectAssertions(sysinfo.DefaultRunner)
+}
+
+func runImpactWithIO(args []string, stdin io.Reader, stdout, stderr io.Writer, getenv func(string) string, collectAssertions func() []sysinfo.PowerAssertion) int {
+	fs := flag.NewFlagSet("spectra impact", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human table")
+	fromJSON := fs.String("from-json", "", "Read a JSON array of ImpactInput records (or '-' for stdin)")
+	formula := fs.Bool("formula", false, "Print the impact formula and active weights, then exit")
+
+	weights, err := sysinfo.LoadWeights(getenv)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: spectra impact [--json] [--from-json file|-] [--formula]")
+		fmt.Fprintln(stderr)
+		fs.PrintDefaults()
+		fmt.Fprintln(stderr)
+		fmt.Fprint(stderr, sysinfo.ImpactFormulaHelp(weights))
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *formula {
+		fmt.Fprint(stdout, sysinfo.ImpactFormulaHelp(weights))
+		return 0
+	}
+
+	inputs, err := readImpactInputs(*fromJSON, stdin)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+
+	rows := sysinfo.ScoreImpacts(inputs, collectAssertions(), weights)
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(rows)
+		return 0
+	}
+
+	printImpactTable(stdout, rows)
+	return 0
+}
+
+func readImpactInputs(path string, stdin io.Reader) ([]sysinfo.ImpactInput, error) {
+	if path == "" {
+		return nil, nil
+	}
+	var src io.Reader
+	if path == "-" {
+		src = stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("open %s: %w", path, err)
+		}
+		defer f.Close()
+		src = f
+	}
+	var inputs []sysinfo.ImpactInput
+	if err := json.NewDecoder(src).Decode(&inputs); err != nil {
+		return nil, fmt.Errorf("decode impact inputs: %w", err)
+	}
+	return inputs, nil
+}
+
+func printImpactTable(w io.Writer, rows []sysinfo.ScoredImpact) {
+	fmt.Fprintf(w, "%-7s  %-6s  %-6s  %-6s  %-6s  %-5s  %-6s  %s\n",
+		"PID", "SCORE", "ENERGY", "WAKE", "GPU", "ASRT", "IO", "COMMAND")
+	for _, r := range rows {
+		b := r.Breakdown
+		fmt.Fprintf(w, "%-7d  %-6.1f  %-6.1f  %-6.1f  %-6.1f  %-5.1f  %-6.1f  %s\n",
+			r.Input.PID, b.Total, b.FromEnergy, b.FromWakeups, b.FromGPU, b.FromAssertions, b.FromIO,
+			truncate(r.Input.Command, 45))
+	}
+}

--- a/cmd/spectra/impact_test.go
+++ b/cmd/spectra/impact_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/sysinfo"
+)
+
+func emptyEnv(string) string                 { return "" }
+func noAssertions() []sysinfo.PowerAssertion { return nil }
+
+func TestRunImpactFormulaFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runImpactWithIO([]string{"--formula"}, nil, &stdout, &stderr, emptyEnv, noAssertions)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"score = energy",
+		"billed_energy_J",
+		"SPECTRA_IMPACT_WEIGHTS",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("formula output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunImpactReadsInputsFromStdin(t *testing.T) {
+	inputs := []sysinfo.ImpactInput{
+		{PID: 91829, Command: "Claude Helper (GPU)", Interval: time.Second, BilledEnergyJ: 0.28, GPUTimeNs: 41_000_000},
+		{PID: 407, Command: "WindowServer", Interval: time.Second, BilledEnergyJ: 0.18, GPUTimeNs: 148_000_000},
+	}
+	raw, err := json.Marshal(inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runImpactWithIO([]string{"--from-json", "-", "--json"}, bytes.NewReader(raw), &stdout, &stderr, emptyEnv, noAssertions)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	var got []sysinfo.ScoredImpact
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\noutput:\n%s", err, stdout.String())
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Input.PID != 407 {
+		t.Fatalf("top PID = %d, want 407 (WindowServer beats helper on GPU); rows=%+v",
+			got[0].Input.PID, got)
+	}
+	if got[0].Breakdown.FromGPU <= 0 {
+		t.Fatalf("WindowServer FromGPU = %g, want >0", got[0].Breakdown.FromGPU)
+	}
+}
+
+func TestRunImpactHumanTableShowsBreakdown(t *testing.T) {
+	inputs := []sysinfo.ImpactInput{
+		{PID: 100, Command: "yes", Interval: time.Second, BilledEnergyJ: 3.0},
+	}
+	raw, _ := json.Marshal(inputs)
+
+	var stdout, stderr bytes.Buffer
+	code := runImpactWithIO([]string{"--from-json", "-"}, bytes.NewReader(raw), &stdout, &stderr, emptyEnv, noAssertions)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"PID", "SCORE", "ENERGY", "WAKE", "GPU", "ASRT", "IO", "COMMAND", "yes"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("table missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunImpactWeightOverrideViaEnv(t *testing.T) {
+	inputs := []sysinfo.ImpactInput{{PID: 1, Interval: time.Second, BilledEnergyJ: 1.0}}
+	raw, _ := json.Marshal(inputs)
+
+	env := func(k string) string {
+		if k == "SPECTRA_IMPACT_WEIGHTS" {
+			return "energy=200"
+		}
+		return ""
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runImpactWithIO([]string{"--from-json", "-", "--json"}, bytes.NewReader(raw), &stdout, &stderr, env, noAssertions)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	var got []sysinfo.ScoredImpact
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Breakdown.FromEnergy != 200 {
+		t.Fatalf("FromEnergy = %g, want 200 (env-override 200 J⁻¹ × 1 J)",
+			got[0].Breakdown.FromEnergy)
+	}
+}
+
+func TestRunImpactBadEnvIsError(t *testing.T) {
+	env := func(k string) string {
+		if k == "SPECTRA_IMPACT_WEIGHTS" {
+			return "garbage=1"
+		}
+		return ""
+	}
+	var stdout, stderr bytes.Buffer
+	code := runImpactWithIO(nil, nil, &stdout, &stderr, env, noAssertions)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if stderr.Len() == 0 {
+		t.Fatalf("expected error on stderr")
+	}
+}
+
+func TestRunImpactAssertionRanksAboveIdle(t *testing.T) {
+	inputs := []sysinfo.ImpactInput{
+		{PID: 500, Command: "caffeinate", Interval: time.Second},
+		{PID: 501, Command: "idle-daemon", Interval: time.Second},
+	}
+	raw, _ := json.Marshal(inputs)
+	assertions := func() []sysinfo.PowerAssertion {
+		return []sysinfo.PowerAssertion{{PID: 500, Type: sysinfo.AssertionPreventUserIdleSleep}}
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runImpactWithIO([]string{"--from-json", "-", "--json"}, bytes.NewReader(raw), &stdout, &stderr, emptyEnv, assertions)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	var got []sysinfo.ScoredImpact
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Input.PID != 500 {
+		t.Fatalf("top PID = %d, want 500 (caffeinate outranks idle); rows=%+v",
+			got[0].Input.PID, got)
+	}
+}
+
+func TestRunImpactFlagError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runImpactWithIO([]string{"--nope"}, nil, &stdout, &stderr, emptyEnv, noAssertions)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -41,6 +41,7 @@ func subcommandList() []subcommand {
 		{"toolchain", "Show installed language runtimes and package managers", runToolchain},
 		{"network", "Show current network state (routes, DNS, VPN, proxy, listening ports)", runNetwork},
 		{"power", "Show current battery and thermal state", runPower},
+		{"impact", "Compute the documented per-pid energy impact score from delta records", runImpact},
 		{"storage", "Show disk volumes and ~/Library footprint", runStorage},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
 		{"playbook", "Show diagnostic playbooks and command plans", runPlaybook},

--- a/internal/sysinfo/energy_impact.go
+++ b/internal/sysinfo/energy_impact.go
@@ -1,0 +1,238 @@
+package sysinfo
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ImpactInput is the per-pid power signal that ComputeImpact scores. It is
+// the union of what rusage (BilledEnergyJ, wakeups, disk) and powermetrics
+// (GPU time) can provide; FromRusage and FromTaskSample build it from each
+// source so producers don't have to know the formula's shape.
+type ImpactInput struct {
+	PID              int           `json:"pid"`
+	Command          string        `json:"command,omitempty"`
+	Interval         time.Duration `json:"interval_ns,omitempty"`
+	BilledEnergyJ    float64       `json:"billed_energy_j,omitempty"`
+	InterruptWakeups uint64        `json:"interrupt_wakeups,omitempty"`
+	GPUTimeNs        uint64        `json:"gpu_time_ns,omitempty"`
+	DiskBytes        uint64        `json:"disk_bytes,omitempty"`
+}
+
+// FromRusage lifts a rusage delta (nanojoules, separate read/write bytes)
+// into the unit-normalised ImpactInput.
+func FromRusage(d EnergyDelta) ImpactInput {
+	return ImpactInput{
+		PID:              d.PID,
+		Command:          d.Command,
+		Interval:         d.Interval,
+		BilledEnergyJ:    float64(d.BilledEnergyNJ) / 1e9,
+		InterruptWakeups: d.InterruptWakeups,
+		DiskBytes:        d.DiskBytesRead + d.DiskBytesWritten,
+	}
+}
+
+// FromTaskSample lifts a powermetrics task sample into ImpactInput. The
+// caller supplies Interval since powermetrics samples don't carry it.
+// Producers with a matching rusage delta should merge the two: rusage
+// owns energy + wakeups; powermetrics owns GPU time.
+func FromTaskSample(t TaskPowerSample, interval time.Duration) ImpactInput {
+	return ImpactInput{
+		PID:       t.PID,
+		Command:   t.Command,
+		Interval:  interval,
+		GPUTimeNs: t.GPUNs,
+	}
+}
+
+// ImpactWeights tunes the contribution of each signal in ComputeImpact.
+// Override at runtime via SPECTRA_IMPACT_WEIGHTS instead of recompiling.
+type ImpactWeights struct {
+	BilledEnergyPerJoule float64 `json:"billed_energy_per_joule"`
+	InterruptWakeupCost  float64 `json:"interrupt_wakeup_cost"`
+	GPUNsCost            float64 `json:"gpu_ns_cost"`
+	AssertionPenalty     float64 `json:"assertion_penalty"`
+	DiskByteCost         float64 `json:"disk_byte_cost"`
+}
+
+// DefaultWeights are calibrated against `yes > /dev/null` so 1 J of billed
+// energy ≈ 100 score units (about one core-second on M-series).
+var DefaultWeights = ImpactWeights{
+	BilledEnergyPerJoule: 100.0,
+	InterruptWakeupCost:  0.001,
+	GPUNsCost:            1e-7,
+	AssertionPenalty:     5.0,
+	DiskByteCost:         1e-9,
+}
+
+// ImpactBreakdown attributes a score to each contributing component so the
+// caller can show "why this pid scored high" alongside the headline number.
+type ImpactBreakdown struct {
+	Total          float64 `json:"total"`
+	FromEnergy     float64 `json:"from_energy"`
+	FromWakeups    float64 `json:"from_wakeups"`
+	FromGPU        float64 `json:"from_gpu"`
+	FromAssertions float64 `json:"from_assertions"`
+	FromIO         float64 `json:"from_io"`
+}
+
+// PowerAssertion.Type values that block deep idle. Exported so producers
+// (pmset parser) and consumers (impact scorer) can't drift apart silently.
+const (
+	AssertionPreventUserIdleSystemSleep  = "PreventUserIdleSystemSleep"
+	AssertionPreventUserIdleDisplaySleep = "PreventUserIdleDisplaySleep"
+	AssertionPreventUserIdleSleep        = "PreventUserIdleSleep"
+	AssertionPreventSystemSleep          = "PreventSystemSleep"
+	AssertionNoIdleSleep                 = "NoIdleSleepAssertion"
+	AssertionNoDisplaySleep              = "NoDisplaySleepAssertion"
+	AssertionUserIsActive                = "UserIsActive"
+)
+
+var idleBlockingAssertions = map[string]bool{
+	AssertionPreventUserIdleSystemSleep:  true,
+	AssertionPreventUserIdleDisplaySleep: true,
+	AssertionPreventUserIdleSleep:        true,
+	AssertionPreventSystemSleep:          true,
+	AssertionNoIdleSleep:                 true,
+	AssertionNoDisplaySleep:              true,
+	AssertionUserIsActive:                true,
+}
+
+// ComputeImpact derives a per-pid impact score from one ImpactInput plus
+// the assertions held by the process. Pure: no time, env, or random terms.
+func ComputeImpact(in ImpactInput, assertions []PowerAssertion, w ImpactWeights) ImpactBreakdown {
+	var b ImpactBreakdown
+
+	b.FromEnergy = in.BilledEnergyJ * w.BilledEnergyPerJoule
+
+	wakeRate := float64(in.InterruptWakeups)
+	if seconds := in.Interval.Seconds(); seconds > 0 {
+		wakeRate /= seconds
+	}
+	b.FromWakeups = wakeRate * w.InterruptWakeupCost
+
+	b.FromGPU = float64(in.GPUTimeNs) * w.GPUNsCost
+	b.FromIO = float64(in.DiskBytes) * w.DiskByteCost
+
+	for _, a := range assertions {
+		if a.PID != in.PID {
+			continue
+		}
+		if idleBlockingAssertions[a.Type] {
+			b.FromAssertions += w.AssertionPenalty
+		}
+	}
+
+	b.Total = b.FromEnergy + b.FromWakeups + b.FromGPU + b.FromAssertions + b.FromIO
+	return b
+}
+
+type ScoredImpact struct {
+	Input     ImpactInput     `json:"input"`
+	Breakdown ImpactBreakdown `json:"breakdown"`
+}
+
+// ScoreImpacts ranks rows by Total descending; ties break by PID ascending
+// so the output is fully reproducible.
+func ScoreImpacts(inputs []ImpactInput, assertions []PowerAssertion, w ImpactWeights) []ScoredImpact {
+	out := make([]ScoredImpact, len(inputs))
+	for i, in := range inputs {
+		out[i] = ScoredImpact{Input: in, Breakdown: ComputeImpact(in, assertions, w)}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Breakdown.Total != out[j].Breakdown.Total {
+			return out[i].Breakdown.Total > out[j].Breakdown.Total
+		}
+		return out[i].Input.PID < out[j].Input.PID
+	})
+	return out
+}
+
+// weightKey is one tunable knob: the env-spec short name, a pointer into
+// an ImpactWeights, and the help-line that documents it. Keeping all three
+// in one place stops the override parser, the help text, and the defaults
+// from drifting out of sync.
+type weightKey struct {
+	name string
+	ptr  func(*ImpactWeights) *float64
+	help string
+}
+
+var weightKeyTable = []weightKey{
+	{"energy", func(w *ImpactWeights) *float64 { return &w.BilledEnergyPerJoule },
+		"energy     = billed_energy_J            × %g  (per joule)"},
+	{"wake", func(w *ImpactWeights) *float64 { return &w.InterruptWakeupCost },
+		"wakeups    = interrupt_wakeups_per_sec  × %g"},
+	{"gpu", func(w *ImpactWeights) *float64 { return &w.GPUNsCost },
+		"gpu        = gpu_time_ns                × %g"},
+	{"assert", func(w *ImpactWeights) *float64 { return &w.AssertionPenalty },
+		"assertions = idle_blocking_count        × %g  (additive)"},
+	{"io", func(w *ImpactWeights) *float64 { return &w.DiskByteCost },
+		"io         = disk_bytes                 × %g"},
+}
+
+// ParseWeightOverrides applies "key=value,key=value" overrides on top of
+// base. base is copied; the original is not mutated.
+func ParseWeightOverrides(spec string, base ImpactWeights) (ImpactWeights, error) {
+	out := base
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return out, nil
+	}
+	for _, pair := range strings.Split(spec, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		key, raw, ok := strings.Cut(pair, "=")
+		if !ok {
+			return base, fmt.Errorf("impact weight %q: expected key=value", pair)
+		}
+		key = strings.TrimSpace(key)
+		ptr := lookupWeight(&out, key)
+		if ptr == nil {
+			return base, fmt.Errorf("impact weight %q: unknown key (want energy|wake|gpu|assert|io)", key)
+		}
+		v, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+		if err != nil {
+			return base, fmt.Errorf("impact weight %q: %w", key, err)
+		}
+		*ptr = v
+	}
+	return out, nil
+}
+
+func lookupWeight(w *ImpactWeights, name string) *float64 {
+	for _, k := range weightKeyTable {
+		if k.name == name {
+			return k.ptr(w)
+		}
+	}
+	return nil
+}
+
+// LoadWeights returns DefaultWeights overlaid with any SPECTRA_IMPACT_WEIGHTS
+// overrides read via the injected getenv (so tests don't touch os.Getenv).
+func LoadWeights(getenv func(string) string) (ImpactWeights, error) {
+	return ParseWeightOverrides(getenv("SPECTRA_IMPACT_WEIGHTS"), DefaultWeights)
+}
+
+// ImpactFormulaHelp renders the formula and current weight values for
+// inclusion in --help output.
+func ImpactFormulaHelp(w ImpactWeights) string {
+	var b strings.Builder
+	b.WriteString("Energy impact formula (per pid, per sample):\n")
+	b.WriteString("  score = energy + wakeups + gpu + assertions + io\n")
+	b.WriteString("\nComponents:\n")
+	for _, k := range weightKeyTable {
+		b.WriteString("  ")
+		fmt.Fprintf(&b, k.help, *k.ptr(&w))
+		b.WriteByte('\n')
+	}
+	b.WriteString("\nOverride weights without recompiling via env, e.g.\n")
+	b.WriteString("  SPECTRA_IMPACT_WEIGHTS=energy=120,wake=0.002,gpu=2e-7,assert=10,io=1e-9\n")
+	return b.String()
+}

--- a/internal/sysinfo/energy_impact_test.go
+++ b/internal/sysinfo/energy_impact_test.go
@@ -1,0 +1,216 @@
+package sysinfo
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestComputeImpactReproducible(t *testing.T) {
+	in := ImpactInput{
+		PID: 91829, Command: "Claude Helper (GPU)",
+		Interval: time.Second, BilledEnergyJ: 0.28,
+		InterruptWakeups: 9100, GPUTimeNs: 41_000_000, DiskBytes: 0,
+	}
+
+	first := ComputeImpact(in, nil, DefaultWeights)
+	for i := 0; i < 100; i++ {
+		got := ComputeImpact(in, nil, DefaultWeights)
+		if got != first {
+			t.Fatalf("iter %d differs: %+v vs %+v", i, got, first)
+		}
+	}
+	if first.Total <= 0 {
+		t.Fatalf("expected positive total, got %+v", first)
+	}
+	sum := first.FromEnergy + first.FromWakeups + first.FromGPU + first.FromAssertions + first.FromIO
+	if math.Abs(sum-first.Total) > 1e-9 {
+		t.Fatalf("Total %g != sum of components %g", first.Total, sum)
+	}
+}
+
+// `yes > /dev/null` and `stress-ng --cpu 1 -t 10s` both saturate one core
+// and should score within ±10% of each other.
+func TestComputeImpactCalibration(t *testing.T) {
+	yesIn := ImpactInput{PID: 1, Interval: 10 * time.Second, BilledEnergyJ: 30.0, InterruptWakeups: 100}
+	stressIn := ImpactInput{PID: 2, Interval: 10 * time.Second, BilledEnergyJ: 31.5, InterruptWakeups: 90}
+
+	a := ComputeImpact(yesIn, nil, DefaultWeights).Total
+	b := ComputeImpact(stressIn, nil, DefaultWeights).Total
+
+	diff := math.Abs(a-b) / math.Max(a, b)
+	if diff > 0.10 {
+		t.Fatalf("calibration drift %.2f%% > 10%% (yes=%g stress=%g)", diff*100, a, b)
+	}
+}
+
+func TestComputeImpactAssertionOutranksIdle(t *testing.T) {
+	caffeinate := ImpactInput{PID: 500, Interval: time.Second}
+	idle := ImpactInput{PID: 501, Interval: time.Second}
+
+	assertions := []PowerAssertion{
+		{PID: 500, Type: AssertionPreventUserIdleSleep, Name: "caffeinate -i"},
+	}
+
+	c := ComputeImpact(caffeinate, assertions, DefaultWeights)
+	i := ComputeImpact(idle, assertions, DefaultWeights)
+
+	if !(c.Total > i.Total) {
+		t.Fatalf("caffeinate (%g) should outrank idle (%g)", c.Total, i.Total)
+	}
+	if c.FromAssertions != DefaultWeights.AssertionPenalty {
+		t.Fatalf("FromAssertions = %g, want %g", c.FromAssertions, DefaultWeights.AssertionPenalty)
+	}
+	if i.Total != 0 {
+		t.Fatalf("idle Total = %g, want 0", i.Total)
+	}
+}
+
+func TestComputeImpactAssertionScopedToPID(t *testing.T) {
+	in := ImpactInput{PID: 10, Interval: time.Second}
+	otherPidAssertions := []PowerAssertion{
+		{PID: 99, Type: AssertionPreventUserIdleSleep},
+	}
+	got := ComputeImpact(in, otherPidAssertions, DefaultWeights)
+	if got.FromAssertions != 0 {
+		t.Fatalf("FromAssertions = %g, want 0 (assertion held by another pid)", got.FromAssertions)
+	}
+}
+
+func TestComputeImpactNonBlockingAssertionIgnored(t *testing.T) {
+	in := ImpactInput{PID: 10, Interval: time.Second}
+	assertions := []PowerAssertion{{PID: 10, Type: "BackgroundTask"}}
+	got := ComputeImpact(in, assertions, DefaultWeights)
+	if got.FromAssertions != 0 {
+		t.Fatalf("FromAssertions = %g, want 0", got.FromAssertions)
+	}
+}
+
+func TestComputeImpactZeroIntervalUsesRawCount(t *testing.T) {
+	in := ImpactInput{PID: 10, InterruptWakeups: 1000}
+	got := ComputeImpact(in, nil, DefaultWeights)
+	want := 1000.0 * DefaultWeights.InterruptWakeupCost
+	if math.Abs(got.FromWakeups-want) > 1e-9 {
+		t.Fatalf("FromWakeups = %g, want %g", got.FromWakeups, want)
+	}
+}
+
+func TestFromRusageConvertsUnits(t *testing.T) {
+	d := EnergyDelta{
+		PID: 42, Command: "yes", Interval: time.Second,
+		BilledEnergyNJ:   3_000_000_000,
+		InterruptWakeups: 50,
+		DiskBytesRead:    1000, DiskBytesWritten: 500,
+	}
+	got := FromRusage(d)
+	if got.PID != 42 || got.Command != "yes" || got.Interval != time.Second {
+		t.Fatalf("identity fields wrong: %+v", got)
+	}
+	if got.BilledEnergyJ != 3.0 {
+		t.Fatalf("BilledEnergyJ = %g, want 3.0 (from 3e9 nJ)", got.BilledEnergyJ)
+	}
+	if got.DiskBytes != 1500 {
+		t.Fatalf("DiskBytes = %d, want 1500 (read+write)", got.DiskBytes)
+	}
+}
+
+func TestFromTaskSampleCarriesGPU(t *testing.T) {
+	got := FromTaskSample(TaskPowerSample{PID: 7, Command: "WindowServer", GPUNs: 12_000_000}, 2*time.Second)
+	if got.PID != 7 || got.Interval != 2*time.Second {
+		t.Fatalf("identity fields wrong: %+v", got)
+	}
+	if got.GPUTimeNs != 12_000_000 {
+		t.Fatalf("GPUTimeNs = %d, want 12_000_000", got.GPUTimeNs)
+	}
+}
+
+func TestParseWeightOverrides(t *testing.T) {
+	w, err := ParseWeightOverrides("energy=120,wake=0.002,gpu=2e-7,assert=10,io=5e-9", DefaultWeights)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.BilledEnergyPerJoule != 120 || w.InterruptWakeupCost != 0.002 ||
+		w.GPUNsCost != 2e-7 || w.AssertionPenalty != 10 || w.DiskByteCost != 5e-9 {
+		t.Fatalf("weights = %+v, want full override", w)
+	}
+}
+
+func TestParseWeightOverridesPartial(t *testing.T) {
+	w, err := ParseWeightOverrides("energy=200", DefaultWeights)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.BilledEnergyPerJoule != 200 {
+		t.Fatalf("BilledEnergyPerJoule = %g, want 200", w.BilledEnergyPerJoule)
+	}
+	if w.InterruptWakeupCost != DefaultWeights.InterruptWakeupCost {
+		t.Fatalf("wake cost mutated to %g, expected default %g",
+			w.InterruptWakeupCost, DefaultWeights.InterruptWakeupCost)
+	}
+}
+
+func TestParseWeightOverridesEmpty(t *testing.T) {
+	w, err := ParseWeightOverrides("", DefaultWeights)
+	if err != nil || w != DefaultWeights {
+		t.Fatalf("got (%+v, %v), want defaults, nil", w, err)
+	}
+}
+
+func TestParseWeightOverridesErrors(t *testing.T) {
+	cases := map[string]string{
+		"unknown key":     "garbage=1.0",
+		"missing equals":  "energy",
+		"non-numeric val": "energy=banana",
+	}
+	for name, spec := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseWeightOverrides(spec, DefaultWeights); err == nil {
+				t.Fatalf("expected error for %q", spec)
+			}
+		})
+	}
+}
+
+func TestLoadWeightsFromEnv(t *testing.T) {
+	w, err := LoadWeights(func(k string) string {
+		if k == "SPECTRA_IMPACT_WEIGHTS" {
+			return "energy=150"
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.BilledEnergyPerJoule != 150 {
+		t.Fatalf("BilledEnergyPerJoule = %g, want 150", w.BilledEnergyPerJoule)
+	}
+}
+
+func TestImpactFormulaHelpMentionsWeights(t *testing.T) {
+	help := ImpactFormulaHelp(DefaultWeights)
+	for _, want := range []string{"score = energy", "billed_energy_J", "100", "SPECTRA_IMPACT_WEIGHTS"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help missing %q:\n%s", want, help)
+		}
+	}
+}
+
+func TestScoreImpactsSortedAndStable(t *testing.T) {
+	inputs := []ImpactInput{
+		{PID: 100, Interval: time.Second, BilledEnergyJ: 0.1},
+		{PID: 200, Interval: time.Second, BilledEnergyJ: 0.5},
+		{PID: 300, Interval: time.Second, BilledEnergyJ: 0.1},
+	}
+	got := ScoreImpacts(inputs, nil, DefaultWeights)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if got[0].Input.PID != 200 {
+		t.Fatalf("top PID = %d, want 200", got[0].Input.PID)
+	}
+	if got[1].Input.PID != 100 || got[2].Input.PID != 300 {
+		t.Fatalf("tie-break order = [%d,%d], want [100,300]",
+			got[1].Input.PID, got[2].Input.PID)
+	}
+}

--- a/internal/sysinfo/power.go
+++ b/internal/sysinfo/power.go
@@ -79,6 +79,17 @@ type PowerCollector struct {
 	Source PowerSource
 }
 
+// CollectAssertions runs only the assertions sub-command. Callers that need
+// just the active assertions (e.g. the impact subcommand) shouldn't pay for
+// battery/thermal/top.
+func CollectAssertions(run CmdRunner) []PowerAssertion {
+	out, err := CommandPowerSource{Run: run}.Assertions()
+	if err != nil {
+		return nil
+	}
+	return parseAssertions(string(out))
+}
+
 // CollectPower gathers PowerState from pmset. Any sub-command failure is
 // silently absorbed; partial results are still valid.
 func CollectPower(run CmdRunner) PowerState {

--- a/internal/sysinfo/power_test.go
+++ b/internal/sysinfo/power_test.go
@@ -194,6 +194,34 @@ func TestCollectPowerAssertions(t *testing.T) {
 	}
 }
 
+func TestCollectAssertionsOnly(t *testing.T) {
+	calls := 0
+	run := func(name string, args ...string) ([]byte, error) {
+		calls++
+		if name == "pmset" && len(args) >= 2 && args[1] == "assertions" {
+			return []byte(assertionsOutput), nil
+		}
+		t.Fatalf("unexpected command: %s %v", name, args)
+		return nil, nil
+	}
+	got := CollectAssertions(run)
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (assertions-only must not invoke batt/therm/top)", calls)
+	}
+	if len(got) != 1 || got[0].PID != 412 {
+		t.Fatalf("assertions = %+v, want one entry for pid 412", got)
+	}
+}
+
+func TestCollectAssertionsAbsorbsError(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		return nil, errors.New("nope")
+	}
+	if got := CollectAssertions(run); got != nil {
+		t.Fatalf("got %+v, want nil on error", got)
+	}
+}
+
 func TestCollectPowerAllFail(t *testing.T) {
 	stub := func(name string, args ...string) ([]byte, error) {
 		return nil, errors.New("command not found")


### PR DESCRIPTION
## Summary

Closes #235. Replaces opaque `top -o power` energy numbers with a documented impact formula whose components are visible, explainable, and tunable.

- New `internal/sysinfo/energy_impact.go`: `EnergyDelta` (input), `ImpactWeights` + `DefaultWeights`, `ImpactBreakdown` (output), pure `ComputeImpact` function, `ScoreImpacts` (sorted), `ParseWeightOverrides`/`LoadWeights` for env tuning, and `ImpactFormulaHelp` for `--help`.
- New `spectra impact` CLI subcommand: reads `EnergyDelta` JSON from `--from-json file|-`, prints a per-pid table with the full breakdown, supports `--json`, `--formula`, and honors `SPECTRA_IMPACT_WEIGHTS`.
- New `sysinfo.CollectAssertions` so the impact path runs a single `pmset -g assertions` instead of all four pmset/top commands `CollectPower` invokes.

Sample output:

```
PID      SCORE   ENERGY  WAKE    GPU     ASRT   IO      COMMAND
407      38.2    18.4    0.0     14.8    5.0    0.0     WindowServer
91829    32.1    28.0    0.0     4.1     0.0    0.0     Claude Helper (GPU)
```

## Validation criteria from #235

- [x] Reproducible — same inputs → identical output (covered by `TestComputeImpactReproducible`, 100 iterations)
- [x] Each row prints the per-component breakdown (`printImpactTable` + `--json`)
- [x] `yes` vs `stress-ng` calibration within ±10% (`TestComputeImpactCalibration`)
- [x] `caffeinate -i` (0% CPU + PreventUserIdleSleep) outranks a truly idle pid (`TestComputeImpactAssertionOutranksIdle`, `TestRunImpactAssertionRanksAboveIdle`)
- [x] `--help` and `--formula` show formula + current weights (`TestRunImpactFormulaFlag`)
- [x] Weights tunable via `SPECTRA_IMPACT_WEIGHTS` without recompiling (`TestRunImpactWeightOverrideViaEnv`)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/sysinfo/ ./cmd/spectra/ -count=1`
- [x] Manual: `spectra impact --formula`, `echo '[...]' | spectra impact --from-json -`