### PR TITLE
Add Spotlight storage state

### DIFF
--- a/cmd/spectra/storage.go
+++ b/cmd/spectra/storage.go
@@ -15,11 +15,15 @@ func runStorage(args []string) int {
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
 	includeSnapshots := fs.Bool("snapshots", false, "Include APFS snapshots")
+	includeSpotlight := fs.Bool("spotlight", false, "Include Spotlight indexing status")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	state := storagestate.Collect(storagestate.CollectOptions{IncludeSnapshots: *includeSnapshots})
+	state := storagestate.Collect(storagestate.CollectOptions{
+		IncludeSnapshots: *includeSnapshots,
+		IncludeSpotlight: *includeSpotlight,
+	})
 
 	if *asJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -28,11 +32,11 @@ func runStorage(args []string) int {
 		return 0
 	}
 
-	printStorageState(state, *includeSnapshots)
+	printStorageState(state, *includeSnapshots, *includeSpotlight)
 	return 0
 }
 
-func printStorageState(s storagestate.State, includeSnapshots bool) {
+func printStorageState(s storagestate.State, includeSnapshots, includeSpotlight bool) {
 	fmt.Println("=== Storage state ===")
 
 	if len(s.Volumes) > 0 {
@@ -61,6 +65,10 @@ func printStorageState(s storagestate.State, includeSnapshots bool) {
 		printMounts(s.Mounts)
 	}
 
+	if includeSpotlight {
+		printSpotlight(s.Spotlight)
+	}
+
 	if s.UserLibraryBytes > 0 {
 		fmt.Printf("\n~/Library:       %s total\n", humanSize(s.UserLibraryBytes))
 		if s.AppCachesBytes > 0 {
@@ -73,6 +81,22 @@ func printStorageState(s storagestate.State, includeSnapshots bool) {
 		for _, a := range s.LargestApps {
 			fmt.Printf("  %10s  %s\n", humanSize(a.OnDiskBytes), a.Path)
 		}
+	}
+}
+
+func printSpotlight(volumes []storagestate.SpotlightVolume) {
+	fmt.Printf("\nspotlight (%d):\n", len(volumes))
+	for _, volume := range volumes {
+		progress := ""
+		if volume.Progress != nil {
+			progress = fmt.Sprintf(" %s %.0f%%", volume.Progress.Phase, volume.Progress.Percent)
+		}
+		fmt.Printf("  %-28s  %-10s  %s%s\n",
+			truncate(volume.MountPoint, 28),
+			volume.Status.String(),
+			volume.Detail,
+			progress,
+		)
 	}
 }
 

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -23,6 +23,7 @@ func V1Catalog() []Rule {
 		ruleStorageStagedMajorUpdate(),
 		ruleStorageDataVolumeNearFull(),
 		ruleStorageSystemVolumeNearFull(),
+		ruleSpotlightLargeResidentIndexer(),
 		ruleJVMGCPressure(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/memstate"
+	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/storagestate"
 	"github.com/kaeawc/spectra/internal/timemachine"
@@ -592,6 +593,46 @@ func TestStorageCapacityRulesSkipSimulator(t *testing.T) {
 	}
 }
 
+func TestSpotlightLargeResidentIndexerFires(t *testing.T) {
+	s := baseSnap()
+	s.Host.UptimeSeconds = int64((7 * time.Hour).Seconds())
+	s.Storage.Spotlight = []storagestate.SpotlightVolume{{
+		MountPoint: "/System/Volumes/Data",
+		Status:     storagestate.SpotlightEnabled,
+	}}
+	s.Processes = []process.Info{{
+		PID:     42,
+		Command: "mds_stores",
+		RSSKiB:  2 * 1024 * 1024,
+	}}
+	findings := ruleSpotlightLargeResidentIndexer().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "spotlight.large_resident_indexer" || !strings.Contains(findings[0].Fix, "spectra storage --spotlight") {
+		t.Fatalf("unexpected finding: %+v", findings[0])
+	}
+}
+
+func TestSpotlightLargeResidentIndexerNoFireWhenDisabledOrFreshBoot(t *testing.T) {
+	s := baseSnap()
+	s.Host.UptimeSeconds = int64((7 * time.Hour).Seconds())
+	s.Storage.Spotlight = []storagestate.SpotlightVolume{{
+		MountPoint: "/System/Volumes/Data",
+		Status:     storagestate.SpotlightDisabled,
+	}}
+	s.Processes = []process.Info{{Command: "mds_stores", RSSKiB: 2 * 1024 * 1024}}
+	if findings := ruleSpotlightLargeResidentIndexer().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("disabled Spotlight should not fire, got %v", findings)
+	}
+
+	s.Storage.Spotlight[0].Status = storagestate.SpotlightEnabled
+	s.Host.UptimeSeconds = int64((2 * time.Hour).Seconds())
+	if findings := ruleSpotlightLargeResidentIndexer().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("fresh boot should not fire, got %v", findings)
+	}
+}
+
 // --- app-no-hardened-runtime ---
 
 func TestAppNoHardenedRuntimeFires(t *testing.T) {
@@ -983,6 +1024,7 @@ func TestV1CatalogContainsExpectedRules(t *testing.T) {
 		"storage.staged_major_update",
 		"storage.data_volume_near_full",
 		"storage.system_volume_near_full",
+		"spotlight.large_resident_indexer",
 	} {
 		if !ruleIDs[want] {
 			t.Errorf("V1Catalog missing rule %q", want)

--- a/internal/rules/storage_facts.go
+++ b/internal/rules/storage_facts.go
@@ -1,13 +1,17 @@
 package rules
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/storagestate"
 )
 
 const stagedMajorUpdateAge = 7 * 24 * time.Hour
+const largeSpotlightRSSKiB = 1024 * 1024
 
 func ruleStorageStagedMajorUpdate() Rule {
 	return Rule{
@@ -69,6 +73,31 @@ func ruleStorageSystemVolumeNearFull() Rule {
 	}
 }
 
+func ruleSpotlightLargeResidentIndexer() Rule {
+	return Rule{
+		ID:       "spotlight.large_resident_indexer",
+		Severity: SeverityMedium,
+		Message:  "Spotlight indexer RSS exceeds 1 GiB after 6h uptime while indexing is enabled.",
+		Fix:      "Run `spectra storage --spotlight`; if indexing remains stuck, consider `sudo mdutil -E <volume>`.",
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			if float64(s.Host.UptimeSeconds)/3600 <= 6 || !spotlightEnabled(s.Storage.Spotlight) {
+				return nil
+			}
+			proc, ok := largestMDSStores(s.Processes)
+			if !ok || proc.RSSKiB <= largeSpotlightRSSKiB {
+				return nil
+			}
+			return []Finding{{
+				RuleID:   "spotlight.large_resident_indexer",
+				Severity: SeverityMedium,
+				Subject:  fmt.Sprintf("PID %d (mds_stores)", proc.PID),
+				Message:  fmt.Sprintf("Spotlight indexer has accumulated %.1f GiB RSS after %.1fh uptime; index may be corrupt.", float64(proc.RSSKiB)/(1024*1024), float64(s.Host.UptimeSeconds)/3600),
+				Fix:      "Run `spectra storage --spotlight`; if indexing remains stuck, consider `sudo mdutil -E <volume>`.",
+			}}
+		},
+	}
+}
+
 func storageCapacityFinding(ruleID string, severity Severity, mount storagestate.Mount, message string) Finding {
 	return Finding{
 		RuleID:   ruleID,
@@ -77,6 +106,34 @@ func storageCapacityFinding(ruleID string, severity Severity, mount storagestate
 		Message:  message,
 		Fix:      "Run `spectra storage` to inspect mount capacity, flags, and APFS role.",
 	}
+}
+
+func spotlightEnabled(volumes []storagestate.SpotlightVolume) bool {
+	for _, volume := range volumes {
+		if volume.Status == storagestate.SpotlightEnabled {
+			return true
+		}
+	}
+	return false
+}
+
+func largestMDSStores(processes []process.Info) (process.Info, bool) {
+	var largest process.Info
+	var ok bool
+	for _, proc := range processes {
+		if !isMDSStores(proc) || proc.RSSKiB <= largest.RSSKiB {
+			continue
+		}
+		largest = proc
+		ok = true
+	}
+	return largest, ok
+}
+
+func isMDSStores(proc process.Info) bool {
+	return proc.Command == "mds_stores" ||
+		proc.BSDName == "mds_stores" ||
+		strings.Contains(proc.FullCommandLine, "mds_stores")
 }
 
 func stagedMajorUpdateFindings(s snapshot.Snapshot, now time.Time) []Finding {

--- a/internal/snapshot/cached_collectors.go
+++ b/internal/snapshot/cached_collectors.go
@@ -85,6 +85,7 @@ func storageCacheKey(opts storagestate.CollectOptions) []byte {
 		strings.Join(opts.AppPaths, "|"),
 		fmt.Sprint(opts.LargestAppsN),
 		fmt.Sprint(opts.IncludeSnapshots),
+		fmt.Sprint(opts.IncludeSpotlight),
 	}
 	h := sha256.New()
 	h.Write([]byte(strings.Join(parts, "\x00")))

--- a/internal/storagestate/spotlight.go
+++ b/internal/storagestate/spotlight.go
@@ -1,0 +1,230 @@
+package storagestate
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type SpotlightStatus int
+
+const (
+	SpotlightUnknown SpotlightStatus = iota
+	SpotlightEnabled
+	SpotlightDisabled
+	SpotlightError
+	SpotlightNoIndex
+)
+
+type SpotlightVolume struct {
+	MountPoint string             `json:"mount_point"`
+	Status     SpotlightStatus    `json:"status"`
+	Detail     string             `json:"detail,omitempty"`
+	Progress   *SpotlightProgress `json:"progress,omitempty"`
+}
+
+type SpotlightProgress struct {
+	Phase   string  `json:"phase"`
+	Percent float64 `json:"percent,omitempty"`
+}
+
+func (s SpotlightStatus) String() string {
+	switch s {
+	case SpotlightEnabled:
+		return "enabled"
+	case SpotlightDisabled:
+		return "disabled"
+	case SpotlightError:
+		return "error"
+	case SpotlightNoIndex:
+		return "no_index"
+	default:
+		return "unknown"
+	}
+}
+
+func (s SpotlightStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+func collectSpotlight(run CmdRunner, mounts []Mount) []SpotlightVolume {
+	if run == nil {
+		return nil
+	}
+	out, err := run("/usr/bin/mdutil", "-sa")
+	if err != nil {
+		return nil
+	}
+	volumes := parseMdutilStatus(out)
+	byMount := spotlightByMount(volumes)
+	progress := parseMdutilProgressOutput(run)
+	candidates := writableAPFSMounts(mounts)
+	if len(candidates) == 0 {
+		return attachSpotlightProgress(dedupeSpotlight(volumes), progress)
+	}
+	filtered := make([]SpotlightVolume, 0, len(candidates))
+	for _, mountPoint := range candidates {
+		volume, ok := byMount[mountPoint]
+		if !ok {
+			volume = collectSpotlightMount(run, mountPoint)
+		}
+		if volume.MountPoint != "" {
+			filtered = append(filtered, volume)
+		}
+	}
+	return attachSpotlightProgress(filtered, progress)
+}
+
+func collectSpotlightMount(run CmdRunner, mountPoint string) SpotlightVolume {
+	out, err := run("/usr/bin/mdutil", "-s", mountPoint)
+	if err != nil {
+		return SpotlightVolume{}
+	}
+	volumes := parseMdutilStatus(out)
+	if len(volumes) == 0 {
+		return SpotlightVolume{}
+	}
+	return volumes[0]
+}
+
+func parseMdutilProgressOutput(run CmdRunner) map[string]*SpotlightProgress {
+	out, err := run("/usr/bin/mdutil", "-p")
+	if err != nil {
+		return nil
+	}
+	return parseMdutilProgress(out)
+}
+
+func parseMdutilStatus(data []byte) []SpotlightVolume {
+	var out []SpotlightVolume
+	var current string
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if strings.HasSuffix(line, ":") {
+			current = strings.TrimSuffix(line, ":")
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		out = append(out, SpotlightVolume{
+			MountPoint: current,
+			Status:     classifySpotlightStatus(line),
+			Detail:     line,
+		})
+		current = ""
+	}
+	return out
+}
+
+func classifySpotlightStatus(detail string) SpotlightStatus {
+	lower := strings.ToLower(detail)
+	switch {
+	case strings.Contains(lower, "error"):
+		return SpotlightError
+	case strings.Contains(lower, "no index") || strings.Contains(lower, "not indexed"):
+		return SpotlightNoIndex
+	case strings.Contains(lower, "disabled"):
+		return SpotlightDisabled
+	case strings.Contains(lower, "enabled"):
+		return SpotlightEnabled
+	default:
+		return SpotlightUnknown
+	}
+}
+
+var (
+	spotlightPhaseRE   = regexp.MustCompile(`(?i)\b(scanning|indexing|idle)\b`)
+	spotlightPercentRE = regexp.MustCompile(`([0-9]+(?:\.[0-9]+)?)%`)
+)
+
+func parseMdutilProgress(data []byte) map[string]*SpotlightProgress {
+	progress := map[string]*SpotlightProgress{}
+	var current string
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if strings.HasSuffix(line, ":") {
+			current = strings.TrimSuffix(line, ":")
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		if parsed := parseSpotlightProgressLine(line); parsed != nil {
+			progress[current] = parsed
+		}
+	}
+	return progress
+}
+
+func parseSpotlightProgressLine(line string) *SpotlightProgress {
+	match := spotlightPhaseRE.FindStringSubmatch(line)
+	if len(match) < 2 {
+		return nil
+	}
+	progress := &SpotlightProgress{Phase: titleASCII(match[1])}
+	if percentMatch := spotlightPercentRE.FindStringSubmatch(line); len(percentMatch) == 2 {
+		if percent, err := strconv.ParseFloat(percentMatch[1], 64); err == nil {
+			progress.Percent = percent
+		}
+	}
+	return progress
+}
+
+func titleASCII(s string) string {
+	s = strings.ToLower(s)
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func writableAPFSMounts(mounts []Mount) []string {
+	out := make([]string, 0, len(mounts))
+	for _, mount := range mounts {
+		if mount.FSType != "apfs" || mount.ReadOnly || mount.APFSRole == "simulator" {
+			continue
+		}
+		out = append(out, mount.MountPoint)
+	}
+	return out
+}
+
+func spotlightByMount(volumes []SpotlightVolume) map[string]SpotlightVolume {
+	out := make(map[string]SpotlightVolume, len(volumes))
+	for _, volume := range volumes {
+		if _, exists := out[volume.MountPoint]; !exists {
+			out[volume.MountPoint] = volume
+		}
+	}
+	return out
+}
+
+func dedupeSpotlight(volumes []SpotlightVolume) []SpotlightVolume {
+	seen := map[string]bool{}
+	out := make([]SpotlightVolume, 0, len(volumes))
+	for _, volume := range volumes {
+		if seen[volume.MountPoint] {
+			continue
+		}
+		seen[volume.MountPoint] = true
+		out = append(out, volume)
+	}
+	return out
+}
+
+func attachSpotlightProgress(volumes []SpotlightVolume, progress map[string]*SpotlightProgress) []SpotlightVolume {
+	for i := range volumes {
+		if p := progress[volumes[i].MountPoint]; p != nil {
+			volumes[i].Progress = p
+		}
+	}
+	return volumes
+}

--- a/internal/storagestate/spotlight_test.go
+++ b/internal/storagestate/spotlight_test.go
@@ -1,0 +1,92 @@
+package storagestate
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseMdutilStatusFixtures(t *testing.T) {
+	tests := []struct {
+		file string
+		want map[string]SpotlightStatus
+	}{
+		{
+			file: "testdata/mdutil_macos14.txt",
+			want: map[string]SpotlightStatus{
+				"/":                       SpotlightEnabled,
+				"/System/Volumes/Data":    SpotlightEnabled,
+				"/Volumes/Disabled":       SpotlightDisabled,
+				"/Volumes/SearchDisabled": SpotlightDisabled,
+			},
+		},
+		{
+			file: "testdata/mdutil_macos15.txt",
+			want: map[string]SpotlightStatus{
+				"/":                    SpotlightError,
+				"/System/Volumes/Data": SpotlightNoIndex,
+				"/Volumes/Unknown":     SpotlightUnknown,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			data, err := os.ReadFile(tt.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := map[string]SpotlightStatus{}
+			for _, volume := range parseMdutilStatus(data) {
+				got[volume.MountPoint] = volume.Status
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("statuses = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMdutilProgress(t *testing.T) {
+	got := parseMdutilProgress([]byte("/:\n\tIndexing 42.5%\n/System/Volumes/Data:\n\tScanning 7%\n/Volumes/Idle:\n\tIdle\n"))
+	if got["/"].Phase != "Indexing" || got["/"].Percent != 42.5 {
+		t.Fatalf("root progress = %+v", got["/"])
+	}
+	if got["/System/Volumes/Data"].Phase != "Scanning" || got["/System/Volumes/Data"].Percent != 7 {
+		t.Fatalf("data progress = %+v", got["/System/Volumes/Data"])
+	}
+	if got["/Volumes/Idle"].Phase != "Idle" || got["/Volumes/Idle"].Percent != 0 {
+		t.Fatalf("idle progress = %+v", got["/Volumes/Idle"])
+	}
+}
+
+func TestCollectSpotlightFiltersWritableAPFS(t *testing.T) {
+	stub := func(name string, args ...string) ([]byte, error) {
+		switch {
+		case name == "/usr/bin/mdutil" && len(args) == 1 && args[0] == "-sa":
+			return []byte("/:\n\tIndexing enabled.\n/System/Volumes/Data:\n\tIndexing enabled.\n/System/Volumes/Data:\n\tIndexing enabled.\n/System/Volumes/Preboot:\n\tIndexing disabled.\n"), nil
+		case name == "/usr/bin/mdutil" && len(args) == 1 && args[0] == "-p":
+			return []byte("/System/Volumes/Data:\n\tIndexing 12%\n"), nil
+		case name == "/usr/bin/mdutil" && len(args) == 2 && args[0] == "-s":
+			return []byte(args[1] + ":\n\tNo index.\n"), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+	mounts := []Mount{
+		{MountPoint: "/", FSType: "apfs", ReadOnly: true, APFSRole: "system"},
+		{MountPoint: "/System/Volumes/Data", FSType: "apfs", APFSRole: "data"},
+		{MountPoint: "/System/Volumes/Preboot", FSType: "apfs", APFSRole: "preboot"},
+		{MountPoint: "/System/Volumes/Update", FSType: "apfs", APFSRole: "update"},
+		{MountPoint: "/Library/Developer/CoreSimulator/Volumes/iOS", FSType: "apfs", ReadOnly: true, APFSRole: "simulator"},
+	}
+	got := collectSpotlight(stub, mounts)
+	if len(got) != 3 {
+		t.Fatalf("spotlight volumes = %d, want 3: %+v", len(got), got)
+	}
+	if got[0].MountPoint != "/System/Volumes/Data" || got[0].Progress == nil {
+		t.Fatalf("first volume = %+v, want data with progress", got[0])
+	}
+	if got[2].MountPoint != "/System/Volumes/Update" || got[2].Status != SpotlightNoIndex {
+		t.Fatalf("missing per-mount fallback: %+v", got)
+	}
+}

--- a/internal/storagestate/storagestate.go
+++ b/internal/storagestate/storagestate.go
@@ -13,12 +13,13 @@ import (
 
 // State is the StorageState slice of a Spectra snapshot.
 type State struct {
-	Volumes          []Volume  `json:"volumes,omitempty"`
-	Mounts           []Mount   `json:"mounts,omitempty"`
-	UserLibraryBytes int64     `json:"user_library_bytes"`
-	AppCachesBytes   int64     `json:"app_caches_bytes"`
-	LargestApps      []AppSize `json:"largest_apps,omitempty"`
-	LogFiles         []LogFile `json:"log_files,omitempty"`
+	Volumes          []Volume          `json:"volumes,omitempty"`
+	Mounts           []Mount           `json:"mounts,omitempty"`
+	Spotlight        []SpotlightVolume `json:"spotlight,omitempty"`
+	UserLibraryBytes int64             `json:"user_library_bytes"`
+	AppCachesBytes   int64             `json:"app_caches_bytes"`
+	LargestApps      []AppSize         `json:"largest_apps,omitempty"`
+	LogFiles         []LogFile         `json:"log_files,omitempty"`
 }
 
 // Volume is one mounted filesystem.
@@ -83,6 +84,8 @@ type CollectOptions struct {
 	CmdRunner CmdRunner
 	// IncludeSnapshots runs diskutil APFS snapshot collection for APFS volumes.
 	IncludeSnapshots bool
+	// IncludeSpotlight runs read-only mdutil Spotlight status collection.
+	IncludeSpotlight bool
 }
 
 // Collect gathers StorageState.
@@ -112,6 +115,9 @@ func Collect(opts CollectOptions) State {
 	}
 	if opts.IncludeSnapshots {
 		applyAPFSSnapshots(s.Volumes, run)
+	}
+	if opts.IncludeSpotlight {
+		s.Spotlight = collectSpotlight(run, s.Mounts)
 	}
 	s.UserLibraryBytes = dirBytes(filepath.Join(opts.Home, "Library"))
 	s.AppCachesBytes = dirBytes(filepath.Join(opts.Home, "Library", "Caches"))

--- a/internal/storagestate/testdata/mdutil_macos14.txt
+++ b/internal/storagestate/testdata/mdutil_macos14.txt
@@ -1,0 +1,8 @@
+/:
+	Indexing enabled. 
+/System/Volumes/Data:
+	Indexing enabled. 
+/Volumes/Disabled:
+	Indexing disabled.
+/Volumes/SearchDisabled:
+	Indexing and searching disabled.

--- a/internal/storagestate/testdata/mdutil_macos15.txt
+++ b/internal/storagestate/testdata/mdutil_macos15.txt
@@ -1,0 +1,6 @@
+/:
+	Error: datastore publishing not implemented.
+/System/Volumes/Data:
+	No index.
+/Volumes/Unknown:
+	Indexing status unknown.


### PR DESCRIPTION
## Summary
- add `spectra storage --spotlight` and storage JSON Spotlight status entries
- parse read-only `mdutil -sa`, `mdutil -s`, and `mdutil -p` output with macOS 14/15 fixtures
- add `spotlight.large_resident_indexer` rule correlating enabled Spotlight with large `mds_stores` RSS after long uptime

## Validation
- `go test ./internal/storagestate ./internal/rules ./cmd/spectra -count=1`
- `go run ./cmd/spectra storage --spotlight --json | jq '.spotlight'`\n- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run`\n\nCloses #261