### PR TITLE
Add fseventsd leak playbook

### DIFF
--- a/cmd/spectra/playbook.go
+++ b/cmd/spectra/playbook.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/kaeawc/spectra/internal/logquery"
 	"github.com/kaeawc/spectra/internal/playbook"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/storagestate"
 )
 
 type playbookCatalog interface {
@@ -21,11 +27,16 @@ func runPlaybook(args []string) int {
 }
 
 func runPlaybookWith(args []string, stdout io.Writer, stderr io.Writer, catalog playbookCatalog) int {
+	args, runFlags := extractPlaybookRunFlags(args)
 	fs := flag.NewFlagSet("spectra playbook", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of human output")
 	commandsOnly := fs.Bool("commands", false, "Show only command plan for a playbook")
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if runFlags.autoFix && runFlags.nonInteractive && !runFlags.yes {
+		fmt.Fprintln(stderr, "--auto-fix cannot be combined with --non-interactive unless --yes is also passed")
 		return 2
 	}
 
@@ -39,6 +50,9 @@ func runPlaybookWith(args []string, stdout io.Writer, stderr io.Writer, catalog 
 		fmt.Fprintf(stderr, "unknown playbook %q\n", id)
 		printPlaybookUsage(stderr)
 		return 2
+	}
+	if id == "fseventsd-leak" && !*commandsOnly {
+		return runFSEventsdLeakPlaybook(stdout, stderr, *asJSON, runFlags)
 	}
 	if *asJSON {
 		enc := json.NewEncoder(stdout)
@@ -55,6 +69,116 @@ func runPlaybookWith(args []string, stdout io.Writer, stderr io.Writer, catalog 
 	}
 	printPlaybook(stdout, pb)
 	return 0
+}
+
+type playbookRunFlags struct {
+	autoFix        bool
+	nonInteractive bool
+	yes            bool
+}
+
+func extractPlaybookRunFlags(args []string) ([]string, playbookRunFlags) {
+	out := make([]string, 0, len(args))
+	var flags playbookRunFlags
+	for _, arg := range args {
+		switch arg {
+		case "--auto-fix":
+			flags.autoFix = true
+		case "--non-interactive":
+			flags.nonInteractive = true
+		case "--yes", "-y":
+			flags.yes = true
+		default:
+			out = append(out, arg)
+		}
+	}
+	return out, flags
+}
+
+func runFSEventsdLeakPlaybook(stdout io.Writer, stderr io.Writer, asJSON bool, flags playbookRunFlags) int {
+	ctx := context.Background()
+	snap := snapshot.Build(ctx, snapshot.Options{
+		SpectraVersion: version,
+		SkipApps:       true,
+		SkipJVMs:       true,
+		SkipUpdates:    true,
+		StorageOpts: storagestate.CollectOptions{
+			IncludeSnapshots: true,
+		},
+	})
+	logs, err := logquery.Run(ctx, logquery.Query{
+		Process:  "backupd",
+		MinLevel: "Error",
+		Last:     24 * time.Hour,
+		MaxRows:  50,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "warning: backupd log query failed: %v\n", err)
+	}
+	report := playbook.AnalyzeFSEventsdLeak(snap, logs)
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+		return 0
+	}
+	printFSEventsdLeakReport(stdout, report)
+	if flags.autoFix {
+		return handleFSEventsdAutoFix(stdout, flags, report)
+	}
+	return 0
+}
+
+func printFSEventsdLeakReport(w io.Writer, report playbook.FSEventsdLeakReport) {
+	if report.ExitReason != "" {
+		fmt.Fprintln(w, report.ExitReason)
+		return
+	}
+	if report.Matched {
+		fmt.Fprintf(w, "=> Match: %s\n", report.RuleID)
+	} else {
+		fmt.Fprintf(w, "=> No match: %s\n", report.RuleID)
+	}
+	s := report.Signals
+	fmt.Fprintf(w, "   - fseventsd RSS: %s\n", playbook.FormatBytes(s.FSEventsdRSSBytes))
+	fmt.Fprintf(w, "   - swap used: %.1f%% of physical memory\n", s.SwapRatio*100)
+	fmt.Fprintf(w, "   - TM destinations: %d\n", s.TMDestinationCount)
+	fmt.Fprintf(w, "   - backupd-auto: %s\n", loadedString(s.BackupdAutoLoaded))
+	fmt.Fprintf(w, "   - MSUPrepareUpdate snapshot: %s\n", yesNo(s.MSUPrepareSnapshot))
+	fmt.Fprintf(w, "   - backupd error rate: %s\n", playbook.FormatBackupdErrorRate(s.BackupdErrorCount, 24*time.Hour))
+	if len(report.Remediation) > 0 {
+		fmt.Fprintln(w, "Remediation:")
+		for _, cmd := range report.Remediation {
+			fmt.Fprintf(w, "   %s\n", cmd)
+		}
+	}
+}
+
+func handleFSEventsdAutoFix(stdout io.Writer, flags playbookRunFlags, report playbook.FSEventsdLeakReport) int {
+	if !report.Matched {
+		fmt.Fprintln(stdout, "auto-fix skipped: playbook did not match")
+		return 0
+	}
+	if !flags.yes {
+		fmt.Fprint(stdout, "Apply remediation through spectra-helper? [y/N] ")
+		answer, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+		if !strings.EqualFold(strings.TrimSpace(answer), "y") && !strings.EqualFold(strings.TrimSpace(answer), "yes") {
+			fmt.Fprintln(stdout, "auto-fix cancelled")
+			return 0
+		}
+	}
+	fmt.Fprintln(stdout, "confirmed remediation commands:")
+	for _, cmd := range report.Remediation {
+		fmt.Fprintf(stdout, "   %s\n", cmd)
+	}
+	return 0
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
 }
 
 func runPlaybookList(stdout io.Writer, stderr io.Writer, catalog playbookCatalog, asJSON bool) int {
@@ -128,4 +252,5 @@ func printPlaybookCommands(w io.Writer, pb playbook.Playbook) {
 func printPlaybookUsage(w io.Writer) {
 	fmt.Fprintln(w, "usage: spectra playbook [--json] [list|<id>]")
 	fmt.Fprintln(w, "   or: spectra playbook --commands <id>")
+	fmt.Fprintln(w, "   or: spectra playbook fseventsd-leak [--auto-fix] [--non-interactive --yes]")
 }

--- a/cmd/spectra/playbook_test.go
+++ b/cmd/spectra/playbook_test.go
@@ -101,6 +101,36 @@ func TestRunPlaybookUnknown(t *testing.T) {
 	}
 }
 
+func TestRunPlaybookAutoFixNonInteractiveRequiresYes(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runPlaybookWith([]string{"fseventsd-leak", "--auto-fix", "--non-interactive"}, &stdout, &stderr, fakePlaybookCatalog{rows: []playbook.Playbook{
+		{ID: "fseventsd-leak", Title: "fseventsd", Symptom: "memory", Steps: []playbook.Step{{ID: "s", Title: "s", Commands: []playbook.Command{{Args: []string{"memory"}}}}}},
+	}})
+	if code != 2 {
+		t.Fatalf("exit code = %d", code)
+	}
+	if !strings.Contains(stderr.String(), "--auto-fix cannot be combined") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunPlaybookCommandsOnlyFSEventsdDoesNotExecute(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	pb := playbook.MustDefaultCatalog().List()[0]
+	if pb.ID != "fseventsd-leak" {
+		t.Fatalf("first default playbook = %s", pb.ID)
+	}
+	code := runPlaybookWith([]string{"--commands", "fseventsd-leak"}, &stdout, &stderr, fakePlaybookCatalog{rows: []playbook.Playbook{pb}})
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "spectra memory --json") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
 func TestSubcommandListIncludesPlaybook(t *testing.T) {
 	for _, sc := range subcommandList() {
 		if sc.name == "playbook" {

--- a/docs/playbooks/fseventsd-leak.md
+++ b/docs/playbooks/fseventsd-leak.md
@@ -1,0 +1,38 @@
+# fseventsd backup leak
+
+Use this playbook when a Mac has severe memory pressure and `fseventsd`,
+`backupd`, APFS snapshots, or Time Machine scheduling appear in the same
+incident window.
+
+```bash
+spectra playbook fseventsd-leak
+spectra playbook fseventsd-leak --json
+spectra playbook --commands fseventsd-leak
+```
+
+The playbook exits early with `no memory pressure detected.` unless either
+compressed memory is more than 25% of physical memory or swap use is more than
+10% of physical memory.
+
+When memory pressure is present, Spectra correlates:
+
+- `spectra process --min-rss=1GB --sort=rss --json`
+- `spectra timemachine --json`
+- `spectra storage --snapshots --json`
+- `spectra services --label com.apple.backupd-auto --json`
+- `spectra logs --process backupd --level Error --last 24h --top 50 --json`
+
+A match reports `backup.destinationless_scheduler_leak` when `fseventsd` is in
+the top resident processes, Time Machine has no destinations, `backupd-auto` is
+loaded, and an `MSUPrepareUpdate` APFS snapshot is present.
+
+The remediation is intentionally explicit:
+
+```bash
+sudo tmutil disable
+sudo killall backupd
+sudo killall -HUP fseventsd
+```
+
+`--auto-fix` prints the remediation and requires confirmation. It cannot be
+combined with `--non-interactive` unless `--yes` is also passed.

--- a/docs/playbooks/index.md
+++ b/docs/playbooks/index.md
@@ -11,6 +11,7 @@ Use them when the question is operational:
 |---|---|
 | Java app is slow or memory-heavy | [JVM memory](jvm-memory.md) |
 | App cannot reach a service or endpoint | [Network failure](network-failure.md) |
+| fseventsd or backupd is consuming extreme memory | [fseventsd backup leak](fseventsd-leak.md) |
 | Disk is filling up or an app is unexpectedly large | [Storage bloat](storage-bloat.md) |
 | Terminal sessions die immediately at launch | [Terminal spawning](terminal-spawning.md) |
 | Another Mac is behaving differently | [Remote triage](remote-triage.md) |

--- a/internal/playbook/defaults.go
+++ b/internal/playbook/defaults.go
@@ -2,12 +2,95 @@ package playbook
 
 func defaultPlaybooks() []Playbook {
 	return []Playbook{
+		fseventsdLeak(),
 		jvmMemory(),
 		networkFailure(),
 		storageBloat(),
 		terminalSpawning(),
 		remoteTriage(),
 		toolchainDrift(),
+	}
+}
+
+func fseventsdLeak() Playbook {
+	return Playbook{
+		ID:          "fseventsd-leak",
+		Title:       "fseventsd backup leak",
+		Symptom:     "Memory pressure, large fseventsd RSS, backupd errors, and Time Machine scheduling with no destination.",
+		Description: "Correlate memory, process RSS, Time Machine state, APFS snapshots, launchd services, and backupd unified logs into the backup.destinationless_scheduler_leak finding.",
+		Steps: []Step{
+			{
+				ID:      "memory",
+				Title:   "Confirm memory pressure",
+				Purpose: "Exit early unless compressor or swap pressure is high enough to make a leak diagnosis meaningful.",
+				Commands: []Command{
+					{Args: []string{"memory", "--json"}, Description: "Check physical memory, compressor occupancy, and swap use"},
+				},
+				Signals: []Signal{
+					{Name: "Compressor >25% or swap >10%", Meaning: "Continue to process attribution."},
+					{Name: "No memory pressure", Meaning: "Exit cleanly with no fseventsd leak finding."},
+				},
+			},
+			{
+				ID:      "process",
+				Title:   "Rank resident processes",
+				Purpose: "Confirm whether fseventsd is one of the largest resident processes.",
+				Commands: []Command{
+					{Args: []string{"process", "--min-rss=1GB", "--sort=rss", "--json"}, Description: "List large resident processes with PPID, started time, elapsed, RSS, VSZ, CPU, and memory percent"},
+				},
+				Signals: []Signal{
+					{Name: "fseventsd in top 3", Meaning: "The backup/log signals should be checked next."},
+				},
+			},
+			{
+				ID:      "backup-state",
+				Title:   "Check backup scheduler and destinations",
+				Purpose: "Find the destinationless Time Machine scheduler pattern.",
+				Commands: []Command{
+					{Args: []string{"timemachine", "--json"}, Description: "Check Time Machine destinations and scheduler state"},
+					{Args: []string{"services", "--label", "com.apple.backupd-auto", "--json"}, Description: "Confirm the launchd scheduler job is loaded"},
+				},
+				Signals: []Signal{
+					{Name: "No destinations + backupd-auto loaded", Meaning: "A scheduled backup loop may be running without a destination."},
+				},
+			},
+			{
+				ID:      "snapshot-state",
+				Title:   "Check APFS update snapshots",
+				Purpose: "Find staged major update snapshots that correlate with the incident.",
+				Commands: []Command{
+					{Args: []string{"storage", "--snapshots", "--json"}, Description: "List APFS snapshots and classify MSUPrepareUpdate snapshots"},
+				},
+				Signals: []Signal{
+					{Name: "MSUPrepare snapshot", Meaning: "A staged update is present on the system volume."},
+				},
+			},
+			{
+				ID:      "backup-logs",
+				Title:   "Count backupd errors",
+				Purpose: "Quantify recent backupd errors and fs_snapshot_list failures.",
+				Commands: []Command{
+					{Args: []string{"logs", "--process", "backupd", "--level", "Error", "--last", "24h", "--top", "50", "--json"}, Description: "Read bounded backupd error logs"},
+				},
+				Signals: []Signal{
+					{Name: "fs_snapshot_list failed", Meaning: "backupd is failing while enumerating snapshots."},
+				},
+			},
+			{
+				ID:      "remediate",
+				Title:   "Remediate with explicit approval",
+				Purpose: "Disable the destinationless scheduler and restart affected daemons only after confirmation.",
+				Commands: []Command{
+					{Args: []string{"playbook", "fseventsd-leak", "--auto-fix"}, Description: "Prompt before routing remediation through the helper", Destructive: true},
+				},
+			},
+		},
+		References: []Reference{
+			{Title: "FSEvents leak playbook", Path: "docs/playbooks/fseventsd-leak.md"},
+			{Title: "Running processes", Path: "docs/inspection/running-processes.md"},
+			{Title: "Snapshots and hosts", Path: "docs/operations/snapshots-and-hosts.md"},
+			{Title: "CLI commands", Path: "docs/operations/cli.md"},
+		},
 	}
 }
 

--- a/internal/playbook/fseventsd.go
+++ b/internal/playbook/fseventsd.go
@@ -1,0 +1,213 @@
+package playbook
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/logquery"
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/services"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/storagestate"
+)
+
+const FSEventsdLeakRuleID = "backup.destinationless_scheduler_leak"
+
+var FSEventsdLeakRemediation = []string{
+	"sudo tmutil disable",
+	"sudo killall backupd",
+	"sudo killall -HUP fseventsd",
+}
+
+type FSEventsdLeakReport struct {
+	RuleID      string               `json:"rule_id"`
+	Matched     bool                 `json:"matched"`
+	ExitReason  string               `json:"exit_reason,omitempty"`
+	Signals     FSEventsdLeakSignals `json:"signals"`
+	Steps       []FSEventsdLeakStep  `json:"steps"`
+	Remediation []string             `json:"remediation,omitempty"`
+	Finding     string               `json:"finding,omitempty"`
+}
+
+type FSEventsdLeakSignals struct {
+	MemoryPressure       bool    `json:"memory_pressure"`
+	CompressorRatio      float64 `json:"compressor_ratio"`
+	SwapRatio            float64 `json:"swap_ratio"`
+	FSEventsdTop3        bool    `json:"fseventsd_top3"`
+	FSEventsdRSSBytes    int64   `json:"fseventsd_rss_bytes"`
+	TMDestinationCount   int     `json:"tm_destination_count"`
+	BackupdAutoLoaded    bool    `json:"backupd_auto_loaded"`
+	MSUPrepareSnapshot   bool    `json:"msu_prepare_snapshot"`
+	BackupdErrorCount    int     `json:"backupd_error_count"`
+	FSSnapshotListFailed int     `json:"fs_snapshot_list_failed"`
+}
+
+type FSEventsdLeakStep struct {
+	ID      string   `json:"id"`
+	Command []string `json:"command"`
+	Passed  bool     `json:"passed"`
+	Summary string   `json:"summary"`
+}
+
+func AnalyzeFSEventsdLeak(s snapshot.Snapshot, logs logquery.Result) FSEventsdLeakReport {
+	signals := fseventsdSignals(s, logs)
+	report := FSEventsdLeakReport{
+		RuleID:  FSEventsdLeakRuleID,
+		Signals: signals,
+		Steps:   fseventsdSteps(signals),
+	}
+	if !signals.MemoryPressure {
+		report.ExitReason = "no memory pressure detected."
+		return report
+	}
+	report.Matched = signals.FSEventsdTop3 &&
+		signals.TMDestinationCount == 0 &&
+		signals.BackupdAutoLoaded &&
+		signals.MSUPrepareSnapshot
+	if report.Matched {
+		report.Remediation = append([]string(nil), FSEventsdLeakRemediation...)
+		report.Finding = fseventsdFinding(signals)
+	}
+	return report
+}
+
+func fseventsdSignals(s snapshot.Snapshot, logs logquery.Result) FSEventsdLeakSignals {
+	physical := s.Host.Memory.PhysicalBytes
+	compressorRatio := ratio(s.Host.Memory.CompressorOccupied, physical)
+	swapRatio := ratio(s.Host.Memory.Swap.UsedBytes, physical)
+	fseventsd := largestProcessByName(s.Processes, "fseventsd")
+	errorCount, snapshotFailures := backupdLogCounts(logs)
+	return FSEventsdLeakSignals{
+		MemoryPressure:       compressorRatio > 0.25 || swapRatio > 0.10,
+		CompressorRatio:      compressorRatio,
+		SwapRatio:            swapRatio,
+		FSEventsdTop3:        processInTopRSS(s.Processes, "fseventsd", 3),
+		FSEventsdRSSBytes:    processRSSBytes(fseventsd),
+		TMDestinationCount:   len(s.Host.TimeMachine.Destinations),
+		BackupdAutoLoaded:    backupdAutoLoaded(s.Services.Jobs),
+		MSUPrepareSnapshot:   hasMSUPrepareSnapshot(s.Storage.Volumes),
+		BackupdErrorCount:    errorCount,
+		FSSnapshotListFailed: snapshotFailures,
+	}
+}
+
+func fseventsdSteps(signals FSEventsdLeakSignals) []FSEventsdLeakStep {
+	return []FSEventsdLeakStep{
+		{ID: "memory", Command: []string{"memory", "--json"}, Passed: signals.MemoryPressure, Summary: fmt.Sprintf("compressor=%.0f%% swap=%.0f%%", signals.CompressorRatio*100, signals.SwapRatio*100)},
+		{ID: "process", Command: []string{"process", "--min-rss=1GB", "--sort=rss", "--json"}, Passed: signals.FSEventsdTop3, Summary: fmt.Sprintf("fseventsd RSS: %s", FormatBytes(signals.FSEventsdRSSBytes))},
+		{ID: "timemachine", Command: []string{"timemachine", "--json"}, Passed: signals.TMDestinationCount == 0, Summary: fmt.Sprintf("destinations=%d", signals.TMDestinationCount)},
+		{ID: "storage", Command: []string{"storage", "--snapshots", "--json"}, Passed: signals.MSUPrepareSnapshot, Summary: fmt.Sprintf("MSUPrepare snapshot=%t", signals.MSUPrepareSnapshot)},
+		{ID: "services", Command: []string{"services", "--label", "com.apple.backupd-auto", "--json"}, Passed: signals.BackupdAutoLoaded, Summary: fmt.Sprintf("backupd-auto loaded=%t", signals.BackupdAutoLoaded)},
+		{ID: "logs", Command: []string{"logs", "--process", "backupd", "--level", "Error", "--last", "24h", "--top", "50", "--json"}, Passed: signals.BackupdErrorCount > 0, Summary: fmt.Sprintf("backupd errors=%d fs_snapshot_list failed=%d", signals.BackupdErrorCount, signals.FSSnapshotListFailed)},
+	}
+}
+
+func fseventsdFinding(signals FSEventsdLeakSignals) string {
+	return fmt.Sprintf("%s matched: fseventsd RSS %s, swap %.0f%%, TM destinations %d, backupd-auto loaded=%t, MSUPrepare snapshot=%t, backupd errors=%d.",
+		FSEventsdLeakRuleID,
+		FormatBytes(signals.FSEventsdRSSBytes),
+		signals.SwapRatio*100,
+		signals.TMDestinationCount,
+		signals.BackupdAutoLoaded,
+		signals.MSUPrepareSnapshot,
+		signals.BackupdErrorCount,
+	)
+}
+
+func backupdLogCounts(logs logquery.Result) (errors int, snapshotFailures int) {
+	for _, entry := range logs.Entries {
+		if strings.EqualFold(entry.MessageType, "Error") || strings.EqualFold(entry.MessageType, "Fault") {
+			errors++
+		}
+		if strings.Contains(entry.EventMessage, "fs_snapshot_list failed") {
+			snapshotFailures++
+		}
+	}
+	return errors, snapshotFailures
+}
+
+func processInTopRSS(procs []process.Info, name string, n int) bool {
+	rows := append([]process.Info(nil), procs...)
+	sort.Slice(rows, func(i, j int) bool { return rows[i].RSSKiB > rows[j].RSSKiB })
+	if n > len(rows) {
+		n = len(rows)
+	}
+	for _, proc := range rows[:n] {
+		if processNameMatches(proc, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func largestProcessByName(processes []process.Info, name string) process.Info {
+	var largest process.Info
+	for _, proc := range processes {
+		if !processNameMatches(proc, name) || proc.RSSKiB <= largest.RSSKiB {
+			continue
+		}
+		largest = proc
+	}
+	return largest
+}
+
+func processNameMatches(proc process.Info, name string) bool {
+	return proc.Command == name ||
+		proc.BSDName == name ||
+		strings.Contains(proc.FullCommandLine, name)
+}
+
+func processRSSBytes(proc process.Info) int64 {
+	if proc.RSSKiB <= 0 {
+		return 0
+	}
+	return proc.RSSKiB * 1024
+}
+
+func backupdAutoLoaded(jobs []services.LaunchJob) bool {
+	for _, job := range jobs {
+		if job.Label == "com.apple.backupd-auto" && (job.PID > 0 || job.PlistPath != "") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMSUPrepareSnapshot(volumes []storagestate.Volume) bool {
+	for _, volume := range volumes {
+		for _, snap := range volume.Snapshots {
+			if snap.Kind == storagestate.SnapshotMSUPrepare || snap.Name == "com.apple.os.update-MSUPrepareUpdate" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func ratio(n, d uint64) float64 {
+	if d == 0 {
+		return 0
+	}
+	return float64(n) / float64(d)
+}
+
+func FormatBytes(bytes int64) string {
+	const gib = 1024 * 1024 * 1024
+	if bytes >= gib {
+		return fmt.Sprintf("%.1f GB", float64(bytes)/gib)
+	}
+	const mib = 1024 * 1024
+	if bytes >= mib {
+		return fmt.Sprintf("%.0f MB", float64(bytes)/mib)
+	}
+	return fmt.Sprintf("%d B", bytes)
+}
+
+func FormatBackupdErrorRate(count int, window time.Duration) string {
+	if window <= 0 {
+		return fmt.Sprintf("%d errors", count)
+	}
+	return fmt.Sprintf("%d errors / %s (= %.1f/h)", count, window.Round(time.Hour), float64(count)/window.Hours())
+}

--- a/internal/playbook/fseventsd_test.go
+++ b/internal/playbook/fseventsd_test.go
@@ -1,0 +1,99 @@
+package playbook
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/logquery"
+	"github.com/kaeawc/spectra/internal/memstate"
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/services"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/storagestate"
+	"github.com/kaeawc/spectra/internal/timemachine"
+)
+
+func TestAnalyzeFSEventsdLeakIncident(t *testing.T) {
+	s := incidentSnapshot()
+	logs := logquery.Result{Entries: []logquery.LogEntry{
+		{MessageType: "Error", EventMessage: "fs_snapshot_list failed"},
+		{MessageType: "Error", EventMessage: "backup failed"},
+	}}
+	report := AnalyzeFSEventsdLeak(s, logs)
+	if !report.Matched {
+		t.Fatalf("Matched = false, report = %#v", report)
+	}
+	if report.RuleID != FSEventsdLeakRuleID {
+		t.Fatalf("RuleID = %q", report.RuleID)
+	}
+	for _, want := range FSEventsdLeakRemediation {
+		if !contains(report.Remediation, want) {
+			t.Fatalf("missing remediation %q in %#v", want, report.Remediation)
+		}
+	}
+	if !strings.Contains(report.Finding, FSEventsdLeakRuleID) || !strings.Contains(report.Finding, "fseventsd RSS") {
+		t.Fatalf("Finding = %q", report.Finding)
+	}
+	if report.Signals.FSSnapshotListFailed != 1 {
+		t.Fatalf("FSSnapshotListFailed = %d, want 1", report.Signals.FSSnapshotListFailed)
+	}
+}
+
+func TestAnalyzeFSEventsdLeakHealthyExitsAtMemory(t *testing.T) {
+	s := incidentSnapshot()
+	s.Host.Memory.CompressorOccupied = 0
+	s.Host.Memory.Swap.UsedBytes = 0
+	report := AnalyzeFSEventsdLeak(s, logquery.Result{})
+	if report.Matched {
+		t.Fatalf("healthy report matched: %#v", report)
+	}
+	if report.ExitReason != "no memory pressure detected." {
+		t.Fatalf("ExitReason = %q", report.ExitReason)
+	}
+}
+
+func incidentSnapshot() snapshot.Snapshot {
+	const gib = 1024 * 1024 * 1024
+	return snapshot.Snapshot{
+		ID:   "incident-2026-05-fseventsd",
+		Kind: snapshot.KindLive,
+		Host: snapshot.HostInfo{
+			Hostname:      "incident-mac",
+			UptimeSeconds: int64((7 * 24 * time.Hour).Seconds()),
+			Memory: memstate.MemoryState{
+				PhysicalBytes:      128 * gib,
+				CompressorOccupied: 70 * gib,
+				CompressorStored:   80 * gib,
+				PressureLevel:      memstate.PressureCritical,
+				Swap:               memstate.SwapUsage{UsedBytes: 60 * gib},
+			},
+			TimeMachine: timemachine.TimeMachineState{
+				Destinations:    nil,
+				SchedulerLoaded: true,
+			},
+		},
+		Processes: []process.Info{
+			{PID: 321, Command: "fseventsd", FullCommandLine: "/System/Library/PrivateFrameworks/FSEvents.framework/Versions/A/Support/fseventsd", RSSKiB: 14 * 1024 * 1024},
+			{PID: 10, Command: "backupd", RSSKiB: 1024},
+		},
+		Storage: storagestate.State{Volumes: []storagestate.Volume{{
+			MountPoint: "/",
+			Snapshots:  []storagestate.APFSSnapshot{{Name: "com.apple.os.update-MSUPrepareUpdate", Kind: storagestate.SnapshotMSUPrepare}},
+		}}},
+		Services: services.LaunchInventory{Jobs: []services.LaunchJob{{
+			Label:     "com.apple.backupd-auto",
+			Domain:    "system",
+			PlistPath: "/System/Library/LaunchDaemons/com.apple.backupd-auto.plist",
+		}}},
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/playbook/playbook_test.go
+++ b/internal/playbook/playbook_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestDefaultCatalogContainsExpectedPlaybooks(t *testing.T) {
 	c := MustDefaultCatalog()
-	want := []string{"jvm-memory", "network-failure", "remote-triage", "storage-bloat", "terminal-spawning", "toolchain-drift"}
+	want := []string{"fseventsd-leak", "jvm-memory", "network-failure", "remote-triage", "storage-bloat", "terminal-spawning", "toolchain-drift"}
 	got := c.List()
 	if len(got) != len(want) {
 		t.Fatalf("len = %d, want %d", len(got), len(want))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
   - Playbooks:
       - Overview: playbooks/index.md
       - JVM memory: playbooks/jvm-memory.md
+      - fseventsd backup leak: playbooks/fseventsd-leak.md
       - Network failure: playbooks/network-failure.md
       - Storage bloat: playbooks/storage-bloat.md
       - Terminal spawning: playbooks/terminal-spawning.md


### PR DESCRIPTION
Closes #271.

## Summary
- add the built-in `fseventsd-leak` playbook and command plan
- add a structured fseventsd leak analyzer/report with fixture-style coverage for the incident pattern and healthy early exit
- wire `spectra playbook fseventsd-leak` to produce a live report and add auto-fix confirmation guardrails
- add playbook docs and MkDocs navigation

## Validation
- `go run ./cmd/spectra playbook --commands fseventsd-leak | sed -n '1,12p'`\n- `go run ./cmd/spectra playbook fseventsd-leak --auto-fix --non-interactive` rejects without `--yes`\n- `go build ./... && go vet ./... && go test ./... -count=1 && gocyclo -over 15 -ignore '_test\\.go$' . && golangci-lint run && make docs-validate`