### PR TITLE
Expand process inventory fields

### DIFF
--- a/cmd/spectra/process_cmd.go
+++ b/cmd/spectra/process_cmd.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/process"
 )
@@ -17,30 +18,37 @@ func runProcess(args []string) int {
 	fs := flag.NewFlagSet("spectra process", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
-	sortBy := fs.String("sort", "rss", "Sort by: rss, pid, or cmd")
+	sortBy := fs.String("sort", "rss", "Sort by: rss, vsz, cpu, mem, elapsed, startedat, pid, or cmd")
 	topN := fs.Int("top", 0, "Show only top N processes (0 = all)")
 	deep := fs.Bool("deep", false, "Enrich with open FD count and listening ports via lsof (slower)")
 	fdBreakdown := fs.Bool("fd-breakdown", false, "Show typed FD columns (implies --deep)")
+	tree := fs.Bool("tree", false, "Render a parent/child process tree")
+	minRSS := fs.String("min-rss", "", "Minimum RSS (for example 500M, 2G)")
+	minVSZ := fs.String("min-vsz", "", "Minimum VSZ (for example 1G)")
+	minElapsed := fs.Duration("min-elapsed", 0, "Minimum elapsed runtime")
+	ppid := fs.Int("ppid", -1, "Only direct children of PID")
+	user := fs.String("user", "", "Only processes owned by user name")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if *fdBreakdown {
 		*deep = true
 	}
+	filters, ok := processFiltersFromFlags(*minRSS, *minVSZ, *minElapsed, *ppid, *user)
+	if !ok {
+		return 2
+	}
 
 	procs := process.CollectAll(context.Background(), process.CollectOptions{Deep: *deep})
+	procs = filterProcesses(procs, filters)
 	if len(procs) == 0 {
 		fmt.Fprintln(os.Stderr, "no processes found")
 		return 0
 	}
 
-	switch *sortBy {
-	case "pid":
-		sort.Slice(procs, func(i, j int) bool { return procs[i].PID < procs[j].PID })
-	case "cmd":
-		sort.Slice(procs, func(i, j int) bool { return procs[i].Command < procs[j].Command })
-	default: // rss
-		sort.Slice(procs, func(i, j int) bool { return procs[i].RSSKiB > procs[j].RSSKiB })
+	if !sortProcesses(procs, *sortBy) {
+		fmt.Fprintf(os.Stderr, "invalid --sort %q\n", *sortBy)
+		return 2
 	}
 
 	if *topN > 0 && *topN < len(procs) {
@@ -50,12 +58,147 @@ func runProcess(args []string) int {
 	if *asJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
+		if *tree {
+			_ = enc.Encode(process.BuildTree(procs))
+			return 0
+		}
 		_ = enc.Encode(procs)
 		return 0
 	}
 
+	if *tree {
+		printProcessTree(process.BuildTree(procs))
+		return 0
+	}
 	printProcessRows(procs, *deep, *fdBreakdown)
 	return 0
+}
+
+type processFilters struct {
+	minRSSBytes uint64
+	minVSZBytes uint64
+	minElapsed  time.Duration
+	ppid        int
+	user        string
+}
+
+func processFiltersFromFlags(minRSS, minVSZ string, minElapsed time.Duration, ppid int, user string) (processFilters, bool) {
+	rss, err := parseProcessSize(minRSS)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid --min-rss: %v\n", err)
+		return processFilters{}, false
+	}
+	vsz, err := parseProcessSize(minVSZ)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid --min-vsz: %v\n", err)
+		return processFilters{}, false
+	}
+	return processFilters{
+		minRSSBytes: rss,
+		minVSZBytes: vsz,
+		minElapsed:  minElapsed,
+		ppid:        ppid,
+		user:        user,
+	}, true
+}
+
+func filterProcesses(procs []process.Info, filters processFilters) []process.Info {
+	if filters == (processFilters{ppid: -1}) {
+		return procs
+	}
+	out := make([]process.Info, 0, len(procs))
+	for _, p := range procs {
+		if processMatchesFilters(p, filters) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func processMatchesFilters(p process.Info, filters processFilters) bool {
+	if filters.minRSSBytes > 0 && processRSSBytes(p) < filters.minRSSBytes {
+		return false
+	}
+	if filters.minVSZBytes > 0 && processVSZBytes(p) < filters.minVSZBytes {
+		return false
+	}
+	if filters.minElapsed > 0 && p.Elapsed < filters.minElapsed {
+		return false
+	}
+	if filters.ppid >= 0 && p.PPID != filters.ppid {
+		return false
+	}
+	return filters.user == "" || p.User == filters.user
+}
+
+func sortProcesses(procs []process.Info, sortBy string) bool {
+	switch sortBy {
+	case "pid":
+		sort.Slice(procs, func(i, j int) bool { return procs[i].PID < procs[j].PID })
+	case "cmd":
+		sort.Slice(procs, func(i, j int) bool { return procs[i].Command < procs[j].Command })
+	case "rss":
+		sort.Slice(procs, func(i, j int) bool { return processRSSBytes(procs[i]) > processRSSBytes(procs[j]) })
+	case "vsz":
+		sort.Slice(procs, func(i, j int) bool { return processVSZBytes(procs[i]) > processVSZBytes(procs[j]) })
+	case "cpu":
+		sort.Slice(procs, func(i, j int) bool { return procs[i].CPUPercent > procs[j].CPUPercent })
+	case "mem":
+		sort.Slice(procs, func(i, j int) bool { return procs[i].MemPercent > procs[j].MemPercent })
+	case "elapsed":
+		sort.Slice(procs, func(i, j int) bool { return procs[i].Elapsed > procs[j].Elapsed })
+	case "startedat":
+		sort.Slice(procs, func(i, j int) bool { return procs[i].StartedAt.Before(procs[j].StartedAt) })
+	default:
+		return false
+	}
+	return true
+}
+
+func parseProcessSize(raw string) (uint64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
+	}
+	unit := raw[len(raw)-1]
+	multiplier := uint64(1)
+	number := raw
+	switch unit {
+	case 'k', 'K':
+		multiplier = 1024
+		number = raw[:len(raw)-1]
+	case 'm', 'M':
+		multiplier = 1024 * 1024
+		number = raw[:len(raw)-1]
+	case 'g', 'G':
+		multiplier = 1024 * 1024 * 1024
+		number = raw[:len(raw)-1]
+	case 't', 'T':
+		multiplier = 1024 * 1024 * 1024 * 1024
+		number = raw[:len(raw)-1]
+	}
+	value, err := strconv.ParseFloat(number, 64)
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("expected non-negative size")
+	}
+	return uint64(value * float64(multiplier)), nil
+}
+
+func processRSSBytes(p process.Info) uint64 {
+	if p.RSSKiB <= 0 {
+		return 0
+	}
+	return uint64(p.RSSKiB) * 1024
+}
+
+func processVSZBytes(p process.Info) uint64 {
+	if p.VSZBytes > 0 {
+		return p.VSZBytes
+	}
+	if p.VSizeKiB <= 0 {
+		return 0
+	}
+	return uint64(p.VSizeKiB) * 1024
 }
 
 func printProcessRows(procs []process.Info, deep, fdBreakdown bool) {
@@ -66,8 +209,8 @@ func printProcessRows(procs []process.Info, deep, fdBreakdown bool) {
 		fmt.Printf("%-7s  %-6s  %-10s  %-10s  %-5s  %s\n", "PID", "THR", "RSS", "CPU%", "FDS", "COMMAND")
 		fmt.Println(strings.Repeat("-", 82))
 	} else {
-		fmt.Printf("%-7s  %-6s  %-10s  %-10s  %s\n", "PID", "THR", "RSS", "CPU%", "COMMAND")
-		fmt.Println(strings.Repeat("-", 76))
+		fmt.Printf("%-7s  %-7s  %-10s  %-10s  %-7s  %-7s  %-20s  %s\n", "PID", "PPID", "RSS", "VSZ", "CPU%", "MEM%", "STARTED", "COMMAND")
+		fmt.Println(strings.Repeat("-", 112))
 	}
 	for _, p := range procs {
 		thr := "-"
@@ -84,9 +227,31 @@ func printProcessRows(procs []process.Info, deep, fdBreakdown bool) {
 		case deep:
 			printProcessDeepRow(p, thr, cpu)
 		default:
-			fmt.Printf("%-7d  %-6s  %-10s  %-10s  %s\n",
-				p.PID, thr, humanSizeKiB(p.RSSKiB), cpu, truncate(p.Command, 45))
+			fmt.Printf("%-7d  %-7d  %-10s  %-10s  %-7s  %-7s  %-20s  %s\n",
+				p.PID, p.PPID, humanSizeKiB(p.RSSKiB), humanSizeBytes(processVSZBytes(p)), cpu,
+				percentString(p.MemPercent), startedString(p.StartedAt), truncate(p.Command, 40))
 		}
+	}
+}
+
+func printProcessTree(roots []*process.TreeNode) {
+	fmt.Printf("%-7s  %-7s  %-20s  %s\n", "PID", "PPID", "STARTED", "COMMAND")
+	fmt.Println(strings.Repeat("-", 76))
+	for _, root := range roots {
+		printProcessTreeNode(root, 0)
+	}
+}
+
+func printProcessTreeNode(node *process.TreeNode, depth int) {
+	p := node.Info
+	prefix := strings.Repeat("  ", depth)
+	width := 50 - depth*2
+	if width < 20 {
+		width = 20
+	}
+	fmt.Printf("%-7d  %-7d  %-20s  %s%s\n", p.PID, p.PPID, startedString(p.StartedAt), prefix, truncate(p.Command, width))
+	for _, child := range node.Children {
+		printProcessTreeNode(child, depth+1)
 	}
 }
 
@@ -126,4 +291,39 @@ func humanSizeKiB(kib int64) string {
 	default:
 		return fmt.Sprintf("%dK", kib)
 	}
+}
+
+func humanSizeBytes(bytes uint64) string {
+	if bytes == 0 {
+		return "-"
+	}
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case bytes >= gib:
+		return fmt.Sprintf("%.1fG", float64(bytes)/gib)
+	case bytes >= mib:
+		return fmt.Sprintf("%.1fM", float64(bytes)/mib)
+	case bytes >= kib:
+		return fmt.Sprintf("%dK", bytes/kib)
+	default:
+		return fmt.Sprintf("%dB", bytes)
+	}
+}
+
+func percentString(v float64) string {
+	if v <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", v)
+}
+
+func startedString(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Format("2006-01-02 15:04")
 }

--- a/cmd/spectra/process_cmd_test.go
+++ b/cmd/spectra/process_cmd_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+func TestProcessFiltersAndSort(t *testing.T) {
+	procs := []process.Info{
+		{PID: 10, PPID: 1, User: "root", RSSKiB: 1024, VSizeKiB: 4096, VSZBytes: 4096 * 1024, CPUPercent: 1, MemPercent: 0.1, Elapsed: time.Hour, Command: "short"},
+		{PID: 20, PPID: 1, User: "root", RSSKiB: 4096, VSizeKiB: 8192, VSZBytes: 8192 * 1024, CPUPercent: 4, MemPercent: 0.4, Elapsed: 3 * time.Hour, Command: "long"},
+		{PID: 30, PPID: 20, User: "alice", RSSKiB: 8192, VSizeKiB: 16384, VSZBytes: 16384 * 1024, CPUPercent: 2, MemPercent: 0.8, Elapsed: 2 * time.Hour, Command: "child"},
+	}
+	filtered := filterProcesses(procs, processFilters{
+		minRSSBytes: 2 * 1024 * 1024,
+		minElapsed:  2 * time.Hour,
+		ppid:        1,
+		user:        "root",
+	})
+	if len(filtered) != 1 || filtered[0].PID != 20 {
+		t.Fatalf("filtered = %+v, want PID 20", filtered)
+	}
+	if !sortProcesses(procs, "elapsed") {
+		t.Fatal("sort elapsed returned false")
+	}
+	if procs[0].PID != 20 || procs[1].PID != 30 || procs[2].PID != 10 {
+		t.Fatalf("elapsed sort PIDs = %d,%d,%d", procs[0].PID, procs[1].PID, procs[2].PID)
+	}
+	if !sortProcesses(procs, "mem") {
+		t.Fatal("sort mem returned false")
+	}
+	if procs[0].PID != 30 {
+		t.Fatalf("mem sort first PID = %d, want 30", procs[0].PID)
+	}
+	if sortProcesses(procs, "bad") {
+		t.Fatal("bad sort returned true")
+	}
+}
+
+func TestParseProcessSize(t *testing.T) {
+	cases := map[string]uint64{
+		"":     0,
+		"512":  512,
+		"2K":   2 * 1024,
+		"1.5M": 1536 * 1024,
+		"3G":   3 * 1024 * 1024 * 1024,
+	}
+	for in, want := range cases {
+		got, err := parseProcessSize(in)
+		if err != nil {
+			t.Fatalf("parseProcessSize(%q): %v", in, err)
+		}
+		if got != want {
+			t.Fatalf("parseProcessSize(%q) = %d, want %d", in, got, want)
+		}
+	}
+	if _, err := parseProcessSize("-1"); err == nil {
+		t.Fatal("expected negative size error")
+	}
+}

--- a/internal/process/memory_darwin.go
+++ b/internal/process/memory_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package process
+
+import "golang.org/x/sys/unix"
+
+func systemMemoryBytes() uint64 {
+	n, err := unix.SysctlUint64("hw.memsize")
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/process/memory_other.go
+++ b/internal/process/memory_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package process
+
+func systemMemoryBytes() uint64 {
+	return 0
+}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -19,19 +19,24 @@ import (
 
 // Info is one running process at snapshot time.
 type Info struct {
-	PID             int       `json:"pid"`
-	PPID            int       `json:"ppid"`
-	UID             int       `json:"uid"`
-	User            string    `json:"user,omitempty"`
-	Command         string    `json:"command"`            // short (comm) — just the exe name
-	BSDName         string    `json:"bsd_name,omitempty"` // p_comm from libproc when available
-	ExecutablePath  string    `json:"executable_path,omitempty"`
-	FullCommandLine string    `json:"full_command_line"` // full argv[0...] string
-	RSSKiB          int64     `json:"rss_kib"`
-	VSizeKiB        int64     `json:"vsize_kib"`
-	ThreadCount     int       `json:"thread_count"`         // number of process threads
-	CPUPct          float64   `json:"cpu_pct"`              // CPU % at sample time (pcpu)
-	StartTime       time.Time `json:"start_time,omitempty"` // process start time (lstart)
+	PID             int           `json:"pid"`
+	PPID            int           `json:"ppid"`
+	UID             int           `json:"uid"`
+	User            string        `json:"user,omitempty"`
+	Command         string        `json:"command"`            // short (comm) — just the exe name
+	BSDName         string        `json:"bsd_name,omitempty"` // p_comm from libproc when available
+	ExecutablePath  string        `json:"executable_path,omitempty"`
+	FullCommandLine string        `json:"full_command_line"` // full argv[0...] string
+	RSSKiB          int64         `json:"rss_kib"`
+	VSizeKiB        int64         `json:"vsize_kib"`
+	VSZBytes        uint64        `json:"vsz_bytes,omitempty"`
+	ThreadCount     int           `json:"thread_count"`         // number of process threads
+	CPUPct          float64       `json:"cpu_pct"`              // CPU % at sample time (pcpu)
+	CPUPercent      float64       `json:"cpu_percent"`          // alias for CPU percent in new process views
+	MemPercent      float64       `json:"mem_percent"`          // RSS / physical memory * 100
+	StartTime       time.Time     `json:"start_time,omitempty"` // process start time (lstart)
+	StartedAt       time.Time     `json:"started_at,omitempty"` // alias for StartTime
+	Elapsed         time.Duration `json:"elapsed,omitempty"`
 
 	// Deep fields — populated only when CollectOptions.Deep is true.
 	OpenFDs             int          `json:"open_fds,omitempty"`             // open file descriptor count
@@ -85,6 +90,12 @@ type CollectOptions struct {
 	// ThreadCounter overrides the platform thread-count collector for testing.
 	// Deprecated: use DetailCollector for new tests.
 	ThreadCounter func([]Info) map[int]int
+
+	// Now overrides the sample time for elapsed-duration derivation.
+	Now func() time.Time
+
+	// MemoryBytes overrides physical memory size for MemPercent tests.
+	MemoryBytes func() uint64
 }
 
 // Details contains direct per-process metadata collected without spawning
@@ -119,6 +130,7 @@ func CollectAll(ctx context.Context, opts CollectOptions) []Info {
 		return nil
 	}
 	procs := parsePS(string(out))
+	applyDerivedFields(procs, collectNow(opts), collectMemoryBytes(opts))
 	applyProcessDetails(procs, opts.DetailCollector)
 	threadCounter := opts.ThreadCounter
 	if threadCounter == nil && opts.DetailCollector == nil {
@@ -132,6 +144,43 @@ func CollectAll(ctx context.Context, opts CollectOptions) []Info {
 		enrichDeep(procs, run)
 	}
 	return procs
+}
+
+func collectNow(opts CollectOptions) time.Time {
+	if opts.Now != nil {
+		return opts.Now()
+	}
+	return time.Now()
+}
+
+func collectMemoryBytes(opts CollectOptions) uint64 {
+	if opts.MemoryBytes != nil {
+		return opts.MemoryBytes()
+	}
+	return systemMemoryBytes()
+}
+
+func applyDerivedFields(procs []Info, now time.Time, memBytes uint64) {
+	for i := range procs {
+		if procs[i].VSizeKiB > 0 {
+			procs[i].VSZBytes = kibToBytes(procs[i].VSizeKiB)
+		}
+		procs[i].CPUPercent = procs[i].CPUPct
+		procs[i].StartedAt = procs[i].StartTime
+		if !procs[i].StartedAt.IsZero() && now.After(procs[i].StartedAt) {
+			procs[i].Elapsed = now.Sub(procs[i].StartedAt).Round(time.Second)
+		}
+		if memBytes > 0 && procs[i].RSSKiB > 0 {
+			procs[i].MemPercent = float64(kibToBytes(procs[i].RSSKiB)) / float64(memBytes) * 100
+		}
+	}
+}
+
+func kibToBytes(kib int64) uint64 {
+	if kib <= 0 {
+		return 0
+	}
+	return uint64(kib) * 1024
 }
 
 func applyProcessDetails(procs []Info, collector func([]Info) map[int]Details) {
@@ -225,13 +274,16 @@ func parseRow(line string) Info {
 		PID:             pid,
 		PPID:            ppid,
 		CPUPct:          cpu,
+		CPUPercent:      cpu,
 		RSSKiB:          rss,
 		VSizeKiB:        vsz,
+		VSZBytes:        kibToBytes(vsz),
 		UID:             uid,
 		User:            fields[6],
 		Command:         shortName(full),
 		FullCommandLine: full,
 		StartTime:       startTime,
+		StartedAt:       startTime,
 	}
 }
 

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -96,10 +96,30 @@ func TestParsePSStartTime(t *testing.T) {
 }
 
 func TestCollectAll(t *testing.T) {
-	opts := CollectOptions{CmdRunner: fakePS(psFixture)}
+	opts := CollectOptions{
+		CmdRunner:   fakePS(psFixture),
+		Now:         func() time.Time { return time.Date(2026, 5, 3, 22, 40, 0, 0, time.Local) },
+		MemoryBytes: func() uint64 { return 1024 * 1024 * 1024 },
+	}
 	procs := CollectAll(context.Background(), opts)
 	if len(procs) != 4 {
 		t.Errorf("CollectAll: got %d procs, want 4", len(procs))
+	}
+	slack := procs[1]
+	if slack.VSZBytes != 409600*1024 {
+		t.Errorf("VSZBytes = %d, want %d", slack.VSZBytes, uint64(409600*1024))
+	}
+	if slack.CPUPercent != slack.CPUPct {
+		t.Errorf("CPUPercent = %v, CPUPct = %v", slack.CPUPercent, slack.CPUPct)
+	}
+	if slack.MemPercent < 17.5 || slack.MemPercent > 17.6 {
+		t.Errorf("MemPercent = %.3f, want about 17.578", slack.MemPercent)
+	}
+	if slack.Elapsed != 24*time.Hour {
+		t.Errorf("Elapsed = %s, want 24h", slack.Elapsed)
+	}
+	if !slack.StartedAt.Equal(slack.StartTime) {
+		t.Errorf("StartedAt = %v, StartTime = %v", slack.StartedAt, slack.StartTime)
 	}
 }
 


### PR DESCRIPTION
Closes #270.

## Summary
- add VSZ bytes, StartedAt, elapsed runtime, CPUPercent, and MemPercent derivation to process inventory
- add `spectra process` filters for min RSS/VSZ/elapsed, PPID, and user
- expand process sorting and tree output with PPID/StartedAt visibility

## Validation
- `go run ./cmd/spectra process --sort=elapsed --user=root --json | jq '{count:length, all_root: all(.[]; .user == "root"), sorted: ([range(0; (length-1)) as $i | .[$i].elapsed >= .[$i+1].elapsed] | all)}'`\n- `c=$(go run ./cmd/spectra process --ppid=1 --json | jq 'length'); ps_c=$(ps -o pid,ppid -ax | awk '$2==1 {c++} END {print c+0}'); printf 'ppid=1 spectra=%s ps=%s\\n' "$c" "$ps_c"`\n- `go run ./cmd/spectra process --min-elapsed=24h --json | jq '{count:length, all_long: all(.[]; .elapsed >= 86400000000000), first:(.[0] // null | {pid, ppid, user, started_at, elapsed, rss_kib, vsz_bytes, cpu_percent, mem_percent})}'`\n- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run`