### PR TITLE
Stabilize async writer zero queue fallback

### DIFF
--- a/internal/cache/async_writer.go
+++ b/internal/cache/async_writer.go
@@ -57,6 +57,15 @@ func (w *AsyncWriter) Write(key, data []byte) (wroteSync bool) {
 		_ = w.store.Put(key, data)
 		return true
 	}
+	if cap(w.queue) == 0 {
+		if err := w.store.Put(key, data); err != nil {
+			w.Failed.Add(1)
+		} else {
+			w.Completed.Add(1)
+			w.Bytes.Add(int64(len(data)))
+		}
+		return true
+	}
 	job := writeJob{key: key, data: data}
 	select {
 	case w.queue <- job:


### PR DESCRIPTION
## Summary
- make `AsyncWriter.Write` use synchronous fallback directly when queue capacity is zero
- preserves the existing queue-full fallback semantics while removing a race in `TestAsyncWriterQueueFull`

Stacked on #253.

## Validation
- `go test ./internal/cache -count=1`
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`