### PR TITLE
Add system resource limits diagnostics

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -43,6 +43,7 @@ func subcommandList() []subcommand {
 		{"power", "Show current battery and thermal state", runPower},
 		{"impact", "Compute the documented per-pid energy impact score from delta records", runImpact},
 		{"storage", "Show disk volumes and ~/Library footprint", runStorage},
+		{"system", "Show system resource limits and saturation", runSystem},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
 		{"playbook", "Show diagnostic playbooks and command plans", runPlaybook},
 		{"diff", "Diff two stored snapshots (alias for snapshot diff)", runSnapshotDiff},

--- a/cmd/spectra/system.go
+++ b/cmd/spectra/system.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/syslimits"
+)
+
+func systemSubcommands() []subcommand {
+	return []subcommand{
+		{"limits", "Show pty/file/process kernel limits vs current usage", runSystemLimits},
+	}
+}
+
+func runSystem(args []string) int {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		for _, sc := range systemSubcommands() {
+			if args[0] == sc.name {
+				return sc.run(args[1:])
+			}
+		}
+	}
+	fmt.Fprintln(os.Stderr, "usage: spectra system limits [--json] [--top]")
+	return 2
+}
+
+func runSystemLimits(args []string) int {
+	fs := flag.NewFlagSet("spectra system limits", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	showTop := fs.Bool("top", false, "Show top process holders for saturated resources")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	limits := syslimits.Collect(syslimits.Options{})
+	var top syslimits.TopHolders
+	if *showTop {
+		top = syslimits.CollectTopHolders(context.Background(), 10, processCollectOptions())
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if *showTop {
+			_ = enc.Encode(struct {
+				Limits     syslimits.SystemLimits `json:"limits"`
+				TopHolders syslimits.TopHolders   `json:"top_holders,omitempty"`
+			}{Limits: limits, TopHolders: top})
+		} else {
+			_ = enc.Encode(limits)
+		}
+		return criticalExit(limits)
+	}
+
+	printSystemLimits(limits)
+	if *showTop {
+		printSystemLimitTop(limits, top)
+	}
+	return criticalExit(limits)
+}
+
+func processCollectOptions() process.CollectOptions {
+	return process.CollectOptions{}
+}
+
+func criticalExit(limits syslimits.SystemLimits) int {
+	if limits.AnyCritical() {
+		return 1
+	}
+	return 0
+}
+
+func printSystemLimits(limits syslimits.SystemLimits) {
+	fmt.Printf("%-14s  %-8s  %-8s  %-7s  %s\n", "RESOURCE", "USED", "LIMIT", "PCT", "STATE")
+	fmt.Println(strings.Repeat("-", 52))
+	printUsageRow("pty slots", limits.PTY)
+	printUsageRow("open files", limits.Files)
+	printUsageRow("processes", limits.Procs)
+	printUsageRow("processes/uid", limits.ProcsPerUID)
+	fmt.Printf("%-14s  %-8s  %-8d  %-7s  %s\n", "files/proc", "-", limits.FilesPerProc, "-", "")
+	if len(limits.PartialFailures) > 0 {
+		fmt.Fprintf(os.Stderr, "warning: partial collection failures: %s\n", strings.Join(limits.PartialFailures, ", "))
+	}
+}
+
+func printUsageRow(label string, usage syslimits.ResourceUsage) {
+	state := ""
+	switch {
+	case usage.Critical:
+		state = "CRITICAL"
+	case usage.Warn:
+		state = "WARN"
+	}
+	pct := "-"
+	if usage.Limit > 0 {
+		pct = fmt.Sprintf("%.0f%%", usage.Pct)
+	}
+	fmt.Printf("%-14s  %-8d  %-8d  %-7s  %s\n", label, usage.Current, usage.Limit, pct, state)
+}
+
+func printSystemLimitTop(limits syslimits.SystemLimits, top syslimits.TopHolders) {
+	printTopForResource("pty slots", "pty", limits.PTY, top)
+	printTopForResource("open files", "files", limits.Files, top)
+	printTopForResource("processes", "procs", limits.Procs, top)
+	printTopForResource("processes/uid", "procs_per_uid", limits.ProcsPerUID, top)
+}
+
+func printTopForResource(label, key string, usage syslimits.ResourceUsage, top syslimits.TopHolders) {
+	if !usage.Warn && !usage.Critical {
+		return
+	}
+	rows := top[key]
+	if len(rows) == 0 {
+		return
+	}
+	state := "WARN"
+	if usage.Critical {
+		state = "CRITICAL"
+	}
+	fmt.Printf("\nRESOURCE: %s (%d/%d, %s)\n", label, usage.Current, usage.Limit, state)
+	fmt.Printf("  %-7s  %-7s  %s\n", "PID", "COUNT", "COMMAND")
+	for _, row := range rows {
+		fmt.Printf("  %-7d  %-7d  %s\n", row.PID, row.Count, truncate(row.Command, 48))
+	}
+}

--- a/docs/inspection/system-limits.md
+++ b/docs/inspection/system-limits.md
@@ -1,0 +1,69 @@
+# System limits
+
+System limits explain machine-wide failures that surface in one unlucky app.
+When `forkpty()`, `posix_spawn()`, or `open()` starts failing, the terminal,
+IDE, or shell that reports the error is often only the victim. The culprit is
+usually another long-running process holding too many pseudo-ttys, file
+descriptors, or process slots.
+
+Use:
+
+```bash
+spectra system limits
+spectra system limits --json
+spectra system limits --top
+```
+
+The command reports:
+
+- pty slots from `kern.tty.ptmx_max` plus live `/dev/ptmx` and `/dev/ttys*`
+  descriptor counts
+- system open files from `kern.num_files` and `kern.maxfiles`
+- per-process file cap from `kern.maxfilesperproc`
+- system process cap from `kern.maxproc`
+- per-user process cap from `kern.maxprocperuid`
+
+Rows over 80% are `WARN`; rows over 95% are `CRITICAL`. The command exits
+non-zero when any resource is critical so it can be used from cron, CI, or a
+monitoring wrapper.
+
+## Pty exhaustion
+
+Terminal launch failures are the canonical pty symptom:
+
+```text
+Session Ended
+```
+
+or an empty terminal pane with no shell output. Check limits first:
+
+```bash
+spectra system limits --top
+```
+
+If `pty slots` is critical, the top table points at processes with the highest
+pty descriptor counts. Pair that with the process breakdown:
+
+```bash
+spectra process --deep --fd-breakdown --sort rss
+```
+
+Quit or restart the suspect app, then rerun `spectra system limits`. A drop in
+pty usage confirms that the terminal app was not the root cause.
+
+## macOS quirks
+
+Some macOS versions restrict selected `sysctl` values for non-root users. When
+that happens, Spectra keeps the rest of the report and records the missing
+source under `partial_failures` in JSON output.
+
+`lsof` can also return partial data with a non-zero exit when some processes
+are protected. Spectra still parses any stdout it receives, so unprivileged
+diagnostics remain useful even when system-owned processes are hidden.
+
+## Snapshots
+
+Snapshots include `system_limits`, so `spectra snapshot diff a b` can show when
+limit pressure changed between two captures. This is useful when the machine has
+already recovered and you need to identify whether resource saturation was part
+of the incident.

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -171,6 +171,35 @@ type Dependencies struct {
 }
 ```
 
+## System limits
+
+`spectra system limits --json` and snapshot `system_limits` fields use this
+shape:
+
+```go
+type SystemLimits struct {
+    PTY             ResourceUsage
+    Files           ResourceUsage
+    FilesPerProc    int
+    Procs           ResourceUsage
+    ProcsPerUID     ResourceUsage
+    CollectedAt     time.Time
+    PartialFailures []string
+}
+
+type ResourceUsage struct {
+    Limit    int
+    Current  int
+    Pct      float64
+    Warn     bool
+    Critical bool
+}
+```
+
+JSON field names are `pty`, `files`, `max_files_per_proc`, `procs`,
+`procs_per_uid`, `collected_at`, and `partial_failures`. `Warn` is true above
+80%; `Critical` is true above 95%.
+
 ### SwiftInspection
 
 ```go

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -65,6 +65,7 @@ func Compare(a, b snapshot.Snapshot) Result {
 			diffListeningPorts(a, b),
 			diffVPN(a, b),
 			diffPathDirs(a, b),
+			diffSystemLimits(a, b),
 			diffSysctls(a, b),
 		},
 	}
@@ -339,6 +340,32 @@ func diffSysctls(a, b snapshot.Snapshot) Section {
 		}
 	}
 	return Section{Name: "sysctls", Changes: changes}
+}
+
+func diffSystemLimits(a, b snapshot.Snapshot) Section {
+	type row struct {
+		name string
+		a    float64
+		b    float64
+	}
+	rows := []row{
+		{"pty", a.SystemLimits.PTY.Pct, b.SystemLimits.PTY.Pct},
+		{"files", a.SystemLimits.Files.Pct, b.SystemLimits.Files.Pct},
+		{"procs", a.SystemLimits.Procs.Pct, b.SystemLimits.Procs.Pct},
+		{"procs_per_uid", a.SystemLimits.ProcsPerUID.Pct, b.SystemLimits.ProcsPerUID.Pct},
+	}
+	var changes []Change
+	for _, r := range rows {
+		if fmt.Sprintf("%.1f", r.a) != fmt.Sprintf("%.1f", r.b) {
+			changes = append(changes, Change{
+				Kind:   Changed,
+				Key:    r.name + ":pct",
+				Before: fmt.Sprintf("%.1f", r.a),
+				After:  fmt.Sprintf("%.1f", r.b),
+			})
+		}
+	}
+	return Section{Name: "system_limits", Changes: changes}
 }
 
 // diffActiveRuntimes compares the active version for each language runtime

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/syslimits"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
@@ -262,6 +263,27 @@ func TestDiffSysctls(t *testing.T) {
 	}
 	if hasChange(sec.Changes, Changed, "hw.ncpu") {
 		t.Error("hw.ncpu unchanged, should not appear")
+	}
+}
+
+func TestDiffSystemLimits(t *testing.T) {
+	a := base()
+	b := base()
+	a.SystemLimits.PTY = syslimits.ResourceUsage{Pct: 40}
+	b.SystemLimits.PTY = syslimits.ResourceUsage{Pct: 98}
+	a.SystemLimits.Files = syslimits.ResourceUsage{Pct: 30}
+	b.SystemLimits.Files = syslimits.ResourceUsage{Pct: 30}
+
+	r := Compare(a, b)
+	sec := findSection(r, "system_limits")
+	if sec == nil {
+		t.Fatal("system_limits section missing")
+	}
+	if !hasChange(sec.Changes, Changed, "pty:pct") {
+		t.Fatalf("expected pty pct change, got %+v", sec.Changes)
+	}
+	if hasChange(sec.Changes, Changed, "files:pct") {
+		t.Fatalf("unexpected files pct change: %+v", sec.Changes)
 	}
 }
 

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/storagestate"
 	"github.com/kaeawc/spectra/internal/sysinfo"
+	"github.com/kaeawc/spectra/internal/syslimits"
 	"github.com/kaeawc/spectra/internal/telemetry"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
@@ -32,17 +33,18 @@ const (
 
 // Snapshot is the structured capture of one host at one point in time.
 type Snapshot struct {
-	ID         string               `json:"id"`
-	TakenAt    time.Time            `json:"taken_at"`
-	Kind       Kind                 `json:"kind"`
-	Host       HostInfo             `json:"host"`
-	Apps       []detect.Result      `json:"apps"`
-	Processes  []process.Info       `json:"processes,omitempty"`
-	Toolchains toolchain.Toolchains `json:"toolchains"`
-	Power      sysinfo.PowerState   `json:"power"`
-	Sysctls    map[string]string    `json:"sysctls,omitempty"`
-	Network    netstate.State       `json:"network"`
-	Storage    storagestate.State   `json:"storage"`
+	ID           string                 `json:"id"`
+	TakenAt      time.Time              `json:"taken_at"`
+	Kind         Kind                   `json:"kind"`
+	Host         HostInfo               `json:"host"`
+	Apps         []detect.Result        `json:"apps"`
+	Processes    []process.Info         `json:"processes,omitempty"`
+	Toolchains   toolchain.Toolchains   `json:"toolchains"`
+	Power        sysinfo.PowerState     `json:"power"`
+	SystemLimits syslimits.SystemLimits `json:"system_limits"`
+	Sysctls      map[string]string      `json:"sysctls,omitempty"`
+	Network      netstate.State         `json:"network"`
+	Storage      storagestate.State     `json:"storage"`
 
 	JVMs             []jvm.Info          `json:"jvms,omitempty"`
 	RuntimeTelemetry []telemetry.Process `json:"runtime_telemetry,omitempty"`
@@ -95,6 +97,10 @@ type Options struct {
 	// SysinfoCmdRunner is forwarded to sysinfo collectors (sysctls + power).
 	// Zero value uses the real commands.
 	SysinfoCmdRunner sysinfo.CmdRunner
+
+	// SyslimitsOpts are forwarded to the system limits collector.
+	// Zero value uses production defaults.
+	SyslimitsOpts syslimits.Options
 
 	// NetCmdRunner is forwarded to the network state collector.
 	// Zero value uses the real commands.
@@ -197,6 +203,10 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	}()
 	go func() {
 		defer wg.Done()
+		s.SystemLimits = syslimits.Collect(opts.SyslimitsOpts)
+	}()
+	go func() {
+		defer wg.Done()
 		s.Sysctls = sysinfo.CollectSysctls(siRun)
 	}()
 	go func() {
@@ -243,7 +253,7 @@ func Build(ctx context.Context, opts Options) Snapshot {
 }
 
 func snapshotCollectorCount(opts Options) int {
-	collectors := 5 // host, toolchains, power, sysctls, network
+	collectors := 6 // host, toolchains, power, system limits, sysctls, network
 	if !opts.SkipApps {
 		collectors++
 	}

--- a/internal/syslimits/syslimits.go
+++ b/internal/syslimits/syslimits.go
@@ -1,0 +1,258 @@
+// Package syslimits collects macOS kernel resource limits and current usage.
+package syslimits
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+// CmdRunner abstracts subprocess calls for testability.
+type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// DefaultRunner runs the real command.
+func DefaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// Options configures collection.
+type Options struct {
+	Run CmdRunner
+	UID int
+	Now func() time.Time
+}
+
+// SystemLimits is the kernel resource-limit snapshot.
+type SystemLimits struct {
+	PTY             ResourceUsage `json:"pty"`
+	Files           ResourceUsage `json:"files"`
+	FilesPerProc    int           `json:"max_files_per_proc"`
+	Procs           ResourceUsage `json:"procs"`
+	ProcsPerUID     ResourceUsage `json:"procs_per_uid"`
+	CollectedAt     time.Time     `json:"collected_at"`
+	PartialFailures []string      `json:"partial_failures,omitempty"`
+}
+
+// ResourceUsage is one current-vs-limit measurement.
+type ResourceUsage struct {
+	Limit    int     `json:"limit"`
+	Current  int     `json:"current"`
+	Pct      float64 `json:"pct"`
+	Warn     bool    `json:"warn"`
+	Critical bool    `json:"critical"`
+}
+
+// TopHolder is one process contributing to a saturated resource.
+type TopHolder struct {
+	PID     int    `json:"pid"`
+	Count   int    `json:"count"`
+	Command string `json:"command"`
+}
+
+// TopHolders groups per-resource process attribution.
+type TopHolders map[string][]TopHolder
+
+// Collect gathers resource usage with best-effort fallbacks.
+func Collect(opts Options) SystemLimits {
+	run := opts.Run
+	if run == nil {
+		run = DefaultRunner
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	uid := opts.UID
+	if uid == 0 {
+		uid = os.Getuid()
+	}
+
+	var failures []string
+	intVal := func(key string) int {
+		v, ok := sysctlInt(run, key)
+		if !ok {
+			failures = append(failures, key)
+		}
+		return v
+	}
+
+	ptyCurrent, ok := currentPTYs(run)
+	if !ok {
+		failures = append(failures, "lsof:pty")
+	}
+	procCurrent, ok := processCount(run, "-A")
+	if !ok {
+		failures = append(failures, "ps:procs")
+	}
+	procUIDCurrent, ok := processCount(run, "-u", strconv.Itoa(uid))
+	if !ok {
+		failures = append(failures, "ps:procs_per_uid")
+	}
+
+	return SystemLimits{
+		PTY:             usage(ptyCurrent, intVal("kern.tty.ptmx_max")),
+		Files:           usage(intVal("kern.num_files"), intVal("kern.maxfiles")),
+		FilesPerProc:    intVal("kern.maxfilesperproc"),
+		Procs:           usage(procCurrent, intVal("kern.maxproc")),
+		ProcsPerUID:     usage(procUIDCurrent, intVal("kern.maxprocperuid")),
+		CollectedAt:     now().UTC(),
+		PartialFailures: failures,
+	}
+}
+
+func sysctlInt(run CmdRunner, key string) (int, bool) {
+	out, err := run("sysctl", "-n", key)
+	if err != nil {
+		return 0, false
+	}
+	v, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	return v, err == nil
+}
+
+func currentPTYs(run CmdRunner) (int, bool) {
+	out, err := run("lsof", "-n", "-P", "-d", "^txt")
+	if err != nil && len(out) == 0 {
+		return 0, false
+	}
+	count := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 9 {
+			continue
+		}
+		fd := fields[3]
+		if fd == "" || fd[0] < '0' || fd[0] > '9' {
+			continue
+		}
+		if isPTYPath(strings.Join(fields[8:], " ")) {
+			count++
+		}
+	}
+	return count, true
+}
+
+func processCount(run CmdRunner, args ...string) (int, bool) {
+	fullArgs := append([]string{}, args...)
+	fullArgs = append(fullArgs, "-o", "pid=")
+	out, err := run("ps", fullArgs...)
+	if err != nil {
+		return 0, false
+	}
+	count := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count, true
+}
+
+func usage(current, limit int) ResourceUsage {
+	u := ResourceUsage{Limit: limit, Current: current}
+	if limit > 0 {
+		u.Pct = (float64(current) / float64(limit)) * 100
+	}
+	u.Warn = u.Pct > 80
+	u.Critical = u.Pct > 95
+	return u
+}
+
+// AnyCritical reports whether any resource is above the critical threshold.
+func (s SystemLimits) AnyCritical() bool {
+	return s.PTY.Critical || s.Files.Critical || s.Procs.Critical || s.ProcsPerUID.Critical
+}
+
+// CollectTopHolders returns top process holders for saturated resources.
+func CollectTopHolders(ctx context.Context, limit int, opts process.CollectOptions) TopHolders {
+	if limit <= 0 {
+		limit = 10
+	}
+	opts.Deep = true
+	procs := process.CollectAll(ctx, opts)
+	out := TopHolders{}
+	out["pty"] = topBy(procs, limit, func(p process.Info) int {
+		if p.FDBreakdown == nil {
+			return 0
+		}
+		return p.FDBreakdown.PTY
+	})
+	out["files"] = topBy(procs, limit, func(p process.Info) int { return p.OpenFDs })
+	out["procs"] = topByChildren(procs, limit, -1)
+	out["procs_per_uid"] = topByChildren(procs, limit, os.Getuid())
+	return out
+}
+
+func topBy(procs []process.Info, limit int, count func(process.Info) int) []TopHolder {
+	rows := make([]TopHolder, 0, len(procs))
+	for _, p := range procs {
+		c := count(p)
+		if c <= 0 {
+			continue
+		}
+		rows = append(rows, TopHolder{PID: p.PID, Count: c, Command: p.Command})
+	}
+	sortTop(rows)
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows
+}
+
+func topByChildren(procs []process.Info, limit int, uid int) []TopHolder {
+	parents := make(map[int]TopHolder)
+	names := make(map[int]string)
+	for _, p := range procs {
+		names[p.PID] = p.Command
+	}
+	for _, p := range procs {
+		if uid >= 0 && p.UID != uid {
+			continue
+		}
+		if p.PPID <= 0 {
+			continue
+		}
+		h := parents[p.PPID]
+		h.PID = p.PPID
+		h.Count++
+		h.Command = names[p.PPID]
+		parents[p.PPID] = h
+	}
+	rows := make([]TopHolder, 0, len(parents))
+	for _, h := range parents {
+		if h.Command == "" {
+			h.Command = "pid " + strconv.Itoa(h.PID)
+		}
+		rows = append(rows, h)
+	}
+	sortTop(rows)
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows
+}
+
+func sortTop(rows []TopHolder) {
+	for i := 1; i < len(rows); i++ {
+		for j := i; j > 0 && lessTop(rows[j], rows[j-1]); j-- {
+			rows[j], rows[j-1] = rows[j-1], rows[j]
+		}
+	}
+}
+
+func lessTop(a, b TopHolder) bool {
+	if a.Count != b.Count {
+		return a.Count > b.Count
+	}
+	return a.PID < b.PID
+}
+
+func isPTYPath(name string) bool {
+	return strings.HasPrefix(name, "/dev/ttys") ||
+		strings.HasPrefix(name, "/dev/pty") ||
+		name == "/dev/ptmx"
+}

--- a/internal/syslimits/syslimits_test.go
+++ b/internal/syslimits/syslimits_test.go
@@ -1,0 +1,128 @@
+package syslimits
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCollectHealthyMachine(t *testing.T) {
+	got := Collect(Options{
+		Run: stubRunner(map[string]string{
+			"sysctl -n kern.tty.ptmx_max":    "128\n",
+			"sysctl -n kern.num_files":       "100\n",
+			"sysctl -n kern.maxfiles":        "1000\n",
+			"sysctl -n kern.maxfilesperproc": "256\n",
+			"sysctl -n kern.maxproc":         "2048\n",
+			"sysctl -n kern.maxprocperuid":   "1024\n",
+			"lsof -n -P -d ^txt":             lsofPTYFixture(10),
+			"ps -A -o pid=":                  "1\n2\n3\n4\n",
+			"ps -u 501 -o pid=":              "2\n3\n",
+		}),
+		UID: 501,
+		Now: fixedNow,
+	})
+
+	if got.PTY.Current != 10 || got.PTY.Limit != 128 || got.PTY.Warn || got.PTY.Critical {
+		t.Fatalf("PTY = %+v, want healthy 10/128", got.PTY)
+	}
+	if got.Files.Current != 100 || got.Files.Limit != 1000 || got.FilesPerProc != 256 {
+		t.Fatalf("files = %+v files/proc=%d, want 100/1000 and 256", got.Files, got.FilesPerProc)
+	}
+	if got.Procs.Current != 4 || got.ProcsPerUID.Current != 2 {
+		t.Fatalf("procs = %+v procs/uid = %+v", got.Procs, got.ProcsPerUID)
+	}
+	if !got.CollectedAt.Equal(fixedNow()) {
+		t.Fatalf("CollectedAt = %s, want %s", got.CollectedAt, fixedNow())
+	}
+}
+
+func TestCollectWarnCriticalAndSaturated(t *testing.T) {
+	got := Collect(Options{
+		Run: stubRunner(map[string]string{
+			"sysctl -n kern.tty.ptmx_max":    "100\n",
+			"sysctl -n kern.num_files":       "98\n",
+			"sysctl -n kern.maxfiles":        "100\n",
+			"sysctl -n kern.maxfilesperproc": "256\n",
+			"sysctl -n kern.maxproc":         "100\n",
+			"sysctl -n kern.maxprocperuid":   "100\n",
+			"lsof -n -P -d ^txt":             lsofPTYFixture(85),
+			"ps -A -o pid=":                  numberedLines(120),
+			"ps -u 501 -o pid=":              numberedLines(50),
+		}),
+		UID: 501,
+		Now: fixedNow,
+	})
+
+	if !got.PTY.Warn || got.PTY.Critical {
+		t.Fatalf("PTY = %+v, want warn only", got.PTY)
+	}
+	if !got.Files.Critical {
+		t.Fatalf("Files = %+v, want critical", got.Files)
+	}
+	if got.Procs.Pct != 120 || !got.Procs.Critical {
+		t.Fatalf("Procs = %+v, want saturated critical 120%%", got.Procs)
+	}
+	if got.ProcsPerUID.Warn || got.ProcsPerUID.Critical {
+		t.Fatalf("ProcsPerUID = %+v, want healthy", got.ProcsPerUID)
+	}
+	if !got.AnyCritical() {
+		t.Fatal("AnyCritical = false, want true")
+	}
+}
+
+func TestCollectPartialFailures(t *testing.T) {
+	got := Collect(Options{
+		Run: stubRunner(map[string]string{
+			"sysctl -n kern.tty.ptmx_max":    "100\n",
+			"sysctl -n kern.maxfiles":        "100\n",
+			"sysctl -n kern.maxfilesperproc": "256\n",
+			"sysctl -n kern.maxproc":         "100\n",
+			"sysctl -n kern.maxprocperuid":   "100\n",
+			"lsof -n -P -d ^txt":             "",
+			"ps -A -o pid=":                  "1\n",
+			"ps -u 501 -o pid=":              "1\n",
+		}),
+		UID: 501,
+		Now: fixedNow,
+	})
+
+	want := []string{"kern.num_files"}
+	if !reflect.DeepEqual(got.PartialFailures, want) {
+		t.Fatalf("PartialFailures = %v, want %v", got.PartialFailures, want)
+	}
+}
+
+func stubRunner(responses map[string]string) CmdRunner {
+	return func(name string, args ...string) ([]byte, error) {
+		key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+		out, ok := responses[key]
+		if !ok {
+			return nil, fmt.Errorf("unexpected command: %s", key)
+		}
+		return []byte(out), nil
+	}
+}
+
+func lsofPTYFixture(n int) string {
+	var b strings.Builder
+	b.WriteString("COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n")
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "App 777 alice %du CHR 3,2 0t0 339 /dev/ttys%03d\n", i, i)
+	}
+	return b.String()
+}
+
+func numberedLines(n int) string {
+	var b strings.Builder
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&b, "%d\n", i)
+	}
+	return b.String()
+}
+
+func fixedNow() time.Time {
+	return time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Helpers and XPC: inspection/helpers-and-xpc.md
       - Login items: inspection/login-items.md
       - Running processes: inspection/running-processes.md
+      - System limits: inspection/system-limits.md
       - Power and thermal: inspection/power-thermal.md
       - Python-based apps: inspection/python-apps.md
       - Rust-based apps: inspection/rust-based-apps.md


### PR DESCRIPTION
## Summary
- add `internal/syslimits` for pty, file, process, and per-uid process saturation
- add `spectra system limits` with JSON output, critical exit status, and optional top-holder attribution
- include `system_limits` in snapshots and add a `system_limits` diff section for pct changes
- document the command, snapshot schema, and pty-exhaustion workflow

Stacked on #252.
Closes #248

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`
- `go run ./cmd/spectra system limits`
- `go run ./cmd/spectra system limits --json`

Note: attempted a full `snapshot --no-apps --no-store --json` smoke to inspect `system_limits`, but stopped it because the command was spending time in the normal storage walk; the limits command itself was already validated directly.