### PR TITLE
Add bounded log show facade

### DIFF
--- a/cmd/spectra/logs.go
+++ b/cmd/spectra/logs.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/logquery"
+)
+
+func runLogs(args []string) int {
+	fs := flag.NewFlagSet("spectra logs", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	processName := fs.String("process", "", "Filter by process")
+	subsystem := fs.String("subsystem", "", "Filter by subsystem")
+	level := fs.String("level", "", "Minimum level: Default, Info, Error, Fault")
+	last := fs.Duration("last", time.Hour, "Lookback duration")
+	grep := fs.String("grep", "", "Filter messages by regexp after query")
+	top := fs.Int("top", 5000, "Maximum rows")
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	predicate := fs.String("predicate", "", "Raw NSPredicate")
+	unsafePredicate := fs.Bool("unsafe-predicate", false, "Allow raw NSPredicate")
+	allowLongWindow := fs.Bool("allow-long-window", false, "Allow windows over 24h")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	result, err := logquery.Run(context.Background(), logquery.Query{
+		Process:              *processName,
+		Subsystem:            *subsystem,
+		MinLevel:             *level,
+		Last:                 *last,
+		MaxRows:              *top,
+		Predicate:            *predicate,
+		AllowUnsafePredicate: *unsafePredicate,
+		AllowLongWindow:      *allowLongWindow,
+	})
+	if err != nil {
+		if errors.Is(err, logquery.ErrWindowTooLarge) || errors.Is(err, logquery.ErrUnsafePredicate) {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if *grep != "" {
+		filtered, err := grepLogEntries(result.Entries, *grep)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		result.Entries = filtered
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return 0
+	}
+	printLogs(result)
+	return 0
+}
+
+func grepLogEntries(entries []logquery.LogEntry, expr string) ([]logquery.LogEntry, error) {
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]logquery.LogEntry, 0, len(entries))
+	for _, entry := range entries {
+		if re.MatchString(entry.EventMessage) || re.MatchString(entry.FormatString) {
+			out = append(out, entry)
+		}
+	}
+	return out, nil
+}
+
+func printLogs(result logquery.Result) {
+	fmt.Printf("entries: %d", len(result.Entries))
+	if result.Truncated {
+		fmt.Print(" (truncated)")
+	}
+	if result.Clock.WallClockAdjusted {
+		fmt.Print(" wall-clock-adjusted")
+	}
+	fmt.Println()
+	for _, entry := range result.Entries {
+		fmt.Printf("%s  pid=%d  %-7s  %-18s  %s\n",
+			entry.Timestamp.Format(time.RFC3339),
+			entry.PID,
+			entry.LogType,
+			truncate(entry.Process, 18),
+			entry.EventMessage,
+		)
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -46,6 +46,7 @@ func subcommandList() []subcommand {
 		{"storage", "Show disk volumes and ~/Library footprint", runStorage},
 		{"timemachine", "Show Time Machine status, destinations, and local snapshots", runTimeMachine},
 		{"services", "Show launchd jobs and plist schedules", runServices},
+		{"logs", "Run bounded unified log queries", runLogs},
 		{"system", "Show system resource limits and saturation", runSystem},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
 		{"playbook", "Show diagnostic playbooks and command plans", runPlaybook},

--- a/internal/logquery/show.go
+++ b/internal/logquery/show.go
@@ -1,0 +1,245 @@
+package logquery
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultMaxRows   = 5000
+	defaultMaxWindow = 24 * time.Hour
+	defaultLast      = time.Hour
+)
+
+func Run(ctx context.Context, q Query) (Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	q = withDefaults(q)
+	if err := validate(q); err != nil {
+		return Result{}, err
+	}
+	args := buildArgs(q)
+	started := time.Now()
+	var result Result
+	var stderr []byte
+	var err error
+	if q.Runner != nil {
+		var stdout []byte
+		stdout, stderr, err = q.Runner.Run(ctx, "/usr/bin/log", args...)
+		result, _ = parseNDJSON(bytes.NewReader(stdout), q.MaxRows)
+	} else {
+		result, stderr, err = runLogShow(ctx, args, q.MaxRows)
+	}
+	result.QueryDuration = time.Since(started)
+	result.Clock.WallClockAdjusted = bytes.Contains(stderr, []byte("Wall Clock adjustment detected"))
+	if err != nil && len(result.Entries) == 0 {
+		return result, err
+	}
+	return result, nil
+}
+
+func withDefaults(q Query) Query {
+	if q.MaxRows <= 0 {
+		q.MaxRows = defaultMaxRows
+	}
+	if q.MaxWindow <= 0 {
+		q.MaxWindow = defaultMaxWindow
+	}
+	if q.Last == 0 && q.Start.IsZero() && q.End.IsZero() {
+		q.Last = defaultLast
+	}
+	return q
+}
+
+func validate(q Query) error {
+	if q.Predicate != "" && !q.AllowUnsafePredicate {
+		return ErrUnsafePredicate
+	}
+	if q.AllowLongWindow {
+		return nil
+	}
+	if q.Last > q.MaxWindow {
+		return fmt.Errorf("%w: %s > %s", ErrWindowTooLarge, q.Last, q.MaxWindow)
+	}
+	if !q.Start.IsZero() && !q.End.IsZero() && q.End.Sub(q.Start) > q.MaxWindow {
+		return fmt.Errorf("%w: %s > %s", ErrWindowTooLarge, q.End.Sub(q.Start), q.MaxWindow)
+	}
+	return nil
+}
+
+func buildArgs(q Query) []string {
+	args := []string{"show", "--style", "ndjson", "--info"}
+	if predicate := buildPredicate(q); predicate != "" {
+		args = append(args, "--predicate", predicate)
+	}
+	if q.Last > 0 {
+		args = append(args, "--last", durationArg(q.Last))
+	} else {
+		args = append(args, "--start", logTime(q.Start), "--end", logTime(q.End))
+	}
+	return args
+}
+
+func buildPredicate(q Query) string {
+	var parts []string
+	if q.Predicate != "" {
+		parts = append(parts, "("+q.Predicate+")")
+	}
+	if q.Process != "" {
+		parts = append(parts, `process == "`+escapePredicateString(q.Process)+`"`)
+	}
+	if q.Subsystem != "" {
+		parts = append(parts, `subsystem == "`+escapePredicateString(q.Subsystem)+`"`)
+	}
+	if q.MinLevel != "" {
+		parts = append(parts, minLevelPredicate(q.MinLevel))
+	}
+	return strings.Join(nonEmpty(parts), " AND ")
+}
+
+func minLevelPredicate(level string) string {
+	switch strings.ToLower(level) {
+	case "fault":
+		return `messageType == "Fault"`
+	case "error":
+		return `(messageType == "Error" OR messageType == "Fault")`
+	case "info":
+		return `(messageType == "Info" OR messageType == "Default" OR messageType == "Error" OR messageType == "Fault")`
+	default:
+		return ""
+	}
+}
+
+func escapePredicateString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	return strings.ReplaceAll(s, `"`, `\"`)
+}
+
+func nonEmpty(values []string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func runLogShow(ctx context.Context, args []string, maxRows int) (Result, []byte, error) {
+	cmd := exec.CommandContext(ctx, "/usr/bin/log", args...)
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return Result{}, nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return Result{}, stderr.Bytes(), err
+	}
+	result, parseErr := parseNDJSON(stdout, maxRows)
+	if result.Truncated && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+	waitErr := cmd.Wait()
+	if parseErr != nil {
+		return result, stderr.Bytes(), parseErr
+	}
+	return result, stderr.Bytes(), waitErr
+}
+
+func parseNDJSON(r io.Reader, maxRows int) (Result, error) {
+	var result Result
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if len(result.Entries) >= maxRows {
+			result.Truncated = true
+			break
+		}
+		entry, err := parseLogEntry(scanner.Bytes())
+		if err != nil {
+			return result, err
+		}
+		result.Entries = append(result.Entries, entry)
+	}
+	return result, scanner.Err()
+}
+
+type rawEntry struct {
+	Timestamp        string `json:"timestamp"`
+	ProcessImagePath string `json:"processImagePath"`
+	ProcessID        int32  `json:"processID"`
+	SenderImagePath  string `json:"senderImagePath"`
+	Subsystem        string `json:"subsystem"`
+	Category         string `json:"category"`
+	EventType        string `json:"eventType"`
+	MessageType      string `json:"messageType"`
+	ThreadID         uint64 `json:"threadID"`
+	EventMessage     string `json:"eventMessage"`
+	FormatString     string `json:"formatString"`
+	ActivityID       uint64 `json:"activityIdentifier"`
+	ParentActivityID uint64 `json:"parentActivityIdentifier"`
+	TraceID          uint64 `json:"traceID"`
+}
+
+func parseLogEntry(data []byte) (LogEntry, error) {
+	var raw rawEntry
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return LogEntry{}, err
+	}
+	timestamp, _ := parseLogTimestamp(raw.Timestamp)
+	return LogEntry{
+		Timestamp:        timestamp,
+		Process:          filepath.Base(raw.ProcessImagePath),
+		PID:              raw.ProcessID,
+		Sender:           filepath.Base(raw.SenderImagePath),
+		SenderImagePath:  raw.SenderImagePath,
+		Subsystem:        raw.Subsystem,
+		Category:         raw.Category,
+		EventType:        raw.EventType,
+		LogType:          raw.MessageType,
+		MessageType:      raw.MessageType,
+		ThreadID:         raw.ThreadID,
+		EventMessage:     raw.EventMessage,
+		FormatString:     raw.FormatString,
+		ActivityID:       raw.ActivityID,
+		ParentActivityID: raw.ParentActivityID,
+		TraceID:          raw.TraceID,
+	}, nil
+}
+
+func parseLogTimestamp(value string) (time.Time, error) {
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.999999-0700",
+		"2006-01-02 15:04:05.999999999-0700",
+		time.RFC3339Nano,
+	} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("parse timestamp %q", value)
+}
+
+func durationArg(d time.Duration) string {
+	if d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	}
+	if d%time.Minute == 0 {
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	}
+	return fmt.Sprintf("%ds", int(d/time.Second))
+}
+
+func logTime(t time.Time) string {
+	return t.UTC().Format("2006-01-02 15:04:05")
+}

--- a/internal/logquery/show_test.go
+++ b/internal/logquery/show_test.go
@@ -1,0 +1,75 @@
+package logquery
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+const ndjsonFixture = `{"timestamp":"2026-06-01 13:27:26.997252-0500","messageType":"Info","eventType":"logEvent","processImagePath":"/usr/libexec/backupd","senderImagePath":"/usr/libexec/backupd","processID":123,"threadID":7,"eventMessage":"fs_snapshot_list failed","formatString":"%{public}s","activityIdentifier":9,"parentActivityIdentifier":8,"traceID":6}
+{"timestamp":"2026-06-01 13:27:27.000000-0500","messageType":"Error","eventType":"logEvent","processImagePath":"/usr/libexec/backupd","processID":123,"eventMessage":"Snapshot deletion not completed"}
+`
+
+func TestRunParsesNDJSONAndStderrClockWarning(t *testing.T) {
+	run := RunnerFunc(func(_ context.Context, name string, args ...string) ([]byte, []byte, error) {
+		if name != "/usr/bin/log" || len(args) < 4 {
+			t.Fatalf("unexpected command: %s %v", name, args)
+		}
+		return []byte(ndjsonFixture), []byte("Wall Clock adjustment detected"), nil
+	})
+	result, err := Run(context.Background(), Query{Process: "backupd", Last: time.Minute, MaxRows: 10, Runner: run})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(result.Entries))
+	}
+	if result.Entries[0].Process != "backupd" || result.Entries[0].PID != 123 || result.Entries[0].LogType != "Info" {
+		t.Fatalf("entry not parsed: %+v", result.Entries[0])
+	}
+	if result.Entries[0].Timestamp.IsZero() {
+		t.Fatal("timestamp was not parsed")
+	}
+	if !result.Clock.WallClockAdjusted {
+		t.Fatal("wall-clock warning not detected")
+	}
+}
+
+func TestRunRejectsLargeWindow(t *testing.T) {
+	_, err := Run(context.Background(), Query{Last: 30 * 24 * time.Hour})
+	if !errors.Is(err, ErrWindowTooLarge) {
+		t.Fatalf("err = %v, want ErrWindowTooLarge", err)
+	}
+}
+
+func TestRunRejectsUnsafePredicate(t *testing.T) {
+	_, err := Run(context.Background(), Query{Predicate: `eventMessage CONTAINS "x"`})
+	if !errors.Is(err, ErrUnsafePredicate) {
+		t.Fatalf("err = %v, want ErrUnsafePredicate", err)
+	}
+}
+
+func TestRunHonorsMaxRows(t *testing.T) {
+	run := RunnerFunc(func(context.Context, string, ...string) ([]byte, []byte, error) {
+		return []byte(strings.Repeat(ndjsonFixture, 60)), nil, nil
+	})
+	result, err := Run(context.Background(), Query{Last: time.Minute, MaxRows: 100, Runner: run})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Entries) != 100 || !result.Truncated {
+		t.Fatalf("entries=%d truncated=%v, want 100 true", len(result.Entries), result.Truncated)
+	}
+}
+
+func TestBuildPredicate(t *testing.T) {
+	q := Query{Process: `backup"d`, Subsystem: "com.apple.TimeMachine", MinLevel: "Error"}
+	got := buildPredicate(q)
+	for _, want := range []string{`process == "backup\"d"`, `subsystem == "com.apple.TimeMachine"`, `messageType == "Error"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("predicate %q missing %q", got, want)
+		}
+	}
+}

--- a/internal/logquery/types.go
+++ b/internal/logquery/types.go
@@ -1,0 +1,65 @@
+package logquery
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrWindowTooLarge  = errors.New("log query window too large")
+	ErrUnsafePredicate = errors.New("raw predicate requires unsafe opt-in")
+)
+
+type Query struct {
+	Predicate            string
+	Process              string
+	Subsystem            string
+	MinLevel             string
+	Start                time.Time
+	End                  time.Time
+	Last                 time.Duration
+	MaxRows              int
+	MaxWindow            time.Duration
+	AllowLongWindow      bool
+	AllowUnsafePredicate bool
+	Runner               Runner
+}
+
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) (stdout []byte, stderr []byte, err error)
+}
+
+type RunnerFunc func(context.Context, string, ...string) ([]byte, []byte, error)
+
+func (f RunnerFunc) Run(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	return f(ctx, name, args...)
+}
+
+type LogEntry struct {
+	Timestamp        time.Time `json:"timestamp"`
+	Process          string    `json:"process,omitempty"`
+	PID              int32     `json:"pid,omitempty"`
+	Sender           string    `json:"sender,omitempty"`
+	SenderImagePath  string    `json:"sender_image_path,omitempty"`
+	Subsystem        string    `json:"subsystem,omitempty"`
+	Category         string    `json:"category,omitempty"`
+	EventType        string    `json:"event_type,omitempty"`
+	LogType          string    `json:"log_type,omitempty"`
+	MessageType      string    `json:"message_type,omitempty"`
+	ThreadID         uint64    `json:"thread_id,omitempty"`
+	EventMessage     string    `json:"event_message,omitempty"`
+	FormatString     string    `json:"format_string,omitempty"`
+	ActivityID       uint64    `json:"activity_id,omitempty"`
+	ParentActivityID uint64    `json:"parent_activity_id,omitempty"`
+	TraceID          uint64    `json:"trace_id,omitempty"`
+}
+
+type Result struct {
+	Entries   []LogEntry `json:"entries"`
+	Truncated bool       `json:"truncated,omitempty"`
+	Clock     struct {
+		WallClockAdjusted bool `json:"wall_clock_adjusted,omitempty"`
+	} `json:"clock"`
+	QueryDuration time.Duration `json:"query_duration"`
+}


### PR DESCRIPTION
## Summary
- add `internal/logquery` for bounded `/usr/bin/log show --style ndjson --info` queries
- add `spectra logs` with process/subsystem/level/last/grep/top/json flags and raw predicate safety gate
- parse ndjson entries, enforce row/window caps, detect wall-clock adjustment warnings

## Validation
- `go test ./internal/logquery ./cmd/spectra -count=1`
- `go run ./cmd/spectra logs --process kernel --last 1m --top 5 --json | jq '{count:(.entries|length), truncated, first:(.entries[0] // null)}'`\n- `go run ./cmd/spectra logs --last 720h --json` rejects with window-too-large\n- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run`\n\nCloses #264