### PR TITLE
Add snapshot --since and autosnap retention

### DIFF
--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -37,6 +38,9 @@ func runServe(args []string) int {
 	artifactPolicy := fs.String("artifact-policy", "confirm", "Daemon artifact policy: confirm, deny, or allow")
 	logFile := fs.String("log-file", "", "JSONL daemon log path (default: ~/Library/Logs/Spectra/daemon.jsonl)")
 	noLogFile := fs.Bool("no-log-file", false, "Disable the daemon JSONL log file")
+	autoSnapMode := fs.String("autosnap", "on", "Rolling auto snapshots: on or off")
+	autoSnapInterval := fs.Duration("autosnap-interval", serve.DefaultAutoSnapInterval, "Interval for rolling auto snapshots")
+	autoSnapRetain := fs.Int("autosnap-retain", serve.DefaultAutoSnapRetain, "Number of auto snapshots to retain per host")
 	daemon := fs.Bool("daemon", false, "Start spectra serve in the background and return")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -46,6 +50,11 @@ func runServe(args []string) int {
 		return 2
 	}
 	policy, err := parseArtifactPolicy(*artifactPolicy)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	autoSnap, err := parseAutoSnapConfig(*autoSnapMode, *autoSnapInterval, *autoSnapRetain)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 2
@@ -88,6 +97,7 @@ func runServe(args []string) int {
 		TsnetEnabled:   *tsnetEnabled,
 		TsnetAddr:      *tsnetAddr,
 		ArtifactPolicy: policy,
+		AutoSnap:       autoSnap,
 	})
 
 	var detectStore *cache.ShardedStore
@@ -109,6 +119,7 @@ func runServe(args []string) int {
 		DetectStore:      detectStore,
 		ArtifactPolicy:   policy,
 		Logger:           daemonLog,
+		AutoSnap:         autoSnap,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -124,6 +135,7 @@ type serveStartupStatus struct {
 	TsnetEnabled   bool
 	TsnetAddr      string
 	ArtifactPolicy artifact.Policy
+	AutoSnap       serve.AutoSnapConfig
 }
 
 func printServeStartup(w io.Writer, status serveStartupStatus) {
@@ -141,7 +153,31 @@ func printServeStartup(w io.Writer, status serveStartupStatus) {
 		fmt.Fprintf(w, "spectra serve: joining tailnet via tsnet on %s\n", status.TsnetAddr)
 		fmt.Fprintln(w, "spectra serve: tsnet auth uses existing state or TS_AUTHKEY; first-run login URLs are written to the daemon log or stderr")
 	}
+	autoSnap := status.AutoSnap.Normalize()
+	if autoSnap.Disabled {
+		fmt.Fprintln(w, "spectra serve: autosnap off")
+	} else {
+		fmt.Fprintf(w, "spectra serve: autosnap every %s, retain %d\n", autoSnap.Interval, autoSnap.Retain)
+	}
 	fmt.Fprintf(w, "spectra serve: artifact policy %s\n", status.ArtifactPolicy.Normalize().Mode)
+}
+
+func parseAutoSnapConfig(mode string, interval time.Duration, retain int) (serve.AutoSnapConfig, error) {
+	disabled := false
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "", "on":
+	case "off":
+		disabled = true
+	default:
+		return serve.AutoSnapConfig{}, fmt.Errorf("spectra serve: --autosnap must be on or off")
+	}
+	if interval <= 0 {
+		return serve.AutoSnapConfig{}, fmt.Errorf("spectra serve: --autosnap-interval must be positive")
+	}
+	if retain <= 0 {
+		return serve.AutoSnapConfig{}, fmt.Errorf("spectra serve: --autosnap-retain must be positive")
+	}
+	return serve.AutoSnapConfig{Disabled: disabled, Interval: interval, Retain: retain}, nil
 }
 
 func parseArtifactPolicy(mode string) (artifact.Policy, error) {

--- a/cmd/spectra/serve_test.go
+++ b/cmd/spectra/serve_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/serve"
 )
 
 func TestOpenDaemonLoggerDisabled(t *testing.T) {
@@ -43,6 +46,34 @@ func TestServeChildArgsDropsDaemonFlag(t *testing.T) {
 	want := []string{"serve", "--sock", "/tmp/spectra.sock", "--tsnet", "--tsnet-hostname", "work-mac", "--no-log-file"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("serveChildArgs = %v, want %v", got, want)
+	}
+}
+
+func TestParseAutoSnapConfig(t *testing.T) {
+	cfg, err := parseAutoSnapConfig("on", time.Minute, 12)
+	if err != nil {
+		t.Fatalf("parseAutoSnapConfig on: %v", err)
+	}
+	if cfg.Disabled || cfg.Interval != time.Minute || cfg.Retain != 12 {
+		t.Fatalf("cfg = %+v", cfg)
+	}
+
+	cfg, err = parseAutoSnapConfig("off", serve.DefaultAutoSnapInterval, serve.DefaultAutoSnapRetain)
+	if err != nil {
+		t.Fatalf("parseAutoSnapConfig off: %v", err)
+	}
+	if !cfg.Disabled {
+		t.Fatalf("Disabled = false, want true")
+	}
+
+	if _, err := parseAutoSnapConfig("maybe", time.Minute, 1); err == nil {
+		t.Fatal("expected invalid mode error")
+	}
+	if _, err := parseAutoSnapConfig("on", 0, 1); err == nil {
+		t.Fatal("expected invalid interval error")
+	}
+	if _, err := parseAutoSnapConfig("on", time.Minute, 0); err == nil {
+		t.Fatal("expected invalid retain error")
 	}
 }
 

--- a/cmd/spectra/snapshot.go
+++ b/cmd/spectra/snapshot.go
@@ -189,11 +189,16 @@ func runSnapshotList(args []string) int {
 		return 0
 	}
 
-	fmt.Printf("%-32s  %-8s  %-20s  %-20s  %s\n", "ID", "KIND", "TAKEN AT", "NAME", "APPS")
-	fmt.Println(strings.Repeat("-", 90))
+	fmt.Printf("%-32s  %-8s  %-8s  %-20s  %-20s  %s\n", "ID", "KIND", "TAG", "TAKEN AT", "NAME", "APPS")
+	fmt.Println(strings.Repeat("-", 100))
 	for _, r := range rows {
-		fmt.Printf("%-32s  %-8s  %-20s  %-20s  %d\n",
+		tag := r.Tag
+		if tag == "" {
+			tag = "-"
+		}
+		fmt.Printf("%-32s  %-8s  %-8s  %-20s  %-20s  %d\n",
 			r.ID, r.Kind,
+			tag,
 			r.TakenAt.Format("2006-01-02 15:04:05Z"),
 			truncate(r.Name, 20),
 			r.AppCount,
@@ -275,6 +280,9 @@ func runSnapshotShowFallback(ctx context.Context, db *store.DB, row store.Snapsh
 
 	fmt.Printf("id:         %s\n", row.ID)
 	fmt.Printf("kind:       %s\n", row.Kind)
+	if row.Tag != "" {
+		fmt.Printf("tag:        %s\n", row.Tag)
+	}
 	if row.Name != "" {
 		fmt.Printf("name:       %s\n", row.Name)
 	}
@@ -301,6 +309,9 @@ func printSnapshot(s snapshot.Snapshot) {
 	fmt.Println("=== Spectra snapshot ===")
 	fmt.Printf("id:             %s\n", s.ID)
 	fmt.Printf("kind:           %s\n", s.Kind)
+	if s.Tag != "" {
+		fmt.Printf("tag:            %s\n", s.Tag)
+	}
 	fmt.Printf("taken-at:       %s\n", s.TakenAt.Format("2006-01-02T15:04:05Z07:00"))
 	fmt.Println()
 	fmt.Print(s.Host.String())
@@ -456,16 +467,28 @@ func runSnapshotDiff(args []string) int {
 	fs := flag.NewFlagSet("spectra snapshot diff", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON")
+	since := fs.Duration("since", 0, "Diff the most recent stored snapshot older than this duration against live")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if fs.NArg() < 1 || fs.NArg() > 3 {
-		printDiffUsage()
+	if *since < 0 {
+		fmt.Fprintln(os.Stderr, "spectra snapshot diff: --since must be positive")
 		return 2
 	}
-	if fs.Arg(0) != "baseline" && fs.NArg() != 2 {
-		printDiffUsage()
-		return 2
+	if *since > 0 {
+		if fs.NArg() != 0 {
+			fmt.Fprintln(os.Stderr, "spectra snapshot diff: --since cannot be combined with explicit snapshot IDs")
+			return 2
+		}
+	} else {
+		if fs.NArg() < 1 || fs.NArg() > 3 {
+			printDiffUsage()
+			return 2
+		}
+		if fs.Arg(0) != "baseline" && fs.NArg() != 2 {
+			printDiffUsage()
+			return 2
+		}
 	}
 
 	dbPath, err := store.DefaultPath()
@@ -481,7 +504,12 @@ func runSnapshotDiff(args []string) int {
 	defer db.Close()
 
 	ctx := context.Background()
-	snapA, snapB, err := resolveDiffOperands(ctx, db, fs.Args())
+	var snapA, snapB *snapshot.Snapshot
+	if *since > 0 {
+		snapA, snapB, err = resolveSinceDiffOperands(ctx, db, *since, time.Now())
+	} else {
+		snapA, snapB, err = resolveDiffOperands(ctx, db, fs.Args())
+	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -502,6 +530,7 @@ func runSnapshotDiff(args []string) int {
 
 func printDiffUsage() {
 	fmt.Fprintln(os.Stderr, "usage: spectra snapshot diff <id-a> <id-b|live>")
+	fmt.Fprintln(os.Stderr, "   or: spectra snapshot diff --since <duration>")
 	fmt.Fprintln(os.Stderr, "   or: spectra diff <host-a> <host-b|live>")
 	fmt.Fprintln(os.Stderr, "   or: spectra diff baseline [name|id] [live|id]")
 }
@@ -509,6 +538,11 @@ func printDiffUsage() {
 type remoteSnapshotLoader func(ctx context.Context, host string, snapshotID string) (*snapshot.Snapshot, error)
 
 var loadRemoteSnapshot remoteSnapshotLoader = resolveRemoteSnapshot
+
+var collectLiveSnapshot = func(ctx context.Context) *snapshot.Snapshot {
+	snap := snapshot.Build(ctx, snapshot.Options{SpectraVersion: version})
+	return &snap
+}
 
 type snapshotRegistry interface {
 	SaveSnapshot(context.Context, store.SnapshotInput) error
@@ -518,6 +552,7 @@ type snapshotRegistry interface {
 	ListSnapshots(context.Context, string) ([]store.SnapshotRow, error)
 	GetSnapshot(context.Context, string) (store.SnapshotRow, error)
 	GetSnapshotJSON(context.Context, string) ([]byte, error)
+	MostRecentSnapshotOlderThan(context.Context, time.Time) (*snapshot.Snapshot, error)
 	GetSnapshotApps(context.Context, string) ([]store.AppRow, error)
 	DeleteSnapshot(context.Context, string) error
 	PruneSnapshots(context.Context, int) (int64, error)
@@ -541,6 +576,22 @@ func resolveDiffOperands(ctx context.Context, db snapshotRegistry, args []string
 		return nil, nil, fmt.Errorf("snapshot %q: %w", idB, err)
 	}
 	return snapA, snapB, nil
+}
+
+func resolveSinceDiffOperands(ctx context.Context, db snapshotRegistry, since time.Duration, now time.Time) (*snapshot.Snapshot, *snapshot.Snapshot, error) {
+	if since <= 0 {
+		return nil, nil, fmt.Errorf("--since must be positive")
+	}
+	cutoff := now.UTC().Add(-since)
+	base, err := db.MostRecentSnapshotOlderThan(ctx, cutoff)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, nil, fmt.Errorf("no stored snapshot older than %s exists; run `spectra snapshot create` or start the daemon", since)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	live := collectLiveSnapshot(ctx)
+	return base, live, nil
 }
 
 func resolveBaselineDiffOperands(ctx context.Context, db snapshotRegistry, args []string) (*snapshot.Snapshot, *snapshot.Snapshot, error) {
@@ -573,8 +624,7 @@ func resolveBaselineDiffOperands(ctx context.Context, db snapshotRegistry, args 
 // live snapshot when id is the sentinel "live".
 func resolveSnapshot(ctx context.Context, db snapshotRegistry, id string) (*snapshot.Snapshot, error) {
 	if id == "live" {
-		snap := snapshot.Build(ctx, snapshot.Options{SpectraVersion: version})
-		return &snap, nil
+		return collectLiveSnapshot(ctx), nil
 	}
 	return loadSnapshotFromDB(ctx, db, id)
 }

--- a/cmd/spectra/snapshot_test.go
+++ b/cmd/spectra/snapshot_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -319,6 +321,48 @@ func TestResolveBaselineSnapshotWithFakeRegistry(t *testing.T) {
 	}
 }
 
+func TestResolveSinceDiffOperandsUsesNewestSnapshotOlderThanCutoff(t *testing.T) {
+	ctx := context.Background()
+	reg := newFakeSnapshotRegistry()
+	old := testSnapshot("snap-old", snapshot.KindLive, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
+	newer := testSnapshot("snap-newer", snapshot.KindLive, time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC))
+	tooNew := testSnapshot("snap-too-new", snapshot.KindLive, time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC))
+	reg.putSnapshot(old, "")
+	reg.putSnapshot(newer, "")
+	reg.putSnapshot(tooNew, "")
+
+	oldCollect := collectLiveSnapshot
+	t.Cleanup(func() { collectLiveSnapshot = oldCollect })
+	collectLiveSnapshot = func(context.Context) *snapshot.Snapshot {
+		live := testSnapshot("snap-live", snapshot.KindLive, time.Date(2026, 5, 3, 13, 0, 0, 0, time.UTC))
+		return &live
+	}
+
+	base, live, err := resolveSinceDiffOperands(ctx, reg, 24*time.Hour, time.Date(2026, 5, 3, 12, 30, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("resolveSinceDiffOperands: %v", err)
+	}
+	if base.ID != "snap-newer" {
+		t.Fatalf("base ID = %q, want snap-newer", base.ID)
+	}
+	if live.ID != "snap-live" {
+		t.Fatalf("live ID = %q, want snap-live", live.ID)
+	}
+}
+
+func TestResolveSinceDiffOperandsNoOldEnoughSnapshot(t *testing.T) {
+	reg := newFakeSnapshotRegistry()
+	reg.putSnapshot(testSnapshot("snap-new", snapshot.KindLive, time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)), "")
+
+	_, _, err := resolveSinceDiffOperands(context.Background(), reg, 24*time.Hour, time.Date(2026, 5, 3, 12, 30, 0, 0, time.UTC))
+	if !errors.Is(err, store.ErrNotFound) && err == nil {
+		t.Fatal("expected no old-enough snapshot error")
+	}
+	if err == nil || !strings.Contains(err.Error(), "no stored snapshot older than 24h0m0s") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func testSnapshot(id string, kind snapshot.Kind, takenAt time.Time) snapshot.Snapshot {
 	return snapshot.Snapshot{
 		ID:      id,
@@ -419,6 +463,30 @@ func (f *fakeSnapshotRegistry) GetSnapshotJSON(_ context.Context, id string) ([]
 		return nil, store.ErrNotFound
 	}
 	return raw, nil
+}
+
+func (f *fakeSnapshotRegistry) MostRecentSnapshotOlderThan(_ context.Context, cutoff time.Time) (*snapshot.Snapshot, error) {
+	var best *snapshot.Snapshot
+	for _, row := range f.rows {
+		if row.TakenAt.After(cutoff) {
+			continue
+		}
+		raw, ok := f.jsonByID[row.ID]
+		if !ok {
+			continue
+		}
+		var snap snapshot.Snapshot
+		if err := json.Unmarshal(raw, &snap); err != nil {
+			return nil, err
+		}
+		if best == nil || snap.TakenAt.After(best.TakenAt) {
+			best = &snap
+		}
+	}
+	if best == nil {
+		return nil, store.ErrNotFound
+	}
+	return best, nil
 }
 
 func (f *fakeSnapshotRegistry) GetSnapshotApps(_ context.Context, id string) ([]store.AppRow, error) {

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -32,6 +32,8 @@ spectra serve --tcp 127.0.0.1:7878
 spectra serve --tsnet --tsnet-hostname work-mac
 spectra serve --log-file /tmp/spectra-daemon.jsonl
 spectra serve --no-log-file
+spectra serve --autosnap-interval 5m --autosnap-retain 24
+spectra serve --autosnap=off
 spectra serve --daemon       # start detached and return
 spectra install-daemon       # install and load the per-user LaunchAgent
 ```
@@ -127,12 +129,25 @@ stored rows; the `process.live` RPC returns recent in-memory samples.
 Broader live collector replay is kept as a second in-memory ring of daemon
 snapshot captures. `live.current` returns the newest broad live snapshot and
 `live.history` returns recent captures across the host, process, toolchain,
-power, sysctl, and network collectors. At the default 1-minute daemon cadence,
-the in-memory replay window keeps the last 30 captures.
+power, sysctl, and network collectors. At the default 5-minute autosnapshot
+cadence, the in-memory replay window keeps the last 30 captures.
 
-The daemon also captures a host-focused live snapshot every minute and prunes
-live snapshots to the last 100 rows. Apps, storage, and JVMs are skipped in
-that loop to keep the tick cheap.
+The daemon also captures a lightweight host-focused auto snapshot on a rolling
+cadence. By default this runs every 5 minutes and retains the newest 24
+auto-tagged snapshots per host. Apps, storage, and JVMs are skipped in that
+loop to keep the tick cheap. Auto snapshots are tagged separately in SQLite, so
+their retention does not prune manually captured live snapshots or baselines.
+
+Use `spectra serve --autosnap-interval 10m --autosnap-retain 48` to tune the
+window, or `spectra serve --autosnap=off` to disable daemon auto snapshots.
+Stored auto snapshots can be used with the duration shortcut:
+
+```bash
+spectra snapshot diff --since 30m
+```
+
+`--since` resolves to the most recent stored snapshot older than the requested
+duration and compares it with a fresh live snapshot.
 
 ## Privileged helper
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -77,9 +77,37 @@ type Options struct {
 	ArtifactRecorder artifact.Recorder   // nil = default per-user manifest
 	ArtifactPolicy   artifact.Policy     // empty = confirm per sensitive artifact
 	Logger           logger.Logger       // nil = discard
+	AutoSnap         AutoSnapConfig
 }
 
 const DefaultTsnetAddr = ":7878"
+
+const (
+	DefaultAutoSnapInterval = 5 * time.Minute
+	DefaultAutoSnapRetain   = 24
+)
+
+// AutoSnapConfig controls the daemon's rolling lightweight snapshot loop.
+type AutoSnapConfig struct {
+	Disabled bool
+	Interval time.Duration
+	Retain   int
+}
+
+func (c AutoSnapConfig) normalized() AutoSnapConfig {
+	if c.Interval <= 0 {
+		c.Interval = DefaultAutoSnapInterval
+	}
+	if c.Retain <= 0 {
+		c.Retain = DefaultAutoSnapRetain
+	}
+	return c
+}
+
+// Normalize returns c with default interval and retention values filled in.
+func (c AutoSnapConfig) Normalize() AutoSnapConfig {
+	return c.normalized()
+}
 
 // Run starts the daemon: listens on the Unix socket and serves requests until
 // ctx is cancelled. Run blocks until the listener is shut down.
@@ -189,7 +217,13 @@ func runDaemon(ctx context.Context, log logger.Logger, opts Options, listeners [
 	go sampler.Run(ctx)
 	go jvmSampler.Run(ctx)
 	go flushMetricsLoop(ctx, collector, db)
-	go snapshotLoop(ctx, opts.SpectraVersion, db, history)
+	autoSnap := opts.AutoSnap.normalized()
+	if !autoSnap.Disabled {
+		go snapshotLoop(ctx, opts.SpectraVersion, db, history, autoSnap)
+		log.Info("daemon autosnapshot enabled", "interval", autoSnap.Interval.String(), "retain", autoSnap.Retain)
+	} else {
+		log.Info("daemon autosnapshot disabled")
+	}
 
 	cacheReg := opts.CacheRegistry
 	if cacheReg == nil {
@@ -421,11 +455,11 @@ func flushMetricsLoop(ctx context.Context, c *metrics.Collector, db *store.DB) {
 	}
 }
 
-// snapshotLoop captures a live host-only snapshot every minute and prunes the
-// live snapshot history to the last 100 entries. Apps, storage, and JVMs are
-// skipped to keep the per-tick cost low (~50ms vs seconds for a full snapshot).
-func snapshotLoop(ctx context.Context, version string, db *store.DB, history *livehistory.Ring) {
-	ticker := time.NewTicker(time.Minute)
+// snapshotLoop captures lightweight auto snapshots and prunes only the
+// auto-tagged history. Apps, storage, and JVMs are skipped to keep tick cost low.
+func snapshotLoop(ctx context.Context, version string, db *store.DB, history *livehistory.Ring, cfg AutoSnapConfig) {
+	cfg = cfg.normalized()
+	ticker := time.NewTicker(cfg.Interval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -438,12 +472,13 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB, history *li
 				SkipStorage:    true,
 				SkipJVMs:       true,
 			})
+			snap.Tag = "auto"
 			history.Add(snap)
 			_ = db.SaveSnapshot(ctx, store.FromSnapshot(snap))
 			_ = db.SaveSnapshotProcesses(ctx, snap.ID, store.ProcessesFromSnapshot(snap))
 			_ = db.SaveLoginItems(ctx, snap.ID, store.LoginItemsFromSnapshot(snap))
 			_ = db.SaveGrantedPerms(ctx, snap.ID, store.GrantedPermsFromSnapshot(snap))
-			_, _ = db.PruneSnapshots(ctx, 100)
+			_, _ = db.PruneAutoSnapshots(ctx, cfg.Retain)
 			_, _ = db.PruneJVMSamples(ctx, 7)
 		}
 	}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -38,6 +38,7 @@ type Snapshot struct {
 	ID           string                   `json:"id"`
 	TakenAt      time.Time                `json:"taken_at"`
 	Kind         Kind                     `json:"kind"`
+	Tag          string                   `json:"tag,omitempty"`
 	Host         HostInfo                 `json:"host"`
 	HostFacts    HostFacts                `json:"host_facts"`
 	Apps         []detect.Result          `json:"apps"`

--- a/internal/store/convert.go
+++ b/internal/store/convert.go
@@ -29,6 +29,7 @@ func FromSnapshot(s snapshot.Snapshot) SnapshotInput {
 		MachineUUID:  uuid,
 		TakenAt:      s.TakenAt,
 		Kind:         string(s.Kind),
+		Tag:          s.Tag,
 		SpectraVer:   s.Host.SpectraVersion,
 		Hostname:     s.Host.Hostname,
 		OSName:       s.Host.OSName,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -112,6 +112,7 @@ func (s *DB) migrate() error {
 		return err
 	}
 	// Add snapshot_json column if this is an existing DB without it.
+	_, _ = s.db.Exec(`ALTER TABLE snapshots ADD COLUMN tag TEXT NOT NULL DEFAULT ''`)
 	_, _ = s.db.Exec(`ALTER TABLE snapshots ADD COLUMN snapshot_json TEXT`)
 	return nil
 }
@@ -159,6 +160,7 @@ CREATE TABLE IF NOT EXISTS snapshots (
     machine_uuid  TEXT NOT NULL,
     taken_at      DATETIME NOT NULL,
     kind          TEXT NOT NULL DEFAULT 'live',
+    tag           TEXT NOT NULL DEFAULT '',
     name          TEXT,
     spectra_ver   TEXT,
     app_count     INTEGER NOT NULL DEFAULT 0,
@@ -292,6 +294,7 @@ type SnapshotRow struct {
 	MachineUUID string
 	TakenAt     time.Time
 	Kind        string
+	Tag         string
 	Name        string // optional human label, used for baselines
 	SpectraVer  string
 	AppCount    int
@@ -361,9 +364,9 @@ func upsertHost(tx *sql.Tx, s SnapshotInput) error {
 func insertSnapshot(tx *sql.Tx, s SnapshotInput) error {
 	name := sql.NullString{String: s.Name, Valid: s.Name != ""}
 	_, err := tx.Exec(`
-		INSERT OR IGNORE INTO snapshots (id, machine_uuid, taken_at, kind, name, spectra_ver, app_count, snapshot_json)
-		VALUES (?,?,?,?,?,?,?,?)`,
-		s.ID, s.MachineUUID, s.TakenAt, s.Kind, name, s.SpectraVer, len(s.Apps), nullableJSON(s.SnapshotJSON),
+		INSERT OR IGNORE INTO snapshots (id, machine_uuid, taken_at, kind, tag, name, spectra_ver, app_count, snapshot_json)
+		VALUES (?,?,?,?,?,?,?,?,?)`,
+		s.ID, s.MachineUUID, s.TakenAt, s.Kind, s.Tag, name, s.SpectraVer, len(s.Apps), nullableJSON(s.SnapshotJSON),
 	)
 	return err
 }
@@ -440,11 +443,11 @@ func (s *DB) ListHosts(ctx context.Context) ([]HostRow, error) {
 // ListSnapshots returns summary rows ordered newest-first.
 // Pass machine_uuid="" to list all hosts. Pass kind="" to list all kinds.
 func (s *DB) ListSnapshots(ctx context.Context, machineUUID string) ([]SnapshotRow, error) {
-	q := `SELECT id, machine_uuid, taken_at, kind, COALESCE(name,''), COALESCE(spectra_ver,''), app_count
+	q := `SELECT id, machine_uuid, taken_at, kind, COALESCE(tag,''), COALESCE(name,''), COALESCE(spectra_ver,''), app_count
 	      FROM snapshots ORDER BY taken_at DESC LIMIT 100`
 	args := []any{}
 	if machineUUID != "" {
-		q = `SELECT id, machine_uuid, taken_at, kind, COALESCE(name,''), COALESCE(spectra_ver,''), app_count
+		q = `SELECT id, machine_uuid, taken_at, kind, COALESCE(tag,''), COALESCE(name,''), COALESCE(spectra_ver,''), app_count
 		     FROM snapshots WHERE machine_uuid=? ORDER BY taken_at DESC LIMIT 100`
 		args = append(args, machineUUID)
 	}
@@ -457,7 +460,7 @@ func (s *DB) ListSnapshots(ctx context.Context, machineUUID string) ([]SnapshotR
 	for rows.Next() {
 		var r SnapshotRow
 		var takenAt string
-		if err := rows.Scan(&r.ID, &r.MachineUUID, &takenAt, &r.Kind, &r.Name, &r.SpectraVer, &r.AppCount); err != nil {
+		if err := rows.Scan(&r.ID, &r.MachineUUID, &takenAt, &r.Kind, &r.Tag, &r.Name, &r.SpectraVer, &r.AppCount); err != nil {
 			return nil, err
 		}
 		r.TakenAt, _ = time.Parse(time.RFC3339, takenAt)
@@ -471,9 +474,9 @@ func (s *DB) GetSnapshot(ctx context.Context, id string) (SnapshotRow, error) {
 	var r SnapshotRow
 	var takenAt string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, machine_uuid, taken_at, kind, COALESCE(name,''), COALESCE(spectra_ver,''), app_count
+		`SELECT id, machine_uuid, taken_at, kind, COALESCE(tag,''), COALESCE(name,''), COALESCE(spectra_ver,''), app_count
 		 FROM snapshots WHERE id=?`, id,
-	).Scan(&r.ID, &r.MachineUUID, &takenAt, &r.Kind, &r.Name, &r.SpectraVer, &r.AppCount)
+	).Scan(&r.ID, &r.MachineUUID, &takenAt, &r.Kind, &r.Tag, &r.Name, &r.SpectraVer, &r.AppCount)
 	if errors.Is(err, sql.ErrNoRows) {
 		return r, ErrNotFound
 	}
@@ -502,6 +505,30 @@ func (s *DB) GetSnapshotJSON(ctx context.Context, id string) ([]byte, error) {
 		return nil, nil
 	}
 	return []byte(raw.String), nil
+}
+
+// MostRecentSnapshotOlderThan returns the newest stored snapshot at or before
+// cutoff that has a full JSON blob suitable for diffing.
+func (s *DB) MostRecentSnapshotOlderThan(ctx context.Context, cutoff time.Time) (*snapshot.Snapshot, error) {
+	var raw string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT snapshot_json
+		FROM snapshots
+		WHERE taken_at <= ? AND snapshot_json IS NOT NULL AND snapshot_json != ''
+		ORDER BY taken_at DESC
+		LIMIT 1`, cutoff.UTC(),
+	).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	var snap snapshot.Snapshot
+	if err := json.Unmarshal([]byte(raw), &snap); err != nil {
+		return nil, fmt.Errorf("store: decode snapshot: %w", err)
+	}
+	return &snap, nil
 }
 
 // DeleteSnapshot deletes a snapshot and all its child rows by ID.
@@ -950,16 +977,25 @@ func (s *DB) PruneJVMSamples(ctx context.Context, keepDays int) (int64, error) {
 	return res.RowsAffected()
 }
 
-// PruneSnapshots deletes live snapshots beyond the retention limit for each
-// machine. Baselines (kind != "live") are never deleted. The default limit
-// is 100 live snapshots per machine UUID.
+// PruneSnapshots deletes untagged live snapshots beyond the retention limit
+// for each machine. Baselines and tagged live snapshots are never deleted by
+// this path. The default limit is 100 live snapshots per machine UUID.
 func (s *DB) PruneSnapshots(ctx context.Context, keepN int) (int64, error) {
+	return s.pruneSnapshots(ctx, keepN, `kind='live' AND COALESCE(tag,'')=''`)
+}
+
+// PruneAutoSnapshots deletes auto-tagged snapshots beyond the retention limit
+// for each machine. Baseline and manual live snapshots are left untouched.
+func (s *DB) PruneAutoSnapshots(ctx context.Context, keepN int) (int64, error) {
+	return s.pruneSnapshots(ctx, keepN, `tag='auto'`)
+}
+
+func (s *DB) pruneSnapshots(ctx context.Context, keepN int, where string) (int64, error) {
 	if keepN <= 0 {
 		keepN = 100
 	}
-	// Find all machine UUIDs that have live snapshots.
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT DISTINCT machine_uuid FROM snapshots WHERE kind='live'`)
+		`SELECT DISTINCT machine_uuid FROM snapshots WHERE `+where) // #nosec G202 -- where is an internal literal.
 	if err != nil {
 		return 0, err
 	}
@@ -980,8 +1016,8 @@ func (s *DB) PruneSnapshots(ctx context.Context, keepN int) (int64, error) {
 	var total int64
 	for _, m := range machines {
 		// Delete child rows for to-be-pruned snapshots first (FK constraints).
-		pruneSubquery := `SELECT id FROM snapshots WHERE kind='live' AND machine_uuid=?
-				AND id NOT IN (SELECT id FROM snapshots WHERE kind='live' AND machine_uuid=? ORDER BY taken_at DESC LIMIT ?)`
+		pruneSubquery := `SELECT id FROM snapshots WHERE ` + where + ` AND machine_uuid=?
+				AND id NOT IN (SELECT id FROM snapshots WHERE ` + where + ` AND machine_uuid=? ORDER BY taken_at DESC LIMIT ?)`
 		for _, table := range []string{"snapshot_processes", "login_items", "granted_perms", "snapshot_apps"} {
 			// #nosec G202 -- table is selected from hardcoded literals, not user input.
 			if _, err := s.db.ExecContext(ctx,
@@ -992,13 +1028,13 @@ func (s *DB) PruneSnapshots(ctx context.Context, keepN int) (int64, error) {
 		}
 		res, err := s.db.ExecContext(ctx, `
 			DELETE FROM snapshots
-			WHERE kind='live' AND machine_uuid=?
+			WHERE `+where+` AND machine_uuid=?
 			  AND id NOT IN (
 			    SELECT id FROM snapshots
-			    WHERE kind='live' AND machine_uuid=?
+			    WHERE `+where+` AND machine_uuid=?
 			    ORDER BY taken_at DESC
 			    LIMIT ?
-			  )`, m, m, keepN)
+			  )`, m, m, keepN) // #nosec G202 -- where is an internal literal.
 		if err != nil {
 			return total, fmt.Errorf("store: prune %s: %w", m, err)
 		}
@@ -1017,6 +1053,7 @@ type SnapshotInput struct {
 	MachineUUID  string
 	TakenAt      time.Time
 	Kind         string
+	Tag          string
 	Name         string // optional label for baselines
 	SpectraVer   string
 	Hostname     string

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -93,6 +94,32 @@ func TestSaveAndListSnapshot(t *testing.T) {
 	}
 	if r.Kind != "live" {
 		t.Errorf("Kind = %q, want live", r.Kind)
+	}
+}
+
+func TestSnapshotTagRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	in := sampleInput()
+	in.Tag = "auto"
+	if err := db.SaveSnapshot(ctx, in); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	row, err := db.GetSnapshot(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if row.Tag != "auto" {
+		t.Fatalf("tag = %q, want auto", row.Tag)
+	}
+	rows, err := db.ListSnapshots(ctx, "")
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if rows[0].Tag != "auto" {
+		t.Fatalf("list tag = %q, want auto", rows[0].Tag)
 	}
 }
 
@@ -297,6 +324,122 @@ func TestPruneSnapshotsKeepsBaselines(t *testing.T) {
 	}
 	if row.Kind != "baseline" {
 		t.Errorf("kind = %q, want baseline", row.Kind)
+	}
+}
+
+func TestPruneSnapshotsKeepsAutoTaggedLiveSnapshots(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	for i := 1; i <= 3; i++ {
+		in := sampleInput()
+		in.ID = fmt.Sprintf("snap-live-%02d", i)
+		in.TakenAt = time.Date(2026, 5, 3, 12, i, 0, 0, time.UTC)
+		if err := db.SaveSnapshot(ctx, in); err != nil {
+			t.Fatal(err)
+		}
+	}
+	auto := sampleInput()
+	auto.ID = "snap-auto"
+	auto.Tag = "auto"
+	if err := db.SaveSnapshot(ctx, auto); err != nil {
+		t.Fatal(err)
+	}
+
+	deleted, err := db.PruneSnapshots(ctx, 2)
+	if err != nil {
+		t.Fatalf("PruneSnapshots: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	if _, err := db.GetSnapshot(ctx, "snap-auto"); err != nil {
+		t.Fatalf("auto snapshot was pruned by live retention: %v", err)
+	}
+}
+
+func TestPruneAutoSnapshotsKeepsManualLiveAndBaselines(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	for i := 1; i <= 3; i++ {
+		in := sampleInput()
+		in.ID = fmt.Sprintf("snap-auto-%02d", i)
+		in.Tag = "auto"
+		in.TakenAt = time.Date(2026, 5, 3, 12, i, 0, 0, time.UTC)
+		if err := db.SaveSnapshot(ctx, in); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manual := sampleInput()
+	manual.ID = "snap-manual"
+	if err := db.SaveSnapshot(ctx, manual); err != nil {
+		t.Fatal(err)
+	}
+	baseline := sampleInput()
+	baseline.ID = "snap-baseline"
+	baseline.Kind = "baseline"
+	if err := db.SaveSnapshot(ctx, baseline); err != nil {
+		t.Fatal(err)
+	}
+
+	deleted, err := db.PruneAutoSnapshots(ctx, 2)
+	if err != nil {
+		t.Fatalf("PruneAutoSnapshots: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	if _, err := db.GetSnapshot(ctx, "snap-auto-01"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("oldest auto err = %v, want ErrNotFound", err)
+	}
+	for _, id := range []string{"snap-auto-02", "snap-auto-03", "snap-manual", "snap-baseline"} {
+		if _, err := db.GetSnapshot(ctx, id); err != nil {
+			t.Fatalf("%s missing after auto prune: %v", id, err)
+		}
+	}
+}
+
+func TestMostRecentSnapshotOlderThan(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		id string
+		at time.Time
+	}{
+		{"snap-old", time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)},
+		{"snap-want", time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)},
+		{"snap-new", time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)},
+	} {
+		in := sampleInput()
+		in.ID = tc.id
+		in.TakenAt = tc.at
+		raw, err := json.Marshal(snapshot.Snapshot{
+			ID:      tc.id,
+			TakenAt: tc.at,
+			Kind:    snapshot.KindLive,
+			Host:    snapshot.HostInfo{Hostname: "test.local", MachineUUID: in.MachineUUID, OSName: "macOS"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		in.SnapshotJSON = raw
+		if err := db.SaveSnapshot(ctx, in); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := db.MostRecentSnapshotOlderThan(ctx, time.Date(2026, 5, 2, 12, 30, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("MostRecentSnapshotOlderThan: %v", err)
+	}
+	if got.ID != "snap-want" {
+		t.Fatalf("ID = %q, want snap-want", got.ID)
+	}
+	_, err = db.MostRecentSnapshotOlderThan(ctx, time.Date(2026, 5, 1, 11, 0, 0, 0, time.UTC))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
 


### PR DESCRIPTION
Closes #251

## Summary
- add `spectra snapshot diff --since <duration>` to compare the newest old-enough stored snapshot with live
- tag daemon auto snapshots in SQLite and prune auto-tagged rows separately from manual live snapshots and baselines
- add `spectra serve --autosnap`, `--autosnap-interval`, and `--autosnap-retain` flags with daemon docs

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `gocyclo -over 15 -ignore '_test\\.go$' .`\n- `golangci-lint run`\n- `make docs-validate`