### PR TITLE
Add shared plist reader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.3
 require (
 	github.com/google/cel-go v0.28.1
 	gopkg.in/yaml.v3 v3.0.1
+	howett.net/plist v1.0.0
 	modernc.org/sqlite v1.50.1
 	tailscale.com v1.98.2
 )

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2 h1:9K06NfxkBh25x
 github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2/go.mod h1:3A9PQ1cunSDF/1rbTq99Ts4pVnycWg+vlPkfeD2NLFI=
 github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
 github.com/jellydator/ttlcache/v3 v3.1.0/go.mod h1:hi7MGFdMAwZna5n2tuvh63DvFLzVKySzCVW6+0gA2n4=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jsimonetti/rtnetlink v1.4.0 h1:Z1BF0fRgcETPEa0Kt0MRk3yV5+kF1FWTni6KUFKrq2I=
@@ -244,6 +245,7 @@ google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBN
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gvisor.dev/gvisor v0.0.0-20260224225140-573d5e7127a8 h1:Zy8IV/+FMLxy6j6p87vk/vQGKcdnbprwjTxc8UiUtsA=

--- a/internal/plistread/plistread.go
+++ b/internal/plistread/plistread.go
@@ -1,0 +1,326 @@
+// Package plistread provides typed, read-only access to macOS property lists.
+package plistread
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"time"
+
+	"howett.net/plist"
+)
+
+// ErrNeedsFullDiskAccess marks preference reads that macOS commonly denies
+// until the caller's terminal or helper has Full Disk Access.
+var ErrNeedsFullDiskAccess = errors.New("needs full disk access")
+
+// FullDiskAccessRemediation is suitable for surfacing in CLI error output.
+const FullDiskAccessRemediation = "Grant Full Disk Access to your terminal in System Settings -> Privacy & Security -> Full Disk Access."
+
+// Kind is the concrete plist value kind represented by Value.
+type Kind int
+
+const (
+	Invalid Kind = iota
+	String
+	Int
+	Float
+	Bool
+	Date
+	Data
+	Array
+	Dict
+)
+
+// Value is a normalized plist value. Exactly one value field is meaningful,
+// selected by Kind.
+type Value struct {
+	Kind   Kind
+	String string
+	Int    int64
+	Float  float64
+	Bool   bool
+	Date   time.Time
+	Data   []byte
+	Array  []Value
+	Dict   map[string]Value
+}
+
+// Domain is a decoded plist file plus basic file metadata.
+type Domain struct {
+	Path  string
+	Mtime time.Time
+	Size  int64
+	Root  Value
+}
+
+type fileReader interface {
+	Stat(path string) (fs.FileInfo, error)
+	ReadFile(path string) ([]byte, error)
+	Glob(pattern string) ([]string, error)
+}
+
+type osReader struct{}
+
+func (osReader) Stat(path string) (fs.FileInfo, error) { return os.Stat(path) }
+func (osReader) ReadFile(path string) ([]byte, error)  { return os.ReadFile(path) }
+func (osReader) Glob(pattern string) ([]string, error) { return filepath.Glob(pattern) }
+func preferenceRoot() string                           { return "/Library/Preferences" }
+func byHostPreferenceRoot(root string) string          { return filepath.Join(root, "ByHost") }
+func plistPathForDomain(root, domain string) string    { return filepath.Join(root, domain+".plist") }
+func currentHostPattern(root, domain string) string {
+	return filepath.Join(byHostPreferenceRoot(root), domain+".*.plist")
+}
+func domainLooksLikePath(domain string) bool {
+	return filepath.IsAbs(domain) || strings.HasSuffix(domain, ".plist")
+}
+func cleanDomainPath(domain string) string              { return filepath.Clean(domain) }
+func mapPreferenceReadErr(path string, err error) error { return mapReadErr(path, err) }
+func needsFullDiskAccessPath(path string) bool {
+	return strings.HasPrefix(filepath.Clean(path), preferenceRoot()+string(os.PathSeparator))
+}
+
+// ReadPath reads and decodes a plist file.
+func ReadPath(path string) (Domain, error) {
+	return readPathWithReader(path, osReader{})
+}
+
+func readPathWithReader(path string, files fileReader) (Domain, error) {
+	info, err := files.Stat(path)
+	if err != nil {
+		return Domain{}, mapReadErr(path, err)
+	}
+	data, err := files.ReadFile(path)
+	if err != nil {
+		return Domain{}, mapReadErr(path, err)
+	}
+	root, err := decode(data)
+	if err != nil {
+		return Domain{}, fmt.Errorf("decode plist %s: %w", path, err)
+	}
+	return Domain{
+		Path:  path,
+		Mtime: info.ModTime(),
+		Size:  info.Size(),
+		Root:  root,
+	}, nil
+}
+
+// ReadKey reads one top-level or dotted dictionary key from a plist file.
+func ReadKey(path, key string) (Value, error) {
+	d, err := ReadPath(path)
+	if err != nil {
+		return Value{}, err
+	}
+	v, ok := d.Root.Lookup(key)
+	if !ok {
+		return Value{}, fmt.Errorf("plist key %q in %s: %w", key, path, fs.ErrNotExist)
+	}
+	return v, nil
+}
+
+// ResolveDomain returns the standard macOS preference plist path for a domain.
+//
+// Absolute paths and strings ending in ".plist" are returned unchanged. For
+// normal domains, currentHost=false maps to /Library/Preferences/<domain>.plist.
+// currentHost=true resolves the first existing ByHost match when present, then
+// falls back to the unsuffixed ByHost path.
+func ResolveDomain(domain string, currentHost bool) (string, error) {
+	return resolveDomainWithReader(domain, currentHost, osReader{})
+}
+
+func resolveDomainWithReader(domain string, currentHost bool, files fileReader) (string, error) {
+	domain = strings.TrimSpace(domain)
+	if domain == "" {
+		return "", fmt.Errorf("resolve domain: empty domain")
+	}
+	if domainLooksLikePath(domain) {
+		return cleanDomainPath(domain), nil
+	}
+	root := preferenceRoot()
+	if !currentHost {
+		return plistPathForDomain(root, domain), nil
+	}
+	matches, err := files.Glob(currentHostPattern(root, domain))
+	if err != nil {
+		return "", fmt.Errorf("resolve ByHost domain %q: %w", domain, err)
+	}
+	if len(matches) > 0 {
+		return cleanDomainPath(matches[0]), nil
+	}
+	return plistPathForDomain(byHostPreferenceRoot(root), domain), nil
+}
+
+// Lookup returns a dictionary value by dotted path.
+func (v Value) Lookup(path string) (Value, bool) {
+	if path == "" {
+		return v, true
+	}
+	if v.Kind == Dict {
+		if exact, ok := v.Dict[path]; ok {
+			return exact, true
+		}
+	}
+	cur := v
+	for _, part := range strings.Split(path, ".") {
+		if cur.Kind != Dict || part == "" {
+			return Value{}, false
+		}
+		next, ok := cur.Dict[part]
+		if !ok {
+			return Value{}, false
+		}
+		cur = next
+	}
+	return cur, true
+}
+
+// Any converts Value back into ordinary Go plist-shaped data.
+func (v Value) Any() any {
+	switch v.Kind {
+	case String:
+		return v.String
+	case Int:
+		return v.Int
+	case Float:
+		return v.Float
+	case Bool:
+		return v.Bool
+	case Date:
+		return v.Date
+	case Data:
+		return append([]byte(nil), v.Data...)
+	case Array:
+		out := make([]any, 0, len(v.Array))
+		for _, elem := range v.Array {
+			out = append(out, elem.Any())
+		}
+		return out
+	case Dict:
+		out := make(map[string]any, len(v.Dict))
+		for k, elem := range v.Dict {
+			out[k] = elem.Any()
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func decode(data []byte) (Value, error) {
+	var raw any
+	if _, err := plist.Unmarshal(data, &raw); err != nil {
+		return Value{}, err
+	}
+	return valueFromAny(raw)
+}
+
+func valueFromAny(raw any) (Value, error) {
+	if v, ok, err := scalarValueFromAny(raw); ok || err != nil {
+		return v, err
+	}
+	switch v := raw.(type) {
+	case []any:
+		return arrayValue(v)
+	case map[string]any:
+		return stringMapValue(v)
+	case map[any]any:
+		return anyMapValue(v)
+	default:
+		return Value{}, fmt.Errorf("unsupported plist value %T", raw)
+	}
+}
+
+func scalarValueFromAny(raw any) (Value, bool, error) {
+	switch v := raw.(type) {
+	case string:
+		return Value{Kind: String, String: v}, true, nil
+	case bool:
+		return Value{Kind: Bool, Bool: v}, true, nil
+	case time.Time:
+		return Value{Kind: Date, Date: v}, true, nil
+	case []byte:
+		return Value{Kind: Data, Data: append([]byte(nil), v...)}, true, nil
+	}
+	rv := reflect.ValueOf(raw)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return Value{Kind: Int, Int: rv.Int()}, true, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v, err := uintValue(rv.Uint())
+		return v, true, err
+	case reflect.Float32, reflect.Float64:
+		return Value{Kind: Float, Float: rv.Convert(reflect.TypeOf(float64(0))).Float()}, true, nil
+	default:
+		return Value{}, false, nil
+	}
+}
+
+func arrayValue(values []any) (Value, error) {
+	out := make([]Value, 0, len(values))
+	for i, elem := range values {
+		converted, err := valueFromAny(elem)
+		if err != nil {
+			return Value{}, fmt.Errorf("array[%d]: %w", i, err)
+		}
+		out = append(out, converted)
+	}
+	return Value{Kind: Array, Array: out}, nil
+}
+
+func stringMapValue(values map[string]any) (Value, error) {
+	out := make(map[string]Value, len(values))
+	for k, elem := range values {
+		converted, err := valueFromAny(elem)
+		if err != nil {
+			return Value{}, fmt.Errorf("dict[%s]: %w", k, err)
+		}
+		out[k] = converted
+	}
+	return Value{Kind: Dict, Dict: out}, nil
+}
+
+func anyMapValue(values map[any]any) (Value, error) {
+	out := make(map[string]Value, len(values))
+	for k, elem := range values {
+		key, ok := k.(string)
+		if !ok {
+			return Value{}, fmt.Errorf("dict key %T: not a string", k)
+		}
+		converted, err := valueFromAny(elem)
+		if err != nil {
+			return Value{}, fmt.Errorf("dict[%s]: %w", key, err)
+		}
+		out[key] = converted
+	}
+	return Value{Kind: Dict, Dict: out}, nil
+}
+
+func uintValue(v uint64) (Value, error) {
+	if v > math.MaxInt64 {
+		return Value{}, fmt.Errorf("integer %d overflows int64", v)
+	}
+	return Value{Kind: Int, Int: int64(v)}, nil
+}
+
+func mapReadErr(path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if needsFullDiskAccessPath(path) && isPermissionErr(err) {
+		return fmt.Errorf("%s: %w: %w", path, ErrNeedsFullDiskAccess, err)
+	}
+	return err
+}
+
+func isPermissionErr(err error) bool {
+	return errors.Is(err, fs.ErrPermission) ||
+		errors.Is(err, syscall.EACCES) ||
+		errors.Is(err, syscall.EPERM)
+}

--- a/internal/plistread/plistread_test.go
+++ b/internal/plistread/plistread_test.go
@@ -1,0 +1,250 @@
+package plistread
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"syscall"
+	"testing"
+	"time"
+
+	"howett.net/plist"
+)
+
+func TestReadPathXML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sample.plist")
+	created := "2026-05-28T13:38:24Z"
+	data := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Name</key><string>Spectra</string>
+  <key>Count</key><integer>42</integer>
+  <key>Ratio</key><real>1.25</real>
+  <key>Enabled</key><true/>
+  <key>Created</key><date>` + created + `</date>
+  <key>Payload</key><data>AQID</data>
+  <key>Nested</key>
+  <dict><key>Value</key><string>ok</string></dict>
+  <key>Items</key>
+  <array><string>a</string><string>b</string></array>
+</dict>
+</plist>`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := ReadPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Path != path || d.Size == 0 || d.Mtime.IsZero() {
+		t.Fatalf("metadata not populated: %+v", d)
+	}
+	assertLookup(t, d.Root, "Name", Value{Kind: String, String: "Spectra"})
+	assertLookup(t, d.Root, "Count", Value{Kind: Int, Int: 42})
+	assertLookup(t, d.Root, "Ratio", Value{Kind: Float, Float: 1.25})
+	assertLookup(t, d.Root, "Enabled", Value{Kind: Bool, Bool: true})
+	wantDate, _ := time.Parse(time.RFC3339, created)
+	assertLookup(t, d.Root, "Created", Value{Kind: Date, Date: wantDate})
+	assertLookup(t, d.Root, "Payload", Value{Kind: Data, Data: []byte{1, 2, 3}})
+	assertLookup(t, d.Root, "Nested.Value", Value{Kind: String, String: "ok"})
+	gotItems, ok := d.Root.Lookup("Items")
+	if !ok || gotItems.Kind != Array || len(gotItems.Array) != 2 {
+		t.Fatalf("Items = %+v, want two-element array", gotItems)
+	}
+}
+
+func TestReadPathBinary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "binary.plist")
+	data, err := plist.Marshal(map[string]any{
+		"Name":    "Binary",
+		"Enabled": true,
+	}, plist.BinaryFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := ReadPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertLookup(t, d.Root, "Name", Value{Kind: String, String: "Binary"})
+	assertLookup(t, d.Root, "Enabled", Value{Kind: Bool, Bool: true})
+}
+
+func TestReadKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sample.plist")
+	data := `<plist version="1.0"><dict><key>Outer</key><dict><key>Inner</key><string>value</string></dict></dict></plist>`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadKey(path, "Outer.Inner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != String || got.String != "value" {
+		t.Fatalf("ReadKey = %+v, want string value", got)
+	}
+	if _, err := ReadKey(path, "Missing"); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("ReadKey missing err = %v, want fs.ErrNotExist", err)
+	}
+}
+
+func TestLookupPrefersExactDottedKey(t *testing.T) {
+	root := Value{Kind: Dict, Dict: map[string]Value{
+		"com.apple.example": {Kind: String, String: "exact"},
+		"com": {Kind: Dict, Dict: map[string]Value{
+			"apple": {Kind: String, String: "nested"},
+		}},
+	}}
+
+	got, ok := root.Lookup("com.apple.example")
+	if !ok || got.Kind != String || got.String != "exact" {
+		t.Fatalf("Lookup exact dotted key = %+v, %v", got, ok)
+	}
+}
+
+func TestResolveDomain(t *testing.T) {
+	got, err := ResolveDomain("com.apple.TimeMachine", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/Library/Preferences/com.apple.TimeMachine.plist" {
+		t.Fatalf("ResolveDomain = %q", got)
+	}
+	got, err = ResolveDomain("/tmp/example.plist", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/tmp/example.plist" {
+		t.Fatalf("absolute ResolveDomain = %q", got)
+	}
+}
+
+func TestResolveCurrentHostUsesExistingByHostMatch(t *testing.T) {
+	files := fakeReader{
+		glob: []string{"/Library/Preferences/ByHost/com.apple.Spotlight.ABC.plist"},
+	}
+	got, err := resolveDomainWithReader("com.apple.Spotlight", true, files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/Library/Preferences/ByHost/com.apple.Spotlight.ABC.plist" {
+		t.Fatalf("ResolveDomain ByHost = %q", got)
+	}
+}
+
+func TestPreferencePermissionMapsToFullDiskAccess(t *testing.T) {
+	err := mapPreferenceReadErr("/Library/Preferences/com.apple.TimeMachine.plist", syscall.EACCES)
+	if !errors.Is(err, ErrNeedsFullDiskAccess) {
+		t.Fatalf("err = %v, want ErrNeedsFullDiskAccess", err)
+	}
+	err = mapPreferenceReadErr("/tmp/com.apple.TimeMachine.plist", syscall.EACCES)
+	if errors.Is(err, ErrNeedsFullDiskAccess) {
+		t.Fatalf("non-preference err = %v, did not want ErrNeedsFullDiskAccess", err)
+	}
+}
+
+func TestTypedTimeMachinePrefs(t *testing.T) {
+	root := Value{Kind: Dict, Dict: map[string]Value{
+		"AutoBackup":         {Kind: Bool, Bool: true},
+		"PreferencesVersion": {Kind: Int, Int: 5},
+		"RequiresACPower":    {Kind: Bool, Bool: true},
+		"SkipPaths": {Kind: Array, Array: []Value{
+			{Kind: String, String: "/tmp/skip"},
+		}},
+		"Destinations": {Kind: Array, Array: []Value{
+			{Kind: Dict, Dict: map[string]Value{
+				"Name": {Kind: String, String: "Backup"},
+				"ID":   {Kind: Int, Int: 7},
+			}},
+		}},
+	}}
+
+	got := timeMachinePrefsFromValue(root)
+	if !got.AutoBackup || !got.RequiresACPower || got.PreferencesVersion != 5 {
+		t.Fatalf("prefs booleans/version = %+v", got)
+	}
+	if !reflect.DeepEqual(got.SkipPaths, []string{"/tmp/skip"}) {
+		t.Fatalf("SkipPaths = %#v", got.SkipPaths)
+	}
+	if len(got.Destinations) != 1 || got.Destinations[0]["Name"] != "Backup" || got.Destinations[0]["ID"] != int64(7) {
+		t.Fatalf("Destinations = %#v", got.Destinations)
+	}
+}
+
+func TestTypedSoftwareUpdateAndSpotlightPrefs(t *testing.T) {
+	now := time.Date(2026, 5, 28, 13, 38, 24, 0, time.UTC)
+	suRoot := Value{Kind: Dict, Dict: map[string]Value{
+		"AutomaticCheckEnabled":                  {Kind: Bool, Bool: true},
+		"AutomaticDownload":                      {Kind: Bool, Bool: true},
+		"AutomaticallyInstallMacOSUpdates":       {Kind: Bool, Bool: false},
+		"ConfigDataInstall":                      {Kind: Bool, Bool: true},
+		"CriticalUpdateInstall":                  {Kind: Bool, Bool: true},
+		"LastAttemptSystemVersion":               {Kind: String, String: "15.6.1"},
+		"LastRecommendedMajorOSBundleIdentifier": {Kind: String, String: "com.apple.InstallAssistant.macOS"},
+		"LastSuccessfulDate":                     {Kind: Date, Date: now},
+		"LastRecommendedUpdatesAvailable":        {Kind: Int, Int: 2},
+		"PrimaryLanguages": {Kind: Array, Array: []Value{
+			{Kind: String, String: "en-US"},
+		}},
+	}}
+	su := softwareUpdatePrefsFromValue(suRoot)
+	if !su.AutomaticCheckEnabled || !su.AutomaticDownload || su.AutomaticallyInstallMacOSUpdates {
+		t.Fatalf("software update booleans = %+v", su)
+	}
+	if su.LastAttemptSystemVersion != "15.6.1" || su.LastRecommendedMajorOSBundleID == "" || !su.LastSuccessfulDate.Equal(now) {
+		t.Fatalf("software update fields = %+v", su)
+	}
+	if su.LastRecommendedUpdatesAvailable != 2 || !reflect.DeepEqual(su.PrimaryLanguages, []string{"en-US"}) {
+		t.Fatalf("software update slices/count = %+v", su)
+	}
+
+	spotRoot := Value{Kind: Dict, Dict: map[string]Value{
+		"IndexingEnabled": {Kind: Bool, Bool: true},
+		"MenuItemHidden":  {Kind: Bool, Bool: true},
+		"StoresDisabled":  {Kind: Bool, Bool: false},
+		"Exclusions": {Kind: Array, Array: []Value{
+			{Kind: String, String: "/Volumes/Build"},
+		}},
+		"Volumes": {Kind: Array, Array: []Value{
+			{Kind: String, String: "/"},
+		}},
+	}}
+	spot := spotlightPrefsFromValue(spotRoot)
+	if !spot.IndexingEnabled || !spot.MenuItemHidden || spot.StoresDisabled {
+		t.Fatalf("spotlight booleans = %+v", spot)
+	}
+	if !reflect.DeepEqual(spot.Exclusions, []string{"/Volumes/Build"}) || !reflect.DeepEqual(spot.Volumes, []string{"/"}) {
+		t.Fatalf("spotlight paths = %+v", spot)
+	}
+}
+
+func assertLookup(t *testing.T, root Value, key string, want Value) {
+	t.Helper()
+	got, ok := root.Lookup(key)
+	if !ok {
+		t.Fatalf("Lookup(%q) missing", key)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Lookup(%q) = %#v, want %#v", key, got, want)
+	}
+}
+
+type fakeReader struct {
+	glob []string
+}
+
+func (f fakeReader) Stat(string) (fs.FileInfo, error) { return nil, fs.ErrNotExist }
+func (f fakeReader) ReadFile(string) ([]byte, error)  { return nil, fs.ErrNotExist }
+func (f fakeReader) Glob(string) ([]string, error)    { return f.glob, nil }

--- a/internal/plistread/prefs.go
+++ b/internal/plistread/prefs.go
@@ -1,0 +1,192 @@
+package plistread
+
+import "time"
+
+// TMPrefs is the subset of Time Machine preferences Spectra collectors need.
+type TMPrefs struct {
+	AutoBackup         bool
+	Destinations       []map[string]any
+	SkipPaths          []string
+	RequiresACPower    bool
+	PreferencesVersion int
+}
+
+// SoftwareUpdatePrefs is the stable subset of software update preferences.
+type SoftwareUpdatePrefs struct {
+	AutomaticCheckEnabled            bool
+	AutomaticDownload                bool
+	AutomaticallyInstallMacOSUpdates bool
+	ConfigDataInstall                bool
+	CriticalUpdateInstall            bool
+	LastAttemptSystemVersion         string
+	LastRecommendedMajorOSBundleID   string
+	LastSuccessfulDate               time.Time
+	LastFullSuccessfulDate           time.Time
+	LastRecommendedUpdatesAvailable  int
+	RecommendedUpdates               []map[string]any
+	PrimaryLanguages                 []string
+	PreferencesVersion               int
+}
+
+// SpotlightPrefs is the subset of Spotlight preferences useful to storage and
+// indexing collectors.
+type SpotlightPrefs struct {
+	IndexingEnabled    bool
+	MenuItemHidden     bool
+	StoresDisabled     bool
+	OrderedItems       []map[string]any
+	Exclusions         []string
+	Volumes            []string
+	PreferencesVersion int
+}
+
+// ReadTimeMachinePrefs reads /Library/Preferences/com.apple.TimeMachine.plist.
+func ReadTimeMachinePrefs() (TMPrefs, error) {
+	path, err := ResolveDomain("com.apple.TimeMachine", false)
+	if err != nil {
+		return TMPrefs{}, err
+	}
+	d, err := ReadPath(path)
+	if err != nil {
+		return TMPrefs{}, err
+	}
+	return timeMachinePrefsFromValue(d.Root), nil
+}
+
+// ReadSoftwareUpdatePrefs reads
+// /Library/Preferences/com.apple.SoftwareUpdate.plist.
+func ReadSoftwareUpdatePrefs() (SoftwareUpdatePrefs, error) {
+	path, err := ResolveDomain("com.apple.SoftwareUpdate", false)
+	if err != nil {
+		return SoftwareUpdatePrefs{}, err
+	}
+	d, err := ReadPath(path)
+	if err != nil {
+		return SoftwareUpdatePrefs{}, err
+	}
+	return softwareUpdatePrefsFromValue(d.Root), nil
+}
+
+// ReadSpotlightPrefs reads /Library/Preferences/com.apple.Spotlight.plist.
+func ReadSpotlightPrefs() (SpotlightPrefs, error) {
+	path, err := ResolveDomain("com.apple.Spotlight", false)
+	if err != nil {
+		return SpotlightPrefs{}, err
+	}
+	d, err := ReadPath(path)
+	if err != nil {
+		return SpotlightPrefs{}, err
+	}
+	return spotlightPrefsFromValue(d.Root), nil
+}
+
+func timeMachinePrefsFromValue(root Value) TMPrefs {
+	return TMPrefs{
+		AutoBackup:         boolKey(root, "AutoBackup", "AutoBackupEnabled"),
+		Destinations:       dictArrayKey(root, "Destinations"),
+		SkipPaths:          stringArrayKey(root, "SkipPaths", "ExcludeByPath", "ExcludedPaths"),
+		RequiresACPower:    boolKey(root, "RequiresACPower"),
+		PreferencesVersion: intKey(root, "PreferencesVersion"),
+	}
+}
+
+func softwareUpdatePrefsFromValue(root Value) SoftwareUpdatePrefs {
+	return SoftwareUpdatePrefs{
+		AutomaticCheckEnabled:            boolKey(root, "AutomaticCheckEnabled"),
+		AutomaticDownload:                boolKey(root, "AutomaticDownload"),
+		AutomaticallyInstallMacOSUpdates: boolKey(root, "AutomaticallyInstallMacOSUpdates"),
+		ConfigDataInstall:                boolKey(root, "ConfigDataInstall"),
+		CriticalUpdateInstall:            boolKey(root, "CriticalUpdateInstall"),
+		LastAttemptSystemVersion:         stringKey(root, "LastAttemptSystemVersion"),
+		LastRecommendedMajorOSBundleID:   stringKey(root, "LastRecommendedMajorOSBundleIdentifier"),
+		LastSuccessfulDate:               dateKey(root, "LastSuccessfulDate", "LastSuccessfulDateCheck"),
+		LastFullSuccessfulDate:           dateKey(root, "LastFullSuccessfulDate", "LastFullSuccessfulDateCheck"),
+		LastRecommendedUpdatesAvailable:  intKey(root, "LastRecommendedUpdatesAvailable"),
+		RecommendedUpdates:               dictArrayKey(root, "RecommendedUpdates"),
+		PrimaryLanguages:                 stringArrayKey(root, "PrimaryLanguages"),
+		PreferencesVersion:               intKey(root, "PreferencesVersion"),
+	}
+}
+
+func spotlightPrefsFromValue(root Value) SpotlightPrefs {
+	return SpotlightPrefs{
+		IndexingEnabled:    boolKey(root, "IndexingEnabled", "Enabled"),
+		MenuItemHidden:     boolKey(root, "MenuItemHidden"),
+		StoresDisabled:     boolKey(root, "StoresDisabled"),
+		OrderedItems:       dictArrayKey(root, "orderedItems", "OrderedItems"),
+		Exclusions:         stringArrayKey(root, "Exclusions", "PrivacyExclusions"),
+		Volumes:            stringArrayKey(root, "Volumes"),
+		PreferencesVersion: intKey(root, "PreferencesVersion"),
+	}
+}
+
+func firstKey(root Value, keys ...string) (Value, bool) {
+	for _, key := range keys {
+		if v, ok := root.Lookup(key); ok {
+			return v, true
+		}
+	}
+	return Value{}, false
+}
+
+func boolKey(root Value, keys ...string) bool {
+	v, ok := firstKey(root, keys...)
+	return ok && v.Kind == Bool && v.Bool
+}
+
+func stringKey(root Value, keys ...string) string {
+	v, ok := firstKey(root, keys...)
+	if !ok || v.Kind != String {
+		return ""
+	}
+	return v.String
+}
+
+func intKey(root Value, keys ...string) int {
+	v, ok := firstKey(root, keys...)
+	if !ok || v.Kind != Int {
+		return 0
+	}
+	return int(v.Int)
+}
+
+func dateKey(root Value, keys ...string) time.Time {
+	v, ok := firstKey(root, keys...)
+	if !ok || v.Kind != Date {
+		return time.Time{}
+	}
+	return v.Date
+}
+
+func stringArrayKey(root Value, keys ...string) []string {
+	v, ok := firstKey(root, keys...)
+	if !ok || v.Kind != Array {
+		return nil
+	}
+	out := make([]string, 0, len(v.Array))
+	for _, elem := range v.Array {
+		if elem.Kind == String {
+			out = append(out, elem.String)
+		}
+	}
+	return out
+}
+
+func dictArrayKey(root Value, keys ...string) []map[string]any {
+	v, ok := firstKey(root, keys...)
+	if !ok || v.Kind != Array {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(v.Array))
+	for _, elem := range v.Array {
+		if elem.Kind != Dict {
+			continue
+		}
+		m := make(map[string]any, len(elem.Dict))
+		for k, child := range elem.Dict {
+			m[k] = child.Any()
+		}
+		out = append(out, m)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #269

## Summary
- add internal/plistread with XML/binary plist decoding into normalized Value trees
- add domain resolution, ReadPath/ReadKey, and Full Disk Access permission sentinel/remediation text
- add typed Time Machine, Software Update, and Spotlight preference helpers

## Validation
- go test ./internal/plistread -count=1
- go build ./... && go vet ./...
- go test ./... -count=1