### PR TITLE
Add memory state collector

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -42,6 +42,7 @@ func subcommandList() []subcommand {
 		{"network", "Show current network state (routes, DNS, VPN, proxy, listening ports)", runNetwork},
 		{"power", "Show current battery and thermal state", runPower},
 		{"impact", "Compute the documented per-pid energy impact score from delta records", runImpact},
+		{"memory", "Show VM compressor, swap, and pressure state", runMemory},
 		{"storage", "Show disk volumes and ~/Library footprint", runStorage},
 		{"system", "Show system resource limits and saturation", runSystem},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},

--- a/cmd/spectra/memory.go
+++ b/cmd/spectra/memory.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/memstate"
+)
+
+func runMemory(args []string) int {
+	fs := flag.NewFlagSet("spectra memory", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	watch := fs.String("watch", "", "Repeat every interval (for example: 1, 1s, 5s)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	interval, err := parseMemoryWatch(*watch)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if interval > 0 {
+		return runMemoryWatch(interval, *asJSON)
+	}
+	state, err := memstate.Collect()
+	if err != nil {
+		return printMemoryErr(err)
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(state)
+		return 0
+	}
+	printMemoryState(state, memstate.MemoryState{})
+	return 0
+}
+
+func runMemoryWatch(interval time.Duration, asJSON bool) int {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	var prev memstate.MemoryState
+	for {
+		state, err := memstate.Collect()
+		if err != nil {
+			return printMemoryErr(err)
+		}
+		if asJSON {
+			_ = json.NewEncoder(os.Stdout).Encode(state)
+		} else {
+			printMemoryState(state, prev)
+		}
+		prev = state
+		<-t.C
+	}
+}
+
+func parseMemoryWatch(value string) (time.Duration, error) {
+	if value == "" {
+		return 0, nil
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0, fmt.Errorf("--watch must be positive")
+		}
+		return time.Duration(seconds) * time.Second, nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --watch: %w", err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("--watch must be positive")
+	}
+	return d, nil
+}
+
+func printMemoryErr(err error) int {
+	if errors.Is(err, memstate.ErrNotSupported) {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Fprintln(os.Stderr, err)
+	return 1
+}
+
+func printMemoryState(s, prev memstate.MemoryState) {
+	parts := []string{
+		"phys=" + memoryBytes(s.PhysicalBytes),
+		"wired=" + memoryBytes(s.Wired),
+		"app=" + memoryBytes(s.Anonymous),
+		fmt.Sprintf("compressed=%s(stored=%s ratio=%.1fx)",
+			memoryBytes(s.CompressorOccupied),
+			memoryBytes(s.CompressorStored),
+			s.CompressorRatio,
+		),
+		"swap=" + memoryBytes(s.Swap.UsedBytes),
+		"pressure=" + string(s.PressureLevel),
+		fmt.Sprintf("free=%.0f%%", s.PressureFreePercent),
+	}
+	if !prev.CollectedAt.IsZero() {
+		elapsed := s.CollectedAt.Sub(prev.CollectedAt).Seconds()
+		if elapsed > 0 {
+			parts = append(parts,
+				fmt.Sprintf("compressions/s=%.0f", rate(s.Compressions, prev.Compressions, elapsed)),
+				fmt.Sprintf("swapouts/s=%.0f", rate(s.SwapOuts, prev.SwapOuts, elapsed)),
+			)
+		}
+	}
+	fmt.Println(strings.Join(parts, "  "))
+}
+
+func rate(current, previous uint64, seconds float64) float64 {
+	if current < previous {
+		return 0
+	}
+	return float64(current-previous) / seconds
+}
+
+func memoryBytes(n uint64) string {
+	const k uint64 = 1024
+	switch {
+	case n >= k*k*k:
+		return fmt.Sprintf("%.1fGB", float64(n)/float64(k*k*k))
+	case n >= k*k:
+		return fmt.Sprintf("%.0fMB", float64(n)/float64(k*k))
+	case n >= k:
+		return fmt.Sprintf("%.0fKB", float64(n)/float64(k))
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}

--- a/cmd/spectra/memory_test.go
+++ b/cmd/spectra/memory_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseMemoryWatch(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"1", time.Second},
+		{"5s", 5 * time.Second},
+		{"1m30s", 90 * time.Second},
+	}
+	for _, tc := range cases {
+		got, err := parseMemoryWatch(tc.in)
+		if err != nil {
+			t.Fatalf("parseMemoryWatch(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("parseMemoryWatch(%q) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseMemoryWatchRejectsNonPositive(t *testing.T) {
+	for _, in := range []string{"0", "-1s"} {
+		if _, err := parseMemoryWatch(in); err == nil {
+			t.Fatalf("parseMemoryWatch(%q) succeeded, want error", in)
+		}
+	}
+}
+
+func TestMemoryRate(t *testing.T) {
+	if got := rate(30, 10, 2); got != 10 {
+		t.Fatalf("rate = %.1f, want 10", got)
+	}
+	if got := rate(10, 30, 2); got != 0 {
+		t.Fatalf("counter reset rate = %.1f, want 0", got)
+	}
+}

--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/diff"
+	"github.com/kaeawc/spectra/internal/memstate"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/store"
 	"github.com/kaeawc/spectra/internal/toolchain"
@@ -303,6 +304,10 @@ func printSnapshot(s snapshot.Snapshot) {
 	fmt.Printf("taken-at:       %s\n", s.TakenAt.Format("2006-01-02T15:04:05Z07:00"))
 	fmt.Println()
 	fmt.Print(s.Host.String())
+	if !s.Host.Memory.CollectedAt.IsZero() {
+		fmt.Print("memory:         ")
+		printMemoryState(s.Host.Memory, memstate.MemoryState{})
+	}
 
 	if len(s.Apps) > 0 {
 		fmt.Println()

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -85,6 +85,10 @@ func diffHost(a, b snapshot.Snapshot) Section {
 		{"cpu_brand", a.Host.CPUBrand, b.Host.CPUBrand},
 		{"cpu_cores", fmt.Sprint(a.Host.CPUCores), fmt.Sprint(b.Host.CPUCores)},
 		{"ram_bytes", fmt.Sprint(a.Host.RAMBytes), fmt.Sprint(b.Host.RAMBytes)},
+		{"memory.compressor_occupied", fmt.Sprint(a.Host.Memory.CompressorOccupied), fmt.Sprint(b.Host.Memory.CompressorOccupied)},
+		{"memory.compressor_stored", fmt.Sprint(a.Host.Memory.CompressorStored), fmt.Sprint(b.Host.Memory.CompressorStored)},
+		{"memory.swap_used", fmt.Sprint(a.Host.Memory.Swap.UsedBytes), fmt.Sprint(b.Host.Memory.Swap.UsedBytes)},
+		{"memory.pressure_level", string(a.Host.Memory.PressureLevel), string(b.Host.Memory.PressureLevel)},
 		{"arch", a.Host.Architecture, b.Host.Architecture},
 		{"spectra_version", a.Host.SpectraVersion, b.Host.SpectraVersion},
 	}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/memstate"
 	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/syslimits"
@@ -58,6 +59,36 @@ func TestDiffHostChanged(t *testing.T) {
 	}
 	if hasChange(sec.Changes, Changed, "hostname") {
 		t.Error("unexpected hostname change")
+	}
+}
+
+func TestDiffHostMemoryChanged(t *testing.T) {
+	a := base()
+	b := base()
+	a.Host.Memory = memstate.MemoryState{
+		CompressorOccupied: 1024,
+		CompressorStored:   2048,
+		PressureLevel:      memstate.PressureNormal,
+		Swap:               memstate.SwapUsage{UsedBytes: 0},
+	}
+	b.Host.Memory = memstate.MemoryState{
+		CompressorOccupied: 4096,
+		CompressorStored:   8192,
+		PressureLevel:      memstate.PressureWarning,
+		Swap:               memstate.SwapUsage{UsedBytes: 1024},
+	}
+
+	r := Compare(a, b)
+	sec := findSection(r, "host")
+	for _, key := range []string{
+		"memory.compressor_occupied",
+		"memory.compressor_stored",
+		"memory.swap_used",
+		"memory.pressure_level",
+	} {
+		if !hasChange(sec.Changes, Changed, key) {
+			t.Fatalf("expected %s change, got %+v", key, sec.Changes)
+		}
 	}
 }
 

--- a/internal/memstate/memstate_darwin.go
+++ b/internal/memstate/memstate_darwin.go
@@ -1,0 +1,118 @@
+//go:build darwin && cgo
+
+package memstate
+
+/*
+#include <errno.h>
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#include <mach/vm_statistics.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/sysctl.h>
+
+typedef struct {
+	uint64_t total;
+	uint64_t avail;
+	uint64_t used;
+	uint32_t pagesize;
+	bool encrypted;
+} swap_usage_out;
+
+static int read_swap_usage(swap_usage_out *out) {
+	struct xsw_usage xsu;
+	size_t size = sizeof(xsu);
+	if (sysctlbyname("vm.swapusage", &xsu, &size, NULL, 0) != 0) {
+		return errno;
+	}
+	out->total = xsu.xsu_total;
+	out->avail = xsu.xsu_avail;
+	out->used = xsu.xsu_used;
+	out->pagesize = xsu.xsu_pagesize;
+	out->encrypted = xsu.xsu_encrypted;
+	return 0;
+}
+
+static kern_return_t read_vm_statistics(vm_statistics64_data_t *out) {
+	mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+	memset(out, 0, sizeof(*out));
+	return host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)out, &count);
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// Collect gathers current host memory state.
+func Collect() (MemoryState, error) {
+	return CollectWithOptions(Options{})
+}
+
+// CollectWithOptions gathers current host memory state with testable options.
+func CollectWithOptions(opts Options) (MemoryState, error) {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	ms := MemoryState{
+		PageSizeBytes: uint64(syscall.Getpagesize()),
+		CollectedAt:   now().UTC(),
+		PressureLevel: PressureUnknown,
+	}
+	if v, err := unix.SysctlUint64("hw.memsize"); err == nil {
+		ms.PhysicalBytes = v
+	}
+	if err := readSwapUsage(&ms.Swap); err != nil {
+		return ms, err
+	}
+	if err := readVMStat(&ms); err != nil {
+		return ms, err
+	}
+	if v, err := unix.SysctlUint32("kern.memorystatus_vm_pressure_level"); err == nil {
+		ms.PressureLevel = pressureLevel(uint64(v))
+	}
+	return finish(ms), nil
+}
+
+func readSwapUsage(out *SwapUsage) error {
+	var raw C.swap_usage_out
+	if errno := C.read_swap_usage(&raw); errno != 0 {
+		return fmt.Errorf("sysctl vm.swapusage: %w", syscall.Errno(errno))
+	}
+	out.TotalBytes = uint64(raw.total)
+	out.UsedBytes = uint64(raw.used)
+	out.FreeBytes = uint64(raw.avail)
+	out.Encrypted = bool(raw.encrypted)
+	return nil
+}
+
+func readVMStat(ms *MemoryState) error {
+	var raw C.vm_statistics64_data_t
+	if kr := C.read_vm_statistics(&raw); kr != C.KERN_SUCCESS {
+		return fmt.Errorf("host_statistics64: kern_return=%d", int(kr))
+	}
+	page := ms.PageSizeBytes
+	ms.Wired = uint64(raw.wire_count) * page
+	ms.Active = uint64(raw.active_count) * page
+	ms.Inactive = uint64(raw.inactive_count) * page
+	ms.Speculative = uint64(raw.speculative_count) * page
+	ms.Free = uint64(raw.free_count) * page
+	ms.Purgeable = uint64(raw.purgeable_count) * page
+	ms.FileBacked = uint64(raw.external_page_count) * page
+	ms.Anonymous = uint64(raw.internal_page_count) * page
+	ms.CompressorOccupied = uint64(raw.compressor_page_count) * page
+	ms.CompressorStored = uint64(raw.total_uncompressed_pages_in_compressor) * page
+	ms.Compressions = uint64(raw.compressions)
+	ms.Decompressions = uint64(raw.decompressions)
+	ms.SwapIns = uint64(raw.swapins)
+	ms.SwapOuts = uint64(raw.swapouts)
+	return nil
+}

--- a/internal/memstate/memstate_stub.go
+++ b/internal/memstate/memstate_stub.go
@@ -1,0 +1,13 @@
+//go:build !darwin || !cgo
+
+package memstate
+
+// Collect returns ErrNotSupported outside the macOS cgo build.
+func Collect() (MemoryState, error) {
+	return CollectWithOptions(Options{})
+}
+
+// CollectWithOptions returns ErrNotSupported outside the macOS cgo build.
+func CollectWithOptions(Options) (MemoryState, error) {
+	return MemoryState{}, ErrNotSupported
+}

--- a/internal/memstate/memstate_test.go
+++ b/internal/memstate/memstate_test.go
@@ -1,0 +1,85 @@
+package memstate
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestParseVMStat(t *testing.T) {
+	const page = 4096
+	in := `Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages free:                               10.
+Pages active:                             20.
+Pages inactive:                           30.
+Pages speculative:                        40.
+Pages wired down:                         50.
+Pages purgeable:                          60.
+File-backed pages:                        70.
+Anonymous pages:                          80.
+Pages stored in compressor:               90.
+Pages occupied by compressor:             45.
+Compressions:                             1.234.
+Decompressions:                           234.
+Swapins:                                  12.
+Swapouts:                                 34.
+`
+
+	got, err := ParseVMStat(strings.NewReader(in), page, 1024*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Free != 10*page || got.Active != 20*page || got.Inactive != 30*page {
+		t.Fatalf("basic page fields = %+v", got)
+	}
+	if got.Speculative != 40*page || got.Wired != 50*page || got.Purgeable != 60*page {
+		t.Fatalf("wired/speculative/purgeable = %+v", got)
+	}
+	if got.FileBacked != 70*page || got.Anonymous != 80*page {
+		t.Fatalf("file/anonymous = %+v", got)
+	}
+	if got.CompressorStored != 90*page || got.CompressorOccupied != 45*page || got.CompressorRatio != 2 {
+		t.Fatalf("compressor = %+v", got)
+	}
+	if got.Compressions != 1234 || got.Decompressions != 234 || got.SwapIns != 12 || got.SwapOuts != 34 {
+		t.Fatalf("counters = %+v", got)
+	}
+}
+
+func TestParseXSWUsage(t *testing.T) {
+	var buf bytes.Buffer
+	for _, v := range []uint64{100, 40, 60} {
+		if err := binary.Write(&buf, binary.LittleEndian, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := binary.Write(&buf, binary.LittleEndian, uint32(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ParseXSWUsage(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TotalBytes != 100 || got.FreeBytes != 40 || got.UsedBytes != 60 || !got.Encrypted {
+		t.Fatalf("ParseXSWUsage = %+v", got)
+	}
+}
+
+func TestPressureLevel(t *testing.T) {
+	cases := []struct {
+		raw  uint64
+		want PressureLevel
+	}{
+		{1, PressureNormal},
+		{2, PressureWarning},
+		{4, PressureCritical},
+		{99, PressureUnknown},
+	}
+	for _, tc := range cases {
+		if got := pressureLevel(tc.raw); got != tc.want {
+			t.Fatalf("pressureLevel(%d) = %s, want %s", tc.raw, got, tc.want)
+		}
+	}
+}

--- a/internal/memstate/parse.go
+++ b/internal/memstate/parse.go
@@ -1,0 +1,98 @@
+package memstate
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var vmStatLineRE = regexp.MustCompile(`^(.+):\s+([0-9.]+)\.?$`)
+
+// ParseVMStat parses vm_stat(1) output into the fields that overlap
+// host_statistics64. It is used by fixture tests and by humans comparing
+// Spectra samples with vm_stat output.
+func ParseVMStat(r io.Reader, pageSizeBytes, physicalBytes uint64) (MemoryState, error) {
+	ms := MemoryState{
+		PageSizeBytes: pageSizeBytes,
+		PhysicalBytes: physicalBytes,
+		PressureLevel: PressureUnknown,
+	}
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		key, pages, ok := parseVMStatLine(sc.Text())
+		if !ok {
+			continue
+		}
+		applyVMStatPages(&ms, key, pages)
+	}
+	if err := sc.Err(); err != nil {
+		return MemoryState{}, fmt.Errorf("parse vm_stat: %w", err)
+	}
+	return finish(ms), nil
+}
+
+// ParseXSWUsage decodes the stable leading fields of Darwin's xsw_usage
+// sysctl struct from a little-endian fixture.
+func ParseXSWUsage(data []byte) (SwapUsage, error) {
+	if len(data) < 28 {
+		return SwapUsage{}, fmt.Errorf("xsw_usage fixture too short: %d bytes", len(data))
+	}
+	return SwapUsage{
+		TotalBytes: binary.LittleEndian.Uint64(data[0:8]),
+		FreeBytes:  binary.LittleEndian.Uint64(data[8:16]),
+		UsedBytes:  binary.LittleEndian.Uint64(data[16:24]),
+		Encrypted:  binary.LittleEndian.Uint32(data[24:28]) != 0,
+	}, nil
+}
+
+func parseVMStatLine(line string) (string, uint64, bool) {
+	line = strings.TrimSpace(line)
+	m := vmStatLineRE.FindStringSubmatch(line)
+	if len(m) != 3 {
+		return "", 0, false
+	}
+	value := strings.ReplaceAll(m[2], ".", "")
+	pages, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return strings.ToLower(m[1]), pages, true
+}
+
+func applyVMStatPages(ms *MemoryState, key string, pages uint64) {
+	bytes := pages * ms.PageSizeBytes
+	switch key {
+	case "pages free":
+		ms.Free = bytes
+	case "pages active":
+		ms.Active = bytes
+	case "pages inactive":
+		ms.Inactive = bytes
+	case "pages speculative":
+		ms.Speculative = bytes
+	case "pages wired down":
+		ms.Wired = bytes
+	case "pages purgeable":
+		ms.Purgeable = bytes
+	case "file-backed pages":
+		ms.FileBacked = bytes
+	case "anonymous pages":
+		ms.Anonymous = bytes
+	case "pages occupied by compressor":
+		ms.CompressorOccupied = bytes
+	case "pages stored in compressor":
+		ms.CompressorStored = bytes
+	case "compressions":
+		ms.Compressions = pages
+	case "decompressions":
+		ms.Decompressions = pages
+	case "swapins":
+		ms.SwapIns = pages
+	case "swapouts":
+		ms.SwapOuts = pages
+	}
+}

--- a/internal/memstate/types.go
+++ b/internal/memstate/types.go
@@ -1,0 +1,83 @@
+// Package memstate captures host-wide memory pressure, compressor, and swap
+// state on macOS.
+package memstate
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrNotSupported is returned on platforms without the macOS VM APIs.
+var ErrNotSupported = errors.New("memory state collection not supported")
+
+// PressureLevel is the kernel memorystatus pressure classification.
+type PressureLevel string
+
+const (
+	PressureUnknown  PressureLevel = "Unknown"
+	PressureNormal   PressureLevel = "Normal"
+	PressureWarning  PressureLevel = "Warning"
+	PressureCritical PressureLevel = "Critical"
+)
+
+// SwapUsage is the host swap device state.
+type SwapUsage struct {
+	TotalBytes uint64 `json:"total_bytes"`
+	UsedBytes  uint64 `json:"used_bytes"`
+	FreeBytes  uint64 `json:"free_bytes"`
+	Encrypted  bool   `json:"encrypted"`
+}
+
+// MemoryState is one point-in-time host memory sample.
+type MemoryState struct {
+	PhysicalBytes       uint64        `json:"physical_bytes"`
+	PageSizeBytes       uint64        `json:"page_size_bytes"`
+	Wired               uint64        `json:"wired"`
+	Active              uint64        `json:"active"`
+	Inactive            uint64        `json:"inactive"`
+	Speculative         uint64        `json:"speculative"`
+	Free                uint64        `json:"free"`
+	Purgeable           uint64        `json:"purgeable"`
+	FileBacked          uint64        `json:"file_backed"`
+	Anonymous           uint64        `json:"anonymous"`
+	CompressorOccupied  uint64        `json:"compressor_occupied"`
+	CompressorStored    uint64        `json:"compressor_stored"`
+	CompressorRatio     float64       `json:"compressor_ratio"`
+	Swap                SwapUsage     `json:"swap"`
+	PressureLevel       PressureLevel `json:"pressure_level"`
+	PressureFreePercent float64       `json:"pressure_free_percent"`
+	Compressions        uint64        `json:"compressions"`
+	Decompressions      uint64        `json:"decompressions"`
+	SwapIns             uint64        `json:"swap_ins"`
+	SwapOuts            uint64        `json:"swap_outs"`
+	CollectedAt         time.Time     `json:"collected_at"`
+}
+
+// Options configures collection for tests.
+type Options struct {
+	Now func() time.Time
+}
+
+func finish(ms MemoryState) MemoryState {
+	if ms.CompressorOccupied > 0 {
+		ms.CompressorRatio = float64(ms.CompressorStored) / float64(ms.CompressorOccupied)
+	}
+	if ms.PhysicalBytes > 0 {
+		free := ms.Free + ms.Speculative
+		ms.PressureFreePercent = float64(free) / float64(ms.PhysicalBytes) * 100
+	}
+	return ms
+}
+
+func pressureLevel(raw uint64) PressureLevel {
+	switch raw {
+	case 1:
+		return PressureNormal
+	case 2:
+		return PressureWarning
+	case 4:
+		return PressureCritical
+	default:
+		return PressureUnknown
+	}
+}

--- a/internal/snapshot/host.go
+++ b/internal/snapshot/host.go
@@ -17,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/kaeawc/spectra/internal/memstate"
 )
 
 // CommandRunner runs a system command and returns stdout.
@@ -31,9 +33,10 @@ type HostCollector interface {
 
 // HostCollectOptions configures host collection.
 type HostCollectOptions struct {
-	Hostname func() (string, error)
-	Runner   CommandRunner
-	Now      func() time.Time
+	Hostname      func() (string, error)
+	Runner        CommandRunner
+	Now           func() time.Time
+	MemoryCollect func() (memstate.MemoryState, error)
 }
 
 // LiveHostCollector gathers HostInfo from the current machine.
@@ -56,17 +59,18 @@ func (execCommandRunner) Run(name string, args ...string) (string, error) {
 // time. Every field is best-effort; any collector failure leaves the
 // field empty / zero rather than failing the snapshot.
 type HostInfo struct {
-	Hostname       string `json:"hostname"`
-	MachineUUID    string `json:"machine_uuid,omitempty"`
-	OSName         string `json:"os_name"`            // "macOS"
-	OSVersion      string `json:"os_version"`         // "15.6.1"
-	OSBuild        string `json:"os_build,omitempty"` // "24G90"
-	CPUBrand       string `json:"cpu_brand,omitempty"`
-	CPUCores       int    `json:"cpu_cores"`
-	RAMBytes       uint64 `json:"ram_bytes"`
-	Architecture   string `json:"architecture"` // arm64 | amd64
-	UptimeSeconds  int64  `json:"uptime_seconds"`
-	SpectraVersion string `json:"spectra_version,omitempty"`
+	Hostname       string               `json:"hostname"`
+	MachineUUID    string               `json:"machine_uuid,omitempty"`
+	OSName         string               `json:"os_name"`            // "macOS"
+	OSVersion      string               `json:"os_version"`         // "15.6.1"
+	OSBuild        string               `json:"os_build,omitempty"` // "24G90"
+	CPUBrand       string               `json:"cpu_brand,omitempty"`
+	CPUCores       int                  `json:"cpu_cores"`
+	RAMBytes       uint64               `json:"ram_bytes"`
+	Architecture   string               `json:"architecture"` // arm64 | amd64
+	UptimeSeconds  int64                `json:"uptime_seconds"`
+	SpectraVersion string               `json:"spectra_version,omitempty"`
+	Memory         memstate.MemoryState `json:"memory,omitempty"`
 }
 
 // CollectHost gathers HostInfo from the local machine. Spectra version
@@ -89,6 +93,10 @@ func (c LiveHostCollector) CollectHost(spectraVersion string) HostInfo {
 	now := opts.Now
 	if now == nil {
 		now = time.Now
+	}
+	memoryCollect := opts.MemoryCollect
+	if memoryCollect == nil {
+		memoryCollect = memstate.Collect
 	}
 
 	h := HostInfo{
@@ -125,7 +133,16 @@ func (c LiveHostCollector) CollectHost(spectraVersion string) HostInfo {
 	if uuid := readMachineUUID(runner); uuid != "" {
 		h.MachineUUID = uuid
 	}
+	h.Memory = collectHostMemory(memoryCollect)
 	return h
+}
+
+func collectHostMemory(collect func() (memstate.MemoryState, error)) memstate.MemoryState {
+	memory, err := collect()
+	if err != nil {
+		return memstate.MemoryState{}
+	}
+	return memory
 }
 
 // readUptime parses kern.boottime and returns seconds since boot.

--- a/internal/snapshot/host_test.go
+++ b/internal/snapshot/host_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kaeawc/spectra/internal/memstate"
 )
 
 // TestCollectHostMinimallyPopulated runs against the live machine; we
@@ -73,9 +75,10 @@ func TestLiveHostCollectorUsesInjectedRunner(t *testing.T) {
 		"ioreg\x00-d2\x00-c\x00IOPlatformExpertDevice": `"IOPlatformUUID" = "ABCDEF12-3456-7890-ABCD-EF1234567890"`,
 	}}
 	collector := LiveHostCollector{Options: HostCollectOptions{
-		Hostname: func() (string, error) { return "test-host", nil },
-		Runner:   runner,
-		Now:      func() time.Time { return time.Unix(4600, 0) },
+		Hostname:      func() (string, error) { return "test-host", nil },
+		Runner:        runner,
+		Now:           func() time.Time { return time.Unix(4600, 0) },
+		MemoryCollect: func() (memstate.MemoryState, error) { return memstate.MemoryState{PhysicalBytes: 99}, nil },
 	}}
 
 	got := collector.CollectHost("test-version")
@@ -99,6 +102,9 @@ func TestLiveHostCollectorUsesInjectedRunner(t *testing.T) {
 	}
 	if got.SpectraVersion != "test-version" {
 		t.Errorf("SpectraVersion = %q", got.SpectraVersion)
+	}
+	if got.Memory.PhysicalBytes != 99 {
+		t.Errorf("Memory.PhysicalBytes = %d, want injected value", got.Memory.PhysicalBytes)
 	}
 }
 

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/clock"
 	"github.com/kaeawc/spectra/internal/idgen"
+	"github.com/kaeawc/spectra/internal/memstate"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/telemetry"
 )
@@ -126,11 +128,16 @@ func TestBuildSkipAppsProducesNoApps(t *testing.T) {
 }
 
 func TestBuildUsesInjectedHostCollector(t *testing.T) {
+	collectedAt := time.Date(2026, 5, 28, 13, 38, 24, 0, time.UTC)
 	snap := Build(context.Background(), Options{
 		HostCollector: fakeHostCollector{host: HostInfo{
 			Hostname:    "fake-host",
 			MachineUUID: "FAKE-UUID",
 			OSName:      "macOS",
+			Memory: memstate.MemoryState{
+				PhysicalBytes: 1024,
+				CollectedAt:   collectedAt,
+			},
 		}},
 		SkipApps:      true,
 		SkipProcesses: true,
@@ -143,6 +150,13 @@ func TestBuildUsesInjectedHostCollector(t *testing.T) {
 	}
 	if snap.Host.MachineUUID != "FAKE-UUID" {
 		t.Fatalf("MachineUUID = %q, want FAKE-UUID", snap.Host.MachineUUID)
+	}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"memory"`) || !strings.Contains(string(data), `"physical_bytes":1024`) {
+		t.Fatalf("snapshot JSON missing host.memory: %s", data)
 	}
 }
 


### PR DESCRIPTION
Closes #256

## Summary
- add internal/memstate for VM compressor, swap, pressure, and host VM counters
- add `spectra memory` with JSON and watch output
- include memory state under snapshot host JSON and snapshot diff host changes

## Validation
- `spectra memory --json` live collector smoke test
- gocyclo -over 15 -ignore '_test\\.go$' .\n- go test ./internal/memstate ./internal/diff ./internal/snapshot ./cmd/spectra -count=1\n- go build ./... && go vet ./...\n- go test ./... -count=1