### PR TITLE
Add APFS mount state

### DIFF
--- a/cmd/spectra/storage.go
+++ b/cmd/spectra/storage.go
@@ -57,6 +57,10 @@ func printStorageState(s storagestate.State, includeSnapshots bool) {
 		}
 	}
 
+	if len(s.Mounts) > 0 {
+		printMounts(s.Mounts)
+	}
+
 	if s.UserLibraryBytes > 0 {
 		fmt.Printf("\n~/Library:       %s total\n", humanSize(s.UserLibraryBytes))
 		if s.AppCachesBytes > 0 {
@@ -69,6 +73,22 @@ func printStorageState(s storagestate.State, includeSnapshots bool) {
 		for _, a := range s.LargestApps {
 			fmt.Printf("  %10s  %s\n", humanSize(a.OnDiskBytes), a.Path)
 		}
+	}
+}
+
+func printMounts(mounts []storagestate.Mount) {
+	fmt.Printf("\nmounts (%d):\n", len(mounts))
+	fmt.Printf("  %-28s  %-6s  %-9s  %10s  %6s  %s\n", "MOUNT", "FS", "ROLE", "USED", "PCT", "FLAGS")
+	fmt.Println("  " + strings.Repeat("-", 82))
+	for _, m := range mounts {
+		fmt.Printf("  %-28s  %-6s  %-9s  %10s  %5.0f%%  %s\n",
+			truncate(m.MountPoint, 28),
+			m.FSType,
+			m.APFSRole,
+			humanSizeUint(m.Capacity.Used),
+			m.Capacity.UsedPercent,
+			strings.Join(m.Flags, ","),
+		)
 	}
 }
 
@@ -87,4 +107,17 @@ func printVolumeSnapshots(v storagestate.Volume) {
 		}
 		fmt.Printf("      %-12s  %s%s\n", snap.Kind.String(), snap.Name, created)
 	}
+}
+
+func humanSizeUint(n uint64) string {
+	const k = 1024
+	switch {
+	case n >= k*k*k:
+		return fmt.Sprintf("%.1f GB", float64(n)/float64(k*k*k))
+	case n >= k*k:
+		return fmt.Sprintf("%.0f MB", float64(n)/float64(k*k))
+	case n >= k:
+		return fmt.Sprintf("%.0f KB", float64(n)/float64(k))
+	}
+	return fmt.Sprintf("%d B", n)
 }

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -21,6 +21,8 @@ func V1Catalog() []Rule {
 		ruleMemorySwapExcess(),
 		ruleMemorySustainedPressure(),
 		ruleStorageStagedMajorUpdate(),
+		ruleStorageDataVolumeNearFull(),
+		ruleStorageSystemVolumeNearFull(),
 		ruleJVMGCPressure(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -545,6 +545,53 @@ func TestStorageStagedMajorUpdateNoFireForFreshOrUndatedSnapshot(t *testing.T) {
 	}
 }
 
+func TestStorageDataVolumeNearFullFires(t *testing.T) {
+	s := baseSnap()
+	s.Storage.Mounts = []storagestate.Mount{{
+		MountPoint: "/System/Volumes/Data",
+		APFSRole:   "data",
+		Capacity:   storagestate.Capacity{UsedPercent: 95},
+	}}
+	findings := ruleStorageDataVolumeNearFull().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "storage.data_volume_near_full" || findings[0].Severity != SeverityMedium {
+		t.Fatalf("unexpected finding: %+v", findings[0])
+	}
+}
+
+func TestStorageSystemVolumeNearFullFires(t *testing.T) {
+	s := baseSnap()
+	s.Storage.Mounts = []storagestate.Mount{{
+		MountPoint: "/",
+		APFSRole:   "system",
+		Capacity:   storagestate.Capacity{UsedPercent: 96},
+	}}
+	findings := ruleStorageSystemVolumeNearFull().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "storage.system_volume_near_full" || findings[0].Severity != SeverityHigh {
+		t.Fatalf("unexpected finding: %+v", findings[0])
+	}
+}
+
+func TestStorageCapacityRulesSkipSimulator(t *testing.T) {
+	s := baseSnap()
+	s.Storage.Mounts = []storagestate.Mount{{
+		MountPoint: "/Library/Developer/CoreSimulator/Volumes/iOS",
+		APFSRole:   "simulator",
+		Capacity:   storagestate.Capacity{UsedPercent: 98},
+	}}
+	if findings := ruleStorageDataVolumeNearFull().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("data volume rule should skip simulator, got %v", findings)
+	}
+	if findings := ruleStorageSystemVolumeNearFull().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("system volume rule should skip simulator, got %v", findings)
+	}
+}
+
 // --- app-no-hardened-runtime ---
 
 func TestAppNoHardenedRuntimeFires(t *testing.T) {
@@ -934,6 +981,8 @@ func TestV1CatalogContainsExpectedRules(t *testing.T) {
 		"memory.swap_excess",
 		"memory.sustained_pressure",
 		"storage.staged_major_update",
+		"storage.data_volume_near_full",
+		"storage.system_volume_near_full",
 	} {
 		if !ruleIDs[want] {
 			t.Errorf("V1Catalog missing rule %q", want)

--- a/internal/rules/storage_facts.go
+++ b/internal/rules/storage_facts.go
@@ -21,6 +21,64 @@ func ruleStorageStagedMajorUpdate() Rule {
 	}
 }
 
+func ruleStorageDataVolumeNearFull() Rule {
+	return Rule{
+		ID:       "storage.data_volume_near_full",
+		Severity: SeverityMedium,
+		Message:  "APFS data volume is more than 90% full.",
+		Fix:      "Run `spectra storage` and free space on the Data volume.",
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, mount := range s.Storage.Mounts {
+				if mount.APFSRole != "data" || mount.Capacity.UsedPercent <= 90 {
+					continue
+				}
+				findings = append(findings, storageCapacityFinding(
+					"storage.data_volume_near_full",
+					SeverityMedium,
+					mount,
+					"APFS Data volume is more than 90% full.",
+				))
+			}
+			return findings
+		},
+	}
+}
+
+func ruleStorageSystemVolumeNearFull() Rule {
+	return Rule{
+		ID:       "storage.system_volume_near_full",
+		Severity: SeverityHigh,
+		Message:  "APFS system volume is more than 95% full.",
+		Fix:      "Run `spectra storage`; verify staged macOS updates and system volume snapshots.",
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, mount := range s.Storage.Mounts {
+				if mount.APFSRole != "system" || mount.Capacity.UsedPercent <= 95 {
+					continue
+				}
+				findings = append(findings, storageCapacityFinding(
+					"storage.system_volume_near_full",
+					SeverityHigh,
+					mount,
+					"APFS system volume is more than 95% full.",
+				))
+			}
+			return findings
+		},
+	}
+}
+
+func storageCapacityFinding(ruleID string, severity Severity, mount storagestate.Mount, message string) Finding {
+	return Finding{
+		RuleID:   ruleID,
+		Severity: severity,
+		Subject:  mount.MountPoint,
+		Message:  message,
+		Fix:      "Run `spectra storage` to inspect mount capacity, flags, and APFS role.",
+	}
+}
+
 func stagedMajorUpdateFindings(s snapshot.Snapshot, now time.Time) []Finding {
 	if hasLatestTimeMachineBackup(s) {
 		return nil

--- a/internal/storagestate/mounts_darwin.go
+++ b/internal/storagestate/mounts_darwin.go
@@ -1,0 +1,233 @@
+//go:build darwin
+
+package storagestate
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+
+	"golang.org/x/sys/unix"
+	"howett.net/plist"
+)
+
+type apfsRoleInfo struct {
+	role        string
+	sealed      bool
+	capacity    Capacity
+	hasCapacity bool
+}
+
+var mountRoleCache sync.Map
+
+func collectMounts(run CmdRunner) ([]Mount, error) {
+	n, err := unix.Getfsstat(nil, unix.MNT_NOWAIT)
+	if err != nil {
+		return nil, err
+	}
+	raw := make([]unix.Statfs_t, n)
+	n, err = unix.Getfsstat(raw, unix.MNT_NOWAIT)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Mount, 0, n)
+	for i := range raw[:n] {
+		out = append(out, convertStatfs(&raw[i], run))
+	}
+	return out, nil
+}
+
+func convertStatfs(raw *unix.Statfs_t, run CmdRunner) Mount {
+	m := Mount{
+		Device:     cString(raw.Mntfromname[:]),
+		MountPoint: cString(raw.Mntonname[:]),
+		FSType:     cString(raw.Fstypename[:]),
+		BlockSize:  raw.Bsize,
+		Capacity:   capacityFromStatfs(raw),
+	}
+	m.ReadOnly = raw.Flags&unix.MNT_RDONLY != 0
+	info := roleInfoForMount(m, raw, run)
+	m.APFSRole = info.role
+	m.Sealed = info.sealed
+	if info.hasCapacity {
+		m.Capacity = info.capacity
+	}
+	m.Flags = mountFlagNames(raw.Flags, m.Sealed)
+	return m
+}
+
+func capacityFromStatfs(raw *unix.Statfs_t) Capacity {
+	blockSize := uint64(raw.Bsize)
+	total := raw.Blocks * blockSize
+	available := raw.Bavail * blockSize
+	used := uint64(0)
+	if raw.Blocks > raw.Bfree {
+		used = (raw.Blocks - raw.Bfree) * blockSize
+	}
+	return Capacity{
+		Total:       total,
+		Used:        used,
+		Available:   available,
+		UsedPercent: usedPercent(used, total),
+		Inodes:      raw.Files,
+		InodesFree:  raw.Ffree,
+	}
+}
+
+func usedPercent(used, total uint64) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(used) / float64(total) * 100
+}
+
+func mountFlagNames(flags uint32, sealed bool) []string {
+	var out []string
+	if sealed {
+		out = append(out, "sealed")
+	}
+	for _, item := range []struct {
+		bit  uint32
+		name string
+	}{
+		{unix.MNT_RDONLY, "ro"},
+		{unix.MNT_NOEXEC, "noexec"},
+		{unix.MNT_DONTBROWSE, "nobrowse"},
+		{unix.MNT_JOURNALED, "journaled"},
+		{unix.MNT_LOCAL, "local"},
+		{unix.MNT_NOSUID, "nosuid"},
+		{unix.MNT_NODEV, "nodev"},
+	} {
+		if flags&item.bit != 0 {
+			out = append(out, item.name)
+		}
+	}
+	return out
+}
+
+func roleInfoForMount(m Mount, raw *unix.Statfs_t, run CmdRunner) apfsRoleInfo {
+	if m.FSType != "apfs" {
+		return apfsRoleInfo{}
+	}
+	if strings.HasPrefix(m.MountPoint, "/Library/Developer/CoreSimulator/") {
+		info := apfsInfoFromDiskutil(m.Device, m.MountPoint, run)
+		info.role = "simulator"
+		return info
+	}
+	info := apfsInfoFromDiskutil(m.Device, m.MountPoint, run)
+	if info.role == "" {
+		info.role = inferAPFSRole(m.MountPoint, raw.Flags, raw.Flags_ext)
+	}
+	if raw.Flags&unix.MNT_SNAPSHOT != 0 {
+		info.sealed = true
+	}
+	return info
+}
+
+func inferAPFSRole(mountPoint string, flags, flagsExt uint32) string {
+	switch {
+	case flags&unix.MNT_ROOTFS != 0 || mountPoint == "/":
+		return "system"
+	case flagsExt&unix.MNT_EXT_ROOT_DATA_VOL != 0 || mountPoint == "/System/Volumes/Data":
+		return "data"
+	case mountPoint == "/System/Volumes/Preboot":
+		return "preboot"
+	case mountPoint == "/System/Volumes/VM":
+		return "vm"
+	case strings.HasPrefix(mountPoint, "/System/Volumes/Update"):
+		return "update"
+	default:
+		return ""
+	}
+}
+
+func apfsInfoFromDiskutil(device, mountPoint string, run CmdRunner) apfsRoleInfo {
+	key := device
+	if key == "" {
+		key = mountPoint
+	}
+	if key == "" {
+		return apfsRoleInfo{}
+	}
+	if v, ok := mountRoleCache.Load(key); ok {
+		return v.(apfsRoleInfo)
+	}
+	info := readAPFSInfo(key, run)
+	mountRoleCache.Store(key, info)
+	return info
+}
+
+func readAPFSInfo(target string, run CmdRunner) apfsRoleInfo {
+	if run == nil {
+		return apfsRoleInfo{}
+	}
+	out, err := run("diskutil", "info", "-plist", target)
+	if err != nil {
+		return apfsRoleInfo{}
+	}
+	info := parseDiskutilInfo(out)
+	return info
+}
+
+func parseDiskutilInfo(data []byte) apfsRoleInfo {
+	var root any
+	if _, err := plist.Unmarshal(data, &root); err != nil {
+		return apfsRoleInfo{}
+	}
+	m, ok := root.(map[string]any)
+	if !ok {
+		return apfsRoleInfo{}
+	}
+	info := apfsRoleInfo{
+		role:   normalizeAPFSRole(stringValue(m, "VolumeRole", "APFSVolumeRole", "Role")),
+		sealed: sealedValue(stringValue(m, "Sealed", "APFSSealed")),
+	}
+	if capacity, ok := capacityFromDiskutilInfo(m); ok {
+		info.capacity = capacity
+		info.hasCapacity = true
+	}
+	return info
+}
+
+func normalizeAPFSRole(role string) string {
+	role = strings.ToLower(strings.TrimSpace(role))
+	role = strings.TrimPrefix(role, "apfs ")
+	role = strings.TrimPrefix(role, "role ")
+	switch role {
+	case "system", "data", "preboot", "vm", "update":
+		return role
+	default:
+		return ""
+	}
+}
+
+func sealedValue(value string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+	return value != "" && value != "no" && value != "false" && value != "0"
+}
+
+func capacityFromDiskutilInfo(m map[string]any) (Capacity, bool) {
+	used := uintValue(m, "CapacityInUse")
+	total := uintValue(m, "TotalSize", "Size")
+	available := uintValue(m, "APFSContainerFree", "FreeSpace")
+	if used == 0 || total == 0 {
+		return Capacity{}, false
+	}
+	percentBase := total
+	if used+available > 0 {
+		percentBase = used + available
+	}
+	return Capacity{
+		Total:       total,
+		Used:        used,
+		Available:   available,
+		UsedPercent: usedPercent(used, percentBase),
+	}, true
+}
+
+func cString(buf []byte) string {
+	if i := bytes.IndexByte(buf, 0); i >= 0 {
+		return string(buf[:i])
+	}
+	return string(buf)
+}

--- a/internal/storagestate/mounts_darwin_test.go
+++ b/internal/storagestate/mounts_darwin_test.go
@@ -1,0 +1,72 @@
+//go:build darwin
+
+package storagestate
+
+import (
+	"slices"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestConvertStatfsRootFlagsAndRole(t *testing.T) {
+	raw := statfsFixture("/", "/dev/disk1s1", "apfs", unix.MNT_ROOTFS|unix.MNT_RDONLY|unix.MNT_LOCAL|unix.MNT_JOURNALED|unix.MNT_SNAPSHOT)
+	raw.Blocks = 100
+	raw.Bfree = 10
+	raw.Bavail = 8
+	raw.Files = 1000
+	raw.Ffree = 200
+
+	m := convertStatfs(&raw, nil)
+	if m.APFSRole != "system" {
+		t.Fatalf("APFSRole = %q, want system", m.APFSRole)
+	}
+	if !m.ReadOnly || !m.Sealed {
+		t.Fatalf("ReadOnly=%v Sealed=%v, want both true", m.ReadOnly, m.Sealed)
+	}
+	for _, flag := range []string{"sealed", "ro", "journaled", "local"} {
+		if !slices.Contains(m.Flags, flag) {
+			t.Fatalf("flags = %v, missing %q", m.Flags, flag)
+		}
+	}
+	if m.Capacity.Total != 409600 || m.Capacity.Used != 368640 || m.Capacity.Available != 32768 {
+		t.Fatalf("capacity = %+v", m.Capacity)
+	}
+}
+
+func TestConvertStatfsDataAndSimulatorRoles(t *testing.T) {
+	data := statfsFixture("/System/Volumes/Data", "/dev/disk1s5", "apfs", unix.MNT_LOCAL|unix.MNT_JOURNALED)
+	data.Flags_ext = unix.MNT_EXT_ROOT_DATA_VOL
+	if got := convertStatfs(&data, nil).APFSRole; got != "data" {
+		t.Fatalf("data role = %q, want data", got)
+	}
+
+	sim := statfsFixture("/Library/Developer/CoreSimulator/Volumes/iOS", "/dev/disk5s1", "apfs", unix.MNT_RDONLY|unix.MNT_LOCAL)
+	if got := convertStatfs(&sim, nil).APFSRole; got != "simulator" {
+		t.Fatalf("simulator role = %q, want simulator", got)
+	}
+}
+
+func TestParseDiskutilInfo(t *testing.T) {
+	data := []byte(`<?xml version="1.0"?><plist version="1.0"><dict><key>VolumeRole</key><string>Data</string><key>Sealed</key><string>Yes</string><key>TotalSize</key><integer>1000</integer><key>CapacityInUse</key><integer>900</integer><key>APFSContainerFree</key><integer>100</integer></dict></plist>`)
+	info := parseDiskutilInfo(data)
+	if info.role != "data" || !info.sealed {
+		t.Fatalf("info = %+v, want data sealed", info)
+	}
+	if !info.hasCapacity || info.capacity.UsedPercent != 90 {
+		t.Fatalf("capacity = %+v, has=%v, want 90%%", info.capacity, info.hasCapacity)
+	}
+}
+
+func statfsFixture(mountPoint, device, fsType string, flags uint32) unix.Statfs_t {
+	var raw unix.Statfs_t
+	raw.Bsize = 4096
+	raw.Blocks = 100
+	raw.Bfree = 50
+	raw.Bavail = 50
+	raw.Flags = flags
+	copy(raw.Mntonname[:], mountPoint)
+	copy(raw.Mntfromname[:], device)
+	copy(raw.Fstypename[:], fsType)
+	return raw
+}

--- a/internal/storagestate/mounts_other.go
+++ b/internal/storagestate/mounts_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package storagestate
+
+func collectMounts(_ CmdRunner) ([]Mount, error) {
+	return nil, nil
+}

--- a/internal/storagestate/storagestate.go
+++ b/internal/storagestate/storagestate.go
@@ -14,6 +14,7 @@ import (
 // State is the StorageState slice of a Spectra snapshot.
 type State struct {
 	Volumes          []Volume  `json:"volumes,omitempty"`
+	Mounts           []Mount   `json:"mounts,omitempty"`
 	UserLibraryBytes int64     `json:"user_library_bytes"`
 	AppCachesBytes   int64     `json:"app_caches_bytes"`
 	LargestApps      []AppSize `json:"largest_apps,omitempty"`
@@ -30,6 +31,29 @@ type Volume struct {
 	UsedBytes  int64          `json:"used_bytes"`
 	AvailBytes int64          `json:"avail_bytes"`
 	Snapshots  []APFSSnapshot `json:"snapshots,omitempty"`
+}
+
+// Mount is one currently mounted filesystem from getfsstat.
+type Mount struct {
+	Device     string   `json:"device,omitempty"`
+	MountPoint string   `json:"mount_point"`
+	FSType     string   `json:"fs_type,omitempty"`
+	Flags      []string `json:"flags,omitempty"`
+	Sealed     bool     `json:"sealed,omitempty"`
+	ReadOnly   bool     `json:"read_only,omitempty"`
+	APFSRole   string   `json:"apfs_role,omitempty"`
+	BlockSize  uint32   `json:"block_size,omitempty"`
+	Capacity   Capacity `json:"capacity"`
+}
+
+// Capacity is per-mount capacity from statfs.
+type Capacity struct {
+	Total       uint64  `json:"total"`
+	Used        uint64  `json:"used"`
+	Available   uint64  `json:"available"`
+	UsedPercent float64 `json:"used_percent"`
+	Inodes      uint64  `json:"inodes,omitempty"`
+	InodesFree  uint64  `json:"inodes_free,omitempty"`
 }
 
 // AppSize is one app bundle's on-disk footprint.
@@ -75,6 +99,9 @@ func Collect(opts CollectOptions) State {
 	}
 
 	var s State
+	if mounts, err := collectMounts(run); err == nil {
+		s.Mounts = mounts
+	}
 	if out, err := run("df", "-Pk"); err == nil {
 		s.Volumes = parseDF(string(out))
 	}


### PR DESCRIPTION
## Summary
- add `mounts` to storage state using Darwin `Getfsstat`
- derive mount flags, sealed/read-only status, APFS role, and capacity for storage JSON and the human `spectra storage` output
- add Data/System APFS near-full rules while skipping simulator volumes

## Validation
- `go test ./internal/storagestate ./internal/rules ./cmd/spectra -count=1`
- `go run ./cmd/spectra storage --json | jq '.mounts[] | select(.mount_point=="/" or .mount_point=="/System/Volumes/Data" or .mount_point=="/System/Volumes/Update/mnt1" or (.mount_point | startswith("/Library/Developer/CoreSimulator/Volumes/"))) | {mount_point, flags, apfs_role, used: .capacity.used, available: .capacity.available, used_percent: .capacity.used_percent}'`\n- `go build ./... && go vet ./...`\n- `go test ./... -count=1`\n- `gocyclo -over 15 -ignore '_test\\.go$' .`\n- `golangci-lint run`\n\nCloses #260