### PR TITLE
Classify process file descriptors

### DIFF
--- a/cmd/spectra/process_cmd.go
+++ b/cmd/spectra/process_cmd.go
@@ -20,8 +20,12 @@ func runProcess(args []string) int {
 	sortBy := fs.String("sort", "rss", "Sort by: rss, pid, or cmd")
 	topN := fs.Int("top", 0, "Show only top N processes (0 = all)")
 	deep := fs.Bool("deep", false, "Enrich with open FD count and listening ports via lsof (slower)")
+	fdBreakdown := fs.Bool("fd-breakdown", false, "Show typed FD columns (implies --deep)")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+	if *fdBreakdown {
+		*deep = true
 	}
 
 	procs := process.CollectAll(context.Background(), process.CollectOptions{Deep: *deep})
@@ -50,7 +54,15 @@ func runProcess(args []string) int {
 		return 0
 	}
 
-	if *deep {
+	printProcessRows(procs, *deep, *fdBreakdown)
+	return 0
+}
+
+func printProcessRows(procs []process.Info, deep, fdBreakdown bool) {
+	if fdBreakdown {
+		fmt.Printf("%-7s  %-6s  %-8s  %-5s  %-5s  %-5s  %-5s  %-5s  %-5s  %-5s  %-5s  %s\n", "PID", "THR", "RSS", "FDS", "PTY", "SOCK", "REG", "PIPE", "CHR", "KQ", "OTH", "COMMAND")
+		fmt.Println(strings.Repeat("-", 105))
+	} else if deep {
 		fmt.Printf("%-7s  %-6s  %-10s  %-10s  %-5s  %s\n", "PID", "THR", "RSS", "CPU%", "FDS", "COMMAND")
 		fmt.Println(strings.Repeat("-", 82))
 	} else {
@@ -66,19 +78,38 @@ func runProcess(args []string) int {
 		if p.CPUPct > 0 {
 			cpu = fmt.Sprintf("%.1f%%", p.CPUPct)
 		}
-		if *deep {
-			fds := "-"
-			if p.OpenFDs > 0 {
-				fds = strconv.Itoa(p.OpenFDs)
-			}
-			fmt.Printf("%-7d  %-6s  %-10s  %-10s  %-5s  %s\n",
-				p.PID, thr, humanSizeKiB(p.RSSKiB), cpu, fds, truncate(p.Command, 45))
-		} else {
+		switch {
+		case fdBreakdown:
+			printProcessFDBreakdownRow(p, thr)
+		case deep:
+			printProcessDeepRow(p, thr, cpu)
+		default:
 			fmt.Printf("%-7d  %-6s  %-10s  %-10s  %s\n",
 				p.PID, thr, humanSizeKiB(p.RSSKiB), cpu, truncate(p.Command, 45))
 		}
 	}
-	return 0
+}
+
+func printProcessFDBreakdownRow(p process.Info, thr string) {
+	b := p.FDBreakdown
+	if b == nil {
+		b = &process.FDBreakdown{}
+	}
+	fds := processFDString(p)
+	fmt.Printf("%-7d  %-6s  %-8s  %-5s  %-5d  %-5d  %-5d  %-5d  %-5d  %-5d  %-5d  %s\n",
+		p.PID, thr, humanSizeKiB(p.RSSKiB), fds, b.PTY, b.Socket, b.Regular, b.Pipe, b.Char, b.Kqueue, b.Other, truncate(p.Command, 40))
+}
+
+func printProcessDeepRow(p process.Info, thr, cpu string) {
+	fmt.Printf("%-7d  %-6s  %-10s  %-10s  %-5s  %s\n",
+		p.PID, thr, humanSizeKiB(p.RSSKiB), cpu, processFDString(p), truncate(p.Command, 45))
+}
+
+func processFDString(p process.Info) string {
+	if p.OpenFDs > 0 {
+		return strconv.Itoa(p.OpenFDs)
+	}
+	return "-"
 }
 
 func humanSizeKiB(kib int64) string {

--- a/docs/inspection/process-profiling.md
+++ b/docs/inspection/process-profiling.md
@@ -29,6 +29,17 @@ connections. `process-tree` adds parent/child context. `metrics` shows recent
 daemon samples. `sample` captures call stacks when the process is actively
 burning CPU.
 
+For descriptor leaks, add `--fd-breakdown`:
+
+```bash
+spectra process --deep --fd-breakdown --sort rss
+```
+
+This keeps the same process inventory but splits open descriptors into ptys,
+sockets, regular files, pipes, character devices, kqueues, and other handles.
+The JSON output includes `fd_breakdown` automatically whenever `--deep`
+populates descriptor data.
+
 ## Samples
 
 macOS ships `sample <pid>`, which records stack traces over a bounded interval.
@@ -126,6 +137,31 @@ questions:
 
 For a sustained burn, capture `sample` while CPU is high. For a sawtooth, use a
 longer history window first, then sample during the hot phase.
+
+## Pty leaks
+
+Pseudo-tty leaks usually present as a terminal problem even when another app is
+responsible. iTerm2, Terminal.app, VS Code, or a JetBrains terminal can show an
+empty pane or an immediate "Session Ended" because `forkpty()` cannot allocate a
+new `/dev/ptmx` or `/dev/ttys*` pair.
+
+Start with the descriptor breakdown:
+
+```bash
+spectra process --deep --fd-breakdown --sort rss
+```
+
+Look for one app or helper with a high `PTY` count. Electron and Chromium apps
+normally run several helpers, but they should not hold dozens of ptys when no
+embedded terminal sessions are active. Pair the row with a scoped tree:
+
+```bash
+spectra connect local process-tree /Applications/Claude.app
+```
+
+If the pty count drops after quitting the suspect app, the terminal was the
+victim and the descriptor holder was the culprit. Use snapshots before and
+after remediation when you need a durable incident record.
 
 ## RSS trends
 

--- a/internal/process/deep.go
+++ b/internal/process/deep.go
@@ -20,7 +20,7 @@ func enrichDeep(procs []Info, run func(string, ...string) ([]byte, error)) {
 	pidArg := strings.Join(pids, ",")
 
 	out, err := run("lsof", "-p", pidArg)
-	if err != nil {
+	if err != nil && len(out) == 0 {
 		return
 	}
 	parseLSOFDeep(procs, string(out))
@@ -29,6 +29,7 @@ func enrichDeep(procs []Info, run func(string, ...string) ([]byte, error)) {
 // deepResult accumulates per-PID results during lsof parsing.
 type deepResult struct {
 	fdCount       int
+	breakdown     *FDBreakdown
 	listenPorts   []int
 	outboundConns []string
 	logFiles      []string
@@ -79,6 +80,14 @@ func recordLSOFLine(idx map[int]int, results map[int]*deepResult, line string) {
 	// Count rows where FD starts with a digit — those are real open descriptors.
 	if len(fd) > 0 && fd[0] >= '0' && fd[0] <= '9' {
 		r.fdCount++
+		if r.breakdown == nil {
+			r.breakdown = &FDBreakdown{}
+		}
+		name := ""
+		if len(fields) >= 9 {
+			name = strings.Join(fields[8:], " ")
+		}
+		classifyFD(r.breakdown, fields[4], name)
 	}
 	if len(fields) >= 9 && strings.EqualFold(fields[7], "TCP") {
 		recordTCPName(r, strings.Join(fields[8:], " "))
@@ -86,6 +95,36 @@ func recordLSOFLine(idx map[int]int, results map[int]*deepResult, line string) {
 	if len(fields) >= 9 && strings.EqualFold(fields[4], "REG") && fdIsWritable(fd) {
 		recordLogFile(r, strings.Join(fields[8:], " "))
 	}
+}
+
+func classifyFD(b *FDBreakdown, typ, name string) {
+	b.Total++
+	switch typ {
+	case "IPv4", "IPv6", "unix":
+		b.Socket++
+	case "REG":
+		b.Regular++
+	case "DIR":
+		b.Dir++
+	case "PIPE", "FIFO":
+		b.Pipe++
+	case "KQUEUE":
+		b.Kqueue++
+	case "CHR":
+		if isPTYPath(name) {
+			b.PTY++
+		} else {
+			b.Char++
+		}
+	default:
+		b.Other++
+	}
+}
+
+func isPTYPath(name string) bool {
+	return strings.HasPrefix(name, "/dev/ttys") ||
+		strings.HasPrefix(name, "/dev/pty") ||
+		name == "/dev/ptmx"
 }
 
 // fdIsWritable reports whether the lsof FD column indicates write access.
@@ -171,6 +210,7 @@ func applyDeepResults(procs []Info, idx map[int]int, results map[int]*deepResult
 	for pid, r := range results {
 		i := idx[pid]
 		procs[i].OpenFDs = r.fdCount
+		procs[i].FDBreakdown = r.breakdown
 		if len(r.listenPorts) > 0 {
 			sort.Ints(r.listenPorts)
 			procs[i].ListeningPorts = r.listenPorts

--- a/internal/process/deep_test.go
+++ b/internal/process/deep_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -35,6 +36,84 @@ func TestParseLSOFDeepFDCount(t *testing.T) {
 	// bash: FDs 0, 1, 2 = 3 open FDs.
 	if procs[1].OpenFDs != 3 {
 		t.Errorf("bash OpenFDs = %d, want 3", procs[1].OpenFDs)
+	}
+}
+
+func TestParseLSOFDeepFDBreakdown(t *testing.T) {
+	const fixture = `COMMAND    PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+App        777   alice    0u   CHR                3,2      0t0     339 /dev/ptmx
+App        777   alice    1u   CHR                3,2      0t0     339 /dev/ttys000
+App        777   alice    2u   CHR                3,2      0t0     339 /dev/ptyq1
+App        777   alice    3u  IPv4 0xabc          0t0     TCP 127.0.0.1:1->127.0.0.1:2 (ESTABLISHED)
+App        777   alice    4u  IPv6 0xabc          0t0     TCP [::1]:1->[::1]:2 (ESTABLISHED)
+App        777   alice    5u  unix 0xabc          0t0         0 /var/run/app.sock
+App        777   alice    6u  IPv4 0xabc          0t0     TCP *:3000 (LISTEN)
+App        777   alice    7u  unix 0xabc          0t0         0 /var/run/app2.sock
+App        777   alice    8r   REG               1,15        0     100 /tmp/a
+App        777   alice    9r   REG               1,15        0     101 /tmp/b
+App        777   alice   10r   REG               1,15        0     102 /tmp/c
+App        777   alice   11r   REG               1,15        0     103 /tmp/d
+App        777   alice   12r   REG               1,15        0     104 /tmp/e
+App        777   alice   13r   REG               1,15        0     105 /tmp/f
+App        777   alice   14r   REG               1,15        0     106 /tmp/g
+App        777   alice   15r   REG               1,15        0     107 /tmp/h
+App        777   alice   16r   REG               1,15        0     108 /tmp/i
+App        777   alice   17r   REG               1,15        0     109 /tmp/j
+App        777   alice   18u  PIPE               0,15      0t0         0
+App        777   alice   19u  FIFO               0,15      0t0         0
+App        777   alice   20u KQUEUE                                        count=1, state=0
+`
+	procs := []Info{{PID: 777, Command: "App"}}
+	parseLSOFDeep(procs, fixture)
+
+	b := procs[0].FDBreakdown
+	if b == nil {
+		t.Fatal("FDBreakdown is nil")
+	}
+	if procs[0].OpenFDs != 21 {
+		t.Fatalf("OpenFDs = %d, want 21", procs[0].OpenFDs)
+	}
+	if b.Total != procs[0].OpenFDs {
+		t.Fatalf("breakdown total = %d, want OpenFDs %d", b.Total, procs[0].OpenFDs)
+	}
+	if b.PTY != 3 || b.Socket != 5 || b.Regular != 10 || b.Pipe != 2 || b.Kqueue != 1 {
+		t.Fatalf("breakdown = %+v, want pty=3 socket=5 regular=10 pipe=2 kqueue=1", *b)
+	}
+}
+
+func TestParseLSOFDeepFDBreakdownCharDevice(t *testing.T) {
+	const fixture = `COMMAND    PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+App        777   alice    0u   CHR                3,2      0t0     339 /dev/null
+`
+	procs := []Info{{PID: 777, Command: "App"}}
+	parseLSOFDeep(procs, fixture)
+
+	b := procs[0].FDBreakdown
+	if b == nil {
+		t.Fatal("FDBreakdown is nil")
+	}
+	if b.Char != 1 || b.PTY != 0 {
+		t.Fatalf("breakdown = %+v, want char=1 pty=0", *b)
+	}
+}
+
+func TestParseLSOFDeepFDBreakdownAddsUp(t *testing.T) {
+	procs := []Info{
+		{PID: 412, Command: "Slack"},
+		{PID: 999, Command: "bash"},
+	}
+	parseLSOFDeep(procs, lsofDeepFixture)
+
+	for _, p := range procs {
+		if p.FDBreakdown == nil {
+			t.Fatalf("%s FDBreakdown is nil", p.Command)
+		}
+		sum := p.FDBreakdown.PTY + p.FDBreakdown.Socket + p.FDBreakdown.Regular +
+			p.FDBreakdown.Dir + p.FDBreakdown.Pipe + p.FDBreakdown.Char +
+			p.FDBreakdown.Kqueue + p.FDBreakdown.Other
+		if sum != p.OpenFDs || p.FDBreakdown.Total != p.OpenFDs {
+			t.Fatalf("%s breakdown = %+v, OpenFDs = %d, category sum = %d", p.Command, *p.FDBreakdown, p.OpenFDs, sum)
+		}
 	}
 }
 
@@ -137,6 +216,21 @@ func TestEnrichDeepError(t *testing.T) {
 	enrichDeep(procs, run)
 	if procs[0].OpenFDs != 0 {
 		t.Errorf("expected OpenFDs=0 for empty lsof output, got %d", procs[0].OpenFDs)
+	}
+}
+
+func TestEnrichDeepParsesPartialOutputOnError(t *testing.T) {
+	procs := []Info{{PID: 412, Command: "Slack"}}
+	run := func(string, ...string) ([]byte, error) {
+		return []byte(lsofDeepFixture), errors.New("lsof: partial failure")
+	}
+
+	enrichDeep(procs, run)
+	if procs[0].OpenFDs != 5 {
+		t.Fatalf("OpenFDs = %d, want 5", procs[0].OpenFDs)
+	}
+	if procs[0].FDBreakdown == nil || procs[0].FDBreakdown.Total != 5 {
+		t.Fatalf("FDBreakdown = %+v, want total 5", procs[0].FDBreakdown)
 	}
 }
 

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -34,15 +34,29 @@ type Info struct {
 	StartTime       time.Time `json:"start_time,omitempty"` // process start time (lstart)
 
 	// Deep fields — populated only when CollectOptions.Deep is true.
-	OpenFDs             int      `json:"open_fds,omitempty"`             // open file descriptor count
-	ListeningPorts      []int    `json:"listening_ports,omitempty"`      // TCP ports this process listens on
-	OutboundConnections []string `json:"outbound_connections,omitempty"` // active TCP remote addresses (host:port)
-	LogFiles            []string `json:"log_files,omitempty"`            // writable log-shaped files this process holds open
+	OpenFDs             int          `json:"open_fds,omitempty"`             // open file descriptor count
+	FDBreakdown         *FDBreakdown `json:"fd_breakdown,omitempty"`         // typed FD counts from lsof
+	ListeningPorts      []int        `json:"listening_ports,omitempty"`      // TCP ports this process listens on
+	OutboundConnections []string     `json:"outbound_connections,omitempty"` // active TCP remote addresses (host:port)
+	LogFiles            []string     `json:"log_files,omitempty"`            // writable log-shaped files this process holds open
 
 	// AppPath is set when the process's executable path starts with a known
 	// .app bundle path. Populated only when CollectAll is called with a set
 	// of app paths (BundlePaths option).
 	AppPath string `json:"app_path,omitempty"`
+}
+
+// FDBreakdown groups open descriptors by lsof TYPE and path.
+type FDBreakdown struct {
+	Total   int `json:"total"`
+	PTY     int `json:"pty"`
+	Socket  int `json:"socket"`
+	Regular int `json:"regular"`
+	Dir     int `json:"dir"`
+	Pipe    int `json:"pipe"`
+	Char    int `json:"char"`
+	Kqueue  int `json:"kqueue"`
+	Other   int `json:"other"`
 }
 
 // CollectOptions parameterises CollectAll.


### PR DESCRIPTION
## Summary
- add `process.FDBreakdown` and classify deep `lsof` rows into pty/socket/regular/pipe/char/kqueue/other buckets
- expose `spectra process --fd-breakdown` as a compact table view, with JSON including `fd_breakdown` from deep collection
- parse partial `lsof` stdout even when the batched command exits non-zero
- document pty leak triage in process profiling docs

Closes #247

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
- `go run ./cmd/spectra process --deep --fd-breakdown --top 5`