### PR TITLE
Add Time Machine state collector

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -44,6 +44,7 @@ func subcommandList() []subcommand {
 		{"impact", "Compute the documented per-pid energy impact score from delta records", runImpact},
 		{"memory", "Show VM compressor, swap, and pressure state", runMemory},
 		{"storage", "Show disk volumes and ~/Library footprint", runStorage},
+		{"timemachine", "Show Time Machine status, destinations, and local snapshots", runTimeMachine},
 		{"system", "Show system resource limits and saturation", runSystem},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
 		{"playbook", "Show diagnostic playbooks and command plans", runPlaybook},

--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -308,6 +308,13 @@ func printSnapshot(s snapshot.Snapshot) {
 		fmt.Print("memory:         ")
 		printMemoryState(s.Host.Memory, memstate.MemoryState{})
 	}
+	if !s.Host.TimeMachine.IsZero() {
+		fmt.Printf("time-machine:   destinations=%d local-snapshots=%d scheduler=%s\n",
+			len(s.Host.TimeMachine.Destinations),
+			len(s.Host.TimeMachine.LocalSnapshots),
+			loadedString(s.Host.TimeMachine.SchedulerLoaded),
+		)
+	}
 
 	if len(s.Apps) > 0 {
 		fmt.Println()

--- a/cmd/spectra/timemachine.go
+++ b/cmd/spectra/timemachine.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/timemachine"
+)
+
+func runTimeMachine(args []string) int {
+	fs := flag.NewFlagSet("spectra timemachine", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	state, err := timemachine.Collect(context.Background())
+	if err != nil {
+		if errors.Is(err, timemachine.ErrNeedsFullDiskAccess) {
+			fmt.Fprintln(os.Stderr, timemachine.FullDiskAccessRemediation)
+			return 1
+		}
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(state)
+		return 0
+	}
+	printTimeMachineState(state)
+	return 0
+}
+
+func printTimeMachineState(s timemachine.TimeMachineState) {
+	fmt.Println("=== Time Machine ===")
+	status := "idle"
+	if s.Status.Running {
+		status = fmt.Sprintf("running %.0f%%", s.Status.Percent)
+		if s.Status.BackupPhase != "" {
+			status += " " + s.Status.BackupPhase
+		}
+	}
+	fmt.Printf("status:          %s\n", status)
+	fmt.Printf("auto-backup:     %t\n", s.AutoBackupEnabled)
+	fmt.Printf("scheduler:       %s\n", loadedString(s.SchedulerLoaded))
+
+	if len(s.Destinations) == 0 {
+		fmt.Println("destinations:    no destinations configured")
+	} else {
+		fmt.Printf("destinations:    %d configured\n", len(s.Destinations))
+		for _, d := range s.Destinations {
+			label := firstNonEmpty(d.Name, d.MountPoint, d.URL, d.ID)
+			parts := []string{label}
+			if d.Kind != "" {
+				parts = append(parts, d.Kind)
+			}
+			if d.MountPoint != "" {
+				parts = append(parts, d.MountPoint)
+			}
+			fmt.Printf("  - %s\n", strings.Join(parts, "  "))
+		}
+	}
+
+	fmt.Printf("local snapshots: %d\n", len(s.LocalSnapshots))
+}
+
+func loadedString(v bool) string {
+	if v {
+		return "loaded"
+	}
+	return "not loaded"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return "(unnamed)"
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -5,6 +5,8 @@ package diff
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/toolchain"
@@ -89,6 +91,8 @@ func diffHost(a, b snapshot.Snapshot) Section {
 		{"memory.compressor_stored", fmt.Sprint(a.Host.Memory.CompressorStored), fmt.Sprint(b.Host.Memory.CompressorStored)},
 		{"memory.swap_used", fmt.Sprint(a.Host.Memory.Swap.UsedBytes), fmt.Sprint(b.Host.Memory.Swap.UsedBytes)},
 		{"memory.pressure_level", string(a.Host.Memory.PressureLevel), string(b.Host.Memory.PressureLevel)},
+		{"time_machine.destinations", strings.Join(tmDestinationKeys(a), ","), strings.Join(tmDestinationKeys(b), ",")},
+		{"time_machine.local_snapshots", strings.Join(tmSnapshotKeys(a), ","), strings.Join(tmSnapshotKeys(b), ",")},
 		{"arch", a.Host.Architecture, b.Host.Architecture},
 		{"spectra_version", a.Host.SpectraVersion, b.Host.SpectraVersion},
 	}
@@ -99,6 +103,35 @@ func diffHost(a, b snapshot.Snapshot) Section {
 		}
 	}
 	return Section{Name: "host", Changes: changes}
+}
+
+func tmDestinationKeys(s snapshot.Snapshot) []string {
+	keys := make([]string, 0, len(s.Host.TimeMachine.Destinations))
+	for _, d := range s.Host.TimeMachine.Destinations {
+		key := d.ID
+		if key == "" {
+			key = d.Name
+		}
+		if key == "" {
+			key = d.MountPoint
+		}
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func tmSnapshotKeys(s snapshot.Snapshot) []string {
+	keys := make([]string, 0, len(s.Host.TimeMachine.LocalSnapshots))
+	for _, snap := range s.Host.TimeMachine.LocalSnapshots {
+		if snap.Name != "" {
+			keys = append(keys, snap.Name)
+		}
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 type appInfo struct {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/syslimits"
+	"github.com/kaeawc/spectra/internal/timemachine"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
@@ -86,6 +87,27 @@ func TestDiffHostMemoryChanged(t *testing.T) {
 		"memory.swap_used",
 		"memory.pressure_level",
 	} {
+		if !hasChange(sec.Changes, Changed, key) {
+			t.Fatalf("expected %s change, got %+v", key, sec.Changes)
+		}
+	}
+}
+
+func TestDiffHostTimeMachineChanged(t *testing.T) {
+	a := base()
+	b := base()
+	a.Host.TimeMachine = timemachine.TimeMachineState{
+		Destinations:   []timemachine.TMDestination{{ID: "old"}},
+		LocalSnapshots: []timemachine.TMLocalSnapshot{{Name: "snap-a"}},
+	}
+	b.Host.TimeMachine = timemachine.TimeMachineState{
+		Destinations:   []timemachine.TMDestination{{ID: "new"}},
+		LocalSnapshots: []timemachine.TMLocalSnapshot{{Name: "snap-b"}},
+	}
+
+	r := Compare(a, b)
+	sec := findSection(r, "host")
+	for _, key := range []string{"time_machine.destinations", "time_machine.local_snapshots"} {
 		if !hasChange(sec.Changes, Changed, key) {
 			t.Fatalf("expected %s change, got %+v", key, sec.Changes)
 		}

--- a/internal/snapshot/host.go
+++ b/internal/snapshot/host.go
@@ -9,6 +9,7 @@ package snapshot
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -19,6 +20,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/memstate"
+	"github.com/kaeawc/spectra/internal/timemachine"
 )
 
 // CommandRunner runs a system command and returns stdout.
@@ -37,6 +39,7 @@ type HostCollectOptions struct {
 	Runner        CommandRunner
 	Now           func() time.Time
 	MemoryCollect func() (memstate.MemoryState, error)
+	TMCollect     func() (timemachine.TimeMachineState, error)
 }
 
 // LiveHostCollector gathers HostInfo from the current machine.
@@ -59,18 +62,19 @@ func (execCommandRunner) Run(name string, args ...string) (string, error) {
 // time. Every field is best-effort; any collector failure leaves the
 // field empty / zero rather than failing the snapshot.
 type HostInfo struct {
-	Hostname       string               `json:"hostname"`
-	MachineUUID    string               `json:"machine_uuid,omitempty"`
-	OSName         string               `json:"os_name"`            // "macOS"
-	OSVersion      string               `json:"os_version"`         // "15.6.1"
-	OSBuild        string               `json:"os_build,omitempty"` // "24G90"
-	CPUBrand       string               `json:"cpu_brand,omitempty"`
-	CPUCores       int                  `json:"cpu_cores"`
-	RAMBytes       uint64               `json:"ram_bytes"`
-	Architecture   string               `json:"architecture"` // arm64 | amd64
-	UptimeSeconds  int64                `json:"uptime_seconds"`
-	SpectraVersion string               `json:"spectra_version,omitempty"`
-	Memory         memstate.MemoryState `json:"memory,omitempty"`
+	Hostname       string                       `json:"hostname"`
+	MachineUUID    string                       `json:"machine_uuid,omitempty"`
+	OSName         string                       `json:"os_name"`            // "macOS"
+	OSVersion      string                       `json:"os_version"`         // "15.6.1"
+	OSBuild        string                       `json:"os_build,omitempty"` // "24G90"
+	CPUBrand       string                       `json:"cpu_brand,omitempty"`
+	CPUCores       int                          `json:"cpu_cores"`
+	RAMBytes       uint64                       `json:"ram_bytes"`
+	Architecture   string                       `json:"architecture"` // arm64 | amd64
+	UptimeSeconds  int64                        `json:"uptime_seconds"`
+	SpectraVersion string                       `json:"spectra_version,omitempty"`
+	Memory         memstate.MemoryState         `json:"memory,omitempty"`
+	TimeMachine    timemachine.TimeMachineState `json:"time_machine,omitempty"`
 }
 
 // CollectHost gathers HostInfo from the local machine. Spectra version
@@ -81,23 +85,7 @@ func CollectHost(spectraVersion string) HostInfo {
 }
 
 func (c LiveHostCollector) CollectHost(spectraVersion string) HostInfo {
-	opts := c.Options
-	hostname := opts.Hostname
-	if hostname == nil {
-		hostname = os.Hostname
-	}
-	runner := opts.Runner
-	if runner == nil {
-		runner = execCommandRunner{}
-	}
-	now := opts.Now
-	if now == nil {
-		now = time.Now
-	}
-	memoryCollect := opts.MemoryCollect
-	if memoryCollect == nil {
-		memoryCollect = memstate.Collect
-	}
+	deps := hostDepsFromOptions(c.Options)
 
 	h := HostInfo{
 		OSName:         "macOS",
@@ -105,36 +93,73 @@ func (c LiveHostCollector) CollectHost(spectraVersion string) HostInfo {
 		SpectraVersion: spectraVersion,
 	}
 
-	if name, err := hostname(); err == nil {
+	if name, err := deps.hostname(); err == nil {
 		h.Hostname = name
 	}
-	if v, err := runner.Run("sw_vers", "-productVersion"); err == nil {
+	if v, err := deps.runner.Run("sw_vers", "-productVersion"); err == nil {
 		h.OSVersion = v
 	}
-	if v, err := runner.Run("sw_vers", "-buildVersion"); err == nil {
+	if v, err := deps.runner.Run("sw_vers", "-buildVersion"); err == nil {
 		h.OSBuild = v
 	}
-	if v, err := runner.Run("sysctl", "-n", "machdep.cpu.brand_string"); err == nil {
+	if v, err := deps.runner.Run("sysctl", "-n", "machdep.cpu.brand_string"); err == nil {
 		h.CPUBrand = v
 	}
-	if v, err := runner.Run("sysctl", "-n", "hw.ncpu"); err == nil {
+	if v, err := deps.runner.Run("sysctl", "-n", "hw.ncpu"); err == nil {
 		if n, err := strconv.Atoi(v); err == nil {
 			h.CPUCores = n
 		}
 	}
-	if v, err := runner.Run("sysctl", "-n", "hw.memsize"); err == nil {
+	if v, err := deps.runner.Run("sysctl", "-n", "hw.memsize"); err == nil {
 		if n, err := strconv.ParseUint(v, 10, 64); err == nil {
 			h.RAMBytes = n
 		}
 	}
-	if uptime := readUptime(runner, now); uptime > 0 {
+	if uptime := readUptime(deps.runner, deps.now); uptime > 0 {
 		h.UptimeSeconds = uptime
 	}
-	if uuid := readMachineUUID(runner); uuid != "" {
+	if uuid := readMachineUUID(deps.runner); uuid != "" {
 		h.MachineUUID = uuid
 	}
-	h.Memory = collectHostMemory(memoryCollect)
+	h.Memory = collectHostMemory(deps.memoryCollect)
+	h.TimeMachine = collectHostTimeMachine(deps.tmCollect)
 	return h
+}
+
+type hostDeps struct {
+	hostname      func() (string, error)
+	runner        CommandRunner
+	now           func() time.Time
+	memoryCollect func() (memstate.MemoryState, error)
+	tmCollect     func() (timemachine.TimeMachineState, error)
+}
+
+func hostDepsFromOptions(opts HostCollectOptions) hostDeps {
+	deps := hostDeps{
+		hostname:      opts.Hostname,
+		runner:        opts.Runner,
+		now:           opts.Now,
+		memoryCollect: opts.MemoryCollect,
+		tmCollect:     opts.TMCollect,
+	}
+	if deps.hostname == nil {
+		deps.hostname = os.Hostname
+	}
+	if deps.runner == nil {
+		deps.runner = execCommandRunner{}
+	}
+	if deps.now == nil {
+		deps.now = time.Now
+	}
+	if deps.memoryCollect == nil {
+		deps.memoryCollect = memstate.Collect
+	}
+	if deps.tmCollect == nil {
+		deps.tmCollect = func() (timemachine.TimeMachineState, error) {
+			return timemachine.Collect(context.Background())
+		}
+	}
+	return deps
 }
 
 func collectHostMemory(collect func() (memstate.MemoryState, error)) memstate.MemoryState {
@@ -143,6 +168,14 @@ func collectHostMemory(collect func() (memstate.MemoryState, error)) memstate.Me
 		return memstate.MemoryState{}
 	}
 	return memory
+}
+
+func collectHostTimeMachine(collect func() (timemachine.TimeMachineState, error)) timemachine.TimeMachineState {
+	state, err := collect()
+	if err != nil {
+		return timemachine.TimeMachineState{}
+	}
+	return state
 }
 
 // readUptime parses kern.boottime and returns seconds since boot.

--- a/internal/snapshot/host_test.go
+++ b/internal/snapshot/host_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/memstate"
+	"github.com/kaeawc/spectra/internal/timemachine"
 )
 
 // TestCollectHostMinimallyPopulated runs against the live machine; we
@@ -79,6 +80,9 @@ func TestLiveHostCollectorUsesInjectedRunner(t *testing.T) {
 		Runner:        runner,
 		Now:           func() time.Time { return time.Unix(4600, 0) },
 		MemoryCollect: func() (memstate.MemoryState, error) { return memstate.MemoryState{PhysicalBytes: 99}, nil },
+		TMCollect: func() (timemachine.TimeMachineState, error) {
+			return timemachine.TimeMachineState{SchedulerLoaded: true}, nil
+		},
 	}}
 
 	got := collector.CollectHost("test-version")
@@ -105,6 +109,9 @@ func TestLiveHostCollectorUsesInjectedRunner(t *testing.T) {
 	}
 	if got.Memory.PhysicalBytes != 99 {
 		t.Errorf("Memory.PhysicalBytes = %d, want injected value", got.Memory.PhysicalBytes)
+	}
+	if !got.TimeMachine.SchedulerLoaded {
+		t.Error("TimeMachine.SchedulerLoaded = false, want injected true")
 	}
 }
 

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kaeawc/spectra/internal/memstate"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/telemetry"
+	"github.com/kaeawc/spectra/internal/timemachine"
 )
 
 func TestBuildHostOnly(t *testing.T) {
@@ -138,6 +139,10 @@ func TestBuildUsesInjectedHostCollector(t *testing.T) {
 				PhysicalBytes: 1024,
 				CollectedAt:   collectedAt,
 			},
+			TimeMachine: timemachine.TimeMachineState{
+				SchedulerLoaded: true,
+				CollectedAt:     collectedAt,
+			},
 		}},
 		SkipApps:      true,
 		SkipProcesses: true,
@@ -157,6 +162,9 @@ func TestBuildUsesInjectedHostCollector(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"memory"`) || !strings.Contains(string(data), `"physical_bytes":1024`) {
 		t.Fatalf("snapshot JSON missing host.memory: %s", data)
+	}
+	if !strings.Contains(string(data), `"time_machine"`) || !strings.Contains(string(data), `"scheduler_loaded":true`) {
+		t.Fatalf("snapshot JSON missing host.time_machine: %s", data)
 	}
 }
 

--- a/internal/timemachine/collect.go
+++ b/internal/timemachine/collect.go
@@ -1,0 +1,177 @@
+package timemachine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/plistread"
+)
+
+// CommandRunner runs a subprocess and returns combined output.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// CommandRunnerFunc adapts a function into a CommandRunner.
+type CommandRunnerFunc func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// Run implements CommandRunner.
+func (f CommandRunnerFunc) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return f(ctx, name, args...)
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+// Options configures Time Machine collection.
+type Options struct {
+	Runner    CommandRunner
+	Now       func() time.Time
+	ReadPrefs func() (plistread.TMPrefs, error)
+}
+
+// Collect gathers read-only Time Machine state.
+func Collect(ctx context.Context) (TimeMachineState, error) {
+	return CollectWithOptions(ctx, Options{})
+}
+
+// CollectWithOptions gathers read-only Time Machine state with test hooks.
+func CollectWithOptions(ctx context.Context, opts Options) (TimeMachineState, error) {
+	run := opts.Runner
+	if run == nil {
+		run = execRunner{}
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	readPrefs := opts.ReadPrefs
+	if readPrefs == nil {
+		readPrefs = plistread.ReadTimeMachinePrefs
+	}
+
+	state := TimeMachineState{
+		CollectedAt:    now().UTC(),
+		Destinations:   []TMDestination{},
+		LocalSnapshots: []TMLocalSnapshot{},
+	}
+	if err := readDestinations(ctx, run, &state); err != nil {
+		return state, err
+	}
+	if err := readStatus(ctx, run, &state); err != nil {
+		return state, err
+	}
+	if err := readLocalSnapshots(ctx, run, &state); err != nil {
+		return state, err
+	}
+	loaded, err := launchctlLoaded(ctx, run, "system/com.apple.backupd-auto")
+	if err != nil {
+		return state, err
+	}
+	state.SchedulerLoaded = loaded
+	prefs, err := readPrefs()
+	if err != nil {
+		if isFullDiskAccessErr(err) {
+			return state, err
+		}
+		return state, nil
+	}
+	state.AutoBackupEnabled = prefs.AutoBackup
+	return state, nil
+}
+
+func readDestinations(ctx context.Context, run CommandRunner, state *TimeMachineState) error {
+	out, err := run.Run(ctx, "/usr/bin/tmutil", "destinationinfo", "-X")
+	if err != nil {
+		if isEmptyTMOutput(out) {
+			return nil
+		}
+		if isPermissionOutput(out, err) {
+			return fmt.Errorf("tmutil destinationinfo: %w", ErrNeedsFullDiskAccess)
+		}
+		return fmt.Errorf("tmutil destinationinfo: %w", err)
+	}
+	destinations, err := ParseDestinations(out)
+	if err != nil {
+		return fmt.Errorf("parse tmutil destinationinfo: %w", err)
+	}
+	state.Destinations = destinations
+	return nil
+}
+
+func readStatus(ctx context.Context, run CommandRunner, state *TimeMachineState) error {
+	out, err := run.Run(ctx, "/usr/bin/tmutil", "status", "-X")
+	if err != nil {
+		if isPermissionOutput(out, err) {
+			return fmt.Errorf("tmutil status: %w", ErrNeedsFullDiskAccess)
+		}
+		return nil
+	}
+	status, err := ParseStatus(out)
+	if err != nil {
+		return fmt.Errorf("parse tmutil status: %w", err)
+	}
+	state.Status = status
+	return nil
+}
+
+func readLocalSnapshots(ctx context.Context, run CommandRunner, state *TimeMachineState) error {
+	out, err := run.Run(ctx, "/usr/bin/tmutil", "listlocalsnapshots", "/", "-X")
+	if err != nil {
+		if isEmptyTMOutput(out) {
+			return nil
+		}
+		if isPermissionOutput(out, err) {
+			return fmt.Errorf("tmutil listlocalsnapshots: %w", ErrNeedsFullDiskAccess)
+		}
+		return nil
+	}
+	snapshots, err := ParseLocalSnapshots(out)
+	if err != nil {
+		return fmt.Errorf("parse tmutil listlocalsnapshots: %w", err)
+	}
+	state.LocalSnapshots = snapshots
+	return nil
+}
+
+func launchctlLoaded(ctx context.Context, run CommandRunner, service string) (bool, error) {
+	out, err := run.Run(ctx, "/bin/launchctl", "print", service)
+	if err == nil {
+		return true, nil
+	}
+	if isPermissionOutput(out, err) {
+		return false, fmt.Errorf("launchctl print %s: %w", service, ErrNeedsFullDiskAccess)
+	}
+	text := strings.ToLower(string(out))
+	if strings.Contains(text, "could not find service") ||
+		strings.Contains(text, "no such process") ||
+		strings.Contains(text, "bad request") {
+		return false, nil
+	}
+	return false, nil
+}
+
+func isEmptyTMOutput(out []byte) bool {
+	text := strings.ToLower(string(out))
+	return len(bytes.TrimSpace(out)) == 0 ||
+		strings.Contains(text, "no destinations configured") ||
+		strings.Contains(text, "no local snapshots")
+}
+
+func isPermissionOutput(out []byte, err error) bool {
+	if errors.Is(err, plistread.ErrNeedsFullDiskAccess) {
+		return true
+	}
+	text := strings.ToLower(string(out))
+	return strings.Contains(text, "operation not permitted") ||
+		strings.Contains(text, "full disk access") ||
+		strings.Contains(text, "permission denied")
+}

--- a/internal/timemachine/parse.go
+++ b/internal/timemachine/parse.go
@@ -1,0 +1,283 @@
+package timemachine
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"howett.net/plist"
+)
+
+// ParseDestinations parses `tmutil destinationinfo -X` output.
+func ParseDestinations(data []byte) ([]TMDestination, error) {
+	root, err := decodePlist(data)
+	if err != nil {
+		return nil, err
+	}
+	var items []any
+	switch v := root.(type) {
+	case []any:
+		items = v
+	case map[string]any:
+		if len(v) == 0 {
+			return []TMDestination{}, nil
+		}
+		if raw, ok := firstAny(v, "Destinations", "destinations", "Destination"); ok {
+			items = anySlice(raw)
+		} else {
+			items = []any{v}
+		}
+	default:
+		return nil, fmt.Errorf("destination root %T", root)
+	}
+	out := make([]TMDestination, 0, len(items))
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		d := destinationFromMap(m)
+		if !destinationEmpty(d) {
+			out = append(out, d)
+		}
+	}
+	return out, nil
+}
+
+// ParseStatus parses `tmutil status -X` output.
+func ParseStatus(data []byte) (TMStatus, error) {
+	root, err := decodePlist(data)
+	if err != nil {
+		return TMStatus{}, err
+	}
+	m, ok := root.(map[string]any)
+	if !ok {
+		return TMStatus{}, fmt.Errorf("status root %T", root)
+	}
+	return TMStatus{
+		Running:               boolValue(m, "Running", "running"),
+		Percent:               floatValue(m, "Percent", "percent"),
+		ClientID:              stringValue(m, "ClientID", "Client ID", "client_id"),
+		BackupPhase:           stringValue(m, "BackupPhase", "Backup Phase", "backup_phase"),
+		DestinationID:         stringValue(m, "DestinationID", "Destination ID", "destination_id"),
+		DestinationMountPoint: stringValue(m, "DestinationMountPoint", "Destination Mount Point", "destination_mount_point"),
+		FirstBackup:           boolValue(m, "FirstBackup", "First Backup", "first_backup"),
+	}, nil
+}
+
+// ParseLocalSnapshots parses `tmutil listlocalsnapshots / -X` output.
+func ParseLocalSnapshots(data []byte) ([]TMLocalSnapshot, error) {
+	root, err := decodePlist(data)
+	if err != nil {
+		return nil, err
+	}
+	items := localSnapshotItems(root)
+	out := make([]TMLocalSnapshot, 0, len(items))
+	for _, item := range items {
+		switch v := item.(type) {
+		case string:
+			out = append(out, localSnapshotFromName(v, ""))
+		case map[string]any:
+			name := stringValue(v, "Name", "Snapshot", "snapshot", "name")
+			if name == "" {
+				continue
+			}
+			snap := localSnapshotFromName(name, stringValue(v, "Volume", "volume"))
+			if date, ok := dateValue(v, "Date", "date"); ok {
+				snap.Date = date
+			}
+			out = append(out, snap)
+		}
+	}
+	return out, nil
+}
+
+func decodePlist(data []byte) (any, error) {
+	var root any
+	if _, err := plist.Unmarshal(data, &root); err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
+func destinationFromMap(m map[string]any) TMDestination {
+	return TMDestination{
+		ID:             stringValue(m, "ID", "DestinationID", "Destination ID", "UUID"),
+		Name:           stringValue(m, "Name", "DestinationName", "Destination Name"),
+		Kind:           stringValue(m, "Kind", "DestinationKind", "Destination Kind"),
+		MountPoint:     stringValue(m, "MountPoint", "Mount Point", "DestinationMountPoint"),
+		URL:            stringValue(m, "URL", "NetworkURL", "Network URL"),
+		BytesAvailable: uintValue(m, "BytesAvailable", "Bytes Available", "AvailableBytes"),
+		BytesUsed:      uintValue(m, "BytesUsed", "Bytes Used", "UsedBytes"),
+		LastBackup:     timeValue(m, "LastBackup", "Last Backup", "LastBackupDate"),
+		NextBackup:     timeValue(m, "NextBackup", "Next Backup", "NextBackupDate"),
+		QuotaGB:        uintValue(m, "QuotaGB", "Quota GB"),
+		Encrypted:      boolValue(m, "Encrypted", "IsEncrypted"),
+	}
+}
+
+func destinationEmpty(d TMDestination) bool {
+	return d.ID == "" &&
+		d.Name == "" &&
+		d.Kind == "" &&
+		d.MountPoint == "" &&
+		d.URL == "" &&
+		d.BytesAvailable == 0 &&
+		d.BytesUsed == 0
+}
+
+func localSnapshotItems(root any) []any {
+	switch v := root.(type) {
+	case []any:
+		return v
+	case map[string]any:
+		for _, key := range []string{"Snapshots", "LocalSnapshots", "local_snapshots", "snapshots"} {
+			if raw, ok := v[key]; ok {
+				return anySlice(raw)
+			}
+		}
+		return []any{v}
+	default:
+		return nil
+	}
+}
+
+var snapshotNameDateRE = regexp.MustCompile(`(\d{4}-\d{2}-\d{2}-\d{6})`)
+
+func localSnapshotFromName(name, volume string) TMLocalSnapshot {
+	s := TMLocalSnapshot{Name: name, Volume: volume}
+	if volume == "" {
+		s.Volume = filepath.Dir(name)
+		if s.Volume == "." {
+			s.Volume = ""
+		}
+	}
+	if match := snapshotNameDateRE.FindStringSubmatch(name); len(match) == 2 {
+		if t, err := time.ParseInLocation("2006-01-02-150405", match[1], time.Local); err == nil {
+			s.Date = t
+		}
+	}
+	return s
+}
+
+func anySlice(raw any) []any {
+	switch v := raw.(type) {
+	case []any:
+		return v
+	case nil:
+		return nil
+	default:
+		return []any{v}
+	}
+}
+
+func firstAny(m map[string]any, keys ...string) (any, bool) {
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func stringValue(m map[string]any, keys ...string) string {
+	raw, ok := firstAny(m, keys...)
+	if !ok {
+		return ""
+	}
+	switch v := raw.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
+func boolValue(m map[string]any, keys ...string) bool {
+	raw, ok := firstAny(m, keys...)
+	if !ok {
+		return false
+	}
+	switch v := raw.(type) {
+	case bool:
+		return v
+	case uint64:
+		return v != 0
+	case int64:
+		return v != 0
+	case int:
+		return v != 0
+	default:
+		return false
+	}
+}
+
+func floatValue(m map[string]any, keys ...string) float64 {
+	raw, ok := firstAny(m, keys...)
+	if !ok {
+		return 0
+	}
+	switch v := raw.(type) {
+	case float64:
+		return v
+	case float32:
+		return float64(v)
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case uint64:
+		return float64(v)
+	default:
+		return 0
+	}
+}
+
+func uintValue(m map[string]any, keys ...string) uint64 {
+	raw, ok := firstAny(m, keys...)
+	if !ok {
+		return 0
+	}
+	switch v := raw.(type) {
+	case uint64:
+		return v
+	case uint:
+		return uint64(v)
+	case int:
+		if v > 0 {
+			return uint64(v)
+		}
+	case int64:
+		if v > 0 {
+			return uint64(v)
+		}
+	}
+	return 0
+}
+
+func timeValue(m map[string]any, keys ...string) time.Time {
+	t, _ := dateValue(m, keys...)
+	return t
+}
+
+func dateValue(m map[string]any, keys ...string) (time.Time, bool) {
+	raw, ok := firstAny(m, keys...)
+	if !ok {
+		return time.Time{}, false
+	}
+	switch v := raw.(type) {
+	case time.Time:
+		return v, true
+	case string:
+		for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05 -0700 MST", "2006-01-02 15:04:05"} {
+			if t, err := time.Parse(layout, v); err == nil {
+				return t, true
+			}
+		}
+	}
+	return time.Time{}, false
+}

--- a/internal/timemachine/testdata/empty-array.plist
+++ b/internal/timemachine/testdata/empty-array.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/internal/timemachine/testdata/idle-status.plist
+++ b/internal/timemachine/testdata/idle-status.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Running</key><false/>
+  <key>Percent</key><real>0</real>
+</dict>
+</plist>

--- a/internal/timemachine/testdata/local-snapshots.plist
+++ b/internal/timemachine/testdata/local-snapshots.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+  <string>com.apple.TimeMachine.2026-05-28-133824.local</string>
+  <dict>
+    <key>Name</key><string>com.apple.TimeMachine.2026-05-28-143824.local</string>
+    <key>Volume</key><string>/</string>
+  </dict>
+</array>
+</plist>

--- a/internal/timemachine/testdata/mid-backup-status.plist
+++ b/internal/timemachine/testdata/mid-backup-status.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Running</key><true/>
+  <key>Percent</key><real>42.5</real>
+  <key>ClientID</key><string>com.apple.backupd</string>
+  <key>BackupPhase</key><string>Copying</string>
+  <key>DestinationID</key><string>LOCAL-UUID</string>
+  <key>DestinationMountPoint</key><string>/Volumes/Backup</string>
+  <key>FirstBackup</key><false/>
+</dict>
+</plist>

--- a/internal/timemachine/testdata/one-local.plist
+++ b/internal/timemachine/testdata/one-local.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Destinations</key>
+  <array>
+    <dict>
+      <key>ID</key><string>LOCAL-UUID</string>
+      <key>Name</key><string>Backup SSD</string>
+      <key>Kind</key><string>Local</string>
+      <key>Mount Point</key><string>/Volumes/Backup</string>
+      <key>Bytes Available</key><integer>1000</integer>
+      <key>Bytes Used</key><integer>2000</integer>
+      <key>Last Backup</key><date>2026-05-28T13:38:24Z</date>
+      <key>Next Backup</key><date>2026-05-28T14:38:24Z</date>
+      <key>Quota GB</key><integer>500</integer>
+      <key>Encrypted</key><true/>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/internal/timemachine/testdata/one-network.plist
+++ b/internal/timemachine/testdata/one-network.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+  <dict>
+    <key>ID</key><string>NET-UUID</string>
+    <key>Name</key><string>NAS</string>
+    <key>Kind</key><string>Network</string>
+    <key>URL</key><string>smb://nas/TimeMachine</string>
+  </dict>
+</array>
+</plist>

--- a/internal/timemachine/timemachine_test.go
+++ b/internal/timemachine/timemachine_test.go
@@ -1,0 +1,159 @@
+package timemachine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/plistread"
+)
+
+func TestParseDestinationsLocal(t *testing.T) {
+	got, err := ParseDestinations(readFixture(t, "one-local.plist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("destinations len = %d", len(got))
+	}
+	d := got[0]
+	if d.ID != "LOCAL-UUID" || d.Name != "Backup SSD" || d.Kind != "Local" || d.MountPoint != "/Volumes/Backup" {
+		t.Fatalf("destination = %+v", d)
+	}
+	if d.BytesAvailable != 1000 || d.BytesUsed != 2000 || d.QuotaGB != 500 || !d.Encrypted {
+		t.Fatalf("destination capacity = %+v", d)
+	}
+}
+
+func TestParseDestinationsNetwork(t *testing.T) {
+	got, err := ParseDestinations(readFixture(t, "one-network.plist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].URL != "smb://nas/TimeMachine" || got[0].Kind != "Network" {
+		t.Fatalf("network destination = %+v", got)
+	}
+}
+
+func TestParseDestinationsEmptyDict(t *testing.T) {
+	got, err := ParseDestinations([]byte(`<plist version="1.0"><dict></dict></plist>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("destinations len = %d, want 0", len(got))
+	}
+}
+
+func TestParseStatusMidBackup(t *testing.T) {
+	got, err := ParseStatus(readFixture(t, "mid-backup-status.plist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Running || got.Percent != 42.5 || got.BackupPhase != "Copying" || got.DestinationID != "LOCAL-UUID" {
+		t.Fatalf("status = %+v", got)
+	}
+}
+
+func TestParseLocalSnapshots(t *testing.T) {
+	got, err := ParseLocalSnapshots(readFixture(t, "local-snapshots.plist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("snapshots len = %d", len(got))
+	}
+	if got[0].Name != "com.apple.TimeMachine.2026-05-28-133824.local" || got[0].Date.IsZero() {
+		t.Fatalf("snapshot[0] = %+v", got[0])
+	}
+	if got[1].Volume != "/" {
+		t.Fatalf("snapshot[1] = %+v", got[1])
+	}
+}
+
+func TestCollectNoDestinations(t *testing.T) {
+	now := time.Date(2026, 5, 28, 13, 38, 24, 0, time.UTC)
+	run := fakeRunner{
+		responses: map[string]fakeResponse{
+			"/usr/bin/tmutil\x00destinationinfo\x00-X":                 {out: []byte("No destinations configured."), err: errors.New("exit 1")},
+			"/usr/bin/tmutil\x00status\x00-X":                          {out: readFixture(t, "idle-status.plist")},
+			"/usr/bin/tmutil\x00listlocalsnapshots\x00/\x00-X":         {out: readFixture(t, "empty-array.plist")},
+			"/bin/launchctl\x00print\x00system/com.apple.backupd-auto": {out: []byte("service active")},
+		},
+	}
+	got, err := CollectWithOptions(context.Background(), Options{
+		Runner: run,
+		Now:    func() time.Time { return now },
+		ReadPrefs: func() (plistread.TMPrefs, error) {
+			return plistread.TMPrefs{AutoBackup: false, PreferencesVersion: 5}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.CollectedAt.Equal(now) || len(got.Destinations) != 0 || !got.SchedulerLoaded || got.AutoBackupEnabled {
+		t.Fatalf("state = %+v", got)
+	}
+}
+
+func TestCollectPermissionDenied(t *testing.T) {
+	run := fakeRunner{responses: map[string]fakeResponse{
+		"/usr/bin/tmutil\x00destinationinfo\x00-X": {out: []byte("Operation not permitted"), err: errors.New("exit 1")},
+	}}
+	_, err := CollectWithOptions(context.Background(), Options{Runner: run})
+	if !errors.Is(err, ErrNeedsFullDiskAccess) {
+		t.Fatalf("err = %v, want ErrNeedsFullDiskAccess", err)
+	}
+}
+
+func TestLaunchctlNotLoaded(t *testing.T) {
+	loaded, err := launchctlLoaded(context.Background(), fakeRunner{responses: map[string]fakeResponse{
+		"/bin/launchctl\x00print\x00system/com.apple.backupd-auto": {out: []byte("Could not find service"), err: errors.New("exit 113")},
+	}}, "system/com.apple.backupd-auto")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded {
+		t.Fatal("loaded = true, want false")
+	}
+}
+
+func TestAnySlice(t *testing.T) {
+	if got := anySlice("one"); !reflect.DeepEqual(got, []any{"one"}) {
+		t.Fatalf("anySlice scalar = %#v", got)
+	}
+}
+
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+type fakeResponse struct {
+	out []byte
+	err error
+}
+
+type fakeRunner struct {
+	responses map[string]fakeResponse
+}
+
+func (f fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	key := name
+	for _, arg := range args {
+		key += "\x00" + arg
+	}
+	resp, ok := f.responses[key]
+	if !ok {
+		return nil, errors.New("unexpected command: " + key)
+	}
+	return resp.out, resp.err
+}

--- a/internal/timemachine/types.go
+++ b/internal/timemachine/types.go
@@ -1,0 +1,73 @@
+// Package timemachine collects read-only Time Machine state.
+package timemachine
+
+import (
+	"errors"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/plistread"
+)
+
+// ErrNeedsFullDiskAccess marks Time Machine reads denied by macOS privacy
+// protections.
+var ErrNeedsFullDiskAccess = plistread.ErrNeedsFullDiskAccess
+
+// FullDiskAccessRemediation is the one-line CLI remediation for privacy denial.
+const FullDiskAccessRemediation = plistread.FullDiskAccessRemediation
+
+// TimeMachineState is the read-only host Time Machine state.
+type TimeMachineState struct {
+	Status            TMStatus          `json:"status"`
+	Destinations      []TMDestination   `json:"destinations"`
+	LocalSnapshots    []TMLocalSnapshot `json:"local_snapshots"`
+	AutoBackupEnabled bool              `json:"auto_backup_enabled"`
+	SchedulerLoaded   bool              `json:"scheduler_loaded"`
+	CollectedAt       time.Time         `json:"collected_at"`
+}
+
+// TMStatus is the current tmutil status payload.
+type TMStatus struct {
+	Running               bool    `json:"running"`
+	Percent               float64 `json:"percent"`
+	ClientID              string  `json:"client_id,omitempty"`
+	BackupPhase           string  `json:"backup_phase,omitempty"`
+	DestinationID         string  `json:"destination_id,omitempty"`
+	DestinationMountPoint string  `json:"destination_mount_point,omitempty"`
+	FirstBackup           bool    `json:"first_backup"`
+}
+
+// TMDestination is one configured backup destination.
+type TMDestination struct {
+	ID             string    `json:"id,omitempty"`
+	Name           string    `json:"name,omitempty"`
+	Kind           string    `json:"kind,omitempty"`
+	MountPoint     string    `json:"mount_point,omitempty"`
+	URL            string    `json:"url,omitempty"`
+	BytesAvailable uint64    `json:"bytes_available"`
+	BytesUsed      uint64    `json:"bytes_used"`
+	LastBackup     time.Time `json:"last_backup,omitempty"`
+	NextBackup     time.Time `json:"next_backup,omitempty"`
+	QuotaGB        uint64    `json:"quota_gb"`
+	Encrypted      bool      `json:"encrypted"`
+}
+
+// TMLocalSnapshot is one local APFS Time Machine snapshot.
+type TMLocalSnapshot struct {
+	Name   string    `json:"name"`
+	Date   time.Time `json:"date,omitempty"`
+	Volume string    `json:"volume,omitempty"`
+}
+
+// IsZero lets containing JSON structs omit a missing Time Machine sample.
+func (s TimeMachineState) IsZero() bool {
+	return s.CollectedAt.IsZero() &&
+		len(s.Destinations) == 0 &&
+		len(s.LocalSnapshots) == 0 &&
+		!s.AutoBackupEnabled &&
+		!s.SchedulerLoaded &&
+		!s.Status.Running
+}
+
+func isFullDiskAccessErr(err error) bool {
+	return errors.Is(err, ErrNeedsFullDiskAccess)
+}


### PR DESCRIPTION
Closes #258

## Summary
- add read-only Time Machine collector for status, destinations, local snapshots, auto-backup prefs, and scheduler state
- add `spectra timemachine [--json]` and snapshot host integration
- add destination/local snapshot diff coverage and tmutil plist fixtures

## Validation
- `spectra timemachine --json` live smoke test on a no-destination Mac
- gocyclo -over 15 -ignore '_test\\.go$' .\n- golangci-lint run\n- go test ./internal/timemachine ./internal/snapshot ./internal/diff ./cmd/spectra -count=1\n- go build ./... && go vet ./...\n- go test ./... -count=1