### PR TITLE
Add APFS snapshot inventory

### DIFF
--- a/cmd/spectra/storage.go
+++ b/cmd/spectra/storage.go
@@ -14,11 +14,12 @@ func runStorage(args []string) int {
 	fs := flag.NewFlagSet("spectra storage", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	includeSnapshots := fs.Bool("snapshots", false, "Include APFS snapshots")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	state := storagestate.Collect(storagestate.CollectOptions{})
+	state := storagestate.Collect(storagestate.CollectOptions{IncludeSnapshots: *includeSnapshots})
 
 	if *asJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -27,11 +28,11 @@ func runStorage(args []string) int {
 		return 0
 	}
 
-	printStorageState(state)
+	printStorageState(state, *includeSnapshots)
 	return 0
 }
 
-func printStorageState(s storagestate.State) {
+func printStorageState(s storagestate.State, includeSnapshots bool) {
 	fmt.Println("=== Storage state ===")
 
 	if len(s.Volumes) > 0 {
@@ -50,6 +51,9 @@ func printStorageState(s storagestate.State) {
 				humanSize(v.AvailBytes),
 				pct,
 			)
+			if includeSnapshots {
+				printVolumeSnapshots(v)
+			}
 		}
 	}
 
@@ -65,5 +69,22 @@ func printStorageState(s storagestate.State) {
 		for _, a := range s.LargestApps {
 			fmt.Printf("  %10s  %s\n", humanSize(a.OnDiskBytes), a.Path)
 		}
+	}
+}
+
+func printVolumeSnapshots(v storagestate.Volume) {
+	if len(v.Snapshots) == 0 {
+		if strings.EqualFold(v.FSType, "apfs") {
+			fmt.Println("    snapshots: none")
+		}
+		return
+	}
+	fmt.Printf("    snapshots (%d):\n", len(v.Snapshots))
+	for _, snap := range v.Snapshots {
+		created := ""
+		if !snap.CreatedAt.IsZero() {
+			created = " " + snap.CreatedAt.Format("2006-01-02 15:04:05")
+		}
+		fmt.Printf("      %-12s  %s%s\n", snap.Kind.String(), snap.Name, created)
 	}
 }

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -20,6 +20,7 @@ func V1Catalog() []Rule {
 		ruleMemoryCompressorExcess(),
 		ruleMemorySwapExcess(),
 		ruleMemorySustainedPressure(),
+		ruleStorageStagedMajorUpdate(),
 		ruleJVMGCPressure(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kaeawc/spectra/internal/memstate"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/storagestate"
+	"github.com/kaeawc/spectra/internal/timemachine"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
 
@@ -483,6 +484,67 @@ func TestStorageFootprintNoFire(t *testing.T) {
 	}
 }
 
+func TestStorageStagedMajorUpdateFiresWithoutLatestBackup(t *testing.T) {
+	s := baseSnap()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s.Storage = storagestate.State{
+		Volumes: []storagestate.Volume{{
+			MountPoint: "/",
+			FSType:     "apfs",
+			Snapshots: []storagestate.APFSSnapshot{{
+				Name:      "com.apple.os.update-MSUPrepareUpdate",
+				Kind:      storagestate.SnapshotMSUPrepare,
+				CreatedAt: now.Add(-8 * 24 * time.Hour),
+			}},
+		}},
+	}
+	findings := stagedMajorUpdateFindings(s, now)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "storage.staged_major_update" || !strings.Contains(findings[0].Fix, "spectra storage --snapshots") {
+		t.Fatalf("unexpected finding: %+v", findings[0])
+	}
+}
+
+func TestStorageStagedMajorUpdateNoFireWithLatestBackup(t *testing.T) {
+	s := baseSnap()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s.Host.TimeMachine.Destinations = []timemachine.TMDestination{{
+		Name:       "Backup",
+		LastBackup: now.Add(-2 * time.Hour),
+	}}
+	s.Storage = storagestate.State{
+		Volumes: []storagestate.Volume{{
+			MountPoint: "/",
+			Snapshots: []storagestate.APFSSnapshot{{
+				Kind:      storagestate.SnapshotMSUPrepare,
+				CreatedAt: now.Add(-8 * 24 * time.Hour),
+			}},
+		}},
+	}
+	if findings := stagedMajorUpdateFindings(s, now); len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+func TestStorageStagedMajorUpdateNoFireForFreshOrUndatedSnapshot(t *testing.T) {
+	s := baseSnap()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s.Storage = storagestate.State{
+		Volumes: []storagestate.Volume{{
+			MountPoint: "/",
+			Snapshots: []storagestate.APFSSnapshot{
+				{Kind: storagestate.SnapshotMSUPrepare, CreatedAt: now.Add(-2 * 24 * time.Hour)},
+				{Kind: storagestate.SnapshotMSUPrepare},
+			},
+		}},
+	}
+	if findings := stagedMajorUpdateFindings(s, now); len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(findings))
+	}
+}
+
 // --- app-no-hardened-runtime ---
 
 func TestAppNoHardenedRuntimeFires(t *testing.T) {
@@ -871,6 +933,7 @@ func TestV1CatalogContainsExpectedRules(t *testing.T) {
 		"memory.compressor_excess",
 		"memory.swap_excess",
 		"memory.sustained_pressure",
+		"storage.staged_major_update",
 	} {
 		if !ruleIDs[want] {
 			t.Errorf("V1Catalog missing rule %q", want)

--- a/internal/rules/storage_facts.go
+++ b/internal/rules/storage_facts.go
@@ -1,0 +1,56 @@
+package rules
+
+import (
+	"time"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/storagestate"
+)
+
+const stagedMajorUpdateAge = 7 * 24 * time.Hour
+
+func ruleStorageStagedMajorUpdate() Rule {
+	return Rule{
+		ID:       "storage.staged_major_update",
+		Severity: SeverityInfo,
+		Message:  "A staged macOS upgrade snapshot has been sitting on disk for more than 7 days.",
+		Fix:      "Run `spectra storage --snapshots` and configure or run Time Machine before continuing the macOS upgrade.",
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			return stagedMajorUpdateFindings(s, time.Now())
+		},
+	}
+}
+
+func stagedMajorUpdateFindings(s snapshot.Snapshot, now time.Time) []Finding {
+	if hasLatestTimeMachineBackup(s) {
+		return nil
+	}
+	for _, volume := range s.Storage.Volumes {
+		for _, snap := range volume.Snapshots {
+			if snap.Kind != storagestate.SnapshotMSUPrepare || snap.CreatedAt.IsZero() {
+				continue
+			}
+			age := now.Sub(snap.CreatedAt)
+			if age <= stagedMajorUpdateAge {
+				continue
+			}
+			return []Finding{{
+				RuleID:   "storage.staged_major_update",
+				Severity: SeverityInfo,
+				Subject:  volume.MountPoint,
+				Message:  "Staged macOS upgrade has been sitting on disk for >7 days. On Macs without a Time Machine destination this can drive an fseventsd leak.",
+				Fix:      "Run `spectra storage --snapshots`; configure a Time Machine destination or complete/cancel the staged macOS upgrade.",
+			}}
+		}
+	}
+	return nil
+}
+
+func hasLatestTimeMachineBackup(s snapshot.Snapshot) bool {
+	for _, destination := range s.Host.TimeMachine.Destinations {
+		if !destination.LastBackup.IsZero() {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/snapshot/cached_collectors.go
+++ b/internal/snapshot/cached_collectors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -82,6 +83,8 @@ func storageCacheKey(opts storagestate.CollectOptions) []byte {
 		"storage",
 		opts.Home,
 		strings.Join(opts.AppPaths, "|"),
+		fmt.Sprint(opts.LargestAppsN),
+		fmt.Sprint(opts.IncludeSnapshots),
 	}
 	h := sha256.New()
 	h.Write([]byte(strings.Join(parts, "\x00")))

--- a/internal/storagestate/snapshot_classify_test.go
+++ b/internal/storagestate/snapshot_classify_test.go
@@ -1,0 +1,78 @@
+package storagestate
+
+import (
+	"os"
+	"testing"
+)
+
+func TestClassifySnapshotName(t *testing.T) {
+	tests := []struct {
+		name     string
+		wantKind SnapshotKind
+		wantDate bool
+	}{
+		{
+			name:     "com.apple.os.update-9E3B7EFBB732B00D98BF266D7444FDC8348CC3B2CCEF551FF262CA73E4E23BAE",
+			wantKind: SnapshotOSUpdate,
+		},
+		{
+			name:     "com.apple.os.update-MSUPrepareUpdate",
+			wantKind: SnapshotMSUPrepare,
+		},
+		{
+			name:     "com.apple.TimeMachine.2026-05-24-135501.local",
+			wantKind: SnapshotTMLocal,
+			wantDate: true,
+		},
+		{
+			name:     "com.apple.TimeMachine.2026-05-24-135501",
+			wantKind: SnapshotTMRemote,
+			wantDate: true,
+		},
+		{
+			name:     "manual.snapshot",
+			wantKind: SnapshotUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.wantKind.String(), func(t *testing.T) {
+			gotKind, gotDate := ClassifySnapshotName(tt.name)
+			if gotKind != tt.wantKind {
+				t.Fatalf("kind = %s, want %s", gotKind, tt.wantKind)
+			}
+			if gotDate.IsZero() == tt.wantDate {
+				t.Fatalf("created date zero = %v, want date = %v", gotDate.IsZero(), tt.wantDate)
+			}
+		})
+	}
+}
+
+func TestParseAPFSSnapshotsFixture(t *testing.T) {
+	data, err := os.ReadFile("testdata/apfs-snapshots.plist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ParseAPFSSnapshots(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("snapshots = %d, want 2", len(got))
+	}
+	if got[0].Kind != SnapshotOSUpdate || got[0].UUID == "" || got[0].XID == 0 {
+		t.Fatalf("first snapshot parsed incorrectly: %+v", got[0])
+	}
+	if got[1].Kind != SnapshotMSUPrepare || !got[1].PinsCapacity {
+		t.Fatalf("MSUPrepare snapshot parsed incorrectly: %+v", got[1])
+	}
+}
+
+func TestParseAPFSSnapshotsEmpty(t *testing.T) {
+	got, err := ParseAPFSSnapshots([]byte(`<?xml version="1.0"?><plist version="1.0"><dict><key>Snapshots</key><array/></dict></plist>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("snapshots = %d, want 0", len(got))
+	}
+}

--- a/internal/storagestate/snapshots.go
+++ b/internal/storagestate/snapshots.go
@@ -1,0 +1,261 @@
+package storagestate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"howett.net/plist"
+)
+
+type SnapshotKind int
+
+const (
+	SnapshotUnknown SnapshotKind = iota
+	SnapshotOSUpdate
+	SnapshotMSUPrepare
+	SnapshotTMLocal
+	SnapshotTMRemote
+)
+
+type APFSSnapshot struct {
+	UUID         string       `json:"uuid,omitempty"`
+	Name         string       `json:"name"`
+	XID          uint64       `json:"xid,omitempty"`
+	Purgeable    bool         `json:"purgeable,omitempty"`
+	PinsCapacity bool         `json:"pins_capacity,omitempty"`
+	Kind         SnapshotKind `json:"kind"`
+	CreatedAt    time.Time    `json:"created_at,omitzero,omitempty"`
+}
+
+type VolumeSnapshots struct {
+	Device     string         `json:"device,omitempty"`
+	MountPoint string         `json:"mount_point"`
+	Snapshots  []APFSSnapshot `json:"snapshots"`
+}
+
+var (
+	reOSUpdate   = regexp.MustCompile(`^com\.apple\.os\.update-[A-F0-9]{64,}$`)
+	reMSUPrepare = regexp.MustCompile(`^com\.apple\.os\.update-MSUPrepareUpdate$`)
+	reTMLocal    = regexp.MustCompile(`^com\.apple\.TimeMachine\.(\d{4}-\d{2}-\d{2}-\d{6})\.local$`)
+	reTMRemote   = regexp.MustCompile(`^com\.apple\.TimeMachine\.(\d{4}-\d{2}-\d{2}-\d{6})$`)
+)
+
+func (k SnapshotKind) String() string {
+	switch k {
+	case SnapshotOSUpdate:
+		return "os_update"
+	case SnapshotMSUPrepare:
+		return "msu_prepare"
+	case SnapshotTMLocal:
+		return "tm_local"
+	case SnapshotTMRemote:
+		return "tm_remote"
+	default:
+		return "unknown"
+	}
+}
+
+func (k SnapshotKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
+}
+
+func ClassifySnapshotName(name string) (SnapshotKind, time.Time) {
+	switch {
+	case reOSUpdate.MatchString(name):
+		return SnapshotOSUpdate, time.Time{}
+	case reMSUPrepare.MatchString(name):
+		return SnapshotMSUPrepare, time.Time{}
+	case reTMLocal.MatchString(name):
+		return SnapshotTMLocal, snapshotTimeFromName(reTMLocal, name)
+	case reTMRemote.MatchString(name):
+		return SnapshotTMRemote, snapshotTimeFromName(reTMRemote, name)
+	default:
+		return SnapshotUnknown, time.Time{}
+	}
+}
+
+func ParseAPFSSnapshots(data []byte) ([]APFSSnapshot, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, nil
+	}
+	var root any
+	if _, err := plist.Unmarshal(data, &root); err != nil {
+		return nil, err
+	}
+	items := snapshotItems(root)
+	out := make([]APFSSnapshot, 0, len(items))
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		snap := snapshotFromMap(m)
+		if snap.Name != "" {
+			out = append(out, snap)
+		}
+	}
+	return out, nil
+}
+
+func applyAPFSSnapshots(volumes []Volume, run CmdRunner) {
+	for i := range volumes {
+		if !shouldCollectSnapshots(volumes[i]) {
+			continue
+		}
+		out, err := run("diskutil", "apfs", "listSnapshots", volumes[i].MountPoint, "-plist")
+		if err != nil {
+			continue
+		}
+		snapshots, err := ParseAPFSSnapshots(out)
+		if err == nil {
+			volumes[i].Snapshots = snapshots
+		}
+	}
+}
+
+func shouldCollectSnapshots(v Volume) bool {
+	if !strings.EqualFold(v.FSType, "apfs") {
+		return false
+	}
+	return v.MountPoint == "/" || !v.ReadOnly
+}
+
+func snapshotItems(root any) []any {
+	switch v := root.(type) {
+	case []any:
+		return v
+	case map[string]any:
+		if raw, ok := v["Snapshots"]; ok {
+			return anySlice(raw)
+		}
+		if raw, ok := v["snapshots"]; ok {
+			return anySlice(raw)
+		}
+		return []any{v}
+	default:
+		return nil
+	}
+}
+
+func snapshotFromMap(m map[string]any) APFSSnapshot {
+	name := stringValue(m, "SnapshotName", "Name", "name")
+	kind, created := ClassifySnapshotName(name)
+	if t, ok := dateValue(m, "SnapshotCreationDate", "CreationDate", "CreatedAt", "Date"); ok {
+		created = t
+	}
+	return APFSSnapshot{
+		UUID:         stringValue(m, "SnapshotUUID", "UUID", "uuid"),
+		Name:         name,
+		XID:          uintValue(m, "SnapshotXID", "XID", "xid"),
+		Purgeable:    boolValue(m, "Purgeable", "purgeable"),
+		PinsCapacity: boolValue(m, "LimitingContainerShrink", "PinsCapacity", "pins_capacity"),
+		Kind:         kind,
+		CreatedAt:    created,
+	}
+}
+
+func snapshotTimeFromName(re *regexp.Regexp, name string) time.Time {
+	match := re.FindStringSubmatch(name)
+	if len(match) != 2 {
+		return time.Time{}
+	}
+	t, err := time.ParseInLocation("2006-01-02-150405", match[1], time.Local)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+func anySlice(raw any) []any {
+	switch v := raw.(type) {
+	case []any:
+		return v
+	case nil:
+		return nil
+	default:
+		return []any{v}
+	}
+}
+
+func firstAny(m map[string]any, keys ...string) (any, bool) {
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func stringValue(m map[string]any, keys ...string) string {
+	raw, ok := firstAny(m, keys...)
+	if !ok || raw == nil {
+		return ""
+	}
+	if v, ok := raw.(string); ok {
+		return v
+	}
+	return strings.TrimSpace(fmt.Sprint(raw))
+}
+
+func boolValue(m map[string]any, keys ...string) bool {
+	raw, ok := firstAny(m, keys...)
+	if !ok {
+		return false
+	}
+	switch v := raw.(type) {
+	case bool:
+		return v
+	case uint64:
+		return v != 0
+	case int64:
+		return v != 0
+	case int:
+		return v != 0
+	default:
+		return false
+	}
+}
+
+func uintValue(m map[string]any, keys ...string) uint64 {
+	raw, ok := firstAny(m, keys...)
+	if !ok {
+		return 0
+	}
+	switch v := raw.(type) {
+	case uint64:
+		return v
+	case uint:
+		return uint64(v)
+	case int:
+		if v > 0 {
+			return uint64(v)
+		}
+	case int64:
+		if v > 0 {
+			return uint64(v)
+		}
+	}
+	return 0
+}
+
+func dateValue(m map[string]any, keys ...string) (time.Time, bool) {
+	raw, ok := firstAny(m, keys...)
+	if !ok {
+		return time.Time{}, false
+	}
+	switch v := raw.(type) {
+	case time.Time:
+		return v, true
+	case string:
+		for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05 -0700 MST", "2006-01-02 15:04:05"} {
+			if t, err := time.Parse(layout, v); err == nil {
+				return t, true
+			}
+		}
+	}
+	return time.Time{}, false
+}

--- a/internal/storagestate/storagestate.go
+++ b/internal/storagestate/storagestate.go
@@ -22,11 +22,14 @@ type State struct {
 
 // Volume is one mounted filesystem.
 type Volume struct {
-	MountPoint string `json:"mount_point"`
-	FSType     string `json:"fs_type,omitempty"`
-	TotalBytes int64  `json:"total_bytes"`
-	UsedBytes  int64  `json:"used_bytes"`
-	AvailBytes int64  `json:"avail_bytes"`
+	Device     string         `json:"device,omitempty"`
+	MountPoint string         `json:"mount_point"`
+	FSType     string         `json:"fs_type,omitempty"`
+	ReadOnly   bool           `json:"read_only,omitempty"`
+	TotalBytes int64          `json:"total_bytes"`
+	UsedBytes  int64          `json:"used_bytes"`
+	AvailBytes int64          `json:"avail_bytes"`
+	Snapshots  []APFSSnapshot `json:"snapshots,omitempty"`
 }
 
 // AppSize is one app bundle's on-disk footprint.
@@ -54,6 +57,8 @@ type CollectOptions struct {
 	LargestAppsN int
 	// CmdRunner overrides exec.Command for testing.
 	CmdRunner CmdRunner
+	// IncludeSnapshots runs diskutil APFS snapshot collection for APFS volumes.
+	IncludeSnapshots bool
 }
 
 // Collect gathers StorageState.
@@ -75,8 +80,11 @@ func Collect(opts CollectOptions) State {
 	}
 	if len(s.Volumes) > 0 {
 		if out, err := run("mount"); err == nil {
-			applyFSTypes(s.Volumes, parseMountFSTypes(string(out)))
+			applyMountInfo(s.Volumes, parseMountInfos(string(out)))
 		}
+	}
+	if opts.IncludeSnapshots {
+		applyAPFSSnapshots(s.Volumes, run)
 	}
 	s.UserLibraryBytes = dirBytes(filepath.Join(opts.Home, "Library"))
 	s.AppCachesBytes = dirBytes(filepath.Join(opts.Home, "Library", "Caches"))
@@ -99,7 +107,7 @@ func parseDF(out string) []Volume {
 		mount := fields[5]
 		// Skip pseudo filesystems.
 		if strings.HasPrefix(fields[0], "devfs") ||
-			strings.HasPrefix(fields[0], "map ") ||
+			fields[0] == "map" ||
 			strings.HasPrefix(mount, "/dev") ||
 			strings.HasPrefix(mount, "/System/Volumes/Preboot") ||
 			strings.HasPrefix(mount, "/System/Volumes/Recovery") ||
@@ -111,6 +119,7 @@ func parseDF(out string) []Volume {
 		used := parseInt64(fields[2]) * 1024
 		avail := parseInt64(fields[3]) * 1024
 		volumes = append(volumes, Volume{
+			Device:     fields[0],
 			MountPoint: mount,
 			TotalBytes: total,
 			UsedBytes:  used,
@@ -128,36 +137,63 @@ func applyFSTypes(volumes []Volume, fsTypes map[string]string) {
 	}
 }
 
+func applyMountInfo(volumes []Volume, infos map[string]mountInfo) {
+	for i := range volumes {
+		if info, ok := infos[volumes[i].MountPoint]; ok {
+			volumes[i].FSType = info.fsType
+			volumes[i].ReadOnly = info.readOnly
+		}
+	}
+}
+
 func parseMountFSTypes(out string) map[string]string {
 	fsTypes := map[string]string{}
-	for _, line := range strings.Split(out, "\n") {
-		mountPoint, fsType, ok := parseMountLine(line)
-		if ok {
-			fsTypes[mountPoint] = fsType
-		}
+	for mountPoint, info := range parseMountInfos(out) {
+		fsTypes[mountPoint] = info.fsType
 	}
 	return fsTypes
 }
 
-func parseMountLine(line string) (mountPoint string, fsType string, ok bool) {
+type mountInfo struct {
+	fsType   string
+	readOnly bool
+}
+
+func parseMountInfos(out string) map[string]mountInfo {
+	infos := map[string]mountInfo{}
+	for _, line := range strings.Split(out, "\n") {
+		mountPoint, info, ok := parseMountLine(line)
+		if ok {
+			infos[mountPoint] = info
+		}
+	}
+	return infos
+}
+
+func parseMountLine(line string) (mountPoint string, info mountInfo, ok bool) {
 	_, rest, ok := strings.Cut(line, " on ")
 	if !ok {
-		return "", "", false
+		return "", mountInfo{}, false
 	}
 	mountPoint, options, ok := strings.Cut(rest, " (")
 	if !ok {
-		return "", "", false
+		return "", mountInfo{}, false
 	}
 	fields := strings.Split(options, ",")
 	if len(fields) == 0 {
-		return "", "", false
+		return "", mountInfo{}, false
 	}
-	fsType = strings.TrimSpace(strings.TrimSuffix(fields[0], ")"))
+	info.fsType = strings.TrimSpace(strings.TrimSuffix(fields[0], ")"))
+	for _, field := range fields[1:] {
+		if strings.TrimSpace(strings.TrimSuffix(field, ")")) == "read-only" {
+			info.readOnly = true
+		}
+	}
 	mountPoint = strings.TrimSpace(mountPoint)
-	if mountPoint == "" || fsType == "" {
-		return "", "", false
+	if mountPoint == "" || info.fsType == "" {
+		return "", mountInfo{}, false
 	}
-	return mountPoint, fsType, true
+	return mountPoint, info, true
 }
 
 // dirBytes returns the total on-disk size of all files under dir using

--- a/internal/storagestate/storagestate_test.go
+++ b/internal/storagestate/storagestate_test.go
@@ -13,6 +13,7 @@ devfs                                  386       386         0   100% /dev
 /dev/disk3s2                     971309944  13285364 444843444     3% /System/Volumes/Preboot
 /dev/disk3s4                     971309944   1107516 444843444     1% /System/Volumes/Recovery
 /dev/disk3s5                     971309944   5312168 444843444     2% /data
+map auto_home                            0         0         0   100% /System/Volumes/Data/home
 `
 
 const mountOutput = `/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
@@ -38,6 +39,9 @@ func TestParseDF(t *testing.T) {
 	}
 	if _, ok := mounts["/dev"]; ok {
 		t.Error("/dev (devfs) should be excluded")
+	}
+	if mounts["/"].Device != "/dev/disk3s1s1" {
+		t.Errorf("root device = %q, want /dev/disk3s1s1", mounts["/"].Device)
 	}
 }
 
@@ -70,6 +74,9 @@ func TestApplyFSTypes(t *testing.T) {
 				t.Fatalf("%s fs type = %q, want apfs", v.MountPoint, v.FSType)
 			}
 		}
+	}
+	if got := parseMountInfos(mountOutput)["/"].readOnly; !got {
+		t.Fatal("root should be read-only")
 	}
 }
 
@@ -163,5 +170,45 @@ func TestCollect(t *testing.T) {
 	}
 	if s.UserLibraryBytes == 0 {
 		t.Error("UserLibraryBytes should be > 0")
+	}
+}
+
+func TestCollectSnapshots(t *testing.T) {
+	home := t.TempDir()
+	fixture, err := os.ReadFile("testdata/apfs-snapshots.plist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub := func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "df":
+			return []byte(dfOutput), nil
+		case "mount":
+			return []byte(mountOutput), nil
+		case "diskutil":
+			if len(args) >= 4 && args[2] == "/" {
+				return fixture, nil
+			}
+			return []byte(`<?xml version="1.0"?><plist version="1.0"><dict><key>Snapshots</key><array/></dict></plist>`), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+	s := Collect(CollectOptions{
+		Home:             home,
+		CmdRunner:        stub,
+		IncludeSnapshots: true,
+	})
+	var root Volume
+	for _, v := range s.Volumes {
+		if v.MountPoint == "/" {
+			root = v
+		}
+	}
+	if len(root.Snapshots) != 2 {
+		t.Fatalf("root snapshots = %d, want 2", len(root.Snapshots))
+	}
+	if root.Snapshots[1].Kind != SnapshotMSUPrepare {
+		t.Fatalf("second snapshot kind = %s, want %s", root.Snapshots[1].Kind, SnapshotMSUPrepare)
 	}
 }

--- a/internal/storagestate/testdata/apfs-snapshots.plist
+++ b/internal/storagestate/testdata/apfs-snapshots.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Snapshots</key>
+	<array>
+		<dict>
+			<key>LimitingContainerShrink</key>
+			<false/>
+			<key>Purgeable</key>
+			<false/>
+			<key>RevertTo</key>
+			<false/>
+			<key>RootTo</key>
+			<false/>
+			<key>SnapshotName</key>
+			<string>com.apple.os.update-9E3B7EFBB732B00D98BF266D7444FDC8348CC3B2CCEF551FF262CA73E4E23BAE</string>
+			<key>SnapshotUUID</key>
+			<string>00000000-0000-4000-8000-000000000001</string>
+			<key>SnapshotXID</key>
+			<integer>3068290</integer>
+		</dict>
+		<dict>
+			<key>LimitingContainerShrink</key>
+			<true/>
+			<key>Purgeable</key>
+			<false/>
+			<key>RevertTo</key>
+			<false/>
+			<key>RootTo</key>
+			<false/>
+			<key>SnapshotName</key>
+			<string>com.apple.os.update-MSUPrepareUpdate</string>
+			<key>SnapshotUUID</key>
+			<string>00000000-0000-4000-8000-000000000002</string>
+			<key>SnapshotXID</key>
+			<integer>68099980</integer>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add `spectra storage --snapshots` and JSON APFS snapshot fields on volumes
- parse `diskutil apfs listSnapshots <vol> -plist` output and classify OS update, MSUPrepare, Time Machine local/remote, and unknown snapshots
- add `storage.staged_major_update` rule for stale MSUPrepare snapshots when Time Machine lacks a latest backup

## Validation
- `go test ./internal/storagestate ./internal/rules ./cmd/spectra -count=1`
- `go run ./cmd/spectra storage --snapshots --json | rg '"mount_point": "100%"|created_at|msu_prepare|os_update'`\n- `go build ./... && go vet ./...`\n- `go test ./... -count=1`\n- `gocyclo -over 15 -ignore '_test\\.go$' .`\n- `golangci-lint run`\n\nCloses #259