### PR TITLE
Parallelize PowerCollector probes

### DIFF
--- a/internal/sysinfo/power.go
+++ b/internal/sysinfo/power.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // PowerState captures battery and thermal facts.
@@ -96,8 +97,9 @@ func CollectPower(run CmdRunner) PowerState {
 	return PowerCollector{Source: CommandPowerSource{Run: run}}.Collect()
 }
 
-// Collect gathers PowerState. Any source failure is silently absorbed; partial
-// results are still valid.
+// Collect gathers PowerState. Probes run concurrently; any source failure is
+// silently absorbed and partial results are still valid. Wall-clock is bounded
+// by the slowest single probe — typically ~1s for `top -l 2`.
 func (c PowerCollector) Collect() PowerState {
 	var ps PowerState
 	src := c.Source
@@ -105,19 +107,36 @@ func (c PowerCollector) Collect() PowerState {
 		src = CommandPowerSource{}
 	}
 
-	if out, err := src.Battery(); err == nil {
-		parseBatt(string(out), &ps)
-	}
-	if out, err := src.Thermal(); err == nil {
-		parseTherm(string(out), &ps)
-	}
-	if out, err := src.Assertions(); err == nil {
-		ps.Assertions = parseAssertions(string(out))
-	}
-	if out, err := src.EnergyTop(); err == nil {
-		ps.EnergyTopUsers = parseEnergyTop(string(out))
+	var mu sync.Mutex
+	run := func(fetch func() ([]byte, error), apply func(string, *PowerState)) func() {
+		return func() {
+			out, err := fetch()
+			if err != nil {
+				return
+			}
+			s := string(out)
+			mu.Lock()
+			defer mu.Unlock()
+			apply(s, &ps)
+		}
 	}
 
+	probes := []func(){
+		run(src.Battery, parseBatt),
+		run(src.Thermal, parseTherm),
+		run(src.Assertions, func(s string, p *PowerState) { p.Assertions = parseAssertions(s) }),
+		run(src.EnergyTop, func(s string, p *PowerState) { p.EnergyTopUsers = parseEnergyTop(s) }),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(probes))
+	for _, p := range probes {
+		go func(p func()) {
+			defer wg.Done()
+			p()
+		}(p)
+	}
+	wg.Wait()
 	return ps
 }
 

--- a/internal/sysinfo/power_test.go
+++ b/internal/sysinfo/power_test.go
@@ -3,6 +3,7 @@ package sysinfo
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 const battOnBattery = `Now drawing from 'Battery Power'
@@ -327,6 +328,97 @@ func TestCollectPowerEnergyTopUsers(t *testing.T) {
 	}
 	if ps.EnergyTopUsers[1].PID != 412 {
 		t.Errorf("second PID = %d, want 412", ps.EnergyTopUsers[1].PID)
+	}
+}
+
+// slowPowerSource adds a per-probe sleep so we can observe wall-clock fan-out.
+type slowPowerSource struct {
+	fakePowerSource
+	delay time.Duration
+}
+
+func (s slowPowerSource) Battery() ([]byte, error) {
+	time.Sleep(s.delay)
+	return s.fakePowerSource.Battery()
+}
+
+func (s slowPowerSource) Thermal() ([]byte, error) {
+	time.Sleep(s.delay)
+	return s.fakePowerSource.Thermal()
+}
+
+func (s slowPowerSource) Assertions() ([]byte, error) {
+	time.Sleep(s.delay)
+	return s.fakePowerSource.Assertions()
+}
+
+func (s slowPowerSource) EnergyTop() ([]byte, error) {
+	time.Sleep(s.delay)
+	return s.fakePowerSource.EnergyTop()
+}
+
+func newSlowPowerSource(delay time.Duration) slowPowerSource {
+	return slowPowerSource{
+		delay: delay,
+		fakePowerSource: fakePowerSource{
+			batt:       battOnBattery,
+			therm:      thermNominal,
+			assertions: assertionsOutput,
+			topEnergy:  topEnergyOutput,
+		},
+	}
+}
+
+func TestCollectPowerRunsProbesConcurrently(t *testing.T) {
+	const delay = 150 * time.Millisecond
+	start := time.Now()
+	ps := PowerCollector{Source: newSlowPowerSource(delay)}.Collect()
+	elapsed := time.Since(start)
+
+	// Serial would be 4*delay. Generous slack for slow CI; the cap is well
+	// below the serial floor.
+	if elapsed >= 3*delay {
+		t.Errorf("Collect took %v with 4 probes at %v each; expected concurrent execution", elapsed, delay)
+	}
+	if !ps.OnBattery {
+		t.Error("OnBattery = false, want true")
+	}
+	if ps.ThermalPressure != "nominal" {
+		t.Errorf("ThermalPressure = %q, want nominal", ps.ThermalPressure)
+	}
+	if len(ps.Assertions) != 1 {
+		t.Errorf("Assertions = %d, want 1", len(ps.Assertions))
+	}
+	if len(ps.EnergyTopUsers) != 3 {
+		t.Errorf("EnergyTopUsers = %d, want 3", len(ps.EnergyTopUsers))
+	}
+}
+
+func TestCollectPowerPartialFailure(t *testing.T) {
+	ps := PowerCollector{Source: fakePowerSource{
+		batt:       battOnBattery,
+		assertions: assertionsOutput,
+		topEnergy:  topEnergyOutput,
+	}}.Collect()
+	if !ps.OnBattery {
+		t.Error("OnBattery = false, want true")
+	}
+	if ps.ThermalPressure != "" {
+		t.Errorf("ThermalPressure = %q, want empty after failed thermal probe", ps.ThermalPressure)
+	}
+	if len(ps.Assertions) != 1 {
+		t.Errorf("Assertions = %d, want 1", len(ps.Assertions))
+	}
+	if len(ps.EnergyTopUsers) != 3 {
+		t.Errorf("EnergyTopUsers = %d, want 3", len(ps.EnergyTopUsers))
+	}
+}
+
+func BenchmarkPowerCollect(b *testing.B) {
+	collector := PowerCollector{Source: newSlowPowerSource(100 * time.Millisecond)}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = collector.Collect()
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fan out the four power probes (`pmset -g batt`, `pmset -g therm`, `pmset -g assertions`, `top -l 2 ... -o power`) via `sync.WaitGroup`, merging results under a `sync.Mutex`. Matches the existing `internal/toolchain.Collect` style (run-adapter that returns a closure invoked under lock).
- Wall-clock is now bounded by the slowest single probe (~1s for `top -l 2`) instead of the sum.
- Adds two tests + a benchmark: a wall-clock fan-out check that asserts `elapsed < 3×delay`, a partial-failure check that confirms the other probes still populate `PowerState` when one probe fails, and `BenchmarkPowerCollect`.

Closes #236.

## Validation
- `go test -race ./internal/sysinfo/...` — clean
- `go test ./...` — all packages pass
- `go vet ./...` — clean
- `go test -bench BenchmarkPowerCollect -benchtime=3x -run=^$ ./internal/sysinfo/` — ~100ms/op with 4×100ms probes (~4× speedup vs. serial 400ms baseline)

## Test plan
- [x] Race detector clean
- [x] Existing tests pass (no parser changes)
- [x] Benchmark shows ≥2× speedup once probes exceed 100ms
- [x] Partial-probe failure still populates the other fields