### PR TITLE
Add destinationless backup leak rule

### DIFF
--- a/internal/rules/backup_facts.go
+++ b/internal/rules/backup_facts.go
@@ -1,0 +1,113 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/services"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/storagestate"
+)
+
+type BackupFacts struct {
+	TMDestinationCount    int
+	BackupdAutoLoaded     bool
+	HasMSUPrepareSnapshot bool
+	FSEventsdRSSBytes     int64
+	UptimeHours           float64
+}
+
+const fseventsdCriticalRSSBytes int64 = 2 * 1024 * 1024 * 1024
+
+func BackupFactsFor(s snapshot.Snapshot) BackupFacts {
+	return BackupFacts{
+		TMDestinationCount:    len(s.Host.TimeMachine.Destinations),
+		BackupdAutoLoaded:     backupdAutoLoaded(s.Services.Jobs),
+		HasMSUPrepareSnapshot: hasMSUPrepareSnapshot(s.Storage.Volumes),
+		FSEventsdRSSBytes:     processRSSBytes(largestProcessByName(s.Processes, "fseventsd")),
+		UptimeHours:           float64(s.Host.UptimeSeconds) / 3600,
+	}
+}
+
+func ruleBackupDestinationlessSchedulerLeak() Rule {
+	return Rule{
+		ID:       "backup.destinationless_scheduler_leak",
+		Severity: SeverityMedium,
+		Message:  "backupd-auto is loaded with no Time Machine destination while an MSUPrepare snapshot is present.",
+		Fix:      "Configure a Time Machine destination, or run `sudo tmutil disable` and `sudo killall -HUP fseventsd`.",
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			facts := BackupFactsFor(s)
+			if facts.TMDestinationCount != 0 || !facts.BackupdAutoLoaded || !facts.HasMSUPrepareSnapshot {
+				return nil
+			}
+			severity := SeverityMedium
+			if facts.FSEventsdRSSBytes > fseventsdCriticalRSSBytes {
+				severity = SeverityHigh
+			}
+			return []Finding{{
+				RuleID:   "backup.destinationless_scheduler_leak",
+				Severity: severity,
+				Subject:  "Time Machine scheduler",
+				Message:  fmt.Sprintf("backupd is scheduled with no destination on a Mac with a staged macOS upgrade. This is a known fseventsd memory-leak pattern; fseventsd is currently %s RSS.", formatBytes(facts.FSEventsdRSSBytes)),
+				Fix:      "Remediation: `sudo tmutil disable` (or configure a destination) and `sudo killall -HUP fseventsd`.",
+			}}
+		},
+	}
+}
+
+func backupdAutoLoaded(jobs []services.LaunchJob) bool {
+	for _, job := range jobs {
+		if job.Label == "com.apple.backupd-auto" && (job.PID > 0 || job.PlistPath != "") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMSUPrepareSnapshot(volumes []storagestate.Volume) bool {
+	for _, volume := range volumes {
+		for _, snap := range volume.Snapshots {
+			if snap.Kind == storagestate.SnapshotMSUPrepare || snap.Name == "com.apple.os.update-MSUPrepareUpdate" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func largestProcessByName(processes []process.Info, name string) process.Info {
+	var largest process.Info
+	for _, proc := range processes {
+		if !processNameMatches(proc, name) || proc.RSSKiB <= largest.RSSKiB {
+			continue
+		}
+		largest = proc
+	}
+	return largest
+}
+
+func processNameMatches(proc process.Info, name string) bool {
+	return proc.Command == name ||
+		proc.BSDName == name ||
+		strings.Contains(proc.FullCommandLine, name)
+}
+
+func processRSSBytes(proc process.Info) int64 {
+	if proc.RSSKiB <= 0 {
+		return 0
+	}
+	return proc.RSSKiB * 1024
+}
+
+func formatBytes(bytes int64) string {
+	const gib = 1024 * 1024 * 1024
+	if bytes >= gib {
+		return fmt.Sprintf("%.1f GiB", float64(bytes)/gib)
+	}
+	const mib = 1024 * 1024
+	if bytes >= mib {
+		return fmt.Sprintf("%.0f MiB", float64(bytes)/mib)
+	}
+	return fmt.Sprintf("%d B", bytes)
+}

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -24,6 +24,7 @@ func V1Catalog() []Rule {
 		ruleStorageDataVolumeNearFull(),
 		ruleStorageSystemVolumeNearFull(),
 		ruleSpotlightLargeResidentIndexer(),
+		ruleBackupDestinationlessSchedulerLeak(),
 		ruleJVMGCPressure(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/memstate"
 	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/services"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/storagestate"
 	"github.com/kaeawc/spectra/internal/timemachine"
@@ -633,6 +635,98 @@ func TestSpotlightLargeResidentIndexerNoFireWhenDisabledOrFreshBoot(t *testing.T
 	}
 }
 
+func TestBackupDestinationlessSchedulerLeakIncidentFixture(t *testing.T) {
+	data, err := os.ReadFile("testdata/incident-2026-05-fseventsd.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var s snapshot.Snapshot
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatal(err)
+	}
+	findings := ruleBackupDestinationlessSchedulerLeak().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Severity != SeverityHigh {
+		t.Fatalf("severity = %s, want high", findings[0].Severity)
+	}
+	if !strings.Contains(findings[0].Message, "2.4 GiB") || !strings.Contains(findings[0].Fix, "sudo killall -HUP fseventsd") {
+		t.Fatalf("finding missing RSS/remediation: %+v", findings[0])
+	}
+}
+
+func TestBackupDestinationlessSchedulerLeakRequiresAllFacts(t *testing.T) {
+	base := backupLeakSnapshot()
+	tests := []struct {
+		name   string
+		mutate func(*snapshot.Snapshot)
+	}{
+		{
+			name: "has destination",
+			mutate: func(s *snapshot.Snapshot) {
+				s.Host.TimeMachine.Destinations = []timemachine.TMDestination{{Name: "Backup"}}
+			},
+		},
+		{
+			name: "scheduler missing",
+			mutate: func(s *snapshot.Snapshot) {
+				s.Services.Jobs = nil
+			},
+		},
+		{
+			name: "snapshot missing",
+			mutate: func(s *snapshot.Snapshot) {
+				s.Storage.Volumes[0].Snapshots = nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := base
+			tt.mutate(&s)
+			if findings := ruleBackupDestinationlessSchedulerLeak().MatchFn(s); len(findings) != 0 {
+				t.Fatalf("expected no finding, got %v", findings)
+			}
+		})
+	}
+}
+
+func TestBackupDestinationlessSchedulerLeakMediumBelowTwoGiB(t *testing.T) {
+	s := backupLeakSnapshot()
+	s.Processes[0].RSSKiB = 1500 * 1024
+	findings := ruleBackupDestinationlessSchedulerLeak().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Severity != SeverityMedium {
+		t.Fatalf("severity = %s, want medium", findings[0].Severity)
+	}
+}
+
+func backupLeakSnapshot() snapshot.Snapshot {
+	s := baseSnap()
+	s.Host.UptimeSeconds = int64((24 * time.Hour).Seconds())
+	s.Services.Jobs = []services.LaunchJob{{
+		Label:     "com.apple.backupd-auto",
+		Domain:    "system",
+		PlistPath: "/System/Library/LaunchDaemons/com.apple.backupd-auto.plist",
+	}}
+	s.Storage.Volumes = []storagestate.Volume{{
+		MountPoint: "/",
+		Snapshots: []storagestate.APFSSnapshot{{
+			Name: "com.apple.os.update-MSUPrepareUpdate",
+			Kind: storagestate.SnapshotMSUPrepare,
+		}},
+	}}
+	s.Processes = []process.Info{{
+		PID:     88,
+		Command: "fseventsd",
+		RSSKiB:  2500000,
+	}}
+	return s
+}
+
 // --- app-no-hardened-runtime ---
 
 func TestAppNoHardenedRuntimeFires(t *testing.T) {
@@ -1025,6 +1119,7 @@ func TestV1CatalogContainsExpectedRules(t *testing.T) {
 		"storage.data_volume_near_full",
 		"storage.system_volume_near_full",
 		"spotlight.large_resident_indexer",
+		"backup.destinationless_scheduler_leak",
 	} {
 		if !ruleIDs[want] {
 			t.Errorf("V1Catalog missing rule %q", want)

--- a/internal/rules/testdata/incident-2026-05-fseventsd.json
+++ b/internal/rules/testdata/incident-2026-05-fseventsd.json
@@ -1,0 +1,41 @@
+{
+  "id": "incident-2026-05-fseventsd",
+  "kind": "live",
+  "host": {
+    "hostname": "incident-mac",
+    "os_name": "macOS",
+    "uptime_seconds": 86400,
+    "time_machine": {
+      "destinations": []
+    }
+  },
+  "processes": [
+    {
+      "pid": 321,
+      "command": "fseventsd",
+      "full_command_line": "/System/Library/PrivateFrameworks/FSEvents.framework/Versions/A/Support/fseventsd",
+      "rss_kib": 2500000
+    }
+  ],
+  "storage": {
+    "volumes": [
+      {
+        "mount_point": "/",
+        "snapshots": [
+          {
+            "name": "com.apple.os.update-MSUPrepareUpdate"
+          }
+        ]
+      }
+    ]
+  },
+  "services": {
+    "jobs": [
+      {
+        "label": "com.apple.backupd-auto",
+        "domain": "system",
+        "plist_path": "/System/Library/LaunchDaemons/com.apple.backupd-auto.plist"
+      }
+    ]
+  }
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/netstate"
 	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/services"
 	"github.com/kaeawc/spectra/internal/storagestate"
 	"github.com/kaeawc/spectra/internal/sysinfo"
 	"github.com/kaeawc/spectra/internal/syslimits"
@@ -33,18 +34,19 @@ const (
 
 // Snapshot is the structured capture of one host at one point in time.
 type Snapshot struct {
-	ID           string                 `json:"id"`
-	TakenAt      time.Time              `json:"taken_at"`
-	Kind         Kind                   `json:"kind"`
-	Host         HostInfo               `json:"host"`
-	Apps         []detect.Result        `json:"apps"`
-	Processes    []process.Info         `json:"processes,omitempty"`
-	Toolchains   toolchain.Toolchains   `json:"toolchains"`
-	Power        sysinfo.PowerState     `json:"power"`
-	SystemLimits syslimits.SystemLimits `json:"system_limits"`
-	Sysctls      map[string]string      `json:"sysctls,omitempty"`
-	Network      netstate.State         `json:"network"`
-	Storage      storagestate.State     `json:"storage"`
+	ID           string                   `json:"id"`
+	TakenAt      time.Time                `json:"taken_at"`
+	Kind         Kind                     `json:"kind"`
+	Host         HostInfo                 `json:"host"`
+	Apps         []detect.Result          `json:"apps"`
+	Processes    []process.Info           `json:"processes,omitempty"`
+	Toolchains   toolchain.Toolchains     `json:"toolchains"`
+	Power        sysinfo.PowerState       `json:"power"`
+	SystemLimits syslimits.SystemLimits   `json:"system_limits"`
+	Sysctls      map[string]string        `json:"sysctls,omitempty"`
+	Network      netstate.State           `json:"network"`
+	Storage      storagestate.State       `json:"storage"`
+	Services     services.LaunchInventory `json:"services,omitempty"`
 
 	JVMs             []jvm.Info          `json:"jvms,omitempty"`
 	RuntimeTelemetry []telemetry.Process `json:"runtime_telemetry,omitempty"`
@@ -110,6 +112,10 @@ type Options struct {
 	// Zero value uses live filesystem paths.
 	StorageOpts storagestate.CollectOptions
 
+	// ServicesOpts are forwarded to the launchd services collector.
+	// Zero value collects system LaunchDaemons.
+	ServicesOpts services.Options
+
 	// JVMOpts are forwarded to the JVM collector.
 	// Zero value uses the real jps/jcmd commands.
 	JVMOpts jvm.CollectOptions
@@ -131,6 +137,9 @@ type Options struct {
 	// host-only snapshots where app data is not needed (e.g. daemon
 	// periodic captures).
 	SkipApps bool
+
+	// SkipServices disables launchd services collection.
+	SkipServices bool
 
 	// DetectStore is the sharded cache for detect.Result JSON. When non-nil,
 	// collectApps serves cached results keyed by Info.plist + main-exe hash and
@@ -219,6 +228,14 @@ func Build(ctx context.Context, opts Options) Snapshot {
 			s.Storage = collectStorageCached(opts.StorageOpts, opts.StorageCache)
 		}()
 	}
+	if !opts.SkipServices {
+		go func() {
+			defer wg.Done()
+			if inv, err := services.List(ctx, opts.ServicesOpts); err == nil {
+				s.Services = inv
+			}
+		}()
+	}
 
 	if !opts.SkipProcesses {
 		go func() {
@@ -261,6 +278,9 @@ func snapshotCollectorCount(opts Options) int {
 		collectors++
 	}
 	if !opts.SkipStorage {
+		collectors++
+	}
+	if !opts.SkipServices {
 		collectors++
 	}
 	if !opts.SkipJVMs {


### PR DESCRIPTION
## Summary
- add services inventory to snapshots so rules can evaluate launchd state historically
- add `backup.destinationless_scheduler_leak` composite rule over TM destinations, backupd-auto, MSUPrepare snapshots, and fseventsd RSS
- add the 2026-05 incident fixture plus negative-fact and severity tests

## Validation
- `go test ./internal/rules ./internal/snapshot -count=1`
- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run`\n\nCloses #263