### PR TITLE
Add install history updates

### DIFF
--- a/cmd/spectra/updates.go
+++ b/cmd/spectra/updates.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -14,15 +15,24 @@ import (
 func runUpdates(args []string) int {
 	fs := flag.NewFlagSet("spectra updates", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
-	since := fs.Duration("since", 30*24*time.Hour, "Look back duration")
-	grep := fs.String("grep", "", "Substring filter on message")
+	history := fs.Bool("history", false, "Show system_profiler install history")
+	since := fs.Duration("since", 0, "Look back duration (default: 30d for logs, all history)")
+	source := fs.String("source", "", "History source filter: apple or third-party")
+	grep := fs.String("grep", "", "Regex filter for history; substring filter for logs")
 	asJSON := fs.Bool("json", false, "Emit JSON")
 	maxLines := fs.Int("max-lines", 5000, "Maximum entries")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	if *history {
+		return runUpdatesHistory(*since, *source, *grep, *asJSON)
+	}
+	logSince := time.Now().Add(-30 * 24 * time.Hour)
+	if *since > 0 {
+		logSince = time.Now().Add(-*since)
+	}
 	result, err := updates.QueryInstallLog(updates.Query{
-		Since:    time.Now().Add(-*since),
+		Since:    logSince,
 		Grep:     *grep,
 		MaxLines: *maxLines,
 	})
@@ -44,6 +54,31 @@ func runUpdates(args []string) int {
 	return 0
 }
 
+func runUpdatesHistory(since time.Duration, source string, grep string, asJSON bool) int {
+	history, err := updates.Collect(context.Background())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	query := updates.HistoryQuery{Source: source, Grep: grep}
+	if since > 0 {
+		query.Since = time.Now().Add(-since)
+	}
+	filtered, err := updates.FilterHistory(history, query)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(filtered)
+		return 0
+	}
+	printUpdateHistory(filtered)
+	return 0
+}
+
 func printUpdates(result updates.Result) {
 	fmt.Printf("entries: %d\n", len(result.Entries))
 	for _, entry := range result.Entries {
@@ -51,6 +86,18 @@ func printUpdates(result updates.Result) {
 			entry.Timestamp.Format(time.RFC3339),
 			entry.Process,
 			entry.Message,
+		)
+	}
+}
+
+func printUpdateHistory(history updates.InstallHistory) {
+	fmt.Printf("entries: %d\n", len(history.Entries))
+	for _, entry := range history.Entries {
+		fmt.Printf("%s  %-10s  %-36s  %s\n",
+			entry.InstallDate.Format("2006-01-02 15:04:05"),
+			entry.Source,
+			truncate(entry.Name, 36),
+			entry.Version,
 		)
 	}
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/toolchain"
+	"github.com/kaeawc/spectra/internal/updates"
 )
 
 // ChangeKind classifies one diff entry.
@@ -69,6 +70,7 @@ func Compare(a, b snapshot.Snapshot) Result {
 			diffPathDirs(a, b),
 			diffSystemLimits(a, b),
 			diffSysctls(a, b),
+			diffInstallHistory(a, b),
 		},
 	}
 }
@@ -404,6 +406,48 @@ func diffSystemLimits(a, b snapshot.Snapshot) Section {
 	}
 	return Section{Name: "system_limits", Changes: changes}
 }
+
+func diffInstallHistory(a, b snapshot.Snapshot) Section {
+	seen := make(map[string]bool, len(a.Updates.History.Entries))
+	for _, entry := range a.Updates.History.Entries {
+		seen[installEntryKey(entry)] = true
+	}
+	var changes []Change
+	for _, entry := range b.Updates.History.Entries {
+		if seen[installEntryKey(entry)] {
+			continue
+		}
+		changes = append(changes, Change{
+			Kind:  Added,
+			Key:   entry.Name,
+			After: installEntryLabel(entry),
+		})
+	}
+	return Section{Name: "install_history", Changes: changes}
+}
+
+func installEntryKey(entry updates.InstallEntry) string {
+	return strings.Join([]string{
+		entry.Name,
+		entry.Version,
+		entry.Source,
+		entry.InstallDate.UTC().Format(timeKeyLayout),
+		strings.Join(entry.PackageIDs, ","),
+	}, "\x00")
+}
+
+func installEntryLabel(entry updates.InstallEntry) string {
+	parts := []string{entry.InstallDate.Format("2006-01-02 15:04:05")}
+	if entry.Version != "" {
+		parts = append(parts, "version "+entry.Version)
+	}
+	if entry.Source != "" {
+		parts = append(parts, entry.Source)
+	}
+	return strings.Join(parts, " · ")
+}
+
+const timeKeyLayout = "2006-01-02T15:04:05.999999999Z07:00"
 
 // diffActiveRuntimes compares the active version for each language runtime
 // (node, python, go, ruby). A change fires when the active version differs

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/memstate"
@@ -10,6 +11,7 @@ import (
 	"github.com/kaeawc/spectra/internal/syslimits"
 	"github.com/kaeawc/spectra/internal/timemachine"
 	"github.com/kaeawc/spectra/internal/toolchain"
+	"github.com/kaeawc/spectra/internal/updates"
 )
 
 // base returns a minimal snapshot for tests.
@@ -245,6 +247,38 @@ func TestDiffBrewFormulae(t *testing.T) {
 	}
 	if !hasChange(sec.Changes, Added, "jq") {
 		t.Error("expected jq added")
+	}
+}
+
+func TestDiffInstallHistoryAdded(t *testing.T) {
+	a := base()
+	b := base()
+	oldEntry := updates.InstallEntry{
+		Name:        "XProtectPlistConfigData",
+		Version:     "5278",
+		Source:      "Apple",
+		InstallDate: time.Date(2026, 5, 18, 14, 12, 1, 0, time.UTC),
+	}
+	newEntry := updates.InstallEntry{
+		Name:        "ExampleTool",
+		Version:     "1.2.3",
+		Source:      "3rd Party",
+		InstallDate: time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC),
+		PackageIDs:  []string{"com.example.tool.pkg"},
+	}
+	a.Updates.History.Entries = []updates.InstallEntry{oldEntry}
+	b.Updates.History.Entries = []updates.InstallEntry{oldEntry, newEntry}
+
+	r := Compare(a, b)
+	sec := findSection(r, "install_history")
+	if sec == nil {
+		t.Fatal("install_history section missing")
+	}
+	if !hasChange(sec.Changes, Added, "ExampleTool") {
+		t.Fatalf("expected ExampleTool install added, got %+v", sec.Changes)
+	}
+	if hasChange(sec.Changes, Added, "XProtectPlistConfigData") {
+		t.Fatalf("old entry should not be added: %+v", sec.Changes)
 	}
 }
 

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -249,9 +249,7 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	if !opts.SkipUpdates {
 		go func() {
 			defer wg.Done()
-			if result, err := updates.QueryInstallLog(opts.UpdatesOpts); err == nil {
-				s.Updates = result
-			}
+			s.Updates = collectUpdates(ctx, opts.UpdatesOpts)
 		}()
 	}
 
@@ -311,6 +309,17 @@ func snapshotCollectorCount(opts Options) int {
 		collectors++
 	}
 	return collectors
+}
+
+func collectUpdates(ctx context.Context, query updates.Query) updates.Result {
+	var result updates.Result
+	if logs, err := updates.QueryInstallLog(query); err == nil {
+		result = logs
+	}
+	if history, err := updates.Collect(ctx); err == nil {
+		result.History = history
+	}
+	return result
 }
 
 func hostCollectorFor(opts Options) HostCollector {

--- a/internal/updates/install_history.go
+++ b/internal/updates/install_history.go
@@ -1,0 +1,211 @@
+package updates
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"howett.net/plist"
+)
+
+type InstallEntry struct {
+	Name        string    `json:"name"`
+	Version     string    `json:"version,omitempty"`
+	Source      string    `json:"source,omitempty"`
+	InstallDate time.Time `json:"install_date"`
+	PackageIDs  []string  `json:"package_ids,omitempty"`
+}
+
+type InstallHistory struct {
+	Entries     []InstallEntry `json:"entries"`
+	CollectedAt time.Time      `json:"collected_at"`
+}
+
+type HistoryQuery struct {
+	Since  time.Time
+	Source string
+	Grep   string
+}
+
+type historyRunner func(context.Context, string, ...string) ([]byte, error)
+
+func Collect(ctx context.Context) (InstallHistory, error) {
+	return collectHistoryWith(ctx, runHistoryCommand, time.Now)
+}
+
+func collectHistoryWith(ctx context.Context, run historyRunner, now func() time.Time) (InstallHistory, error) {
+	out, err := run(ctx, "system_profiler", "-xml", "SPInstallHistoryDataType")
+	if err != nil {
+		return InstallHistory{}, err
+	}
+	history, err := ParseInstallHistory(out, now())
+	if err != nil {
+		return InstallHistory{}, err
+	}
+	return history, nil
+}
+
+func runHistoryCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.Output()
+}
+
+func ParseInstallHistory(data []byte, collectedAt time.Time) (InstallHistory, error) {
+	items, err := installHistoryItems(data)
+	if err != nil {
+		return InstallHistory{}, err
+	}
+	entries := make([]InstallEntry, 0, len(items))
+	for _, item := range items {
+		entry := installEntryFromItem(item)
+		if entry.Name == "" || entry.InstallDate.IsZero() {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].InstallDate.Before(entries[j].InstallDate)
+	})
+	return InstallHistory{Entries: entries, CollectedAt: collectedAt}, nil
+}
+
+func installHistoryItems(data []byte) ([]map[string]any, error) {
+	var root []map[string]any
+	if _, err := plist.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("decode install history plist: %w", err)
+	}
+	if len(root) == 0 {
+		return nil, nil
+	}
+	rawItems, ok := root[0]["_items"].([]any)
+	if !ok {
+		return nil, nil
+	}
+	items := make([]map[string]any, 0, len(rawItems))
+	for _, raw := range rawItems {
+		if item, ok := raw.(map[string]any); ok {
+			items = append(items, item)
+		}
+	}
+	return items, nil
+}
+
+func installEntryFromItem(item map[string]any) InstallEntry {
+	return InstallEntry{
+		Name:        historyString(item["_name"]),
+		Version:     historyString(item["install_version"]),
+		Source:      normalizeHistorySource(historyString(item["package_source"])),
+		InstallDate: historyTime(item["install_date"]),
+		PackageIDs:  historyStringSlice(firstPresent(item, "package_ids", "packageIdentifiers", "package_identifiers", "_packageIdentifiers")),
+	}
+}
+
+func FilterHistory(history InstallHistory, q HistoryQuery) (InstallHistory, error) {
+	source := normalizeSourceFilter(q.Source)
+	if q.Source != "" && source == "" {
+		return InstallHistory{}, fmt.Errorf("source must be apple or third-party")
+	}
+	var re *regexp.Regexp
+	if q.Grep != "" {
+		compiled, err := regexp.Compile(q.Grep)
+		if err != nil {
+			return InstallHistory{}, fmt.Errorf("grep: %w", err)
+		}
+		re = compiled
+	}
+	filtered := InstallHistory{CollectedAt: history.CollectedAt}
+	for _, entry := range history.Entries {
+		if !q.Since.IsZero() && entry.InstallDate.Before(q.Since) {
+			continue
+		}
+		if source != "" && entry.Source != source {
+			continue
+		}
+		if re != nil && !re.MatchString(historySearchText(entry)) {
+			continue
+		}
+		filtered.Entries = append(filtered.Entries, entry)
+	}
+	return filtered, nil
+}
+
+func historySearchText(entry InstallEntry) string {
+	return strings.Join([]string{
+		entry.Name,
+		entry.Version,
+		entry.Source,
+		strings.Join(entry.PackageIDs, " "),
+	}, " ")
+}
+
+func normalizeSourceFilter(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return ""
+	case "apple":
+		return "Apple"
+	case "third-party", "third party", "3rd-party", "3rd party":
+		return "3rd Party"
+	default:
+		return ""
+	}
+}
+
+func normalizeHistorySource(raw string) string {
+	lower := strings.ToLower(strings.TrimSpace(raw))
+	switch {
+	case lower == "":
+		return ""
+	case strings.Contains(lower, "apple"):
+		return "Apple"
+	case strings.Contains(lower, "third") || strings.Contains(lower, "3rd") || strings.Contains(lower, "other"):
+		return "3rd Party"
+	default:
+		return strings.TrimSpace(raw)
+	}
+}
+
+func firstPresent(item map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := item[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func historyString(v any) string {
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+func historyTime(v any) time.Time {
+	t, _ := v.(time.Time)
+	return t
+}
+
+func historyStringSlice(v any) []string {
+	switch values := v.(type) {
+	case []any:
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			if s := historyString(value); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return append([]string(nil), values...)
+	case string:
+		if strings.TrimSpace(values) == "" {
+			return nil
+		}
+		return []string{strings.TrimSpace(values)}
+	default:
+		return nil
+	}
+}

--- a/internal/updates/install_history_test.go
+++ b/internal/updates/install_history_test.go
@@ -1,0 +1,85 @@
+package updates
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestParseInstallHistoryFixture(t *testing.T) {
+	data, err := os.ReadFile("testdata/install_history.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	collectedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	history, err := ParseInstallHistory(data, collectedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !history.CollectedAt.Equal(collectedAt) {
+		t.Fatalf("CollectedAt = %v, want %v", history.CollectedAt, collectedAt)
+	}
+	if len(history.Entries) != 2 {
+		t.Fatalf("Entries len = %d, want 2", len(history.Entries))
+	}
+	first := history.Entries[0]
+	if first.Name != "XProtectPlistConfigData" || first.Version != "5278" || first.Source != "Apple" {
+		t.Fatalf("first entry = %#v", first)
+	}
+	if len(first.PackageIDs) != 1 || first.PackageIDs[0] != "com.apple.pkg.XProtectPlistConfigData_10_15.16U5278" {
+		t.Fatalf("PackageIDs = %#v", first.PackageIDs)
+	}
+	second := history.Entries[1]
+	if second.Source != "3rd Party" {
+		t.Fatalf("second source = %q", second.Source)
+	}
+}
+
+func TestFilterHistory(t *testing.T) {
+	history := InstallHistory{Entries: []InstallEntry{
+		{Name: "Apple Config", Source: "Apple", InstallDate: time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)},
+		{Name: "ExampleTool", Source: "3rd Party", Version: "1.2.3", InstallDate: time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)},
+	}}
+	filtered, err := FilterHistory(history, HistoryQuery{
+		Since:  time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC),
+		Source: "third-party",
+		Grep:   `Example.*1\.2`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered.Entries) != 1 || filtered.Entries[0].Name != "ExampleTool" {
+		t.Fatalf("filtered entries = %#v", filtered.Entries)
+	}
+	if _, err := FilterHistory(history, HistoryQuery{Source: "bad"}); err == nil {
+		t.Fatal("expected bad source error")
+	}
+	if _, err := FilterHistory(history, HistoryQuery{Grep: "["}); err == nil {
+		t.Fatal("expected bad grep error")
+	}
+}
+
+func TestCollectHistoryUsesRunnerOnce(t *testing.T) {
+	data, err := os.ReadFile("testdata/install_history.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var calls int
+	history, err := collectHistoryWith(context.Background(), func(_ context.Context, name string, args ...string) ([]byte, error) {
+		calls++
+		if name != "system_profiler" || len(args) != 2 || args[0] != "-xml" || args[1] != "SPInstallHistoryDataType" {
+			t.Fatalf("unexpected command %s %#v", name, args)
+		}
+		return data, nil
+	}, func() time.Time { return time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if len(history.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(history.Entries))
+	}
+}

--- a/internal/updates/install_log.go
+++ b/internal/updates/install_log.go
@@ -36,6 +36,7 @@ type Query struct {
 
 type Result struct {
 	Entries   []InstallLogEntry `json:"entries"`
+	History   InstallHistory    `json:"history,omitempty"`
 	FilesRead []string          `json:"files_read"`
 	Truncated bool              `json:"truncated,omitempty"`
 }

--- a/internal/updates/testdata/install_history.xml
+++ b/internal/updates/testdata/install_history.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<array>
+  <dict>
+    <key>_dataType</key>
+    <string>SPInstallHistoryDataType</string>
+    <key>_items</key>
+    <array>
+      <dict>
+        <key>_name</key><string>XProtectPlistConfigData</string>
+        <key>install_date</key><date>2026-05-18T14:12:01Z</date>
+        <key>install_version</key><string>5278</string>
+        <key>package_source</key><string>package_source_apple</string>
+        <key>package_ids</key>
+        <array><string>com.apple.pkg.XProtectPlistConfigData_10_15.16U5278</string></array>
+      </dict>
+      <dict>
+        <key>_name</key><string>ExampleTool</string>
+        <key>install_date</key><date>2026-05-20T10:00:00Z</date>
+        <key>install_version</key><string>1.2.3</string>
+        <key>package_source</key><string>package_source_other</string>
+        <key>package_ids</key>
+        <array><string>com.example.tool.pkg</string></array>
+      </dict>
+    </array>
+  </dict>
+</array>
+</plist>


### PR DESCRIPTION
Closes #268.

## Summary
- add `internal/updates` install history collection from `system_profiler -xml SPInstallHistoryDataType`
- add `spectra updates --history` with since/source/grep/json filters
- include install history in snapshots and report new installs in snapshot diffs

## Validation
- `go run ./cmd/spectra updates --history --source apple --json | jq '{count:(.entries|length), first:(.entries[0] // null), collected_at:.collected_at}'`\n- `go run ./cmd/spectra updates --history --source third-party --grep '.*' --json | jq '{count:(.entries|length), first:(.entries[0] // null)}'`\n- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run`