### PR TITLE
Add install log update inventory

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -47,6 +47,7 @@ func subcommandList() []subcommand {
 		{"timemachine", "Show Time Machine status, destinations, and local snapshots", runTimeMachine},
 		{"services", "Show launchd jobs and plist schedules", runServices},
 		{"logs", "Run bounded unified log queries", runLogs},
+		{"updates", "Show macOS install/update log entries", runUpdates},
 		{"system", "Show system resource limits and saturation", runSystem},
 		{"process", "List running processes sorted by memory (RSS)", runProcess},
 		{"playbook", "Show diagnostic playbooks and command plans", runPlaybook},

--- a/cmd/spectra/updates.go
+++ b/cmd/spectra/updates.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/updates"
+)
+
+func runUpdates(args []string) int {
+	fs := flag.NewFlagSet("spectra updates", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	since := fs.Duration("since", 30*24*time.Hour, "Look back duration")
+	grep := fs.String("grep", "", "Substring filter on message")
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	maxLines := fs.Int("max-lines", 5000, "Maximum entries")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	result, err := updates.QueryInstallLog(updates.Query{
+		Since:    time.Now().Add(-*since),
+		Grep:     *grep,
+		MaxLines: *maxLines,
+	})
+	if err != nil {
+		if errors.Is(err, updates.ErrNeedsFullDiskAccess) {
+			fmt.Fprintln(os.Stderr, updates.FullDiskAccessRemediation)
+			return 1
+		}
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return 0
+	}
+	printUpdates(result)
+	return 0
+}
+
+func printUpdates(result updates.Result) {
+	fmt.Printf("entries: %d\n", len(result.Entries))
+	for _, entry := range result.Entries {
+		fmt.Printf("%s  %-18s  %s\n",
+			entry.Timestamp.Format(time.RFC3339),
+			entry.Process,
+			entry.Message,
+		)
+	}
+}

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -25,6 +25,7 @@ func V1Catalog() []Rule {
 		ruleStorageSystemVolumeNearFull(),
 		ruleSpotlightLargeResidentIndexer(),
 		ruleBackupDestinationlessSchedulerLeak(),
+		ruleUpdatesStaleMajorPrepared(),
 		ruleJVMGCPressure(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kaeawc/spectra/internal/storagestate"
 	"github.com/kaeawc/spectra/internal/timemachine"
 	"github.com/kaeawc/spectra/internal/toolchain"
+	"github.com/kaeawc/spectra/internal/updates"
 )
 
 func baseSnap() snapshot.Snapshot {
@@ -704,6 +705,42 @@ func TestBackupDestinationlessSchedulerLeakMediumBelowTwoGiB(t *testing.T) {
 	}
 }
 
+func TestUpdatesStaleMajorPreparedFires(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := baseSnap()
+	s.TakenAt = now
+	s.Updates.Entries = []updates.InstallLogEntry{{
+		Timestamp: now.Add(-31 * 24 * time.Hour),
+		Message:   `SUOSUBackgroundDownloadEvaluator: <SUOSUMajorProduct: MSU_UPDATE_25F71_patch_26.5_major>(Title:macOS Tahoe 26.5 Version:26.5, Identifier:(null), Size:123, Deferred:0) is already prepared`,
+	}}
+	findings := ruleUpdatesStaleMajorPrepared().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].RuleID != "updates.stale_major_prepared" || !strings.Contains(findings[0].Message, "macOS Tahoe 26.5") {
+		t.Fatalf("unexpected finding: %+v", findings[0])
+	}
+}
+
+func TestUpdatesStaleMajorPreparedNoFireAfterTransition(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := baseSnap()
+	s.TakenAt = now
+	s.Updates.Entries = []updates.InstallLogEntry{
+		{
+			Timestamp: now.Add(-31 * 24 * time.Hour),
+			Message:   `SUOSUBackgroundDownloadEvaluator: <SUOSUMajorProduct: MSU_UPDATE_25F71_patch_26.5_major>(Title:macOS Tahoe 26.5 Version:26.5, Identifier:(null), Deferred:0) is already prepared`,
+		},
+		{
+			Timestamp: now.Add(-2 * 24 * time.Hour),
+			Message:   `Current: SUMacControllerDescriptor(UUID:7B97 SU:macOS Tahoe 26.5 25F71 (Customer)(SU) SFR:macOS Tahoe 26.5 25F71 (Customer) BRAIN:25F71)`,
+		},
+	}
+	if findings := ruleUpdatesStaleMajorPrepared().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("expected 0 findings, got %v", findings)
+	}
+}
+
 func backupLeakSnapshot() snapshot.Snapshot {
 	s := baseSnap()
 	s.Host.UptimeSeconds = int64((24 * time.Hour).Seconds())
@@ -1120,6 +1157,7 @@ func TestV1CatalogContainsExpectedRules(t *testing.T) {
 		"storage.system_volume_near_full",
 		"spotlight.large_resident_indexer",
 		"backup.destinationless_scheduler_leak",
+		"updates.stale_major_prepared",
 	} {
 		if !ruleIDs[want] {
 			t.Errorf("V1Catalog missing rule %q", want)

--- a/internal/rules/update_facts.go
+++ b/internal/rules/update_facts.go
@@ -1,0 +1,74 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/updates"
+)
+
+const staleMajorPreparedAge = 30 * 24 * time.Hour
+
+func ruleUpdatesStaleMajorPrepared() Rule {
+	return Rule{
+		ID:       "updates.stale_major_prepared",
+		Severity: SeverityInfo,
+		Message:  "A prepared major macOS update is older than 30 days without a matching OS transition.",
+		Fix:      "Run `spectra updates --since 30d`; complete the update or remove the pending update with explicit admin approval.",
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			now := s.TakenAt
+			if now.IsZero() {
+				now = time.Now()
+			}
+			return staleMajorPreparedFindings(s, now)
+		},
+	}
+}
+
+func staleMajorPreparedFindings(s snapshot.Snapshot, now time.Time) []Finding {
+	transitions := updateTransitionLabels(s.Updates.Entries)
+	var findings []Finding
+	for _, entry := range s.Updates.Entries {
+		prepared, ok := updates.ParseMajorUpdatePrepared(entry.Message)
+		if !ok {
+			continue
+		}
+		prepared.PreparedAt = entry.Timestamp
+		if now.Sub(prepared.PreparedAt) <= staleMajorPreparedAge || transitionMatches(transitions, prepared) {
+			continue
+		}
+		findings = append(findings, Finding{
+			RuleID:   "updates.stale_major_prepared",
+			Severity: SeverityInfo,
+			Subject:  prepared.AssetID,
+			Message:  fmt.Sprintf("Prepared major macOS update %s %s has been staged since %s with no matching OS transition.", prepared.Title, prepared.Version, prepared.PreparedAt.Format("2006-01-02")),
+			Fix:      "Run `spectra updates --since 30d`; complete the update or remove the pending update with explicit admin approval.",
+		})
+	}
+	return findings
+}
+
+func updateTransitionLabels(entries []updates.InstallLogEntry) []string {
+	var labels []string
+	for _, entry := range entries {
+		transition, ok := updates.ParseOSControllerTransition(entry.Message)
+		if !ok {
+			continue
+		}
+		if transition.CurrentLabel != "" {
+			labels = append(labels, transition.CurrentLabel)
+		}
+	}
+	return labels
+}
+
+func transitionMatches(labels []string, prepared updates.MajorUpdatePrepared) bool {
+	for _, label := range labels {
+		if strings.Contains(label, prepared.Version) || strings.Contains(label, prepared.Title) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kaeawc/spectra/internal/syslimits"
 	"github.com/kaeawc/spectra/internal/telemetry"
 	"github.com/kaeawc/spectra/internal/toolchain"
+	"github.com/kaeawc/spectra/internal/updates"
 )
 
 // Kind distinguishes a live snapshot from an immutable baseline.
@@ -47,6 +48,7 @@ type Snapshot struct {
 	Network      netstate.State           `json:"network"`
 	Storage      storagestate.State       `json:"storage"`
 	Services     services.LaunchInventory `json:"services,omitempty"`
+	Updates      updates.Result           `json:"updates,omitempty"`
 
 	JVMs             []jvm.Info          `json:"jvms,omitempty"`
 	RuntimeTelemetry []telemetry.Process `json:"runtime_telemetry,omitempty"`
@@ -116,6 +118,9 @@ type Options struct {
 	// Zero value collects system LaunchDaemons.
 	ServicesOpts services.Options
 
+	// UpdatesOpts are forwarded to the install.log collector.
+	UpdatesOpts updates.Query
+
 	// JVMOpts are forwarded to the JVM collector.
 	// Zero value uses the real jps/jcmd commands.
 	JVMOpts jvm.CollectOptions
@@ -140,6 +145,9 @@ type Options struct {
 
 	// SkipServices disables launchd services collection.
 	SkipServices bool
+
+	// SkipUpdates disables macOS install/update log collection.
+	SkipUpdates bool
 
 	// DetectStore is the sharded cache for detect.Result JSON. When non-nil,
 	// collectApps serves cached results keyed by Info.plist + main-exe hash and
@@ -236,6 +244,14 @@ func Build(ctx context.Context, opts Options) Snapshot {
 			}
 		}()
 	}
+	if !opts.SkipUpdates {
+		go func() {
+			defer wg.Done()
+			if result, err := updates.QueryInstallLog(opts.UpdatesOpts); err == nil {
+				s.Updates = result
+			}
+		}()
+	}
 
 	if !opts.SkipProcesses {
 		go func() {
@@ -281,6 +297,9 @@ func snapshotCollectorCount(opts Options) int {
 		collectors++
 	}
 	if !opts.SkipServices {
+		collectors++
+	}
+	if !opts.SkipUpdates {
 		collectors++
 	}
 	if !opts.SkipJVMs {

--- a/internal/updates/install_log.go
+++ b/internal/updates/install_log.go
@@ -1,0 +1,240 @@
+package updates
+
+import (
+	"bufio"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+var ErrNeedsFullDiskAccess = errors.New("needs full disk access")
+
+const FullDiskAccessRemediation = "Grant Full Disk Access to the terminal running Spectra, then retry."
+
+type InstallLogEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Hostname  string    `json:"hostname,omitempty"`
+	Process   string    `json:"process,omitempty"`
+	PID       int32     `json:"pid,omitempty"`
+	Message   string    `json:"message"`
+}
+
+type Query struct {
+	Since    time.Time
+	Until    time.Time
+	Process  string
+	Grep     string
+	MaxLines int
+	Paths    []string
+}
+
+type Result struct {
+	Entries   []InstallLogEntry `json:"entries"`
+	FilesRead []string          `json:"files_read"`
+	Truncated bool              `json:"truncated,omitempty"`
+}
+
+type MajorUpdatePrepared struct {
+	AssetID    string    `json:"asset_id"`
+	Title      string    `json:"title,omitempty"`
+	Version    string    `json:"version,omitempty"`
+	SizeBytes  uint64    `json:"size_bytes,omitempty"`
+	PreparedAt time.Time `json:"prepared_at,omitempty"`
+}
+
+type OSControllerTransition struct {
+	PreviousLabel string    `json:"previous_label"`
+	CurrentLabel  string    `json:"current_label"`
+	At            time.Time `json:"at,omitempty"`
+}
+
+func QueryInstallLog(q Query) (Result, error) {
+	if q.MaxLines <= 0 {
+		q.MaxLines = 5000
+	}
+	paths := q.Paths
+	if len(paths) == 0 {
+		paths = defaultInstallLogPaths()
+	}
+	var result Result
+	for _, path := range paths {
+		entries, err := readInstallLogFile(path, q)
+		if err != nil {
+			if errors.Is(err, os.ErrPermission) {
+				return result, ErrNeedsFullDiskAccess
+			}
+			continue
+		}
+		result.FilesRead = append(result.FilesRead, path)
+		for _, entry := range entries {
+			if len(result.Entries) >= q.MaxLines {
+				result.Truncated = true
+				return result, nil
+			}
+			result.Entries = append(result.Entries, entry)
+		}
+	}
+	sort.Slice(result.Entries, func(i, j int) bool {
+		return result.Entries[i].Timestamp.Before(result.Entries[j].Timestamp)
+	})
+	return result, nil
+}
+
+func defaultInstallLogPaths() []string {
+	paths := []string{"/var/log/install.log"}
+	matches, _ := filepath.Glob("/var/log/install.log.*.gz")
+	sort.Strings(matches)
+	paths = append(paths, matches...)
+	return paths
+}
+
+func readInstallLogFile(path string, q Query) ([]InstallLogEntry, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	var reader io.Reader = file
+	if strings.HasSuffix(path, ".gz") {
+		gz, err := gzip.NewReader(file)
+		if err != nil {
+			return nil, err
+		}
+		defer gz.Close()
+		reader = gz
+	}
+	return parseInstallLog(reader, q), nil
+}
+
+var installLineRE = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})([-+]\d{2}) ([^ ]+) ([^\[]+)\[(\d+)\]: (.*)$`)
+
+func parseInstallLog(r io.Reader, q Query) []InstallLogEntry {
+	var entries []InstallLogEntry
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		entry, ok := ParseInstallLogLine(scanner.Text())
+		if !ok || !matchesQuery(entry, q) {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func ParseInstallLogLine(line string) (InstallLogEntry, bool) {
+	match := installLineRE.FindStringSubmatch(line)
+	if len(match) != 7 {
+		return InstallLogEntry{}, false
+	}
+	t, err := time.Parse("2006-01-02 15:04:05-07", match[1]+match[2])
+	if err != nil {
+		return InstallLogEntry{}, false
+	}
+	pid := int32(0)
+	if n, err := parseInt32(match[5]); err == nil {
+		pid = n
+	}
+	return InstallLogEntry{
+		Timestamp: t,
+		Hostname:  match[3],
+		Process:   match[4],
+		PID:       pid,
+		Message:   match[6],
+	}, true
+}
+
+func matchesQuery(entry InstallLogEntry, q Query) bool {
+	if !q.Since.IsZero() && entry.Timestamp.Before(q.Since) {
+		return false
+	}
+	if !q.Until.IsZero() && entry.Timestamp.After(q.Until) {
+		return false
+	}
+	if q.Process != "" && entry.Process != q.Process {
+		return false
+	}
+	return q.Grep == "" || strings.Contains(entry.Message, q.Grep)
+}
+
+func parseInt32(s string) (int32, error) {
+	var n int32
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, errors.New("invalid int32")
+		}
+		n = n*10 + c - '0'
+	}
+	return n, nil
+}
+
+var majorPreparedRE = regexp.MustCompile(`<SUOSUMajorProduct:\s*([^>]+)>\(Title:([^ ]+(?: [^ ]+)*) Version:([^,\)]+).*?\)\s+is already prepared`)
+var majorSizeRE = regexp.MustCompile(`(?:^|[ ,])Size:(\d+)`)
+
+func ParseMajorUpdatePrepared(line string) (MajorUpdatePrepared, bool) {
+	entry, _ := ParseInstallLogLine(line)
+	text := line
+	if entry.Message != "" {
+		text = entry.Message
+	}
+	match := majorPreparedRE.FindStringSubmatch(text)
+	if len(match) != 4 {
+		return MajorUpdatePrepared{}, false
+	}
+	out := MajorUpdatePrepared{
+		AssetID:    strings.TrimSpace(match[1]),
+		Title:      strings.TrimSpace(match[2]),
+		Version:    strings.TrimSpace(match[3]),
+		PreparedAt: entry.Timestamp,
+	}
+	if sizeMatch := majorSizeRE.FindStringSubmatch(text); len(sizeMatch) == 2 {
+		out.SizeBytes = parseUint(sizeMatch[1])
+	}
+	return out, true
+}
+
+var controllerLabelRE = regexp.MustCompile(`SFR:([^)]*) \((?:Customer|Development)\)`)
+
+func ParseOSControllerTransition(line string) (OSControllerTransition, bool) {
+	if !strings.Contains(line, "Previous:") && !strings.Contains(line, "Current:") {
+		return OSControllerTransition{}, false
+	}
+	previous := ""
+	current := ""
+	if strings.Contains(line, "Previous:") {
+		previous = controllerLabel(line)
+	}
+	if strings.Contains(line, "Current:") {
+		current = controllerLabel(line)
+	}
+	if previous == "" && current == "" {
+		return OSControllerTransition{}, false
+	}
+	entry, _ := ParseInstallLogLine(line)
+	return OSControllerTransition{PreviousLabel: previous, CurrentLabel: current, At: entry.Timestamp}, true
+}
+
+func controllerLabel(line string) string {
+	match := controllerLabelRE.FindStringSubmatch(line)
+	if len(match) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(match[1])
+}
+
+func parseUint(s string) uint64 {
+	var n uint64
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			break
+		}
+		n = n*10 + uint64(c-'0')
+	}
+	return n
+}

--- a/internal/updates/install_log_test.go
+++ b/internal/updates/install_log_test.go
@@ -1,0 +1,84 @@
+package updates
+
+import (
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const preparedLine = `2026-05-01 10:00:00-05 mac softwareupdated[100]: SUOSUBackgroundDownloadEvaluator: <SUOSUMajorProduct: MSU_UPDATE_25F71_patch_26.5_major>(Title:macOS Tahoe 26.5 Version:26.5, Identifier:(null), IconSize:1052006, Size:123456789, Deferred:0) is already prepared`
+const previousLine = `2026-06-01 13:14:29-05 mac softwareupdated[93419]: Previous: SUMacControllerDescriptor(UUID:7B97 SU:macOS Sequoia 15.7.7 24G720 (Customer)(SU) SFR:macOS Sequoia 15.7.7 24G720 (Customer) BRAIN:24G720)`
+const currentLine = `2026-06-01 13:14:29-05 mac softwareupdated[93419]: Current: SUMacControllerDescriptor(UUID:7B97 SU:macOS Tahoe 26.5 25F71 (Customer)(SU) SFR:macOS Tahoe 26.5 25F71 (Customer) BRAIN:25F71)`
+
+func TestParseInstallLogLine(t *testing.T) {
+	entry, ok := ParseInstallLogLine(preparedLine)
+	if !ok {
+		t.Fatal("line did not parse")
+	}
+	if entry.Process != "softwareupdated" || entry.PID != 100 || entry.Hostname != "mac" {
+		t.Fatalf("entry = %+v", entry)
+	}
+	if entry.Timestamp.IsZero() {
+		t.Fatal("timestamp not parsed")
+	}
+}
+
+func TestParseMajorUpdatePrepared(t *testing.T) {
+	got, ok := ParseMajorUpdatePrepared(preparedLine)
+	if !ok {
+		t.Fatal("prepared line did not parse")
+	}
+	if got.AssetID != "MSU_UPDATE_25F71_patch_26.5_major" || got.Title != "macOS Tahoe 26.5" || got.Version != "26.5" || got.SizeBytes != 123456789 {
+		t.Fatalf("prepared = %+v", got)
+	}
+}
+
+func TestParseOSControllerTransition(t *testing.T) {
+	prev, ok := ParseOSControllerTransition(previousLine)
+	if !ok || prev.PreviousLabel != "macOS Sequoia 15.7.7 24G720" {
+		t.Fatalf("previous = %+v ok=%v", prev, ok)
+	}
+	cur, ok := ParseOSControllerTransition(currentLine)
+	if !ok || cur.CurrentLabel != "macOS Tahoe 26.5 25F71" {
+		t.Fatalf("current = %+v ok=%v", cur, ok)
+	}
+}
+
+func TestQueryInstallLogReadsGzip(t *testing.T) {
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "install.log")
+	gzPath := filepath.Join(dir, "install.log.1.gz")
+	if err := os.WriteFile(plain, []byte(preparedLine+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeGzip(t, gzPath, currentLine+"\n")
+	result, err := QueryInstallLog(Query{
+		Since:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		MaxLines: 10,
+		Paths:    []string{plain, gzPath},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Entries) != 2 || len(result.FilesRead) != 2 {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func writeGzip(t *testing.T, path, data string) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	gz := gzip.NewWriter(file)
+	if _, err := gz.Write([]byte(data)); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes #266.

## Summary
- add an internal updates install.log reader with gzip rotation support, FDA error signaling, and MajorUpdate/OSController parsers
- add `spectra updates` with since/grep/json output and snapshot integration
- add `updates.stale_major_prepared` rule coverage for stale prepared major updates

## Validation
- `go run ./cmd/spectra updates --since 720h --grep Tahoe --json | jq '{count:(.entries|length), files:.files_read, first:(.entries[0] // null)}'`\n- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run`