### PR TITLE
Add memory pressure rules

### DIFF
--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -17,6 +17,9 @@ func V1Catalog() []Rule {
 	return []Rule{
 		ruleJVMEOLVersion(),
 		ruleJVMHeapVsSystemRAM(),
+		ruleMemoryCompressorExcess(),
+		ruleMemorySwapExcess(),
+		ruleMemorySustainedPressure(),
 		ruleJVMGCPressure(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),

--- a/internal/rules/memstate_facts.go
+++ b/internal/rules/memstate_facts.go
@@ -1,0 +1,104 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/kaeawc/spectra/internal/memstate"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+// MemoryFacts is the rule-facing projection of host memory state.
+type MemoryFacts struct {
+	CompressorOccupiedFraction float64
+	SwapUsedFraction           float64
+	PressureLevel              string
+	UptimeHours                float64
+}
+
+func MemoryFactsFor(s snapshot.Snapshot) MemoryFacts {
+	m := s.Host.Memory
+	physical := float64(m.PhysicalBytes)
+	var f MemoryFacts
+	if physical > 0 {
+		f.CompressorOccupiedFraction = float64(m.CompressorOccupied) / physical
+		f.SwapUsedFraction = float64(m.Swap.UsedBytes) / physical
+	}
+	f.PressureLevel = string(m.PressureLevel)
+	f.UptimeHours = float64(s.Host.UptimeSeconds) / 3600
+	return f
+}
+
+func ruleMemoryCompressorExcess() Rule {
+	return Rule{
+		ID:       "memory.compressor_excess",
+		Severity: SeverityMedium,
+		Message:  "VM compressor holds >25% of physical RAM after 24h+ uptime.",
+		Fix:      "Run `spectra memory` and check long-lived daemons.",
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			f := MemoryFactsFor(s)
+			if f.CompressorOccupiedFraction <= 0.25 || f.UptimeHours <= 24 {
+				return nil
+			}
+			return []Finding{{
+				RuleID:   "memory.compressor_excess",
+				Severity: SeverityMedium,
+				Subject:  "host memory",
+				Message:  fmt.Sprintf("VM compressor holds %.0f%% of physical RAM after %.0fh uptime; likely a leaking subscriber.", f.CompressorOccupiedFraction*100, f.UptimeHours),
+				Fix:      "Run `spectra memory` and check long-lived daemons.",
+			}}
+		},
+	}
+}
+
+func ruleMemorySwapExcess() Rule {
+	return Rule{
+		ID:       "memory.swap_excess",
+		Severity: SeverityMedium,
+		Message:  "Swap used exceeds 10% of physical RAM.",
+		Fix:      "Run `spectra memory`; expect latency spikes until the leaking or memory-heavy process is stopped.",
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			f := MemoryFactsFor(s)
+			if f.SwapUsedFraction <= 0.10 {
+				return nil
+			}
+			return []Finding{{
+				RuleID:   "memory.swap_excess",
+				Severity: SeverityMedium,
+				Subject:  "host memory",
+				Message:  fmt.Sprintf("Swap used is %.0f%% of physical RAM; expect latency spikes.", f.SwapUsedFraction*100),
+				Fix:      "Run `spectra memory` and inspect top resident processes with `spectra process`.",
+			}}
+		},
+	}
+}
+
+func ruleMemorySustainedPressure() Rule {
+	return Rule{
+		ID:       "memory.sustained_pressure",
+		Severity: SeverityMedium,
+		Message:  "Pressure is Warning for >1h uptime, or Critical at any uptime.",
+		Fix:      "Run `spectra memory` to inspect compressor, swap, and pressure details.",
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			f := MemoryFactsFor(s)
+			switch f.PressureLevel {
+			case string(memstate.PressureCritical):
+				return []Finding{memoryPressureFinding(SeverityMedium, f, "Critical memory pressure; user-visible stalls are likely.")}
+			case string(memstate.PressureWarning):
+				if f.UptimeHours > 1 {
+					return []Finding{memoryPressureFinding(SeverityInfo, f, "Memory pressure has stayed at Warning past the first hour of uptime.")}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func memoryPressureFinding(severity Severity, f MemoryFacts, message string) Finding {
+	return Finding{
+		RuleID:   "memory.sustained_pressure",
+		Severity: severity,
+		Subject:  "host memory",
+		Message:  fmt.Sprintf("%s pressure=%s uptime=%.1fh.", message, f.PressureLevel, f.UptimeHours),
+		Fix:      "Run `spectra memory` to inspect compressor, swap, and pressure details.",
+	}
+}

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/memstate"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/storagestate"
 	"github.com/kaeawc/spectra/internal/toolchain"
@@ -139,6 +140,98 @@ func TestJVMHeapVsSystemDemotedForIDE(t *testing.T) {
 	}
 	if !strings.Contains(findings[0].Message, "expected for this app") {
 		t.Errorf("message should be recalibrated, got %q", findings[0].Message)
+	}
+}
+
+// --- memory pressure ---
+
+func TestMemoryFactsFor(t *testing.T) {
+	s := baseSnap()
+	s.Host.UptimeSeconds = 36 * 3600
+	s.Host.Memory = memstate.MemoryState{
+		PhysicalBytes:      1000,
+		CompressorOccupied: 300,
+		Swap:               memstate.SwapUsage{UsedBytes: 125},
+		PressureLevel:      memstate.PressureWarning,
+	}
+	got := MemoryFactsFor(s)
+	if got.CompressorOccupiedFraction != 0.3 {
+		t.Fatalf("CompressorOccupiedFraction = %.2f", got.CompressorOccupiedFraction)
+	}
+	if got.SwapUsedFraction != 0.125 {
+		t.Fatalf("SwapUsedFraction = %.3f", got.SwapUsedFraction)
+	}
+	if got.PressureLevel != "Warning" || got.UptimeHours != 36 {
+		t.Fatalf("facts = %+v", got)
+	}
+}
+
+func TestMemoryCompressorExcessFires(t *testing.T) {
+	s := baseSnap()
+	s.Host.UptimeSeconds = 25 * 3600
+	s.Host.Memory = memstate.MemoryState{
+		PhysicalBytes:      100,
+		CompressorOccupied: 26,
+	}
+	findings := ruleMemoryCompressorExcess().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected compressor finding, got %v", findings)
+	}
+	if findings[0].RuleID != "memory.compressor_excess" || !strings.Contains(findings[0].Fix, "spectra memory") {
+		t.Fatalf("finding = %+v", findings[0])
+	}
+}
+
+func TestMemorySwapExcessFires(t *testing.T) {
+	s := baseSnap()
+	s.Host.Memory = memstate.MemoryState{
+		PhysicalBytes: 100,
+		Swap:          memstate.SwapUsage{UsedBytes: 11},
+	}
+	findings := ruleMemorySwapExcess().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected swap finding, got %v", findings)
+	}
+	if findings[0].RuleID != "memory.swap_excess" || !strings.Contains(findings[0].Message, "11%") {
+		t.Fatalf("finding = %+v", findings[0])
+	}
+}
+
+func TestMemorySustainedPressureFires(t *testing.T) {
+	s := baseSnap()
+	s.Host.UptimeSeconds = 2 * 3600
+	s.Host.Memory = memstate.MemoryState{PressureLevel: memstate.PressureWarning}
+	findings := ruleMemorySustainedPressure().MatchFn(s)
+	if len(findings) != 1 || findings[0].Severity != SeverityInfo {
+		t.Fatalf("warning pressure findings = %+v", findings)
+	}
+
+	s.Host.UptimeSeconds = 10
+	s.Host.Memory = memstate.MemoryState{PressureLevel: memstate.PressureCritical}
+	findings = ruleMemorySustainedPressure().MatchFn(s)
+	if len(findings) != 1 || findings[0].Severity != SeverityMedium {
+		t.Fatalf("critical pressure findings = %+v", findings)
+	}
+}
+
+func TestMemoryRulesNoFalsePositiveOnFreshBoot(t *testing.T) {
+	s := baseSnap()
+	s.Host.RAMBytes = 128 * 1024 * 1024 * 1024
+	s.Host.UptimeSeconds = 4 * 3600
+	s.Host.Memory = memstate.MemoryState{
+		PhysicalBytes:      s.Host.RAMBytes,
+		CompressorOccupied: 10 * 1024 * 1024 * 1024,
+		Swap:               memstate.SwapUsage{UsedBytes: 0},
+		PressureLevel:      memstate.PressureNormal,
+	}
+	for _, rule := range []Rule{
+		ruleMemoryCompressorExcess(),
+		ruleMemorySwapExcess(),
+		ruleMemorySustainedPressure(),
+	} {
+		if findings := rule.MatchFn(s); len(findings) != 0 {
+			t.Fatalf("%s fired unexpectedly: %+v", rule.ID, findings)
+		}
 	}
 }
 
@@ -766,13 +859,19 @@ func TestBrewStalePinnedMultiple(t *testing.T) {
 	}
 }
 
-func TestV1CatalogContainsBrewRules(t *testing.T) {
+func TestV1CatalogContainsExpectedRules(t *testing.T) {
 	catalog := V1Catalog()
 	ruleIDs := make(map[string]bool)
 	for _, r := range catalog {
 		ruleIDs[r.ID] = true
 	}
-	for _, want := range []string{"brew-deprecated-formula", "brew-stale-pinned"} {
+	for _, want := range []string{
+		"brew-deprecated-formula",
+		"brew-stale-pinned",
+		"memory.compressor_excess",
+		"memory.swap_excess",
+		"memory.sustained_pressure",
+	} {
 		if !ruleIDs[want] {
 			t.Errorf("V1Catalog missing rule %q", want)
 		}


### PR DESCRIPTION
Closes #257

## Summary
- add memory facts projected from `host.memory`
- add compressor, swap, and sustained-pressure built-in rules
- cover firing and fresh-boot no-false-positive fixtures

## Validation
- go test ./internal/rules -count=1
- gocyclo -over 15 -ignore '_test\\.go$' .\n- golangci-lint run\n- go build ./... && go vet ./...\n- go test ./... -count=1