### PR TITLE
Add terminal spawning playbook

### DIFF
--- a/docs/playbooks/index.md
+++ b/docs/playbooks/index.md
@@ -12,6 +12,7 @@ Use them when the question is operational:
 | Java app is slow or memory-heavy | [JVM memory](jvm-memory.md) |
 | App cannot reach a service or endpoint | [Network failure](network-failure.md) |
 | Disk is filling up or an app is unexpectedly large | [Storage bloat](storage-bloat.md) |
+| Terminal sessions die immediately at launch | [Terminal spawning](terminal-spawning.md) |
 | Another Mac is behaving differently | [Remote triage](remote-triage.md) |
 | Builds or tools differ across machines | [Toolchain drift](toolchain-drift.md) |
 

--- a/docs/playbooks/terminal-spawning.md
+++ b/docs/playbooks/terminal-spawning.md
@@ -1,0 +1,97 @@
+# Terminal spawning
+
+Use this when iTerm2, Terminal.app, VS Code, or an IDE terminal opens an empty
+pane and immediately reports that the session ended. When there is no shell
+output, the shell is often not the culprit. Another process may have exhausted
+pty slots, file descriptors, or per-user process slots.
+
+## Rule out shell startup
+
+Before chasing system limits, confirm the login shell can start outside the
+terminal UI:
+
+```bash
+time zsh -i -l -c true
+```
+
+If this hangs, prints shell errors, or exits non-zero, inspect `~/.zshenv`,
+`~/.zprofile`, `~/.zshrc`, and sourced files first. If it succeeds quickly,
+continue to system resources.
+
+## Check system limits
+
+Start with the machine-wide view:
+
+```bash
+spectra system limits
+spectra system limits --top
+```
+
+Read the critical row first:
+
+| Signal | Meaning |
+|---|---|
+| `pty slots` is `CRITICAL` | A process is holding too many pseudo-ttys |
+| `open files` is `CRITICAL` | New shells may fail to open stdio or libraries |
+| `processes/uid` is `CRITICAL` | A runaway process tree is consuming user process slots |
+
+`--top` shows the processes most likely to explain the saturated resource.
+
+## Find descriptor holders
+
+When ptys or files are high, inspect live descriptor classes:
+
+```bash
+spectra process --deep --fd-breakdown --sort rss
+spectra process --deep --json
+```
+
+Look for a process with a high `PTY` count outside the terminal app itself.
+Electron, Chromium, IDE, and chat apps can run many helpers, but they should
+not hold dozens of ptys unless they are actively hosting terminal sessions.
+
+## Inspect the suspect
+
+Use the suspect app path from the process table:
+
+```bash
+spectra -v /Applications/Claude.app
+spectra connect local process-tree /Applications/Claude.app
+spectra snapshot --baseline terminal-spawning-before
+```
+
+The app inspection confirms helper count, uptime, and live process ownership.
+The process tree shows whether one parent is repeatedly spawning children. The
+baseline gives you a before state to compare after remediation.
+
+## Confirm recovery
+
+Quit or restart the suspect app, then rerun:
+
+```bash
+spectra system limits
+spectra diff baseline terminal-spawning-before live
+```
+
+If the critical resource drops below `WARN` and terminal sessions launch again,
+the restarted app was holding the exhausted resource. If pressure remains high,
+continue down the top-holder list or inspect processes owned by another user or
+the system.
+
+## Worked example
+
+A terminal pane opens and immediately exits. `time zsh -i -l -c true` succeeds,
+so shell startup is clean. `spectra system limits --top` reports `pty slots` as
+critical and lists a long-running Electron helper as the top pty holder.
+`spectra process --deep --fd-breakdown --sort rss` confirms that helper has a
+large `PTY` count while iTerm2 has only the expected active sessions.
+
+After saving a baseline, quitting the Electron app drops pty usage back below
+the warning threshold. A new terminal session starts normally, and `spectra diff
+baseline terminal-spawning-before live` preserves the before/after evidence.
+
+## References
+
+- [System limits](../inspection/system-limits.md)
+- [Process profiling](../inspection/process-profiling.md)
+- [Helpers and XPC](../inspection/helpers-and-xpc.md)

--- a/internal/playbook/defaults.go
+++ b/internal/playbook/defaults.go
@@ -5,6 +5,7 @@ func defaultPlaybooks() []Playbook {
 		jvmMemory(),
 		networkFailure(),
 		storageBloat(),
+		terminalSpawning(),
 		remoteTriage(),
 		toolchainDrift(),
 	}
@@ -164,6 +165,77 @@ func storageBloat() Playbook {
 			{Title: "Storage footprint", Path: "docs/inspection/storage-footprint.md"},
 			{Title: "Storage design", Path: "docs/design/storage.md"},
 			{Title: "CLI storage commands", Path: "docs/operations/cli.md"},
+		},
+	}
+}
+
+func terminalSpawning() Playbook {
+	return Playbook{
+		ID:          "terminal-spawning",
+		Title:       "Terminal sessions die at launch",
+		Symptom:     "iTerm2, Terminal.app, VS Code, or another terminal app reports Session Ended immediately after spawning a shell, with no shell output.",
+		Description: "Diagnose the system-wide resource that is exhausted, then identify which process or app is holding it.",
+		Steps: []Step{
+			{
+				ID:      "system-limits",
+				Title:   "Check system resource saturation",
+				Purpose: "Identify whether ptys, file descriptors, or process slots are exhausted.",
+				Commands: []Command{
+					{Args: []string{"system", "limits"}, Description: "Show pty, file, and process usage against kernel limits"},
+					{Args: []string{"system", "limits", "--top"}, Description: "Show top holders for saturated resources"},
+					{Args: []string{"system", "limits", "--json"}, Description: "Emit limit state as JSON for sharing or automation"},
+				},
+				Signals: []Signal{
+					{Name: "pty slots CRITICAL", Meaning: "A process is holding too many pseudo-ttys; top pty holders are suspect."},
+					{Name: "open files CRITICAL", Meaning: "FD exhaustion can prevent new shells from opening stdin, stdout, or stderr."},
+					{Name: "processes/uid CRITICAL", Meaning: "The user process cap is saturated by a runaway child-process fleet."},
+				},
+			},
+			{
+				ID:      "fd-breakdown",
+				Title:   "Find descriptor holders",
+				Purpose: "Rank live processes by descriptor type and identify pty-heavy helpers.",
+				Commands: []Command{
+					{Args: []string{"process", "--deep", "--fd-breakdown", "--sort", "rss"}, Description: "Show per-process pty, socket, file, pipe, char, and kqueue counts"},
+					{Args: []string{"process", "--deep", "--json"}, Description: "Emit process rows with fd_breakdown for jq filtering"},
+				},
+				Signals: []Signal{
+					{Name: "High PTY count outside terminal app", Meaning: "The terminal is likely the victim; inspect the pty holder."},
+					{Name: "High FD count with low PTY count", Meaning: "The incident may be file/socket exhaustion rather than pty exhaustion."},
+				},
+			},
+			{
+				ID:      "suspect-app",
+				Title:   "Inspect the suspect app",
+				Purpose: "Confirm helper sprawl, uptime, and app-scoped process ownership.",
+				Commands: []Command{
+					{Args: []string{"-v", "<suspect-app-path>"}, Description: "Inspect the suspect app with helper count, running processes, and storage context"},
+					{Args: []string{"connect", "local", "process-tree", "<suspect-app-path>"}, Description: "Show the app-scoped process tree"},
+					{Args: []string{"snapshot", "--baseline", "terminal-spawning-before"}, Description: "Capture the current state before remediation"},
+				},
+				Signals: []Signal{
+					{Name: "Unexpected helper count", Meaning: "An Electron, Chromium, or IDE helper may be leaking resources."},
+					{Name: "Long uptime plus high descriptor count", Meaning: "Restarting the app is a useful confirmation step."},
+				},
+			},
+			{
+				ID:      "confirm-recovery",
+				Title:   "Confirm recovery",
+				Purpose: "Verify resource pressure drops and preserve a before/after record.",
+				Commands: []Command{
+					{Args: []string{"system", "limits"}, Description: "Recheck resource usage after quitting or restarting the suspect app"},
+					{Args: []string{"diff", "baseline", "terminal-spawning-before", "live"}, Description: "Compare the before snapshot with live state"},
+				},
+				Signals: []Signal{
+					{Name: "Usage drops below WARN", Meaning: "The restarted app was holding the exhausted resource."},
+					{Name: "Usage remains CRITICAL", Meaning: "Continue down the top-holder list or check another user/system process."},
+				},
+			},
+		},
+		References: []Reference{
+			{Title: "System limits", Path: "docs/inspection/system-limits.md"},
+			{Title: "Process profiling", Path: "docs/inspection/process-profiling.md"},
+			{Title: "Helpers and XPC", Path: "docs/inspection/helpers-and-xpc.md"},
 		},
 	}
 }

--- a/internal/playbook/playbook_test.go
+++ b/internal/playbook/playbook_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestDefaultCatalogContainsExpectedPlaybooks(t *testing.T) {
 	c := MustDefaultCatalog()
-	want := []string{"jvm-memory", "network-failure", "remote-triage", "storage-bloat", "toolchain-drift"}
+	want := []string{"jvm-memory", "network-failure", "remote-triage", "storage-bloat", "terminal-spawning", "toolchain-drift"}
 	got := c.List()
 	if len(got) != len(want) {
 		t.Fatalf("len = %d, want %d", len(got), len(want))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - JVM memory: playbooks/jvm-memory.md
       - Network failure: playbooks/network-failure.md
       - Storage bloat: playbooks/storage-bloat.md
+      - Terminal spawning: playbooks/terminal-spawning.md
       - Remote triage: playbooks/remote-triage.md
       - Toolchain drift: playbooks/toolchain-drift.md
   - Operations:


### PR DESCRIPTION
## Summary
- add `terminal-spawning` to the default playbook catalog
- include system-limit, FD-breakdown, suspect-app, and recovery confirmation steps
- add playbook documentation and mkdocs nav/index entries

Stacked on #254.
Closes #249

## Validation
- `go run ./cmd/spectra playbook terminal-spawning`
- `go run ./cmd/spectra playbook --commands terminal-spawning`
- `go run ./cmd/spectra playbook --json terminal-spawning | jq -e ...`
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `make docs-validate`