### PR TITLE
Add launchd services inventory

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -45,6 +45,7 @@ func subcommandList() []subcommand {
 		{"memory", "Show VM compressor, swap, and pressure state", runMemory},
 		{"storage", "Show disk volumes and ~/Library footprint", runStorage},
 		{"timemachine", "Show Time Machine status, destinations, and local snapshots", runTimeMachine},
+		{"services", "Show launchd jobs and plist schedules", runServices},
 		{"system", "Show system resource limits and saturation", runSystem},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
 		{"playbook", "Show diagnostic playbooks and command plans", runPlaybook},

--- a/cmd/spectra/services.go
+++ b/cmd/spectra/services.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/services"
+)
+
+func runServices(args []string) int {
+	fs := flag.NewFlagSet("spectra services", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	domain := fs.String("domain", "system", "Domain: system, user, or all")
+	label := fs.String("label", "", "Filter labels by substring")
+	running := fs.Bool("running", false, "Only show running jobs")
+	onDemand := fs.Bool("on-demand", false, "Only show on-demand jobs")
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	inv, err := services.List(context.Background(), services.Options{Domain: *domain})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	inv.Jobs = filterServiceJobs(inv.Jobs, *label, *running, *onDemand)
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(inv)
+		return 0
+	}
+	printServices(inv)
+	return 0
+}
+
+func filterServiceJobs(jobs []services.LaunchJob, label string, running, onDemand bool) []services.LaunchJob {
+	if label == "" && !running && !onDemand {
+		return jobs
+	}
+	label = strings.ToLower(label)
+	out := make([]services.LaunchJob, 0, len(jobs))
+	for _, job := range jobs {
+		if label != "" && !strings.Contains(strings.ToLower(job.Label), label) {
+			continue
+		}
+		if running && job.PID == 0 {
+			continue
+		}
+		if onDemand && !job.OnDemand {
+			continue
+		}
+		out = append(out, job)
+	}
+	return out
+}
+
+func printServices(inv services.LaunchInventory) {
+	fmt.Println("=== Services ===")
+	fmt.Printf("jobs: %d\n", len(inv.Jobs))
+	fmt.Printf("  %-48s  %-8s  %7s  %s\n", "LABEL", "DOMAIN", "PID", "PLIST")
+	fmt.Println("  " + strings.Repeat("-", 88))
+	for _, job := range inv.Jobs {
+		pid := "-"
+		if job.PID > 0 {
+			pid = fmt.Sprint(job.PID)
+		}
+		fmt.Printf("  %-48s  %-8s  %7s  %s\n",
+			truncate(job.Label, 48),
+			job.Domain,
+			pid,
+			job.PlistPath,
+		)
+	}
+}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -1,0 +1,310 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"howett.net/plist"
+)
+
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type RunnerFunc func(context.Context, string, ...string) ([]byte, error)
+
+func (f RunnerFunc) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return f(ctx, name, args...)
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}
+
+type Options struct {
+	Domain    string
+	Runner    Runner
+	Now       func() time.Time
+	Home      string
+	PlistDirs []string
+}
+
+func List(ctx context.Context, opts Options) (LaunchInventory, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	run := opts.Runner
+	if run == nil {
+		run = execRunner{}
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	domain := normalizeDomain(opts.Domain)
+	plistJobs := readPlistJobs(opts, domain)
+	jobsByLabel := map[string]LaunchJob{}
+	for _, job := range plistJobs {
+		jobsByLabel[job.Label] = job
+	}
+	if out, err := run.Run(ctx, "/bin/launchctl", "list"); err == nil {
+		for _, job := range ParseLaunchctlList(out) {
+			if existing, ok := jobsByLabel[job.Label]; ok {
+				mergeLaunchctlState(&existing, job)
+				jobsByLabel[job.Label] = existing
+				continue
+			}
+			if domain == "all" {
+				jobsByLabel[job.Label] = job
+			}
+		}
+	}
+	jobs := make([]LaunchJob, 0, len(jobsByLabel))
+	for _, job := range jobsByLabel {
+		job.OnDemand = computeOnDemand(job)
+		jobs = append(jobs, job)
+	}
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].Label < jobs[j].Label
+	})
+	return LaunchInventory{Jobs: jobs, CollectedAt: now().UTC()}, nil
+}
+
+func IsLoaded(ctx context.Context, label string) bool {
+	return IsLoadedWithRunner(ctx, execRunner{}, "system", label)
+}
+
+func IsLoadedWithRunner(ctx context.Context, run Runner, domain, label string) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if run == nil || label == "" {
+		return false
+	}
+	service := label
+	if !strings.Contains(label, "/") {
+		service = normalizeDomain(domain) + "/" + label
+	}
+	_, err := run.Run(ctx, "/bin/launchctl", "print", service)
+	return err == nil
+}
+
+func ParseLaunchctlList(data []byte) []LaunchJob {
+	var jobs []LaunchJob
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 || fields[0] == "PID" {
+			continue
+		}
+		pid := parseLaunchctlInt(fields[0])
+		status := parseLaunchctlInt(fields[1])
+		jobs = append(jobs, LaunchJob{
+			Label:          fields[2],
+			Domain:         "loaded",
+			PID:            pid,
+			LastExitStatus: status,
+		})
+	}
+	return jobs
+}
+
+func parseLaunchctlInt(value string) int32 {
+	if value == "-" {
+		return 0
+	}
+	n, _ := strconv.ParseInt(value, 10, 32)
+	return int32(n)
+}
+
+func readPlistJobs(opts Options, domain string) []LaunchJob {
+	dirs := opts.PlistDirs
+	if len(dirs) == 0 {
+		dirs = plistDirs(domain, opts.Home)
+	}
+	var jobs []LaunchJob
+	for _, dir := range dirs {
+		filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error { //nolint:errcheck
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() || filepath.Ext(path) != ".plist" {
+				return nil
+			}
+			job, err := readLaunchPlist(path, domainForPlistPath(path))
+			if err == nil && job.Label != "" {
+				jobs = append(jobs, job)
+			}
+			return nil
+		})
+	}
+	return jobs
+}
+
+func plistDirs(domain, home string) []string {
+	var dirs []string
+	if domain == "system" || domain == "all" {
+		dirs = append(dirs, "/System/Library/LaunchDaemons", "/Library/LaunchDaemons")
+	}
+	if domain == "user" || domain == "all" {
+		if home == "" {
+			home, _ = os.UserHomeDir()
+		}
+		if home != "" {
+			dirs = append(dirs, filepath.Join(home, "Library", "LaunchAgents"))
+		}
+	}
+	return dirs
+}
+
+func readLaunchPlist(path, domain string) (LaunchJob, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return LaunchJob{}, err
+	}
+	var root map[string]any
+	if _, err := plist.Unmarshal(data, &root); err != nil {
+		return LaunchJob{}, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return LaunchJob{}, err
+	}
+	return jobFromPlist(root, path, domain, info.ModTime()), nil
+}
+
+func jobFromPlist(root map[string]any, path, domain string, mtime time.Time) LaunchJob {
+	job := LaunchJob{
+		Label:         stringValue(root, "Label"),
+		Domain:        domain,
+		Disabled:      boolValue(root, "Disabled"),
+		KeepAlive:     keepAliveValue(root["KeepAlive"]),
+		RunAtLoad:     boolValue(root, "RunAtLoad"),
+		Program:       stringValue(root, "Program"),
+		PlistPath:     path,
+		PlistMTime:    mtime,
+		StartInterval: intValue(root, "StartInterval"),
+		StartCalendar: jsonString(root["StartCalendarInterval"]),
+		WatchPaths:    stringSlice(root["WatchPaths"]),
+	}
+	job.ProgramArguments = stringSlice(root["ProgramArguments"])
+	return job
+}
+
+func mergeLaunchctlState(dst *LaunchJob, state LaunchJob) {
+	dst.PID = state.PID
+	dst.LastExitStatus = state.LastExitStatus
+}
+
+func computeOnDemand(job LaunchJob) bool {
+	return !job.KeepAlive &&
+		!job.RunAtLoad &&
+		job.StartInterval == 0 &&
+		job.StartCalendar == "" &&
+		len(job.WatchPaths) == 0
+}
+
+func normalizeDomain(domain string) string {
+	switch domain {
+	case "", "system":
+		return "system"
+	case "user", "all":
+		return domain
+	default:
+		return "system"
+	}
+}
+
+func domainForPlistPath(path string) string {
+	if strings.Contains(path, "/LaunchAgents/") {
+		return "user"
+	}
+	return "system"
+}
+
+func stringValue(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if raw, ok := m[key]; ok && raw != nil {
+			if s, ok := raw.(string); ok {
+				return s
+			}
+			return fmt.Sprint(raw)
+		}
+	}
+	return ""
+}
+
+func boolValue(m map[string]any, keys ...string) bool {
+	for _, key := range keys {
+		if raw, ok := m[key]; ok {
+			if b, ok := raw.(bool); ok {
+				return b
+			}
+		}
+	}
+	return false
+}
+
+func keepAliveValue(raw any) bool {
+	switch v := raw.(type) {
+	case bool:
+		return v
+	case map[string]any:
+		return len(v) > 0
+	default:
+		return false
+	}
+}
+
+func intValue(m map[string]any, keys ...string) int {
+	for _, key := range keys {
+		raw, ok := m[key]
+		if !ok {
+			continue
+		}
+		n, err := strconv.Atoi(fmt.Sprint(raw))
+		if err == nil && n > 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+func stringSlice(raw any) []string {
+	switch v := raw.(type) {
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return append([]string(nil), v...)
+	case string:
+		return []string{v}
+	default:
+		return nil
+	}
+}
+
+func jsonString(raw any) string {
+	if raw == nil {
+		return ""
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Sprint(raw)
+	}
+	return string(data)
+}

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -1,0 +1,108 @@
+package services
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const launchctlListFixture = `PID	Status	Label
+-	0	com.apple.backupd-auto
+123	0	com.example.running
+-	-9	com.example.exited
+`
+
+func TestParseLaunchctlList(t *testing.T) {
+	jobs := ParseLaunchctlList([]byte(launchctlListFixture))
+	if len(jobs) != 3 {
+		t.Fatalf("jobs = %d, want 3", len(jobs))
+	}
+	if jobs[0].Label != "com.apple.backupd-auto" || jobs[0].PID != 0 || jobs[0].LastExitStatus != 0 {
+		t.Fatalf("first job = %+v", jobs[0])
+	}
+	if jobs[1].PID != 123 {
+		t.Fatalf("running PID = %d, want 123", jobs[1].PID)
+	}
+	if jobs[2].LastExitStatus != -9 {
+		t.Fatalf("exit status = %d, want -9", jobs[2].LastExitStatus)
+	}
+}
+
+func TestListMergesLaunchctlAndPlists(t *testing.T) {
+	dir := t.TempDir()
+	writePlist(t, filepath.Join(dir, "com.apple.backupd-auto.plist"), `<?xml version="1.0"?><plist version="1.0"><dict>
+<key>Label</key><string>com.apple.backupd-auto</string>
+<key>Program</key><string>/System/Library/CoreServices/backupd.bundle/Contents/Resources/backupd-helper</string>
+<key>RunAtLoad</key><true/>
+<key>KeepAlive</key><false/>
+<key>StartInterval</key><integer>3600</integer>
+<key>WatchPaths</key><array><string>/Volumes</string></array>
+</dict></plist>`)
+	run := RunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		if name == "/bin/launchctl" && len(args) == 1 && args[0] == "list" {
+			return []byte(launchctlListFixture), nil
+		}
+		return nil, os.ErrNotExist
+	})
+	inv, err := List(context.Background(), Options{
+		Domain:    "system",
+		Runner:    run,
+		Now:       func() time.Time { return time.Unix(100, 0) },
+		PlistDirs: []string{dir},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inv.Jobs) != 1 {
+		t.Fatalf("jobs = %d, want 1: %+v", len(inv.Jobs), inv.Jobs)
+	}
+	job := inv.Jobs[0]
+	if job.Label != "com.apple.backupd-auto" || job.PlistPath == "" || job.PlistMTime.IsZero() {
+		t.Fatalf("job not enriched from plist: %+v", job)
+	}
+	if !job.RunAtLoad || job.StartInterval != 3600 || len(job.WatchPaths) != 1 {
+		t.Fatalf("schedule fields not parsed: %+v", job)
+	}
+}
+
+func TestJobFromPlistParsesKeepAliveDict(t *testing.T) {
+	job := jobFromPlist(map[string]any{
+		"Label":     "com.example.agent",
+		"KeepAlive": map[string]any{"SuccessfulExit": false},
+		"ProgramArguments": []any{
+			"/usr/bin/true",
+			"--flag",
+		},
+	}, "/tmp/com.example.agent.plist", "user", time.Unix(1, 0))
+	if !job.KeepAlive {
+		t.Fatalf("KeepAlive = false, want true")
+	}
+	if len(job.ProgramArguments) != 2 || job.ProgramArguments[1] != "--flag" {
+		t.Fatalf("ProgramArguments = %+v", job.ProgramArguments)
+	}
+}
+
+func TestIsLoadedWithRunner(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	run := RunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = args
+		return []byte("service = com.apple.backupd-auto"), nil
+	})
+	if !IsLoadedWithRunner(context.Background(), run, "system", "com.apple.backupd-auto") {
+		t.Fatal("service should be loaded")
+	}
+	if gotName != "/bin/launchctl" || len(gotArgs) != 2 || gotArgs[1] != "system/com.apple.backupd-auto" {
+		t.Fatalf("launchctl call = %s %v", gotName, gotArgs)
+	}
+}
+
+func writePlist(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/services/types.go
+++ b/internal/services/types.go
@@ -1,0 +1,26 @@
+package services
+
+import "time"
+
+type LaunchJob struct {
+	Label            string    `json:"label"`
+	Domain           string    `json:"domain,omitempty"`
+	PID              int32     `json:"pid,omitempty"`
+	LastExitStatus   int32     `json:"last_exit_status,omitempty"`
+	OnDemand         bool      `json:"on_demand,omitempty"`
+	Disabled         bool      `json:"disabled,omitempty"`
+	KeepAlive        bool      `json:"keep_alive,omitempty"`
+	RunAtLoad        bool      `json:"run_at_load,omitempty"`
+	Program          string    `json:"program,omitempty"`
+	ProgramArguments []string  `json:"program_arguments,omitempty"`
+	PlistPath        string    `json:"plist_path,omitempty"`
+	PlistMTime       time.Time `json:"plist_mtime,omitempty"`
+	StartInterval    int       `json:"start_interval,omitempty"`
+	StartCalendar    string    `json:"start_calendar,omitempty"`
+	WatchPaths       []string  `json:"watch_paths,omitempty"`
+}
+
+type LaunchInventory struct {
+	Jobs        []LaunchJob `json:"jobs"`
+	CollectedAt time.Time   `json:"collected_at"`
+}


### PR DESCRIPTION
## Summary
- add `internal/services` launchctl/plist inventory with label, PID/status, schedule, program, plist path, and mtime
- add `spectra services` with domain, label, running, on-demand, and JSON filters
- add fixture-driven launchctl parser and plist enrichment tests

## Validation
- `go test ./internal/services ./cmd/spectra -count=1`
- `go run ./cmd/spectra services --label com.apple.backupd --json | jq '.jobs[] | {label, domain, pid, plist_path, plist_mtime, run_at_load, keep_alive, start_interval, program}'`\n- `launchctl` union smoke: `launchctl=504 spectra_all=904` on this Mac\n- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run`\n\nNote: this local macOS install has `com.apple.backupd.plist` and `com.apple.backupd-helper.plist`, not `com.apple.backupd-auto.plist`; the label path/mtime flow was verified with `com.apple.backupd`.\n\nCloses #262