### PR TITLE
Add snapshot host facts

### DIFF
--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -304,6 +304,7 @@ func printSnapshot(s snapshot.Snapshot) {
 	fmt.Printf("taken-at:       %s\n", s.TakenAt.Format("2006-01-02T15:04:05Z07:00"))
 	fmt.Println()
 	fmt.Print(s.Host.String())
+	printSnapshotHostFacts(s.HostFacts)
 	if !s.Host.Memory.CollectedAt.IsZero() {
 		fmt.Print("memory:         ")
 		printMemoryState(s.Host.Memory, memstate.MemoryState{})
@@ -338,6 +339,31 @@ func printSnapshot(s snapshot.Snapshot) {
 	printSnapshotToolchains(s)
 	printSnapshotNetwork(s)
 	printSnapshotPower(s)
+}
+
+func printSnapshotHostFacts(f snapshot.HostFacts) {
+	if f.Hostname == "" && f.KernelVersion == "" && f.BootUUID == "" && f.LoadAverages.At.IsZero() {
+		return
+	}
+	if f.KernelVersion != "" {
+		fmt.Printf("kernel:         %s\n", f.KernelVersion)
+	}
+	if !f.BootTime.IsZero() {
+		fmt.Printf("boot-time:      %s\n", f.BootTime.Format(time.RFC3339))
+	}
+	if f.BootUUID != "" {
+		fmt.Printf("boot-uuid:      %s\n", f.BootUUID)
+	}
+	if !f.LoadAverages.At.IsZero() {
+		fmt.Printf("load-average:   %.2f %.2f %.2f\n",
+			f.LoadAverages.OneMinute,
+			f.LoadAverages.FiveMinute,
+			f.LoadAverages.FifteenMinute,
+		)
+	}
+	if len(f.RecentReboots) > 0 {
+		fmt.Printf("recent-reboots: %d\n", len(f.RecentReboots))
+	}
 }
 
 func printSnapshotToolchains(s snapshot.Snapshot) {

--- a/internal/snapshot/host.go
+++ b/internal/snapshot/host.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/memstate"
 	"github.com/kaeawc/spectra/internal/timemachine"
+	"howett.net/plist"
 )
 
 // CommandRunner runs a system command and returns stdout.
@@ -38,6 +39,8 @@ type HostCollectOptions struct {
 	Hostname      func() (string, error)
 	Runner        CommandRunner
 	Now           func() time.Time
+	BootTime      func() (time.Time, error)
+	LoadAverages  func(time.Time) (LoadAverages, error)
 	MemoryCollect func() (memstate.MemoryState, error)
 	TMCollect     func() (timemachine.TimeMachineState, error)
 }
@@ -50,7 +53,9 @@ type LiveHostCollector struct {
 type execCommandRunner struct{}
 
 func (execCommandRunner) Run(name string, args ...string) (string, error) {
-	cmd := exec.Command(name, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -75,6 +80,47 @@ type HostInfo struct {
 	SpectraVersion string                       `json:"spectra_version,omitempty"`
 	Memory         memstate.MemoryState         `json:"memory,omitempty"`
 	TimeMachine    timemachine.TimeMachineState `json:"time_machine,omitempty"`
+	Facts          HostFacts                    `json:"-"`
+}
+
+// HostFacts is the durable host baseline for each snapshot.
+type HostFacts struct {
+	Hostname         string        `json:"hostname"`
+	KernelVersion    string        `json:"kernel_version,omitempty"`
+	Architecture     string        `json:"architecture"`
+	OSProductName    string        `json:"os_product_name"`
+	OSProductVersion string        `json:"os_product_version,omitempty"`
+	OSBuildVersion   string        `json:"os_build_version,omitempty"`
+	Hardware         Hardware      `json:"hardware"`
+	BootTime         time.Time     `json:"boot_time,omitempty"`
+	BootUUID         string        `json:"boot_uuid,omitempty"`
+	Uptime           time.Duration `json:"uptime,omitempty"`
+	LoadAverages     LoadAverages  `json:"load_averages"`
+	RecentReboots    []RebootEvent `json:"recent_reboots,omitempty"`
+}
+
+type Hardware struct {
+	ModelName        string `json:"model_name,omitempty"`
+	ModelIdentifier  string `json:"model_identifier,omitempty"`
+	Chip             string `json:"chip,omitempty"`
+	SerialNumber     string `json:"serial_number,omitempty"`
+	HardwareUUID     string `json:"hardware_uuid,omitempty"`
+	CPUCores         int    `json:"cpu_cores,omitempty"`
+	PerformanceCores int    `json:"performance_cores,omitempty"`
+	EfficiencyCores  int    `json:"efficiency_cores,omitempty"`
+	MemoryBytes      uint64 `json:"memory_bytes,omitempty"`
+}
+
+type LoadAverages struct {
+	OneMinute     float64   `json:"one_minute,omitempty"`
+	FiveMinute    float64   `json:"five_minute,omitempty"`
+	FifteenMinute float64   `json:"fifteen_minute,omitempty"`
+	At            time.Time `json:"at,omitempty"`
+}
+
+type RebootEvent struct {
+	At                    time.Time `json:"at"`
+	PreviousShutdownCause int       `json:"previous_shutdown_cause,omitempty"`
 }
 
 // CollectHost gathers HostInfo from the local machine. Spectra version
@@ -86,50 +132,305 @@ func CollectHost(spectraVersion string) HostInfo {
 
 func (c LiveHostCollector) CollectHost(spectraVersion string) HostInfo {
 	deps := hostDepsFromOptions(c.Options)
+	facts := collectHostFacts(deps)
 
 	h := HostInfo{
-		OSName:         "macOS",
-		Architecture:   runtime.GOARCH,
+		Hostname:       facts.Hostname,
+		MachineUUID:    facts.Hardware.HardwareUUID,
+		OSName:         facts.OSProductName,
+		OSVersion:      facts.OSProductVersion,
+		OSBuild:        facts.OSBuildVersion,
+		CPUBrand:       facts.Hardware.Chip,
+		CPUCores:       facts.Hardware.CPUCores,
+		RAMBytes:       facts.Hardware.MemoryBytes,
+		Architecture:   facts.Architecture,
+		UptimeSeconds:  int64(facts.Uptime.Seconds()),
 		SpectraVersion: spectraVersion,
+		Facts:          facts,
 	}
-
-	if name, err := deps.hostname(); err == nil {
-		h.Hostname = name
+	if h.OSName == "" {
+		h.OSName = "macOS"
 	}
-	if v, err := deps.runner.Run("sw_vers", "-productVersion"); err == nil {
-		h.OSVersion = v
+	if h.Architecture == "" {
+		h.Architecture = runtime.GOARCH
 	}
-	if v, err := deps.runner.Run("sw_vers", "-buildVersion"); err == nil {
-		h.OSBuild = v
-	}
-	if v, err := deps.runner.Run("sysctl", "-n", "machdep.cpu.brand_string"); err == nil {
-		h.CPUBrand = v
-	}
-	if v, err := deps.runner.Run("sysctl", "-n", "hw.ncpu"); err == nil {
-		if n, err := strconv.Atoi(v); err == nil {
-			h.CPUCores = n
+	if h.CPUBrand == "" {
+		if v, err := deps.runner.Run("sysctl", "-n", "machdep.cpu.brand_string"); err == nil {
+			h.CPUBrand = v
 		}
 	}
-	if v, err := deps.runner.Run("sysctl", "-n", "hw.memsize"); err == nil {
-		if n, err := strconv.ParseUint(v, 10, 64); err == nil {
-			h.RAMBytes = n
+	if h.CPUCores == 0 {
+		if v, err := deps.runner.Run("sysctl", "-n", "hw.ncpu"); err == nil {
+			if n, err := strconv.Atoi(v); err == nil {
+				h.CPUCores = n
+			}
 		}
 	}
-	if uptime := readUptime(deps.runner, deps.now); uptime > 0 {
-		h.UptimeSeconds = uptime
+	if h.RAMBytes == 0 {
+		if v, err := deps.runner.Run("sysctl", "-n", "hw.memsize"); err == nil {
+			if n, err := strconv.ParseUint(v, 10, 64); err == nil {
+				h.RAMBytes = n
+			}
+		}
 	}
-	if uuid := readMachineUUID(deps.runner); uuid != "" {
-		h.MachineUUID = uuid
+	if h.UptimeSeconds == 0 {
+		if uptime := readUptime(deps.runner, deps.now); uptime > 0 {
+			h.UptimeSeconds = uptime
+		}
+	}
+	if h.MachineUUID == "" {
+		if uuid := readMachineUUID(deps.runner); uuid != "" {
+			h.MachineUUID = uuid
+		}
 	}
 	h.Memory = collectHostMemory(deps.memoryCollect)
 	h.TimeMachine = collectHostTimeMachine(deps.tmCollect)
 	return h
 }
 
+func collectHostFacts(deps hostDeps) HostFacts {
+	now := deps.now()
+	facts := HostFacts{
+		OSProductName: "macOS",
+		Architecture:  runtime.GOARCH,
+	}
+	if name, err := deps.hostname(); err == nil {
+		facts.Hostname = name
+	}
+	populateHostFactStrings(&facts, deps.runner)
+	facts.Hardware = collectHardware(deps.runner)
+	populateHardwareFallbacks(&facts.Hardware, deps.runner)
+	populateBootFacts(&facts, deps, now)
+	if loads, err := deps.loadAverages(now); err == nil {
+		facts.LoadAverages = loads
+	}
+	facts.RecentReboots = readRecentReboots(deps.runner, now)
+	return facts
+}
+
+func populateHostFactStrings(facts *HostFacts, runner CommandRunner) {
+	if v, err := runner.Run("uname", "-v"); err == nil {
+		facts.KernelVersion = v
+	}
+	if v, err := runner.Run("uname", "-m"); err == nil {
+		facts.Architecture = v
+	}
+	if v, err := runner.Run("sw_vers", "-productName"); err == nil {
+		facts.OSProductName = v
+	}
+	if v, err := runner.Run("sw_vers", "-productVersion"); err == nil {
+		facts.OSProductVersion = v
+	}
+	if v, err := runner.Run("sw_vers", "-buildVersion"); err == nil {
+		facts.OSBuildVersion = v
+	}
+}
+
+func populateHardwareFallbacks(hardware *Hardware, runner CommandRunner) {
+	if hardware.CPUCores == 0 {
+		if v, err := runner.Run("sysctl", "-n", "hw.ncpu"); err == nil {
+			hardware.CPUCores, _ = strconv.Atoi(v)
+		}
+	}
+	if hardware.MemoryBytes == 0 {
+		if v, err := runner.Run("sysctl", "-n", "hw.memsize"); err == nil {
+			hardware.MemoryBytes, _ = strconv.ParseUint(v, 10, 64)
+		}
+	}
+}
+
+func populateBootFacts(facts *HostFacts, deps hostDeps, now time.Time) {
+	if boot, err := deps.bootTime(); err == nil && !boot.IsZero() {
+		facts.BootTime = boot
+	} else {
+		facts.BootTime = readBootTimeFromSysctl(deps.runner)
+	}
+	if !facts.BootTime.IsZero() && now.After(facts.BootTime) {
+		facts.Uptime = now.Sub(facts.BootTime).Round(time.Second)
+	}
+	if uuid := readBootUUID(deps.runner); uuid != "" {
+		facts.BootUUID = uuid
+	}
+}
+
+func collectHardware(runner CommandRunner) Hardware {
+	out, err := runner.Run("system_profiler", "-xml", "SPHardwareDataType")
+	if err != nil {
+		return Hardware{}
+	}
+	item := systemProfilerHardwareItem(out)
+	if len(item) == 0 {
+		return Hardware{}
+	}
+	h := Hardware{
+		ModelName:       stringValue(item["machine_name"]),
+		ModelIdentifier: stringValue(item["machine_model"]),
+		Chip:            stringValue(item["chip_type"]),
+		SerialNumber:    stringValue(item["serial_number"]),
+		HardwareUUID:    stringValue(item["platform_UUID"]),
+	}
+	h.CPUCores, h.PerformanceCores, h.EfficiencyCores = parseProcessorCounts(stringValue(item["number_processors"]))
+	h.MemoryBytes = parseMemoryBytes(stringValue(item["physical_memory"]))
+	return h
+}
+
+func systemProfilerHardwareItem(out string) map[string]any {
+	var root []map[string]any
+	if _, err := plist.Unmarshal([]byte(out), &root); err != nil || len(root) == 0 {
+		return nil
+	}
+	items, ok := root[0]["_items"].([]any)
+	if !ok || len(items) == 0 {
+		return nil
+	}
+	item, _ := items[0].(map[string]any)
+	return item
+}
+
+func stringValue(v any) string {
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+func parseProcessorCounts(raw string) (total, performance, efficiency int) {
+	re := regexp.MustCompile(`proc\s+(\d+):(\d+):(\d+)`)
+	m := re.FindStringSubmatch(raw)
+	if len(m) != 4 {
+		return 0, 0, 0
+	}
+	total, _ = strconv.Atoi(m[1])
+	performance, _ = strconv.Atoi(m[2])
+	efficiency, _ = strconv.Atoi(m[3])
+	return total, performance, efficiency
+}
+
+func parseMemoryBytes(raw string) uint64 {
+	fields := strings.Fields(strings.TrimSpace(raw))
+	if len(fields) == 0 {
+		return 0
+	}
+	value, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0
+	}
+	unit := "B"
+	if len(fields) > 1 {
+		unit = strings.ToUpper(fields[1])
+	}
+	multiplier := float64(1)
+	switch unit {
+	case "KB":
+		multiplier = 1024
+	case "MB":
+		multiplier = 1024 * 1024
+	case "GB":
+		multiplier = 1024 * 1024 * 1024
+	case "TB":
+		multiplier = 1024 * 1024 * 1024 * 1024
+	}
+	return uint64(value * multiplier)
+}
+
+func readBootTimeFromSysctl(runner CommandRunner) time.Time {
+	out, err := runner.Run("sysctl", "-n", "kern.boottime")
+	if err != nil {
+		return time.Time{}
+	}
+	re := regexp.MustCompile(`sec\s*=\s*(\d+)`)
+	m := re.FindStringSubmatch(out)
+	if len(m) < 2 {
+		return time.Time{}
+	}
+	boot, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(boot, 0)
+}
+
+func readBootUUID(runner CommandRunner) string {
+	if out, err := runner.Run("sysctl", "-n", "kern.bootsessionuuid"); err == nil {
+		if uuid := strings.TrimSpace(out); uuid != "" {
+			return uuid
+		}
+	}
+	if out, err := runner.Run("log", "show", "--predicate", `eventMessage CONTAINS "=== system boot"`, "--last", "7d", "--style", "ndjson"); err == nil {
+		if uuid := parseBootUUID(out); uuid != "" {
+			return uuid
+		}
+	}
+	return ""
+}
+
+func parseBootUUID(out string) string {
+	re := regexp.MustCompile(`=== system boot:\s*([A-Fa-f0-9-]{36})`)
+	m := re.FindStringSubmatch(out)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.ToUpper(m[1])
+}
+
+func readRecentReboots(runner CommandRunner, now time.Time) []RebootEvent {
+	out, err := runner.Run("last", "reboot")
+	if err != nil {
+		return nil
+	}
+	return parseRecentReboots(out, now)
+}
+
+func parseRecentReboots(out string, now time.Time) []RebootEvent {
+	var events []RebootEvent
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if len(events) >= 10 {
+			break
+		}
+		at, ok := parseLastRebootLine(line, now)
+		if ok {
+			events = append(events, RebootEvent{At: at})
+		}
+	}
+	return events
+}
+
+func parseLastRebootLine(line string, now time.Time) (time.Time, bool) {
+	if !strings.HasPrefix(line, "reboot") {
+		return time.Time{}, false
+	}
+	parts := strings.Fields(line)
+	if len(parts) < 6 || parts[1] != "time" {
+		return time.Time{}, false
+	}
+	raw := strings.Join(parts[2:6], " ") + fmt.Sprintf(" %d", now.Year())
+	at, err := time.ParseInLocation("Mon Jan _2 15:04 2006", raw, now.Location())
+	if err != nil {
+		return time.Time{}, false
+	}
+	if at.After(now.Add(24 * time.Hour)) {
+		at = at.AddDate(-1, 0, 0)
+	}
+	return at, true
+}
+
+func readUptime(runner CommandRunner, now func() time.Time) int64 {
+	boot := readBootTimeFromSysctl(runner)
+	if boot.IsZero() {
+		return 0
+	}
+	current := now().Unix()
+	if current < boot.Unix() {
+		return 0
+	}
+	return current - boot.Unix()
+}
+
 type hostDeps struct {
 	hostname      func() (string, error)
 	runner        CommandRunner
 	now           func() time.Time
+	bootTime      func() (time.Time, error)
+	loadAverages  func(time.Time) (LoadAverages, error)
 	memoryCollect func() (memstate.MemoryState, error)
 	tmCollect     func() (timemachine.TimeMachineState, error)
 }
@@ -139,6 +440,8 @@ func hostDepsFromOptions(opts HostCollectOptions) hostDeps {
 		hostname:      opts.Hostname,
 		runner:        opts.Runner,
 		now:           opts.Now,
+		bootTime:      opts.BootTime,
+		loadAverages:  opts.LoadAverages,
 		memoryCollect: opts.MemoryCollect,
 		tmCollect:     opts.TMCollect,
 	}
@@ -150,6 +453,12 @@ func hostDepsFromOptions(opts HostCollectOptions) hostDeps {
 	}
 	if deps.now == nil {
 		deps.now = time.Now
+	}
+	if deps.bootTime == nil {
+		deps.bootTime = collectBootTime
+	}
+	if deps.loadAverages == nil {
+		deps.loadAverages = collectLoadAverages
 	}
 	if deps.memoryCollect == nil {
 		deps.memoryCollect = memstate.Collect
@@ -176,29 +485,6 @@ func collectHostTimeMachine(collect func() (timemachine.TimeMachineState, error)
 		return timemachine.TimeMachineState{}
 	}
 	return state
-}
-
-// readUptime parses kern.boottime and returns seconds since boot.
-// `sysctl -n kern.boottime` prints "{ sec = 1234567890, usec = 0 } Mon ...".
-func readUptime(runner CommandRunner, now func() time.Time) int64 {
-	out, err := runner.Run("sysctl", "-n", "kern.boottime")
-	if err != nil {
-		return 0
-	}
-	re := regexp.MustCompile(`sec\s*=\s*(\d+)`)
-	m := re.FindStringSubmatch(out)
-	if len(m) < 2 {
-		return 0
-	}
-	boot, err := strconv.ParseInt(m[1], 10, 64)
-	if err != nil {
-		return 0
-	}
-	current := now().Unix()
-	if current < boot {
-		return 0
-	}
-	return current - boot
 }
 
 // readMachineUUID parses IOPlatformUUID out of `ioreg`. Stable per

--- a/internal/snapshot/host_darwin.go
+++ b/internal/snapshot/host_darwin.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package snapshot
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func collectBootTime() (time.Time, error) {
+	tv, err := unix.SysctlTimeval("kern.boottime")
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(tv.Sec, int64(tv.Usec)*1000), nil
+}
+
+func collectLoadAverages(at time.Time) (LoadAverages, error) {
+	raw, err := unix.SysctlRaw("vm.loadavg")
+	if err != nil {
+		return LoadAverages{}, err
+	}
+	if len(raw) < 24 {
+		return LoadAverages{}, fmt.Errorf("vm.loadavg: short sysctl payload")
+	}
+	fscale := binary.LittleEndian.Uint64(raw[16:24])
+	if fscale == 0 {
+		return LoadAverages{}, fmt.Errorf("vm.loadavg: zero scale")
+	}
+	return LoadAverages{
+		OneMinute:     float64(binary.LittleEndian.Uint32(raw[0:4])) / float64(fscale),
+		FiveMinute:    float64(binary.LittleEndian.Uint32(raw[4:8])) / float64(fscale),
+		FifteenMinute: float64(binary.LittleEndian.Uint32(raw[8:12])) / float64(fscale),
+		At:            at,
+	}, nil
+}

--- a/internal/snapshot/host_other.go
+++ b/internal/snapshot/host_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package snapshot
+
+import "time"
+
+func collectBootTime() (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func collectLoadAverages(time.Time) (LoadAverages, error) {
+	return LoadAverages{}, nil
+}

--- a/internal/snapshot/host_test.go
+++ b/internal/snapshot/host_test.go
@@ -67,18 +67,25 @@ func TestHostInfoString(t *testing.T) {
 
 func TestLiveHostCollectorUsesInjectedRunner(t *testing.T) {
 	runner := fakeHostRunner{responses: map[string]string{
-		"sw_vers\x00-productVersion":                   "15.6.1",
-		"sw_vers\x00-buildVersion":                     "24G90",
-		"sysctl\x00-n\x00machdep.cpu.brand_string":     "Apple M99",
-		"sysctl\x00-n\x00hw.ncpu":                      "12",
-		"sysctl\x00-n\x00hw.memsize":                   "68719476736",
-		"sysctl\x00-n\x00kern.boottime":                "{ sec = 1000, usec = 0 }",
-		"ioreg\x00-d2\x00-c\x00IOPlatformExpertDevice": `"IOPlatformUUID" = "ABCDEF12-3456-7890-ABCD-EF1234567890"`,
+		"uname\x00-v":                                   "Darwin Kernel Version 24.6.0",
+		"uname\x00-m":                                   "arm64",
+		"sw_vers\x00-productName":                       "macOS",
+		"sw_vers\x00-productVersion":                    "15.6.1",
+		"sw_vers\x00-buildVersion":                      "24G90",
+		"system_profiler\x00-xml\x00SPHardwareDataType": testHardwareProfilerXML,
+		"log\x00show\x00--predicate\x00eventMessage CONTAINS \"=== system boot\"\x00--last\x007d\x00--style\x00ndjson": `{"eventMessage":"=== system boot: abcdef12-3456-7890-abcd-ef1234567890"}`,
+		"last\x00reboot": "reboot time                                Sun May 17 08:34\n",
 	}}
 	collector := LiveHostCollector{Options: HostCollectOptions{
-		Hostname:      func() (string, error) { return "test-host", nil },
-		Runner:        runner,
-		Now:           func() time.Time { return time.Unix(4600, 0) },
+		Hostname: func() (string, error) { return "test-host", nil },
+		Runner:   runner,
+		Now:      func() time.Time { return time.Unix(4600, 0) },
+		BootTime: func() (time.Time, error) {
+			return time.Unix(1000, 0), nil
+		},
+		LoadAverages: func(at time.Time) (LoadAverages, error) {
+			return LoadAverages{OneMinute: 1.25, FiveMinute: 2.5, FifteenMinute: 3.75, At: at}, nil
+		},
 		MemoryCollect: func() (memstate.MemoryState, error) { return memstate.MemoryState{PhysicalBytes: 99}, nil },
 		TMCollect: func() (timemachine.TimeMachineState, error) {
 			return timemachine.TimeMachineState{SchedulerLoaded: true}, nil
@@ -113,6 +120,18 @@ func TestLiveHostCollectorUsesInjectedRunner(t *testing.T) {
 	if !got.TimeMachine.SchedulerLoaded {
 		t.Error("TimeMachine.SchedulerLoaded = false, want injected true")
 	}
+	if got.Facts.BootUUID != "ABCDEF12-3456-7890-ABCD-EF1234567890" {
+		t.Errorf("BootUUID = %q", got.Facts.BootUUID)
+	}
+	if got.Facts.Hardware.PerformanceCores != 8 || got.Facts.Hardware.EfficiencyCores != 4 {
+		t.Errorf("hardware cores = %d/%d", got.Facts.Hardware.PerformanceCores, got.Facts.Hardware.EfficiencyCores)
+	}
+	if got.Facts.LoadAverages.OneMinute != 1.25 {
+		t.Errorf("load average = %.2f", got.Facts.LoadAverages.OneMinute)
+	}
+	if len(got.Facts.RecentReboots) != 1 {
+		t.Fatalf("RecentReboots len = %d, want 1", len(got.Facts.RecentReboots))
+	}
 }
 
 func TestLiveHostCollectorToleratesMissingMachineUUID(t *testing.T) {
@@ -144,6 +163,43 @@ func (f fakeHostRunner) Run(name string, args ...string) (string, error) {
 	}
 	return "", fmt.Errorf("unexpected command %s", key)
 }
+
+func TestHostFactsParsers(t *testing.T) {
+	total, perf, eff := parseProcessorCounts("proc 16:12:4")
+	if total != 16 || perf != 12 || eff != 4 {
+		t.Fatalf("parseProcessorCounts = %d/%d/%d", total, perf, eff)
+	}
+	if got := parseMemoryBytes("128 GB"); got != 128*1024*1024*1024 {
+		t.Fatalf("parseMemoryBytes = %d", got)
+	}
+	if got := parseBootUUID(`{"eventMessage":"=== system boot: abcdef12-3456-7890-abcd-ef1234567890"}`); got != "ABCDEF12-3456-7890-ABCD-EF1234567890" {
+		t.Fatalf("parseBootUUID = %q", got)
+	}
+	events := parseRecentReboots("reboot time                                Sun May 17 08:34\nshutdown time Sun May 17 08:34\n", time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
+	if len(events) != 1 || events[0].At.Month() != time.May || events[0].At.Day() != 17 {
+		t.Fatalf("parseRecentReboots = %#v", events)
+	}
+}
+
+const testHardwareProfilerXML = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<array>
+  <dict>
+    <key>_items</key>
+    <array>
+      <dict>
+        <key>machine_name</key><string>MacBook Pro</string>
+        <key>machine_model</key><string>Mac99,1</string>
+        <key>chip_type</key><string>Apple M99</string>
+        <key>number_processors</key><string>proc 12:8:4</string>
+        <key>physical_memory</key><string>64 GB</string>
+        <key>platform_UUID</key><string>ABCDEF12-3456-7890-ABCD-EF1234567890</string>
+        <key>serial_number</key><string>SERIAL123</string>
+      </dict>
+    </array>
+  </dict>
+</array>
+</plist>`
 
 func TestHumanBytes(t *testing.T) {
 	cases := map[uint64]string{

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -39,6 +39,7 @@ type Snapshot struct {
 	TakenAt      time.Time                `json:"taken_at"`
 	Kind         Kind                     `json:"kind"`
 	Host         HostInfo                 `json:"host"`
+	HostFacts    HostFacts                `json:"host_facts"`
 	Apps         []detect.Result          `json:"apps"`
 	Processes    []process.Info           `json:"processes,omitempty"`
 	Toolchains   toolchain.Toolchains     `json:"toolchains"`
@@ -201,6 +202,7 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	go func() {
 		defer wg.Done()
 		s.Host = hostCollectorFor(opts).CollectHost(opts.SpectraVersion)
+		s.HostFacts = s.Host.Facts
 	}()
 	if !opts.SkipApps {
 		go func() {

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -135,6 +135,12 @@ func TestBuildUsesInjectedHostCollector(t *testing.T) {
 			Hostname:    "fake-host",
 			MachineUUID: "FAKE-UUID",
 			OSName:      "macOS",
+			Facts: HostFacts{
+				Hostname:         "fake-host",
+				OSProductName:    "macOS",
+				OSProductVersion: "15.6.1",
+				BootUUID:         "BOOT-UUID",
+			},
 			Memory: memstate.MemoryState{
 				PhysicalBytes: 1024,
 				CollectedAt:   collectedAt,
@@ -165,6 +171,9 @@ func TestBuildUsesInjectedHostCollector(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"time_machine"`) || !strings.Contains(string(data), `"scheduler_loaded":true`) {
 		t.Fatalf("snapshot JSON missing host.time_machine: %s", data)
+	}
+	if !strings.Contains(string(data), `"host_facts"`) || !strings.Contains(string(data), `"boot_uuid":"BOOT-UUID"`) {
+		t.Fatalf("snapshot JSON missing host_facts: %s", data)
 	}
 }
 


### PR DESCRIPTION
Closes #267.

## Summary
- add a top-level `host_facts` snapshot block with OS/kernel identity, hardware, boot time, boot UUID, uptime, load averages, and recent reboot history
- collect boot time/load averages through Darwin sysctls with non-Darwin stubs
- derive legacy host summary fields from the richer facts and print key host facts in snapshot summaries

## Validation
- `go run ./cmd/spectra snapshot --no-store --no-apps --json | jq '{id, host_facts:{hostname:.host_facts.hostname, os:.host_facts.os_product_version, boot_uuid:.host_facts.boot_uuid, boot_time:.host_facts.boot_time, uptime:.host_facts.uptime, load:.host_facts.load_averages, hardware:.host_facts.hardware, reboots:(.host_facts.recent_reboots|length)}}'`\n- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run`