### PR TITLE
Add live log stream

### DIFF
--- a/cmd/spectra/logs.go
+++ b/cmd/spectra/logs.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"regexp"
 	"time"
 
@@ -23,13 +24,14 @@ func runLogs(args []string) int {
 	grep := fs.String("grep", "", "Filter messages by regexp after query")
 	top := fs.Int("top", 5000, "Maximum rows")
 	asJSON := fs.Bool("json", false, "Emit JSON")
+	stream := fs.Bool("stream", false, "Stream live logs")
 	predicate := fs.String("predicate", "", "Raw NSPredicate")
 	unsafePredicate := fs.Bool("unsafe-predicate", false, "Allow raw NSPredicate")
 	allowLongWindow := fs.Bool("allow-long-window", false, "Allow windows over 24h")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	result, err := logquery.Run(context.Background(), logquery.Query{
+	q := logquery.Query{
 		Process:              *processName,
 		Subsystem:            *subsystem,
 		MinLevel:             *level,
@@ -38,7 +40,11 @@ func runLogs(args []string) int {
 		Predicate:            *predicate,
 		AllowUnsafePredicate: *unsafePredicate,
 		AllowLongWindow:      *allowLongWindow,
-	})
+	}
+	if *stream {
+		return runLogStream(q, *grep, *asJSON)
+	}
+	result, err := logquery.Run(context.Background(), q)
 	if err != nil {
 		if errors.Is(err, logquery.ErrWindowTooLarge) || errors.Is(err, logquery.ErrUnsafePredicate) {
 			fmt.Fprintln(os.Stderr, err)
@@ -62,6 +68,43 @@ func runLogs(args []string) int {
 		return 0
 	}
 	printLogs(result)
+	return 0
+}
+
+func runLogStream(q logquery.Query, grep string, asJSON bool) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	entries, errs, err := logquery.Stream(ctx, q)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	var re *regexp.Regexp
+	if grep != "" {
+		compiled, err := regexp.Compile(grep)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 2
+		}
+		re = compiled
+	}
+	enc := json.NewEncoder(os.Stdout)
+	for entry := range entries {
+		if re != nil && !re.MatchString(entry.EventMessage) && !re.MatchString(entry.FormatString) {
+			continue
+		}
+		if asJSON {
+			_ = enc.Encode(entry)
+			continue
+		}
+		printLogEntry(entry)
+	}
+	for err := range errs {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+	}
 	return 0
 }
 
@@ -89,12 +132,16 @@ func printLogs(result logquery.Result) {
 	}
 	fmt.Println()
 	for _, entry := range result.Entries {
-		fmt.Printf("%s  pid=%d  %-7s  %-18s  %s\n",
-			entry.Timestamp.Format(time.RFC3339),
-			entry.PID,
-			entry.LogType,
-			truncate(entry.Process, 18),
-			entry.EventMessage,
-		)
+		printLogEntry(entry)
 	}
+}
+
+func printLogEntry(entry logquery.LogEntry) {
+	fmt.Printf("%s  pid=%d  %-7s  %-18s  %s\n",
+		entry.Timestamp.Format(time.RFC3339),
+		entry.PID,
+		entry.LogType,
+		truncate(entry.Process, 18),
+		entry.EventMessage,
+	)
 }

--- a/internal/logquery/stream.go
+++ b/internal/logquery/stream.go
@@ -1,0 +1,105 @@
+package logquery
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
+)
+
+func Stream(ctx context.Context, q Query) (<-chan LogEntry, <-chan error, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if q.Predicate != "" && !q.AllowUnsafePredicate {
+		return nil, nil, ErrUnsafePredicate
+	}
+	args := buildStreamArgs(q)
+	cmd := exec.CommandContext(ctx, "/usr/bin/log", args...)
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+	entries, errs := StreamReader(ctx, stdout)
+	waitErrs := make(chan error, 1)
+	go func() {
+		if err := cmd.Wait(); err != nil && ctx.Err() == nil {
+			waitErrs <- err
+		}
+		close(waitErrs)
+	}()
+	return entries, mergeStreamErrors(errs, waitErrs), nil
+}
+
+func StreamReader(ctx context.Context, r io.Reader) (<-chan LogEntry, <-chan error) {
+	entries := make(chan LogEntry, 256)
+	errs := make(chan error, 1)
+	go func() {
+		defer close(entries)
+		defer close(errs)
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := bytes.TrimSpace(scanner.Bytes())
+			if !bytes.HasPrefix(line, []byte("{")) {
+				continue
+			}
+			entry, err := parseLogEntry(line)
+			if err != nil {
+				errs <- err
+				return
+			}
+			select {
+			case entries <- entry:
+			case <-ctx.Done():
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			errs <- err
+		}
+	}()
+	return entries, errs
+}
+
+func buildStreamArgs(q Query) []string {
+	args := []string{"stream", "--style", "ndjson", "--info"}
+	if predicate := buildPredicate(q); predicate != "" {
+		args = append(args, "--predicate", predicate)
+	}
+	return args
+}
+
+func mergeStreamErrors(a, b <-chan error) <-chan error {
+	out := make(chan error, 2)
+	go func() {
+		defer close(out)
+		for a != nil || b != nil {
+			select {
+			case err, ok := <-a:
+				if !ok {
+					a = nil
+					continue
+				}
+				if err != nil {
+					out <- err
+				}
+			case err, ok := <-b:
+				if !ok {
+					b = nil
+					continue
+				}
+				if err != nil {
+					out <- err
+				}
+			}
+		}
+	}()
+	return out
+}

--- a/internal/logquery/stream_test.go
+++ b/internal/logquery/stream_test.go
@@ -1,0 +1,47 @@
+package logquery
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestStreamReaderEmitsEntries(t *testing.T) {
+	entries, errs := StreamReader(context.Background(), strings.NewReader("Filtering the log data using process == kernel\n"+ndjsonFixture))
+	var got []LogEntry
+	for entry := range entries {
+		got = append(got, entry)
+	}
+	if len(got) != 2 {
+		t.Fatalf("entries = %d, want 2", len(got))
+	}
+	if got[0].EventMessage != "fs_snapshot_list failed" {
+		t.Fatalf("first entry = %+v", got[0])
+	}
+	if err := <-errs; err != nil {
+		t.Fatalf("unexpected stream error: %v", err)
+	}
+}
+
+func TestStreamReaderReportsDecodeError(t *testing.T) {
+	_, errs := StreamReader(context.Background(), strings.NewReader("{bad json}\n"))
+	if err := <-errs; err == nil {
+		t.Fatal("expected decode error")
+	}
+}
+
+func TestBuildStreamArgs(t *testing.T) {
+	args := buildStreamArgs(Query{Process: "kernel", MinLevel: "Error"})
+	got := strings.Join(args, " ")
+	if !strings.Contains(got, "stream") || !strings.Contains(got, "process == \"kernel\"") || !strings.Contains(got, "messageType == \"Error\"") {
+		t.Fatalf("args = %v", args)
+	}
+}
+
+func TestStreamRejectsUnsafePredicate(t *testing.T) {
+	_, _, err := Stream(context.Background(), Query{Predicate: "eventMessage CONTAINS 'x'"})
+	if !errors.Is(err, ErrUnsafePredicate) {
+		t.Fatalf("err = %v, want ErrUnsafePredicate", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `logquery.Stream` and `StreamReader` for live `/usr/bin/log stream --style ndjson --info` entries
- add `spectra logs --stream` with JSON/human output, grep filtering, and Ctrl-C context cancellation
- skip `log stream` non-JSON prologue lines and cover streaming decode/error/predicate tests

## Validation
- `go test ./internal/logquery ./cmd/spectra -count=1`
- `go run ./cmd/spectra logs --stream --process kernel --json | head -1` returns a kernel entry within 10s; the pipeline then closes stdout as expected
- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run`\n\nCloses #265