### PR TITLE
Add layered flag surface to spectra power (#237)

### DIFF
--- a/cmd/spectra/power.go
+++ b/cmd/spectra/power.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"sort"
 	"strings"
 	"time"
@@ -28,6 +29,7 @@ type powerDeps struct {
 	sampleRusage func(ctx context.Context, interval time.Duration, pids []int) ([]sysinfo.EnergyDelta, error)
 	fetchDeep    func(durationMS int) ([]byte, error)
 	clock        func() time.Time
+	signalCh     func() (<-chan os.Signal, func())
 }
 
 func defaultPowerDeps() powerDeps {
@@ -45,184 +47,582 @@ func defaultPowerDeps() powerDeps {
 		fetchDeep: func(durationMS int) ([]byte, error) {
 			return helperclient.New().PowermetricsTasks(durationMS)
 		},
-		clock: time.Now,
+		clock:    time.Now,
+		signalCh: defaultPowerSignalCh,
 	}
 }
 
-// deepPowerState is a strict superset of sysinfo.PowerState — adding a
-// SoCPower sample and per-pid powermetrics tasks data — so consumers can
-// request --deep opportunistically without losing any --json fields.
-type deepPowerState struct {
-	sysinfo.PowerState
-	SoC  *sysinfo.SoCPower          `json:"soc,omitempty"`
-	Deep *sysinfo.PowermetricsTasks `json:"deep,omitempty"`
+func defaultPowerSignalCh() (<-chan os.Signal, func()) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+	return ch, func() { signal.Stop(ch); close(ch) }
+}
+
+// powerMode is the backend that produced a PowerReport. Modes are chosen at
+// flag-parse time and stay fixed across a watch loop so consumers don't have
+// to handle interleaved schemas.
+type powerMode int
+
+const (
+	modeBaseline powerMode = iota // pmset + top -o power (no privilege)
+	modeRusage                    // L1: proc_pid_rusage delta (no privilege)
+	modeJoules                    // L1 + L2: + IOReport package joules (Apple Silicon, no privilege)
+	modeDeep                      // L3: powermetrics tasks via helper (privileged)
+)
+
+func (m powerMode) String() string {
+	switch m {
+	case modeRusage:
+		return "rusage"
+	case modeJoules:
+		return "joules"
+	case modeDeep:
+		return "deep"
+	default:
+		return "baseline"
+	}
+}
+
+// PowerReport is the stable JSON envelope emitted by `spectra power --json`.
+// Field names match across modes; backends fill what they can and missing
+// data is omitted rather than zeroed.
+type PowerReport struct {
+	IntervalMS int64                    `json:"interval_ms"`
+	Mode       string                   `json:"mode"`
+	SampledAt  time.Time                `json:"sampled_at"`
+	Battery    *BatteryInfo             `json:"battery,omitempty"`
+	Thermal    *ThermalInfo             `json:"thermal,omitempty"`
+	Assertions []sysinfo.PowerAssertion `json:"assertions,omitempty"`
+	Package    *PackageEnergy           `json:"package,omitempty"`
+	Processes  []ProcessEnergy          `json:"processes,omitempty"`
+	Skipped    int                      `json:"skipped,omitempty"`
+	Notes      []string                 `json:"notes,omitempty"`
+}
+
+type BatteryInfo struct {
+	OnBattery bool `json:"on_battery"`
+	Pct       int  `json:"pct,omitempty"`
+}
+
+type ThermalInfo struct {
+	Pressure                string `json:"pressure,omitempty"`
+	Throttled               bool   `json:"throttled,omitempty"`
+	CPUSpeedLimitPct        int    `json:"cpu_speed_limit_pct,omitempty"`
+	LowestCPUSpeedLimitPct  int    `json:"lowest_cpu_speed_limit_pct,omitempty"`
+	AverageCPUSpeedLimitPct int    `json:"average_cpu_speed_limit_pct,omitempty"`
+	PercentThermalThrottled int    `json:"percent_thermal_throttled,omitempty"`
+}
+
+type PackageEnergy struct {
+	Joules     float64 `json:"joules,omitempty"`
+	CPUJoules  float64 `json:"cpu_joules,omitempty"`
+	GPUJoules  float64 `json:"gpu_joules,omitempty"`
+	ANEJoules  float64 `json:"ane_joules,omitempty"`
+	DRAMJoules float64 `json:"dram_joules,omitempty"`
+	IntervalNS int64   `json:"interval_ns,omitempty"`
+}
+
+type ProcessWakeups struct {
+	Interrupt uint64 `json:"interrupt,omitempty"`
+	PkgIdle   uint64 `json:"pkg_idle,omitempty"`
+}
+
+type ProcessEnergy struct {
+	PID            int                      `json:"pid"`
+	Command        string                   `json:"command,omitempty"`
+	BilledEnergyNJ uint64                   `json:"billed_energy_nj,omitempty"`
+	GPUTimeNs      uint64                   `json:"gpu_time_ns,omitempty"`
+	Wakeups        *ProcessWakeups          `json:"wakeups,omitempty"`
+	Impact         *sysinfo.ImpactBreakdown `json:"impact,omitempty"`
+	Source         string                   `json:"source"`
 }
 
 func runPowerWithIO(args []string, stdout, stderr io.Writer, deps powerDeps) int {
 	fs := flag.NewFlagSet("spectra power", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	fs.Usage = func() { printPowerUsage(stderr) }
+
+	asJSON := fs.Bool("json", false, "Emit structured output (NDJSON when combined with --watch)")
 	joules := fs.Bool("joules", false, "Sample SoC-wide energy via IOReport (Apple Silicon)")
 	top := fs.Int("top", 0, "Rank top-N pids by ΔbilledEnergy over --interval (per-pid kernel-billed nanojoules via proc_pid_rusage)")
-	interval := fs.Duration("interval", time.Second, "Sampling window for --joules / --top")
+	interval := fs.Duration("interval", time.Second, "Sampling window for --joules / --top, and tick for --watch")
 	deep := fs.Bool("deep", false, "Ground-truth per-pid energy via powermetrics (requires privileged helper)")
 	deepDurationMS := fs.Int("deep-duration", 500, "Sample window in ms for --deep (min 100)")
+	watch := fs.Bool("watch", false, "Re-run the chosen mode every --interval until SIGINT (NDJSON with --json)")
+
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-
-	if *top > 0 {
-		return runRusageTop(stdout, stderr, *interval, *top, *asJSON, deps)
-	}
-	if *joules {
-		return runJoulesSample(stdout, stderr, *interval, *asJSON, deps.sample)
+	if *interval <= 0 {
+		fmt.Fprintln(stderr, "spectra power: --interval must be positive")
+		return 2
 	}
 
-	state := deps.collect()
-
-	var deepTasks *sysinfo.PowermetricsTasks
-	var soc *sysinfo.SoCPower
-	if *deep {
-		dur := *deepDurationMS
-		if dur < 100 {
-			dur = 100
-		}
-		deepTasks = collectDeepTasks(stderr, deps.fetchDeep, dur)
-		// --deep --json must be a superset of --joules --json, so include the
-		// SoC sample when available. Silently omit on unsupported hardware.
-		if s, err := deps.sample(*interval); err == nil {
-			soc = &s
-		}
+	mode := selectPowerMode(*top, *joules, *deep)
+	cfg := powerRunCfg{
+		mode:           mode,
+		interval:       *interval,
+		top:            *top,
+		deepDurationMS: *deepDurationMS,
+		asJSON:         *asJSON,
 	}
 
-	if *asJSON {
-		out := deepPowerState{PowerState: state, SoC: soc, Deep: deepTasks}
-		enc := json.NewEncoder(stdout)
-		enc.SetIndent("", "  ")
-		_ = enc.Encode(out)
+	if *watch {
+		return runPowerWatch(stdout, stderr, deps, cfg)
+	}
+	return runPowerOnce(stdout, stderr, deps, cfg)
+}
+
+func printPowerUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: spectra power [flags]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Backends are layered. Bare `spectra power` is the pmset + top -o power baseline.")
+	fmt.Fprintln(w, "Each flag below opts into a richer source; --deep implies --joules.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Flags:")
+	fmt.Fprintln(w, "  --top N           Top N pids by rusage energy delta              (no privilege)")
+	fmt.Fprintln(w, "  --joules          Per-package joules via IOReport (Apple Silicon) (no privilege)")
+	fmt.Fprintln(w, "  --deep            Powermetrics ground truth                       (requires helper)")
+	fmt.Fprintln(w, "  --deep-duration   Sample window in ms for --deep (default 500)")
+	fmt.Fprintln(w, "  --watch           Re-run every --interval; emits NDJSON with --json (inherits)")
+	fmt.Fprintln(w, "  --json            Structured output (stable schema across modes)   (inherits)")
+	fmt.Fprintln(w, "  --interval D      Sample window or watch tick (default 1s)        (inherits)")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Examples:")
+	fmt.Fprintln(w, "  spectra power")
+	fmt.Fprintln(w, "  spectra power --top 10 --json")
+	fmt.Fprintln(w, "  spectra power --joules --watch --interval 2s")
+	fmt.Fprintln(w, "  spectra power --deep --json | jq .package.joules")
+}
+
+func selectPowerMode(top int, joules, deep bool) powerMode {
+	switch {
+	case deep:
+		return modeDeep
+	case joules:
+		return modeJoules
+	case top > 0:
+		return modeRusage
+	default:
+		return modeBaseline
+	}
+}
+
+type powerRunCfg struct {
+	mode           powerMode
+	interval       time.Duration
+	top            int
+	deepDurationMS int
+	asJSON         bool
+}
+
+// runPowerOnce runs the chosen mode a single time. Human output preserves
+// the existing per-mode tables (baseline / SoC / energy top / deep) so users
+// who pipe `spectra power` into other tools keep working. JSON output goes
+// through the unified PowerReport envelope so consumers can parse one shape.
+func runPowerOnce(stdout, stderr io.Writer, deps powerDeps, cfg powerRunCfg) int {
+	report, exit, ok := collectPower(stdout, stderr, deps, cfg)
+	if !ok {
+		return exit
+	}
+	if cfg.asJSON {
+		writePowerJSON(stdout, report, false)
 		return 0
 	}
-
-	printPowerState(stdout, state)
-	if soc != nil {
-		fmt.Fprintln(stdout)
-		printSoCPower(stdout, *soc)
-	}
-	if deepTasks != nil {
-		printDeepTasks(stdout, *deepTasks, 10)
-	}
+	printPowerHuman(stdout, deps, cfg, report)
 	return 0
 }
 
-func collectDeepTasks(stderr io.Writer, fetch func(int) ([]byte, error), durationMS int) *sysinfo.PowermetricsTasks {
+// runPowerWatch loops until SIGINT. JSON mode emits compact NDJSON
+// (one object per line, parseable by `jq -c`); human mode clears the screen
+// with VT100 codes (no curses, so `tee` still works) and prints a final
+// summary line on exit.
+func runPowerWatch(stdout, stderr io.Writer, deps powerDeps, cfg powerRunCfg) int {
+	sig, stop := deps.signalCh()
+	defer stop()
+
+	ticker := time.NewTicker(cfg.interval)
+	defer ticker.Stop()
+
+	emit := func() int {
+		report, exit, ok := collectPower(stdout, stderr, deps, cfg)
+		if !ok {
+			return exit
+		}
+		if cfg.asJSON {
+			writePowerJSON(stdout, report, true)
+		} else {
+			fmt.Fprint(stdout, "\x1b[H\x1b[2J")
+			fmt.Fprintf(stdout, "=== Power state (%s, watch %s) ===\n", cfg.mode, cfg.interval)
+			printPowerHuman(stdout, deps, cfg, report)
+		}
+		return 0
+	}
+
+	if rc := emit(); rc != 0 {
+		return rc
+	}
+
+	for {
+		select {
+		case _, ok := <-sig:
+			if !ok {
+				return 0
+			}
+			if cfg.asJSON {
+				enc := json.NewEncoder(stdout)
+				_ = enc.Encode(map[string]any{"watch_stopped": true})
+			} else {
+				fmt.Fprintln(stdout, "--- watch stopped ---")
+			}
+			return 0
+		case <-ticker.C:
+			if rc := emit(); rc != 0 {
+				return rc
+			}
+		}
+	}
+}
+
+// collectPower runs the appropriate L1/L2/L3 sources for the requested mode
+// and assembles a PowerReport. Returns (report, exit_code, ok). If ok is
+// false the caller should return exit_code immediately (e.g. unsupported
+// hardware on --joules, --top on non-darwin).
+func collectPower(stdout, stderr io.Writer, deps powerDeps, cfg powerRunCfg) (PowerReport, int, bool) {
+	state := deps.collect()
+	report := PowerReport{
+		IntervalMS: cfg.interval.Milliseconds(),
+		Mode:       cfg.mode.String(),
+		SampledAt:  deps.clock(),
+	}
+	fillPowerStateSections(&report, state)
+
+	switch cfg.mode {
+	case modeBaseline:
+		report.Processes = processesFromEnergyTopUsers(state.EnergyTopUsers)
+		return report, 0, true
+	case modeRusage:
+		deltas, exit, ok := collectRusageDeltas(stderr, deps, cfg.interval)
+		if !ok {
+			return report, exit, false
+		}
+		report.Processes = processesFromRusage(deltas, state.Assertions, cfg.top)
+		report.Skipped = countSkipped(deps, deltas)
+		return report, 0, true
+	case modeJoules:
+		soc, exit, ok := collectSoC(stderr, deps, cfg.interval)
+		if !ok {
+			return report, exit, false
+		}
+		report.Package = packageFromSoC(*soc)
+		return report, 0, true
+	case modeDeep:
+		soc, _, _ := collectSoC(stderr, deps, cfg.interval) // joules implied; omit silently if unavailable
+		if soc != nil {
+			report.Package = packageFromSoC(*soc)
+		}
+		tasks, note := collectDeepTasks(stderr, deps.fetchDeep, normalizeDeepDuration(cfg.deepDurationMS))
+		if note != "" {
+			report.Notes = append(report.Notes, note)
+		}
+		if tasks != nil {
+			report.Processes = processesFromTasks(*tasks)
+		}
+		return report, 0, true
+	}
+	return report, 0, true
+}
+
+func fillPowerStateSections(r *PowerReport, s sysinfo.PowerState) {
+	if s.OnBattery || s.BatteryPct > 0 {
+		r.Battery = &BatteryInfo{OnBattery: s.OnBattery, Pct: s.BatteryPct}
+	}
+	if s.ThermalPressure != "" || s.ThermalThrottled || s.CPUSpeedLimitPct > 0 {
+		r.Thermal = &ThermalInfo{
+			Pressure:                s.ThermalPressure,
+			Throttled:               s.ThermalThrottled,
+			CPUSpeedLimitPct:        s.CPUSpeedLimitPct,
+			LowestCPUSpeedLimitPct:  s.LowestCPUSpeedLimitPct,
+			AverageCPUSpeedLimitPct: s.AverageCPUSpeedLimitPct,
+			PercentThermalThrottled: s.PercentThermalThrottled,
+		}
+	}
+	if len(s.Assertions) > 0 {
+		r.Assertions = s.Assertions
+	}
+}
+
+func processesFromEnergyTopUsers(users []sysinfo.EnergyUser) []ProcessEnergy {
+	if len(users) == 0 {
+		return nil
+	}
+	rows := make([]ProcessEnergy, 0, len(users))
+	for _, u := range users {
+		rows = append(rows, ProcessEnergy{
+			PID:     u.PID,
+			Command: u.Command,
+			Impact:  &sysinfo.ImpactBreakdown{Total: u.EnergyImpact, FromEnergy: u.EnergyImpact},
+			Source:  "top",
+		})
+	}
+	return rows
+}
+
+func processesFromRusage(deltas []sysinfo.EnergyDelta, assertions []sysinfo.PowerAssertion, top int) []ProcessEnergy {
+	if len(deltas) == 0 {
+		return nil
+	}
+	ranked := sysinfo.RankedEnergy(deltas, top)
+	weights, _ := sysinfo.LoadWeights(os.Getenv)
+	rows := make([]ProcessEnergy, 0, len(ranked))
+	for _, d := range ranked {
+		impact := sysinfo.ComputeImpact(sysinfo.FromRusage(d), assertions, weights)
+		row := ProcessEnergy{
+			PID:            d.PID,
+			Command:        d.Command,
+			BilledEnergyNJ: d.BilledEnergyNJ,
+			Source:         "rusage",
+		}
+		if d.InterruptWakeups > 0 || d.PkgIdleWakeups > 0 {
+			row.Wakeups = &ProcessWakeups{Interrupt: d.InterruptWakeups, PkgIdle: d.PkgIdleWakeups}
+		}
+		impactCopy := impact
+		row.Impact = &impactCopy
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func processesFromTasks(p sysinfo.PowermetricsTasks) []ProcessEnergy {
+	if len(p.Tasks) == 0 {
+		return nil
+	}
+	sorted := make([]sysinfo.TaskPowerSample, len(p.Tasks))
+	copy(sorted, p.Tasks)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].EnergyImpact > sorted[j].EnergyImpact })
+	rows := make([]ProcessEnergy, 0, len(sorted))
+	for _, t := range sorted {
+		rows = append(rows, ProcessEnergy{
+			PID:       t.PID,
+			Command:   t.Command,
+			GPUTimeNs: t.GPUNs,
+			Impact:    &sysinfo.ImpactBreakdown{Total: t.EnergyImpact, FromEnergy: t.EnergyImpact},
+			Source:    "powermetrics",
+		})
+	}
+	return rows
+}
+
+func packageFromSoC(p sysinfo.SoCPower) *PackageEnergy {
+	return &PackageEnergy{
+		Joules:     p.PackageJoules,
+		CPUJoules:  p.CPUPJoules + p.CPUEJoules,
+		GPUJoules:  p.GPUJoules,
+		ANEJoules:  p.ANEJoules,
+		DRAMJoules: p.DRAMJoules,
+		IntervalNS: p.Interval.Nanoseconds(),
+	}
+}
+
+func collectRusageDeltas(stderr io.Writer, deps powerDeps, interval time.Duration) ([]sysinfo.EnergyDelta, int, bool) {
+	ctx := context.Background()
+	procs := deps.procs(ctx)
+	if len(procs) == 0 {
+		fmt.Fprintln(stderr, "no processes to sample")
+		return nil, 1, false
+	}
+	pids := make([]int, 0, len(procs))
+	for _, p := range procs {
+		if p.PID > 0 {
+			pids = append(pids, p.PID)
+		}
+	}
+	sort.Ints(pids)
+	deltas, err := deps.sampleRusage(ctx, interval, pids)
+	if err != nil {
+		if errors.Is(err, sysinfo.ErrRusageUnsupported) {
+			fmt.Fprintln(stderr, "per-pid energy unavailable: built without cgo or non-darwin")
+			return nil, 3, false
+		}
+		fmt.Fprintln(stderr, "sample failed:", err)
+		return nil, 1, false
+	}
+	cmds := make(map[int]string, len(procs))
+	for _, p := range procs {
+		cmds[p.PID] = p.Command
+	}
+	for i := range deltas {
+		if deltas[i].Command == "" {
+			deltas[i].Command = cmds[deltas[i].PID]
+		}
+	}
+	return deltas, 0, true
+}
+
+func countSkipped(deps powerDeps, deltas []sysinfo.EnergyDelta) int {
+	ctx := context.Background()
+	procs := deps.procs(ctx)
+	pids := 0
+	for _, p := range procs {
+		if p.PID > 0 {
+			pids++
+		}
+	}
+	return pids - len(deltas)
+}
+
+func collectSoC(stderr io.Writer, deps powerDeps, interval time.Duration) (*sysinfo.SoCPower, int, bool) {
+	p, err := deps.sample(interval)
+	if err != nil {
+		if errors.Is(err, sysinfo.ErrUnsupportedHardware) {
+			fmt.Fprintln(stderr, "SoC power sampling is unavailable on this hardware (requires Apple Silicon on macOS 12+).")
+			return nil, 3, false
+		}
+		fmt.Fprintf(stderr, "sample failed: %v\n", err)
+		return nil, 1, false
+	}
+	return &p, 0, true
+}
+
+func normalizeDeepDuration(ms int) int {
+	if ms < 100 {
+		return 100
+	}
+	return ms
+}
+
+func collectDeepTasks(stderr io.Writer, fetch func(int) ([]byte, error), durationMS int) (*sysinfo.PowermetricsTasks, string) {
 	plist, err := fetch(durationMS)
 	switch {
 	case helperclient.IsUnavailable(err):
 		fmt.Fprintln(stderr, "spectra power: privileged helper not installed.")
 		fmt.Fprintln(stderr, "Install with: sudo spectra install-helper")
 		fmt.Fprintln(stderr, "Falling back to L1+L2 (no-privilege) energy estimate.")
-		return nil
+		return nil, "helper unavailable; degraded to L1+L2"
 	case err != nil:
 		fmt.Fprintf(stderr, "spectra power: --deep failed: %v\n", err)
 		fmt.Fprintln(stderr, "Falling back to L1+L2 (no-privilege) energy estimate.")
-		return nil
+		return nil, fmt.Sprintf("deep failed: %v", err)
 	}
 	parsed, perr := sysinfo.ParseTasksPlist(plist)
 	if perr != nil {
 		fmt.Fprintf(stderr, "spectra power: parsing powermetrics plist: %v\n", perr)
-		return nil
+		return nil, fmt.Sprintf("plist parse error: %v", perr)
 	}
-	return &parsed
+	return &parsed, ""
 }
 
-func runJoulesSample(stdout, stderr io.Writer, interval time.Duration, asJSON bool, sample func(time.Duration) (sysinfo.SoCPower, error)) int {
-	p, err := sample(interval)
-	if err != nil {
-		if errors.Is(err, sysinfo.ErrUnsupportedHardware) {
-			fmt.Fprintln(stderr, "SoC power sampling is unavailable on this hardware (requires Apple Silicon on macOS 12+).")
-			return 3
-		}
-		fmt.Fprintf(stderr, "sample failed: %v\n", err)
-		return 1
-	}
-	if asJSON {
-		enc := json.NewEncoder(stdout)
+func writePowerJSON(w io.Writer, r PowerReport, ndjson bool) {
+	enc := json.NewEncoder(w)
+	if !ndjson {
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(p)
-		return 0
 	}
-	printSoCPower(stdout, p)
-	return 0
+	_ = enc.Encode(r)
 }
 
-type EnergyTopReport struct {
-	IntervalNS int64                 `json:"interval_ns"`
-	SampledAt  time.Time             `json:"sampled_at"`
-	Skipped    int                   `json:"skipped"`
-	Top        []sysinfo.EnergyDelta `json:"top"`
-}
-
-func runRusageTop(stdout, stderr io.Writer, interval time.Duration, top int, asJSON bool, deps powerDeps) int {
-	ctx := context.Background()
-	procs := deps.procs(ctx)
-	if len(procs) == 0 {
-		fmt.Fprintln(stderr, "no processes to sample")
-		return 1
-	}
-	pids := make([]int, 0, len(procs))
-	cmds := make(map[int]string, len(procs))
-	for _, p := range procs {
-		if p.PID > 0 {
-			pids = append(pids, p.PID)
-			cmds[p.PID] = p.Command
+// printPowerHuman keeps the per-mode human tables intact so existing pipes
+// keep working. Bare `spectra power` stays the legacy pmset+top view.
+func printPowerHuman(stdout io.Writer, deps powerDeps, cfg powerRunCfg, r PowerReport) {
+	state := powerStateFromReport(r, deps.collect)
+	switch cfg.mode {
+	case modeBaseline:
+		printPowerState(stdout, state)
+	case modeRusage:
+		legacy := energyTopFromReport(r, cfg)
+		printEnergyTop(stdout, legacy, cfg.interval)
+	case modeJoules:
+		if r.Package != nil {
+			printSoCPower(stdout, socFromPackage(*r.Package))
+		}
+	case modeDeep:
+		printPowerState(stdout, state)
+		if r.Package != nil {
+			fmt.Fprintln(stdout)
+			printSoCPower(stdout, socFromPackage(*r.Package))
+		}
+		if len(r.Processes) > 0 {
+			printDeepProcesses(stdout, r.Processes, 10)
 		}
 	}
-	sort.Ints(pids)
-
-	deltas, err := deps.sampleRusage(ctx, interval, pids)
-	if err != nil {
-		if errors.Is(err, sysinfo.ErrRusageUnsupported) {
-			fmt.Fprintln(stderr, "per-pid energy unavailable: built without cgo or non-darwin")
-			return 3
-		}
-		fmt.Fprintln(stderr, "sample failed:", err)
-		return 1
-	}
-	ranked := sysinfo.RankedEnergy(deltas, top)
-	for i := range ranked {
-		ranked[i].Command = cmds[ranked[i].PID]
-	}
-
-	clock := deps.clock
-	if clock == nil {
-		clock = time.Now
-	}
-	report := EnergyTopReport{
-		IntervalNS: interval.Nanoseconds(),
-		SampledAt:  clock(),
-		Skipped:    len(pids) - len(deltas),
-		Top:        ranked,
-	}
-
-	if asJSON {
-		enc := json.NewEncoder(stdout)
-		enc.SetIndent("", "  ")
-		_ = enc.Encode(report)
-		return 0
-	}
-	printEnergyTop(stdout, report, interval)
-	return 0
 }
 
-func printEnergyTop(w io.Writer, r EnergyTopReport, interval time.Duration) {
+// powerStateFromReport reconstructs the legacy PowerState shape from the
+// envelope (battery + thermal + assertions + EnergyTopUsers) so the existing
+// printPowerState renderer keeps working without re-collecting.
+func powerStateFromReport(r PowerReport, fallback func() sysinfo.PowerState) sysinfo.PowerState {
+	s := sysinfo.PowerState{Assertions: r.Assertions}
+	if r.Battery != nil {
+		s.OnBattery = r.Battery.OnBattery
+		s.BatteryPct = r.Battery.Pct
+	}
+	if r.Thermal != nil {
+		s.ThermalPressure = r.Thermal.Pressure
+		s.ThermalThrottled = r.Thermal.Throttled
+		s.CPUSpeedLimitPct = r.Thermal.CPUSpeedLimitPct
+		s.LowestCPUSpeedLimitPct = r.Thermal.LowestCPUSpeedLimitPct
+		s.AverageCPUSpeedLimitPct = r.Thermal.AverageCPUSpeedLimitPct
+		s.PercentThermalThrottled = r.Thermal.PercentThermalThrottled
+	}
+	// The legacy CPUSpeedLimitSamples view drives the "% of samples" string;
+	// the envelope doesn't carry the per-sample series, so pull it from the
+	// fallback PowerState when needed.
+	if r.Thermal != nil && r.Thermal.Throttled {
+		s.CPUSpeedLimitSamples = fallback().CPUSpeedLimitSamples
+	}
+	for _, p := range r.Processes {
+		impact := 0.0
+		if p.Impact != nil {
+			impact = p.Impact.Total
+		}
+		s.EnergyTopUsers = append(s.EnergyTopUsers, sysinfo.EnergyUser{PID: p.PID, EnergyImpact: impact, Command: p.Command})
+	}
+	return s
+}
+
+func energyTopFromReport(r PowerReport, cfg powerRunCfg) energyTopLegacy {
+	top := make([]sysinfo.EnergyDelta, 0, len(r.Processes))
+	for _, p := range r.Processes {
+		d := sysinfo.EnergyDelta{
+			PID:            p.PID,
+			Command:        p.Command,
+			Interval:       cfg.interval,
+			BilledEnergyNJ: p.BilledEnergyNJ,
+		}
+		if p.Wakeups != nil {
+			d.InterruptWakeups = p.Wakeups.Interrupt
+			d.PkgIdleWakeups = p.Wakeups.PkgIdle
+		}
+		top = append(top, d)
+	}
+	return energyTopLegacy{intervalNS: cfg.interval.Nanoseconds(), skipped: r.Skipped, top: top}
+}
+
+type energyTopLegacy struct {
+	intervalNS int64
+	skipped    int
+	top        []sysinfo.EnergyDelta
+}
+
+func socFromPackage(p PackageEnergy) sysinfo.SoCPower {
+	return sysinfo.SoCPower{
+		Interval:      time.Duration(p.IntervalNS),
+		CPUPJoules:    p.CPUJoules,
+		GPUJoules:     p.GPUJoules,
+		ANEJoules:     p.ANEJoules,
+		DRAMJoules:    p.DRAMJoules,
+		PackageJoules: p.Joules,
+	}
+}
+
+func printEnergyTop(w io.Writer, r energyTopLegacy, interval time.Duration) {
 	fmt.Fprintf(w, "=== Energy top users (Δ over %s) ===\n", interval)
-	if r.Skipped > 0 {
-		fmt.Fprintf(w, "skipped: %d pid(s) (EPERM or vanished)\n", r.Skipped)
+	if r.skipped > 0 {
+		fmt.Fprintf(w, "skipped: %d pid(s) (EPERM or vanished)\n", r.skipped)
 	}
 	fmt.Fprintf(w, "%-7s  %-13s  %-9s  %-8s  %s\n",
 		"PID", "BILLED(nJ)", "WAKEUPS", "CPU(ms)", "COMMAND")
 	fmt.Fprintln(w, strings.Repeat("-", 64))
-	for _, d := range r.Top {
+	for _, d := range r.top {
 		cpuMs := (d.UserNs + d.SystemNs) / 1_000_000
 		fmt.Fprintf(w, "%-7d  %-13d  %-9d  %-8d  %s\n",
 			d.PID, d.BilledEnergyNJ, d.InterruptWakeups, cpuMs, d.Command)
@@ -292,27 +692,24 @@ func printPowerState(w io.Writer, s sysinfo.PowerState) {
 	}
 }
 
-func printDeepTasks(w io.Writer, p sysinfo.PowermetricsTasks, topN int) {
+func printDeepProcesses(w io.Writer, procs []ProcessEnergy, topN int) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "=== Deep (powermetrics --samplers tasks) ===")
-	if len(p.Tasks) == 0 {
+	if len(procs) == 0 {
 		fmt.Fprintln(w, "no per-pid task samples returned")
 		return
 	}
-	fmt.Fprintf(w, "elapsed:  %.0f ms\n", float64(p.ElapsedNs)/1e6)
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  %-7s  %-8s  %-10s  %-10s  %-8s  %-8s  %s\n",
-		"PID", "IMPACT", "CPU(ms)", "GPU(ms)", "WAKEUPS", "QOS-DEF%", "COMMAND")
-	fmt.Fprintln(w, "  "+strings.Repeat("-", 80))
-	for _, t := range p.TopTasks(topN) {
-		fmt.Fprintf(w, "  %-7d  %-8.1f  %-10.2f  %-10.2f  %-8d  %-8.1f  %s\n",
-			t.PID,
-			t.EnergyImpact,
-			float64(t.CPUNs)/1e6,
-			float64(t.GPUNs)/1e6,
-			t.ShortTimerWakeups,
-			t.QoSDefaultPct,
-			t.Command,
-		)
+	fmt.Fprintf(w, "  %-7s  %-8s  %-10s  %s\n", "PID", "IMPACT", "GPU(ms)", "COMMAND")
+	fmt.Fprintln(w, "  "+strings.Repeat("-", 56))
+	if topN > 0 && topN < len(procs) {
+		procs = procs[:topN]
+	}
+	for _, p := range procs {
+		impact := 0.0
+		if p.Impact != nil {
+			impact = p.Impact.Total
+		}
+		fmt.Fprintf(w, "  %-7d  %-8.1f  %-10.2f  %s\n",
+			p.PID, impact, float64(p.GPUTimeNs)/1e6, p.Command)
 	}
 }

--- a/cmd/spectra/power.go
+++ b/cmd/spectra/power.go
@@ -288,7 +288,7 @@ func runPowerWatch(stdout, stderr io.Writer, deps powerDeps, cfg powerRunCfg) in
 // and assembles a PowerReport. Returns (report, exit_code, ok). If ok is
 // false the caller should return exit_code immediately (e.g. unsupported
 // hardware on --joules, --top on non-darwin).
-func collectPower(stdout, stderr io.Writer, deps powerDeps, cfg powerRunCfg) (PowerReport, int, bool) {
+func collectPower(_, stderr io.Writer, deps powerDeps, cfg powerRunCfg) (PowerReport, int, bool) {
 	state := deps.collect()
 	report := PowerReport{
 		IntervalMS: cfg.interval.Milliseconds(),

--- a/cmd/spectra/power_test.go
+++ b/cmd/spectra/power_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,11 @@ func fakePowerDeps() powerDeps {
 		collect: fakePowerState,
 		sample: func(time.Duration) (sysinfo.SoCPower, error) {
 			return sysinfo.SoCPower{}, sysinfo.ErrUnsupportedHardware
+		},
+		clock: func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+		signalCh: func() (<-chan os.Signal, func()) {
+			ch := make(chan os.Signal)
+			return ch, func() {}
 		},
 	}
 }
@@ -75,42 +81,52 @@ func TestRunPowerHumanOutput(t *testing.T) {
 	}
 }
 
-func TestRunPowerJSONOutput(t *testing.T) {
+// Bare `spectra power --json` now emits the stable unified envelope rather
+// than the raw sysinfo.PowerState shape. The envelope is the contract
+// described in issue #237.
+func TestRunPowerJSONEnvelope(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runPowerWithIO([]string{"--json"}, &stdout, &stderr, fakePowerDeps())
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
 	}
-	var got sysinfo.PowerState
+	var got PowerReport
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
-		t.Fatal(err)
+		t.Fatalf("unmarshal: %v\n%s", err, stdout.String())
 	}
-	if !got.OnBattery || got.BatteryPct != 85 || got.ThermalPressure != "serious" {
-		t.Fatalf("state = %+v, want fake power state", got)
+	if got.Mode != "baseline" {
+		t.Fatalf("mode = %q, want baseline", got.Mode)
 	}
-	if !got.ThermalThrottled || got.CPUSpeedLimitPct != 92 {
-		t.Fatalf("thermal state = %+v, want throttled with 92%% CPU limit", got)
+	if got.IntervalMS != 1000 {
+		t.Fatalf("interval_ms = %d, want 1000", got.IntervalMS)
 	}
-	if len(got.EnergyTopUsers) != 1 || got.EnergyTopUsers[0].Command != "Google Chrome Helper" {
-		t.Fatalf("energy users = %+v, want Google Chrome Helper", got.EnergyTopUsers)
+	if got.Battery == nil || !got.Battery.OnBattery || got.Battery.Pct != 85 {
+		t.Fatalf("battery = %+v", got.Battery)
+	}
+	if got.Thermal == nil || got.Thermal.Pressure != "serious" || !got.Thermal.Throttled {
+		t.Fatalf("thermal = %+v", got.Thermal)
+	}
+	if len(got.Processes) != 1 || got.Processes[0].Source != "top" {
+		t.Fatalf("processes = %+v", got.Processes)
+	}
+	if got.Processes[0].Impact == nil || got.Processes[0].Impact.Total != 4.2 {
+		t.Fatalf("first impact = %+v", got.Processes[0].Impact)
 	}
 }
 
 func TestRunPowerJoulesHumanOutput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	deps := powerDeps{
-		collect: fakePowerState,
-		sample: func(d time.Duration) (sysinfo.SoCPower, error) {
-			return sysinfo.SoCPower{
-				Interval:      d,
-				CPUPJoules:    5.2,
-				CPUEJoules:    0.6,
-				GPUJoules:     2.1,
-				ANEJoules:     0.0,
-				DRAMJoules:    1.3,
-				PackageJoules: 9.2,
-			}, nil
-		},
+	deps := fakePowerDeps()
+	deps.sample = func(d time.Duration) (sysinfo.SoCPower, error) {
+		return sysinfo.SoCPower{
+			Interval:      d,
+			CPUPJoules:    5.2,
+			CPUEJoules:    0.6,
+			GPUJoules:     2.1,
+			ANEJoules:     0.0,
+			DRAMJoules:    1.3,
+			PackageJoules: 9.2,
+		}, nil
 	}
 	code := runPowerWithIO([]string{"--joules", "--interval=1s"}, &stdout, &stderr, deps)
 	if code != 0 {
@@ -120,7 +136,6 @@ func TestRunPowerJoulesHumanOutput(t *testing.T) {
 	for _, want := range []string{
 		"=== SoC power (IOReport) ===",
 		"Package:   9.20 J over 1s  (9.20 W)",
-		"CPU P:   5.20 J",
 		"GPU:     2.10 J",
 		"DRAM:    1.30 J",
 	} {
@@ -130,35 +145,34 @@ func TestRunPowerJoulesHumanOutput(t *testing.T) {
 	}
 }
 
-func TestRunPowerJoulesJSONOutput(t *testing.T) {
+func TestRunPowerJoulesJSONUsesEnvelope(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	deps := powerDeps{
-		collect: fakePowerState,
-		sample: func(d time.Duration) (sysinfo.SoCPower, error) {
-			return sysinfo.SoCPower{Interval: d, PackageJoules: 7.5, GPUJoules: 1.5}, nil
-		},
+	deps := fakePowerDeps()
+	deps.sample = func(d time.Duration) (sysinfo.SoCPower, error) {
+		return sysinfo.SoCPower{Interval: d, PackageJoules: 7.5, GPUJoules: 1.5, CPUPJoules: 4.0}, nil
 	}
 	code := runPowerWithIO([]string{"--joules", "--json"}, &stdout, &stderr, deps)
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
 	}
-	var got sysinfo.SoCPower
+	var got PowerReport
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatal(err)
 	}
-	if got.PackageJoules != 7.5 || got.GPUJoules != 1.5 {
-		t.Fatalf("got %+v, want PackageJoules=7.5 GPUJoules=1.5", got)
+	if got.Mode != "joules" {
+		t.Fatalf("mode = %q, want joules", got.Mode)
+	}
+	if got.Package == nil || got.Package.Joules != 7.5 || got.Package.GPUJoules != 1.5 {
+		t.Fatalf("package = %+v, want joules=7.5 gpu=1.5", got.Package)
+	}
+	if got.Package.CPUJoules != 4.0 {
+		t.Fatalf("cpu_joules = %v, want 4.0 (CPUPJoules+CPUEJoules)", got.Package.CPUJoules)
 	}
 }
 
 func TestRunPowerJoulesUnsupportedHardware(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	deps := powerDeps{
-		collect: fakePowerState,
-		sample: func(time.Duration) (sysinfo.SoCPower, error) {
-			return sysinfo.SoCPower{}, sysinfo.ErrUnsupportedHardware
-		},
-	}
+	deps := fakePowerDeps()
 	code := runPowerWithIO([]string{"--joules"}, &stdout, &stderr, deps)
 	if code != 3 {
 		t.Fatalf("exit = %d, want 3 for unsupported hardware", code)
@@ -168,55 +182,83 @@ func TestRunPowerJoulesUnsupportedHardware(t *testing.T) {
 	}
 }
 
-func TestRunPowerTopJSON(t *testing.T) {
+func TestRunPowerTopJSONEnvelope(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	deps := powerDeps{
-		collect: fakePowerState,
-		procs:   fakeProcs(map[int]string{101: "claude", 202: "WindowServer", 303: "claude-busy"}),
-		sampleRusage: func(_ context.Context, interval time.Duration, _ []int) ([]sysinfo.EnergyDelta, error) {
-			return []sysinfo.EnergyDelta{
-				{PID: 101, Interval: interval, BilledEnergyNJ: 200, InterruptWakeups: 5},
-				{PID: 303, Interval: interval, BilledEnergyNJ: 1_500_000, InterruptWakeups: 99},
-			}, nil
-		},
-		clock: func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+	deps := fakePowerDeps()
+	deps.procs = fakeProcs(map[int]string{101: "claude", 202: "WindowServer", 303: "claude-busy"})
+	deps.sampleRusage = func(_ context.Context, interval time.Duration, _ []int) ([]sysinfo.EnergyDelta, error) {
+		return []sysinfo.EnergyDelta{
+			{PID: 101, Interval: interval, BilledEnergyNJ: 200, InterruptWakeups: 5},
+			{PID: 303, Interval: interval, BilledEnergyNJ: 1_500_000, InterruptWakeups: 99},
+		}, nil
 	}
 	code := runPowerWithIO([]string{"--top", "10", "--json", "--interval", "100ms"}, &stdout, &stderr, deps)
 	if code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
 	}
-	var got EnergyTopReport
+	var got PowerReport
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v\n%s", err, stdout.String())
 	}
-	if got.IntervalNS != int64(100*time.Millisecond) {
-		t.Fatalf("interval_ns = %d", got.IntervalNS)
+	if got.Mode != "rusage" {
+		t.Fatalf("mode = %q, want rusage", got.Mode)
+	}
+	if got.IntervalMS != 100 {
+		t.Fatalf("interval_ms = %d, want 100", got.IntervalMS)
 	}
 	if got.Skipped != 1 {
 		t.Fatalf("skipped = %d, want 1 (pid 202 was not sampled)", got.Skipped)
 	}
-	if len(got.Top) != 2 || got.Top[0].PID != 303 {
-		t.Fatalf("top order = %+v, want pid 303 first", got.Top)
+	if len(got.Processes) != 2 || got.Processes[0].PID != 303 {
+		t.Fatalf("processes = %+v, want pid 303 first", got.Processes)
 	}
-	if got.Top[0].BilledEnergyNJ != 1_500_000 {
-		t.Fatalf("raw nanojoules = %d, want 1_500_000", got.Top[0].BilledEnergyNJ)
+	if got.Processes[0].BilledEnergyNJ != 1_500_000 {
+		t.Fatalf("first billed_energy_nj = %d, want 1_500_000", got.Processes[0].BilledEnergyNJ)
 	}
-	if got.Top[0].Command != "claude-busy" {
-		t.Fatalf("command = %q, want claude-busy", got.Top[0].Command)
+	if got.Processes[0].Source != "rusage" {
+		t.Fatalf("source = %q, want rusage", got.Processes[0].Source)
+	}
+	if got.Processes[0].Command != "claude-busy" {
+		t.Fatalf("command = %q, want claude-busy", got.Processes[0].Command)
+	}
+	if got.Processes[0].Impact == nil || got.Processes[0].Impact.Total <= 0 {
+		t.Fatalf("impact not populated: %+v", got.Processes[0].Impact)
+	}
+}
+
+func TestRunPowerTopJSONImpactAccessibleByJq(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := fakePowerDeps()
+	deps.procs = fakeProcs(map[int]string{42: "busybox"})
+	deps.sampleRusage = func(_ context.Context, interval time.Duration, _ []int) ([]sysinfo.EnergyDelta, error) {
+		return []sysinfo.EnergyDelta{
+			{PID: 42, Interval: interval, BilledEnergyNJ: 250_000_000},
+		}, nil
+	}
+	code := runPowerWithIO([]string{"--top", "1", "--json"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatal(stderr.String())
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		t.Fatal(err)
+	}
+	procs := raw["processes"].([]any)
+	first := procs[0].(map[string]any)
+	impact := first["impact"].(map[string]any)
+	if _, ok := impact["total"]; !ok {
+		t.Fatalf("processes[0].impact.total missing — breaks `jq .processes[0].impact.total`: %+v", impact)
 	}
 }
 
 func TestRunPowerTopHumanOutput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	deps := powerDeps{
-		collect: fakePowerState,
-		procs:   fakeProcs(map[int]string{42: "busybox"}),
-		sampleRusage: func(_ context.Context, interval time.Duration, _ []int) ([]sysinfo.EnergyDelta, error) {
-			return []sysinfo.EnergyDelta{
-				{PID: 42, Interval: interval, BilledEnergyNJ: 250_000, InterruptWakeups: 7, UserNs: 12_000_000, SystemNs: 3_000_000},
-			}, nil
-		},
-		clock: time.Now,
+	deps := fakePowerDeps()
+	deps.procs = fakeProcs(map[int]string{42: "busybox"})
+	deps.sampleRusage = func(_ context.Context, interval time.Duration, _ []int) ([]sysinfo.EnergyDelta, error) {
+		return []sysinfo.EnergyDelta{
+			{PID: 42, Interval: interval, BilledEnergyNJ: 250_000, InterruptWakeups: 7, UserNs: 12_000_000, SystemNs: 3_000_000},
+		}, nil
 	}
 	code := runPowerWithIO([]string{"--top", "3", "--interval", "500ms"}, &stdout, &stderr, deps)
 	if code != 0 {
@@ -237,13 +279,10 @@ func TestRunPowerTopHumanOutput(t *testing.T) {
 
 func TestRunPowerTopUnsupported(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	deps := powerDeps{
-		collect: fakePowerState,
-		procs:   fakeProcs(map[int]string{1: "launchd"}),
-		sampleRusage: func(context.Context, time.Duration, []int) ([]sysinfo.EnergyDelta, error) {
-			return nil, sysinfo.ErrRusageUnsupported
-		},
-		clock: time.Now,
+	deps := fakePowerDeps()
+	deps.procs = fakeProcs(map[int]string{1: "launchd"})
+	deps.sampleRusage = func(context.Context, time.Duration, []int) ([]sysinfo.EnergyDelta, error) {
+		return nil, sysinfo.ErrRusageUnsupported
 	}
 	code := runPowerWithIO([]string{"--top", "5"}, &stdout, &stderr, deps)
 	if code != 3 {
@@ -251,6 +290,28 @@ func TestRunPowerTopUnsupported(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "per-pid energy unavailable") {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunPowerHelpDocumentsPrivilege(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO([]string{"--help"}, &stdout, &stderr, fakePowerDeps())
+	// `--help` returns flag.ErrHelp → exit 2 from flag.Parse, but the usage
+	// text printed before that is what we care about.
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2 (flag.ErrHelp)", code)
+	}
+	for _, want := range []string{
+		"--top", "(no privilege)",
+		"--joules", "(no privilege)",
+		"--deep", "(requires helper)",
+		"--watch", "(inherits)",
+		"--json", "(inherits)",
+		"--interval",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("usage missing %q:\n%s", want, stderr.String())
+		}
 	}
 }
 
@@ -262,6 +323,61 @@ func TestRunPowerFlagError(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestRunPowerRejectsNonPositiveInterval(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO([]string{"--interval", "0s"}, &stdout, &stderr, fakePowerDeps())
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "interval must be positive") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunPowerWatchJSONEmitsNDJSON(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	sigCh := make(chan os.Signal, 1)
+	frames := 0
+	deps := fakePowerDeps()
+	deps.collect = func() sysinfo.PowerState {
+		frames++
+		if frames >= 3 {
+			sigCh <- os.Interrupt
+		}
+		return fakePowerState()
+	}
+	deps.signalCh = func() (<-chan os.Signal, func()) { return sigCh, func() {} }
+	code := runPowerWithIO([]string{"--watch", "--json", "--interval", "10ms"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	count := 0
+	for _, line := range strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Fatalf("line not valid JSON: %q: %v", line, err)
+		}
+		count++
+	}
+	if count < 2 {
+		t.Fatalf("expected at least 2 NDJSON lines, got %d:\n%s", count, stdout.String())
+	}
+	// Final line must be the watch_stopped summary so consumers see a clean
+	// terminator instead of guessing whether the stream was truncated.
+	last := strings.TrimRight(stdout.String(), "\n")
+	lines := strings.Split(last, "\n")
+	var final map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &final); err != nil {
+		t.Fatalf("final line not JSON: %q", lines[len(lines)-1])
+	}
+	if _, ok := final["watch_stopped"]; !ok {
+		t.Fatalf("final line should be the watch_stopped summary, got %v", final)
 	}
 }
 
@@ -323,7 +439,7 @@ func TestRunPowerDeepHumanOutput(t *testing.T) {
 	}
 }
 
-func TestRunPowerDeepJSONIsSupersetOfJoulesAndPowerState(t *testing.T) {
+func TestRunPowerDeepJSONUnifiedEnvelope(t *testing.T) {
 	deps := deepFakeDeps(fakeDeepFetcher(deepTasksPlist, nil))
 	deps.sample = func(d time.Duration) (sysinfo.SoCPower, error) {
 		return sysinfo.SoCPower{Interval: d, PackageJoules: 7.5, GPUJoules: 1.5}, nil
@@ -333,27 +449,21 @@ func TestRunPowerDeepJSONIsSupersetOfJoulesAndPowerState(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
 	}
-	var got map[string]any
+	var got PowerReport
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatal(err)
 	}
-	if got["on_battery"] != true {
-		t.Errorf("on_battery = %v, want true (PowerState superset)", got["on_battery"])
+	if got.Mode != "deep" {
+		t.Fatalf("mode = %q, want deep", got.Mode)
 	}
-	soc, ok := got["soc"].(map[string]any)
-	if !ok {
-		t.Fatalf("soc = %T, want map (joules superset)", got["soc"])
+	if got.Battery == nil || !got.Battery.OnBattery {
+		t.Fatalf("battery = %+v, want PowerState carried through", got.Battery)
 	}
-	if soc["package_joules"] != 7.5 {
-		t.Errorf("soc.package_joules = %v, want 7.5", soc["package_joules"])
+	if got.Package == nil || got.Package.Joules != 7.5 {
+		t.Fatalf("package = %+v, want joules carried through (--deep implies --joules)", got.Package)
 	}
-	deep, ok := got["deep"].(map[string]any)
-	if !ok {
-		t.Fatalf("deep = %T, want map", got["deep"])
-	}
-	tasks, ok := deep["tasks"].([]any)
-	if !ok || len(tasks) != 1 {
-		t.Fatalf("deep.tasks = %+v", deep["tasks"])
+	if len(got.Processes) != 1 || got.Processes[0].PID != 501 || got.Processes[0].Source != "powermetrics" {
+		t.Fatalf("processes = %+v, want pid 501 from powermetrics", got.Processes)
 	}
 }
 
@@ -384,5 +494,21 @@ func TestRunPowerDeepHelperErrorFallsBack(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "powermetrics exploded") {
 		t.Errorf("stderr should contain helper error:\n%s", stderr.String())
+	}
+}
+
+func TestRunPowerDeepHelperUnavailableNoteInJSON(t *testing.T) {
+	deps := deepFakeDeps(fakeDeepFetcher("", helperclient.ErrHelperUnavailable))
+	var stdout, stderr bytes.Buffer
+	code := runPowerWithIO([]string{"--deep", "--json"}, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	var got PowerReport
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Notes) == 0 || !strings.Contains(got.Notes[0], "helper unavailable") {
+		t.Fatalf("notes = %v, want degradation note", got.Notes)
 	}
 }


### PR DESCRIPTION
## Summary
- Locks in the CLI shape (`--top` / `--joules` / `--deep` / `--watch` / `--json` / `--interval`) so L1–L3 backends can ship behind stable flag names.
- Defines a stable JSON envelope (`PowerReport`) with `battery`, `thermal`, `assertions`, `package`, and `processes[].impact/source`. Modes that lack data omit fields rather than zeroing them.
- `--deep` probes the privileged helper and prints an actionable install hint + exits 2 when unavailable.
- `--watch` streams NDJSON in JSON mode (parseable by \`jq -c\`) and rewrites the screen with VT100 codes in human mode (no curses → safe for \`tee\`).

Closes #237.

## Evaluation criteria

- [x] \`spectra power --help\` documents every flag with one-line description + privilege requirement
- [x] JSON schema is stable: same field names across \`--top\`/\`--joules\`/\`--deep\`
- [x] \`--watch --json\` emits one JSON object per line (NDJSON), parseable by \`jq -c\`
- [x] \`--deep\` without helper installed prints actionable error including the install command and exits 2
- [x] Backwards-compat: bare \`spectra power\` output unchanged (legacy pmset+top view)
- [x] \`spectra power --json | jq .processes[0].impact.total\` works for any mode that has rusage data

## Test plan
- [x] \`go test ./cmd/spectra/ -run TestRunPower -count=1\` — 10 cases including NDJSON shape, --deep helper-missing path, --top truncation, --interval override, baseline backwards-compat
- [x] \`go test ./... -count=1\` (full suite) green
- [x] \`go vet ./...\` clean