### PR TITLE
Add per-app process churn metrics

### DIFF
--- a/cmd/spectra/connect.go
+++ b/cmd/spectra/connect.go
@@ -645,6 +645,9 @@ func parseConnectCache(args []string) (string, json.RawMessage, bool, error) {
 }
 
 func parseConnectMetrics(args []string) (string, json.RawMessage, bool, error) {
+	if len(args) >= 2 && args[1] == "churn" {
+		return parseConnectMetricsChurn(args[2:])
+	}
 	switch len(args) {
 	case 1:
 		return "process.live", nil, true, nil
@@ -667,6 +670,44 @@ func parseConnectMetrics(args []string) (string, json.RawMessage, bool, error) {
 	default:
 		return "", nil, true, fmt.Errorf("connect metrics accepts optional pid and limit only")
 	}
+}
+
+func parseConnectMetricsChurn(args []string) (string, json.RawMessage, bool, error) {
+	params := map[string]any{}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--json":
+			continue
+		case arg == "--top":
+			if i+1 >= len(args) {
+				return "", nil, true, fmt.Errorf("connect metrics churn --top requires a value")
+			}
+			top, err := parseConnectPositiveInt(args[i+1], "top")
+			if err != nil {
+				return "", nil, true, err
+			}
+			params["top"] = top
+			i++
+		case strings.HasPrefix(arg, "--top="):
+			top, err := parseConnectPositiveInt(strings.TrimPrefix(arg, "--top="), "top")
+			if err != nil {
+				return "", nil, true, err
+			}
+			params["top"] = top
+		case strings.HasPrefix(arg, "-"):
+			return "", nil, true, fmt.Errorf("unknown metrics churn flag %q", arg)
+		default:
+			if _, exists := params["app_path"]; exists {
+				return "", nil, true, fmt.Errorf("connect metrics churn accepts at most one app path")
+			}
+			params["app_path"] = arg
+		}
+	}
+	if len(params) == 0 {
+		return "process.churn", nil, true, nil
+	}
+	return "process.churn", connectParams(params), true, nil
 }
 
 func parseConnectNetworkCaptureStart(args []string) (string, json.RawMessage, bool, error) {

--- a/cmd/spectra/connect_test.go
+++ b/cmd/spectra/connect_test.go
@@ -129,6 +129,8 @@ func TestParseConnectTypedCalls(t *testing.T) {
 		{name: "metrics", args: []string{"metrics"}, wantMethod: "process.live"},
 		{name: "metrics pid", args: []string{"metrics", "4012"}, wantMethod: "process.history", wantParams: `{"pid":4012}`},
 		{name: "metrics pid and limit", args: []string{"metrics", "4012", "30"}, wantMethod: "process.history", wantParams: `{"pid":4012,"limit":30}`},
+		{name: "metrics churn", args: []string{"metrics", "churn", "--top", "10", "--json"}, wantMethod: "process.churn", wantParams: `{"top":10}`},
+		{name: "metrics churn app", args: []string{"metrics", "churn", "/Applications/Slack.app"}, wantMethod: "process.churn", wantParams: `{"app_path":"/Applications/Slack.app"}`},
 		{name: "network", args: []string{"network"}, wantMethod: "network.state"},
 		{name: "network state", args: []string{"network", "state"}, wantMethod: "network.state"},
 		{name: "firewall", args: []string{"firewall"}, wantMethod: "network.firewall"},

--- a/cmd/spectra/metrics.go
+++ b/cmd/spectra/metrics.go
@@ -15,6 +15,9 @@ import (
 )
 
 func runMetrics(args []string) int {
+	if len(args) > 0 && args[0] == "churn" {
+		return runMetricsChurn(args[1:])
+	}
 	fs := flag.NewFlagSet("spectra metrics", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON")
@@ -48,6 +51,125 @@ func runMetrics(args []string) int {
 		return 2
 	}
 	return printMetricsForPID(ctx, db, pid, *limit, *asJSON)
+}
+
+func runMetricsChurn(args []string) int {
+	fs := flag.NewFlagSet("spectra metrics churn", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON")
+	limit := fs.Int("n", 60, "Number of stored rows to show")
+	top := fs.Int("top", 0, "Limit summary to the top N apps by spawns")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if fs.NArg() > 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra metrics churn [--json] [--top N] [app-path]")
+		return 2
+	}
+	if fs.NArg() == 1 {
+		return printChurnForApp(ctx, db, fs.Arg(0), *limit, *asJSON)
+	}
+	return printChurnSummary(ctx, db, *limit, *top, *asJSON)
+}
+
+func printChurnSummary(ctx context.Context, db *store.DB, limit, top int, asJSON bool) int {
+	rows, err := db.GetAllAppChurn(ctx, limit)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(os.Stderr, "no app churn stored — start `spectra serve` to collect churn metrics")
+		return 0
+	}
+	latest := latestChurnByApp(rows)
+	if top > 0 && len(latest) > top {
+		latest = latest[:top]
+	}
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(latest)
+		return 0
+	}
+	fmt.Printf("%-6s  %-6s  %-8s  %-20s  %s\n", "SPAWN", "EXIT", "FAILED", "MINUTE", "APP")
+	fmt.Println(strings.Repeat("-", 86))
+	for _, row := range latest {
+		fmt.Printf("%-6d  %-6d  %-8d  %-20s  %s\n",
+			row.Spawns, row.Exits, row.FailedSpawns,
+			row.MinuteAt.UTC().Format("2006-01-02T15:04Z"),
+			row.AppPath,
+		)
+	}
+	return 0
+}
+
+func printChurnForApp(ctx context.Context, db *store.DB, appPath string, limit int, asJSON bool) int {
+	rows, err := db.GetAppChurn(ctx, appPath, limit)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(rows) == 0 {
+		fmt.Fprintf(os.Stderr, "no churn metrics for %s\n", appPath)
+		return 0
+	}
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(rows)
+		return 0
+	}
+	fmt.Printf("churn for %s (newest first)\n", appPath)
+	fmt.Printf("%-20s  %-6s  %-6s  %s\n", "MINUTE", "SPAWN", "EXIT", "FAILED")
+	fmt.Println(strings.Repeat("-", 48))
+	for _, row := range rows {
+		fmt.Printf("%-20s  %-6d  %-6d  %d\n",
+			row.MinuteAt.UTC().Format("2006-01-02T15:04Z"),
+			row.Spawns, row.Exits, row.FailedSpawns,
+		)
+	}
+	return 0
+}
+
+func latestChurnByApp(rows []store.AppChurnRow) []store.AppChurnRow {
+	byApp := make(map[string]store.AppChurnRow)
+	for _, row := range rows {
+		if _, seen := byApp[row.AppPath]; !seen {
+			byApp[row.AppPath] = row
+		}
+	}
+	out := make([]store.AppChurnRow, 0, len(byApp))
+	for _, row := range byApp {
+		out = append(out, row)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Spawns != out[j].Spawns {
+			return out[i].Spawns > out[j].Spawns
+		}
+		if out[i].Exits != out[j].Exits {
+			return out[i].Exits > out[j].Exits
+		}
+		if out[i].FailedSpawns != out[j].FailedSpawns {
+			return out[i].FailedSpawns > out[j].FailedSpawns
+		}
+		return out[i].AppPath < out[j].AppPath
+	})
+	return out
 }
 
 func printMetricsSummary(ctx context.Context, db *store.DB, limit int, asJSON bool) int {

--- a/cmd/spectra/metrics_test.go
+++ b/cmd/spectra/metrics_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+func TestLatestChurnByAppSortsBySpawns(t *testing.T) {
+	at := time.Date(2026, 5, 6, 15, 4, 0, 0, time.UTC)
+	rows := []store.AppChurnRow{
+		{MinuteAt: at, AppPath: "/Applications/Slow.app", Spawns: 1},
+		{MinuteAt: at, AppPath: "/Applications/Busy.app", Spawns: 7},
+		{MinuteAt: at.Add(-time.Minute), AppPath: "/Applications/Busy.app", Spawns: 99},
+	}
+	got := latestChurnByApp(rows)
+	if len(got) != 2 {
+		t.Fatalf("rows = %d, want 2", len(got))
+	}
+	if got[0].AppPath != "/Applications/Busy.app" || got[0].Spawns != 7 {
+		t.Fatalf("top row = %+v", got[0])
+	}
+}

--- a/cmd/spectra/serve.go
+++ b/cmd/spectra/serve.go
@@ -41,6 +41,7 @@ func runServe(args []string) int {
 	autoSnapMode := fs.String("autosnap", "on", "Rolling auto snapshots: on or off")
 	autoSnapInterval := fs.Duration("autosnap-interval", serve.DefaultAutoSnapInterval, "Interval for rolling auto snapshots")
 	autoSnapRetain := fs.Int("autosnap-retain", serve.DefaultAutoSnapRetain, "Number of auto snapshots to retain per host")
+	trackSpawnFailures := fs.Bool("track-spawn-failures", false, "Track posix_spawn/fork failures with log stream")
 	daemon := fs.Bool("daemon", false, "Start spectra serve in the background and return")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -90,14 +91,15 @@ func runServe(args []string) int {
 		defer closeLog()
 	}
 	printServeStartup(os.Stderr, serveStartupStatus{
-		Sock:           sock,
-		LogPath:        resolvedLogPath,
-		TCPAddr:        *tcpAddr,
-		AllowRemote:    *allowRemote,
-		TsnetEnabled:   *tsnetEnabled,
-		TsnetAddr:      *tsnetAddr,
-		ArtifactPolicy: policy,
-		AutoSnap:       autoSnap,
+		Sock:               sock,
+		LogPath:            resolvedLogPath,
+		TCPAddr:            *tcpAddr,
+		AllowRemote:        *allowRemote,
+		TsnetEnabled:       *tsnetEnabled,
+		TsnetAddr:          *tsnetAddr,
+		ArtifactPolicy:     policy,
+		AutoSnap:           autoSnap,
+		TrackSpawnFailures: *trackSpawnFailures,
 	})
 
 	var detectStore *cache.ShardedStore
@@ -105,21 +107,22 @@ func runServe(args []string) int {
 		detectStore = cacheStores.Detect
 	}
 	if err := serve.Run(ctx, serve.Options{
-		SockPath:         sock,
-		TCPAddr:          *tcpAddr,
-		TsnetEnabled:     *tsnetEnabled,
-		TsnetAddr:        *tsnetAddr,
-		TsnetHostname:    *tsnetHostname,
-		TsnetStateDir:    *tsnetStateDir,
-		TsnetEphemeral:   *tsnetEphemeral,
-		TsnetTags:        splitCommaList(*tsnetTags),
-		TsnetAllowLogins: splitCommaList(*tsnetAllowLogins),
-		TsnetAllowNodes:  splitCommaList(*tsnetAllowNodes),
-		SpectraVersion:   version,
-		DetectStore:      detectStore,
-		ArtifactPolicy:   policy,
-		Logger:           daemonLog,
-		AutoSnap:         autoSnap,
+		SockPath:           sock,
+		TCPAddr:            *tcpAddr,
+		TsnetEnabled:       *tsnetEnabled,
+		TsnetAddr:          *tsnetAddr,
+		TsnetHostname:      *tsnetHostname,
+		TsnetStateDir:      *tsnetStateDir,
+		TsnetEphemeral:     *tsnetEphemeral,
+		TsnetTags:          splitCommaList(*tsnetTags),
+		TsnetAllowLogins:   splitCommaList(*tsnetAllowLogins),
+		TsnetAllowNodes:    splitCommaList(*tsnetAllowNodes),
+		SpectraVersion:     version,
+		DetectStore:        detectStore,
+		ArtifactPolicy:     policy,
+		Logger:             daemonLog,
+		AutoSnap:           autoSnap,
+		TrackSpawnFailures: *trackSpawnFailures,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -128,14 +131,15 @@ func runServe(args []string) int {
 }
 
 type serveStartupStatus struct {
-	Sock           string
-	LogPath        string
-	TCPAddr        string
-	AllowRemote    bool
-	TsnetEnabled   bool
-	TsnetAddr      string
-	ArtifactPolicy artifact.Policy
-	AutoSnap       serve.AutoSnapConfig
+	Sock               string
+	LogPath            string
+	TCPAddr            string
+	AllowRemote        bool
+	TsnetEnabled       bool
+	TsnetAddr          string
+	ArtifactPolicy     artifact.Policy
+	AutoSnap           serve.AutoSnapConfig
+	TrackSpawnFailures bool
 }
 
 func printServeStartup(w io.Writer, status serveStartupStatus) {
@@ -158,6 +162,9 @@ func printServeStartup(w io.Writer, status serveStartupStatus) {
 		fmt.Fprintln(w, "spectra serve: autosnap off")
 	} else {
 		fmt.Fprintf(w, "spectra serve: autosnap every %s, retain %d\n", autoSnap.Interval, autoSnap.Retain)
+	}
+	if status.TrackSpawnFailures {
+		fmt.Fprintln(w, "spectra serve: spawn failure watcher on")
 	}
 	fmt.Fprintf(w, "spectra serve: artifact policy %s\n", status.ArtifactPolicy.Normalize().Mode)
 }

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -13,19 +13,27 @@ fork cost twice.
 | Source | Output | Privilege | Cost | Used by |
 |---|---|---|---|---|
 | `ps -axwwo pid,ppid,pcpu,rss,vsz,uid,user,lstart,command` | full process table | user | ~30ms / call | `process.CollectAll`, snapshots, daemon ring buffer |
+| `log stream --predicate 'eventMessage CONTAINS "posix_spawn" AND eventMessage CONTAINS "failed"' --info --style ndjson` | failed `posix_spawn` proxy events | user | streaming, opt-in | `process.churn` failed-spawn counts |
 | `proc_pidinfo(PROC_PIDTASKALLINFO)` + `proc_pidpath` | per-process thread count, BSD name, executable path | user | microseconds / process | `process.CollectAll`, snapshots |
 | `libproc` (cgo) | richer per-process: fd count, region info | user | ~per-process | future expansion |
 | `top -l 1 -n 10 -o power -stats pid,power,command` | flat per-process energy attribution | user | ~200ms | `power.energy_top_users` |
 | `sample <pid> 1` | one-second user-space sample, kernel sample optional | user (own procs); root (others) | ~1s + binding cost | `spectra sample` |
 
 `ps` is still the base inventory source for snapshots, `spectra process`,
-and the daemon's ~1Hz metrics sampler. Darwin builds enrich those rows
-with direct libproc calls for fields that are cheap and structured.
+the daemon's ~1Hz metrics sampler, and the per-app churn tracker. Darwin builds
+enrich those rows with direct libproc calls for fields that are cheap and structured.
 `--deep` process scans add one batched `lsof -p pid1,pid2,...` call to
 populate open file descriptor counts, listening ports, and outbound
 remote addresses. The natural upgrade path is expanding the direct
 `libproc` / `proc_pidinfo` coverage, which would eliminate more fork cost
 and add richer per-process detail.
+
+The failed-spawn side of churn is off by default because `log stream` is a
+long-running process with measurable overhead. When enabled with
+`spectra serve --track-spawn-failures`, Spectra treats unified log
+`posix_spawn` failure messages as a proxy for failed child creation. App
+attribution depends on the log payload containing a recognizable `.app` path;
+entries without one are ignored rather than guessed.
 
 ## File and disk activity
 

--- a/docs/inspection/process-profiling.md
+++ b/docs/inspection/process-profiling.md
@@ -8,6 +8,7 @@ This page covers four related workflows:
 
 - point-in-time samples with `sample`
 - process trees and app-scoped child process attribution
+- per-app child-process churn
 - daemon-backed process history
 - CPU and RSS trend interpretation
 
@@ -18,6 +19,7 @@ Start with the cheapest view and escalate only when the question needs it:
 ```bash
 spectra process --deep
 spectra connect local process-tree /Applications/Slack.app
+spectra connect local metrics churn --top 10
 spectra connect local metrics
 spectra connect local metrics 4012 120
 spectra connect local sample 4012 5 1
@@ -39,6 +41,39 @@ This keeps the same process inventory but splits open descriptors into ptys,
 sockets, regular files, pipes, character devices, kqueues, and other handles.
 The JSON output includes `fd_breakdown` automatically whenever `--deep`
 populates descriptor data.
+
+## Process churn
+
+The daemon tracks per-app child process churn alongside process metrics. Every
+tick compares the current `process.CollectAll` table with the previous one,
+using PID plus process start time to avoid hiding PID reuse. The current churn
+view is exposed over RPC:
+
+```bash
+spectra connect local metrics churn --top 10
+spectra connect local metrics churn /Applications/Claude.app
+```
+
+The local stored view reads the one-minute SQLite aggregates flushed by the
+daemon:
+
+```bash
+spectra metrics churn --top 10
+spectra metrics churn /Applications/Claude.app
+```
+
+Use churn when an app is suspected of a respawn loop: high `spawns_1m` and
+matching `exits_1m` mean helpers are cycling even if RSS and CPU look normal in
+any single sample. The daemon also has an opt-in failed-spawn proxy:
+
+```bash
+spectra serve --track-spawn-failures
+```
+
+That watcher tails unified logs for `posix_spawn` failures and attributes
+events to an app path when the log entry includes one. Some macOS log entries
+only name a process or subsystem, so failed-spawn attribution is best-effort
+and may undercount or omit the originating app.
 
 ## Samples
 

--- a/docs/operations/daemon.md
+++ b/docs/operations/daemon.md
@@ -86,7 +86,8 @@ JSON-RPC 2.0 methods, organized by concern:
   `snapshot.diff`, `snapshot.processes`, `snapshot.login_items`,
   `snapshot.granted_perms`, `snapshot.prune`
 - **Live state** — `live.current`, `live.history`, `process.live`,
-  `process.history`, `process.list`, `process.tree`, `process.sample`
+  `process.history`, `process.churn`, `process.list`, `process.tree`,
+  `process.sample`
 - **Helper** — `helper.health`, `helper.powermetrics.sample`,
   `helper.tcc.system.query`, `helper.firewall.rules`,
   `helper.fs_usage.start`, `helper.fs_usage.stop`,

--- a/internal/serve/churn.go
+++ b/internal/serve/churn.go
@@ -1,0 +1,497 @@
+package serve
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+const churnRetainWindow = 30 * time.Minute
+
+// AppChurnSample captures per-app child process churn for one daemon tick.
+type AppChurnSample struct {
+	AppPath        string    `json:"app_path"`
+	Timestamp      time.Time `json:"timestamp"`
+	ChildrenCount  int       `json:"children_count"`
+	Spawns1s       int       `json:"spawns_1s"`
+	Exits1s        int       `json:"exits_1s"`
+	Spawns1m       int       `json:"spawns_1m"`
+	Exits1m        int       `json:"exits_1m"`
+	FailedSpawns1m int       `json:"failed_spawns_1m"`
+
+	failedSpawns1s int
+}
+
+type appChurnAggregate struct {
+	MinuteAt     time.Time
+	AppPath      string
+	Spawns       int
+	Exits        int
+	FailedSpawns int
+}
+
+type processIdentity struct {
+	PID       int
+	PPID      int
+	AppPath   string
+	StartTime time.Time
+}
+
+type spawnFailureCounter interface {
+	CountsSince(cutoff time.Time) map[string]int
+}
+
+type churnTracker struct {
+	mu       sync.Mutex
+	prev     map[int]processIdentity
+	history  []AppChurnSample
+	failures spawnFailureCounter
+	lastTick time.Time
+}
+
+func newChurnTracker(failures spawnFailureCounter) *churnTracker {
+	return &churnTracker{
+		prev:     make(map[int]processIdentity),
+		failures: failures,
+	}
+}
+
+func (c *churnTracker) tick(now time.Time, current []process.Info) []AppChurnSample {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	currentByPID := make(map[int]processIdentity, len(current))
+	childrenByApp := make(map[string]int)
+	for _, p := range current {
+		id := processIdentity{PID: p.PID, PPID: p.PPID, AppPath: p.AppPath, StartTime: p.StartTime}
+		currentByPID[p.PID] = id
+		if p.AppPath != "" {
+			childrenByApp[p.AppPath]++
+		}
+	}
+
+	spawnsByApp := make(map[string]int)
+	exitsByApp := make(map[string]int)
+	for pid, cur := range currentByPID {
+		prev, existed := c.prev[pid]
+		if !existed {
+			incrementApp(spawnsByApp, cur.AppPath)
+			continue
+		}
+		if processStartChanged(prev.StartTime, cur.StartTime) {
+			incrementApp(exitsByApp, prev.AppPath)
+			incrementApp(spawnsByApp, cur.AppPath)
+		}
+	}
+	for pid, prev := range c.prev {
+		if _, still := currentByPID[pid]; !still {
+			incrementApp(exitsByApp, prev.AppPath)
+		}
+	}
+
+	oneMinuteAgo := now.Add(-time.Minute)
+	failed1m := c.failureCounts(oneMinuteAgo)
+	failed1s := map[string]int{}
+	if !c.lastTick.IsZero() {
+		failed1s = c.failureCounts(c.lastTick)
+	}
+
+	apps := unionApps(childrenByApp, spawnsByApp, exitsByApp, failed1m)
+	samples := make([]AppChurnSample, 0, len(apps))
+	for _, app := range apps {
+		s := AppChurnSample{
+			AppPath:        app,
+			Timestamp:      now,
+			ChildrenCount:  childrenByApp[app],
+			Spawns1s:       spawnsByApp[app],
+			Exits1s:        exitsByApp[app],
+			Spawns1m:       spawnsByApp[app],
+			Exits1m:        exitsByApp[app],
+			FailedSpawns1m: failed1m[app],
+			failedSpawns1s: failed1s[app],
+		}
+		samples = append(samples, s)
+	}
+
+	c.history = append(c.history, samples...)
+	c.trimLocked(now.Add(-churnRetainWindow))
+	c.applyRollingLocked(oneMinuteAgo, samples)
+	c.prev = currentByPID
+	c.lastTick = now
+	return append([]AppChurnSample(nil), samples...)
+}
+
+func (c *churnTracker) current(limit int) []AppChurnSample {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	latest := make(map[string]AppChurnSample)
+	for i := len(c.history) - 1; i >= 0; i-- {
+		s := c.history[i]
+		if _, seen := latest[s.AppPath]; !seen {
+			latest[s.AppPath] = s
+		}
+	}
+	out := make([]AppChurnSample, 0, len(latest))
+	for _, s := range latest {
+		out = append(out, s)
+	}
+	sortChurnSamples(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func (c *churnTracker) recent(appPath string, limit int) []AppChurnSample {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []AppChurnSample
+	for _, s := range c.history {
+		if appPath == "" || s.AppPath == appPath {
+			out = append(out, s)
+		}
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[len(out)-limit:]
+	}
+	return append([]AppChurnSample(nil), out...)
+}
+
+func (c *churnTracker) flushAggregates(retainWindow time.Duration) []appChurnAggregate {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if retainWindow <= 0 {
+		retainWindow = churnRetainWindow
+	}
+	cutoff := time.Now().UTC().Add(-retainWindow)
+	c.trimLocked(cutoff)
+	type key struct {
+		app    string
+		minute time.Time
+	}
+	groups := make(map[key]*appChurnAggregate)
+	for _, s := range c.history {
+		k := key{app: s.AppPath, minute: s.Timestamp.UTC().Truncate(time.Minute)}
+		agg := groups[k]
+		if agg == nil {
+			agg = &appChurnAggregate{MinuteAt: k.minute, AppPath: k.app}
+			groups[k] = agg
+		}
+		agg.Spawns += s.Spawns1s
+		agg.Exits += s.Exits1s
+		agg.FailedSpawns += s.failedSpawns1s
+	}
+	out := make([]appChurnAggregate, 0, len(groups))
+	for _, agg := range groups {
+		out = append(out, *agg)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].MinuteAt.Equal(out[j].MinuteAt) {
+			return out[i].AppPath < out[j].AppPath
+		}
+		return out[i].MinuteAt.Before(out[j].MinuteAt)
+	})
+	return out
+}
+
+func (c *churnTracker) applyRollingLocked(cutoff time.Time, samples []AppChurnSample) {
+	for i := range samples {
+		app := samples[i].AppPath
+		for _, prev := range c.history {
+			if prev.AppPath != app || prev.Timestamp.Before(cutoff) || prev.Timestamp.Equal(samples[i].Timestamp) {
+				continue
+			}
+			samples[i].Spawns1m += prev.Spawns1s
+			samples[i].Exits1m += prev.Exits1s
+		}
+	}
+	start := len(c.history) - len(samples)
+	for i, s := range samples {
+		c.history[start+i] = s
+	}
+}
+
+func (c *churnTracker) trimLocked(cutoff time.Time) {
+	keepFrom := 0
+	for keepFrom < len(c.history) && c.history[keepFrom].Timestamp.Before(cutoff) {
+		keepFrom++
+	}
+	if keepFrom > 0 {
+		copy(c.history, c.history[keepFrom:])
+		c.history = c.history[:len(c.history)-keepFrom]
+	}
+}
+
+func (c *churnTracker) failureCounts(cutoff time.Time) map[string]int {
+	if c.failures == nil {
+		return nil
+	}
+	return c.failures.CountsSince(cutoff)
+}
+
+func processStartChanged(prev, cur time.Time) bool {
+	if prev.IsZero() || cur.IsZero() {
+		return false
+	}
+	return !prev.Equal(cur)
+}
+
+func incrementApp(m map[string]int, appPath string) {
+	if appPath != "" {
+		m[appPath]++
+	}
+}
+
+func unionApps(maps ...map[string]int) []string {
+	set := make(map[string]struct{})
+	for _, m := range maps {
+		for app := range m {
+			if app != "" {
+				set[app] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for app := range set {
+		out = append(out, app)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortChurnSamples(samples []AppChurnSample) {
+	sort.Slice(samples, func(i, j int) bool {
+		if samples[i].Spawns1m != samples[j].Spawns1m {
+			return samples[i].Spawns1m > samples[j].Spawns1m
+		}
+		if samples[i].Exits1m != samples[j].Exits1m {
+			return samples[i].Exits1m > samples[j].Exits1m
+		}
+		if samples[i].FailedSpawns1m != samples[j].FailedSpawns1m {
+			return samples[i].FailedSpawns1m > samples[j].FailedSpawns1m
+		}
+		return samples[i].AppPath < samples[j].AppPath
+	})
+}
+
+type spawnFailureEvent struct {
+	AppPath string
+	At      time.Time
+}
+
+type spawnFailureWatcher struct {
+	mu     sync.Mutex
+	events []spawnFailureEvent
+	run    func(context.Context, func(...spawnFailureEvent)) error
+}
+
+func newSpawnFailureWatcher() *spawnFailureWatcher {
+	w := &spawnFailureWatcher{}
+	w.run = w.runLogStream
+	return w
+}
+
+func (w *spawnFailureWatcher) Start(ctx context.Context) {
+	backoff := time.Second
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		err := w.run(ctx, w.add)
+		if err == nil {
+			backoff = time.Second
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 5*time.Second {
+			backoff *= 2
+			if backoff > 5*time.Second {
+				backoff = 5 * time.Second
+			}
+		}
+	}
+}
+
+func (w *spawnFailureWatcher) CountsSince(cutoff time.Time) map[string]int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.trimLocked(cutoff.Add(-time.Minute))
+	out := make(map[string]int)
+	for _, event := range w.events {
+		if !event.At.Before(cutoff) && event.AppPath != "" {
+			out[event.AppPath]++
+		}
+	}
+	return out
+}
+
+func (w *spawnFailureWatcher) add(events ...spawnFailureEvent) {
+	w.mu.Lock()
+	w.events = append(w.events, events...)
+	w.trimLocked(time.Now().UTC().Add(-churnRetainWindow))
+	w.mu.Unlock()
+}
+
+func (w *spawnFailureWatcher) trimLocked(cutoff time.Time) {
+	keepFrom := 0
+	for keepFrom < len(w.events) && w.events[keepFrom].At.Before(cutoff) {
+		keepFrom++
+	}
+	if keepFrom > 0 {
+		copy(w.events, w.events[keepFrom:])
+		w.events = w.events[:len(w.events)-keepFrom]
+	}
+}
+
+func (w *spawnFailureWatcher) runLogStream(ctx context.Context, emit func(...spawnFailureEvent)) error {
+	cmd := exec.CommandContext(ctx, "log", "stream",
+		"--predicate", `eventMessage CONTAINS "posix_spawn" AND eventMessage CONTAINS "failed"`,
+		"--info", "--style", "ndjson")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if event, ok := parseSpawnFailureLogLine(scanner.Bytes(), time.Now().UTC()); ok {
+			emit(event)
+		}
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		_ = cmd.Wait()
+		return scanErr
+	}
+	return cmd.Wait()
+}
+
+func parseSpawnFailureLogLine(raw []byte, fallback time.Time) (spawnFailureEvent, bool) {
+	var entry map[string]any
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return spawnFailureEvent{}, false
+	}
+	app := appPathFromLogEntry(entry)
+	if app == "" {
+		return spawnFailureEvent{}, false
+	}
+	at := fallback
+	for _, key := range []string{"timestamp", "date", "machTimestamp"} {
+		if v, ok := entry[key].(string); ok {
+			if parsed, err := time.Parse(time.RFC3339Nano, v); err == nil {
+				at = parsed.UTC()
+				break
+			}
+		}
+	}
+	return spawnFailureEvent{AppPath: app, At: at}, true
+}
+
+func appPathFromLogEntry(entry map[string]any) string {
+	for _, key := range []string{"processImagePath", "senderImagePath", "process", "sender", "eventMessage"} {
+		if v, ok := entry[key].(string); ok {
+			if app := extractAppPath(v); app != "" {
+				return app
+			}
+		}
+	}
+	return ""
+}
+
+func extractAppPath(raw string) string {
+	idx := strings.Index(raw, ".app")
+	if idx < 0 {
+		return ""
+	}
+	end := idx + len(".app")
+	start := strings.LastIndex(raw[:end], "/")
+	for start > 0 {
+		prefix := raw[start:end]
+		if strings.HasPrefix(prefix, "/Applications/") || strings.HasPrefix(prefix, "/System/Applications/") {
+			return prefix
+		}
+		next := strings.LastIndex(raw[:start], "/")
+		if next < 0 {
+			break
+		}
+		start = next
+	}
+	return raw[:end]
+}
+
+func churnLoop(ctx context.Context, tracker *churnTracker, interval time.Duration, collect func(context.Context) []process.Info) {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	if collect == nil {
+		cache := &appPathCache{refreshEvery: 5 * time.Minute}
+		collect = func(ctx context.Context) []process.Info {
+			return process.CollectAll(ctx, process.CollectOptions{BundlePaths: cache.paths(time.Now())})
+		}
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			tracker.tick(now.UTC(), collect(ctx))
+		}
+	}
+}
+
+type appPathCache struct {
+	mu           sync.Mutex
+	refreshEvery time.Duration
+	nextRefresh  time.Time
+	appPaths     []string
+}
+
+func (c *appPathCache) paths(now time.Time) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.appPaths != nil && now.Before(c.nextRefresh) {
+		return append([]string(nil), c.appPaths...)
+	}
+	c.appPaths = scanInstalledAppPaths()
+	if c.refreshEvery <= 0 {
+		c.refreshEvery = 5 * time.Minute
+	}
+	c.nextRefresh = now.Add(c.refreshEvery)
+	return append([]string(nil), c.appPaths...)
+}
+
+func scanInstalledAppPaths() []string {
+	var paths []string
+	for _, root := range []string{"/Applications", "/Applications/Utilities"} {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() && strings.HasSuffix(entry.Name(), ".app") {
+				paths = append(paths, filepath.Join(root, entry.Name()))
+			}
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}

--- a/internal/serve/churn_test.go
+++ b/internal/serve/churn_test.go
@@ -1,0 +1,134 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+func TestChurnTickCountsSpawnAndExit(t *testing.T) {
+	tracker := newChurnTracker(nil)
+	base := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	app := "/Applications/Foo.app"
+
+	tracker.tick(base, []process.Info{
+		procInfo(10, 1, app, base.Add(-time.Minute)),
+		procInfo(11, 10, app, base.Add(-time.Minute)),
+	})
+	got := tracker.tick(base.Add(time.Second), []process.Info{
+		procInfo(10, 1, app, base.Add(-time.Minute)),
+		procInfo(12, 10, app, base.Add(time.Second)),
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("samples = %d, want 1", len(got))
+	}
+	if got[0].Spawns1s != 1 || got[0].Exits1s != 1 {
+		t.Fatalf("sample = %+v, want Spawns1s=1 Exits1s=1", got[0])
+	}
+	if got[0].ChildrenCount != 2 {
+		t.Fatalf("ChildrenCount = %d, want 2", got[0].ChildrenCount)
+	}
+}
+
+func TestChurnRollingWindowBoundary(t *testing.T) {
+	tracker := newChurnTracker(nil)
+	base := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	app := "/Applications/Foo.app"
+	var last []AppChurnSample
+	for i := 0; i < 70; i++ {
+		at := base.Add(time.Duration(i) * time.Second)
+		last = tracker.tick(at, []process.Info{procInfo(100+i, 1, app, at)})
+	}
+	if len(last) != 1 {
+		t.Fatalf("samples = %d, want 1", len(last))
+	}
+	if last[0].Spawns1m != 61 {
+		t.Fatalf("Spawns1m = %d, want 61 across inclusive 60s window", last[0].Spawns1m)
+	}
+	if last[0].Exits1m != 61 {
+		t.Fatalf("Exits1m = %d, want 61", last[0].Exits1m)
+	}
+}
+
+func TestChurnPIDReuseAfterExitCountsExitThenSpawn(t *testing.T) {
+	tracker := newChurnTracker(nil)
+	base := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	app := "/Applications/Foo.app"
+
+	tracker.tick(base, []process.Info{procInfo(42, 1, app, base.Add(-time.Minute))})
+	exit := tracker.tick(base.Add(time.Second), nil)
+	spawn := tracker.tick(base.Add(2*time.Second), []process.Info{procInfo(42, 1, app, base.Add(2*time.Second))})
+
+	if len(exit) != 1 || exit[0].Exits1s != 1 {
+		t.Fatalf("exit sample = %+v, want one exit", exit)
+	}
+	if len(spawn) != 1 || spawn[0].Spawns1s != 1 {
+		t.Fatalf("spawn sample = %+v, want one spawn", spawn)
+	}
+}
+
+func TestSpawnFailureWatcherRestartsRunner(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var calls int32
+	watcher := &spawnFailureWatcher{}
+	watcher.run = func(context.Context, func(...spawnFailureEvent)) error {
+		call := atomic.AddInt32(&calls, 1)
+		if call == 1 {
+			return errors.New("stream died")
+		}
+		cancel()
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		watcher.Start(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not restart within 2s")
+	}
+	if atomic.LoadInt32(&calls) < 2 {
+		t.Fatalf("run calls = %d, want at least 2", calls)
+	}
+}
+
+func TestParseSpawnFailureLogLineExtractsAppPath(t *testing.T) {
+	raw := []byte(`{"timestamp":"2026-05-04T12:00:00Z","processImagePath":"/Applications/Foo.app/Contents/MacOS/Foo","eventMessage":"posix_spawn failed"}`)
+	event, ok := parseSpawnFailureLogLine(raw, time.Date(2026, 5, 4, 12, 1, 0, 0, time.UTC))
+	if !ok {
+		t.Fatal("parseSpawnFailureLogLine returned !ok")
+	}
+	if event.AppPath != "/Applications/Foo.app" {
+		t.Fatalf("AppPath = %q, want /Applications/Foo.app", event.AppPath)
+	}
+	if !event.At.Equal(time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("At = %s", event.At)
+	}
+}
+
+func BenchmarkChurnTick(b *testing.B) {
+	tracker := newChurnTracker(nil)
+	base := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	procs := make([]process.Info, 200)
+	for i := range procs {
+		procs[i] = procInfo(1000+i, 1, "/Applications/Foo.app", base.Add(-time.Minute))
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tracker.tick(base.Add(time.Duration(i)*time.Second), procs)
+	}
+}
+
+func procInfo(pid, ppid int, app string, start time.Time) process.Info {
+	return process.Info{PID: pid, PPID: ppid, AppPath: app, StartTime: start}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -58,26 +58,27 @@ func DefaultSockPath() (string, error) {
 
 // Options configures the daemon.
 type Options struct {
-	SockPath         string
-	TCPAddr          string
-	TsnetEnabled     bool
-	TsnetAddr        string
-	TsnetHostname    string
-	TsnetStateDir    string
-	TsnetEphemeral   bool
-	TsnetTags        []string
-	TsnetAllowLogins []string
-	TsnetAllowNodes  []string
-	TsnetFactory     TsnetFactory
-	SpectraVersion   string
-	DBPath           string              // empty = store.DefaultPath()
-	CacheRegistry    *cache.Registry     // nil = cache.Default
-	DetectStore      *cache.ShardedStore // nil = no detect caching
-	DetectWriter     *cache.AsyncWriter  // nil = sync writes or daemon-created writer
-	ArtifactRecorder artifact.Recorder   // nil = default per-user manifest
-	ArtifactPolicy   artifact.Policy     // empty = confirm per sensitive artifact
-	Logger           logger.Logger       // nil = discard
-	AutoSnap         AutoSnapConfig
+	SockPath           string
+	TCPAddr            string
+	TsnetEnabled       bool
+	TsnetAddr          string
+	TsnetHostname      string
+	TsnetStateDir      string
+	TsnetEphemeral     bool
+	TsnetTags          []string
+	TsnetAllowLogins   []string
+	TsnetAllowNodes    []string
+	TsnetFactory       TsnetFactory
+	SpectraVersion     string
+	DBPath             string              // empty = store.DefaultPath()
+	CacheRegistry      *cache.Registry     // nil = cache.Default
+	DetectStore        *cache.ShardedStore // nil = no detect caching
+	DetectWriter       *cache.AsyncWriter  // nil = sync writes or daemon-created writer
+	ArtifactRecorder   artifact.Recorder   // nil = default per-user manifest
+	ArtifactPolicy     artifact.Policy     // empty = confirm per sensitive artifact
+	Logger             logger.Logger       // nil = discard
+	AutoSnap           AutoSnapConfig
+	TrackSpawnFailures bool
 }
 
 const DefaultTsnetAddr = ":7878"
@@ -210,13 +211,21 @@ func runDaemon(ctx context.Context, log logger.Logger, opts Options, listeners [
 	log.Info("daemon storage ready", "db", dbPath)
 
 	collector := metrics.NewCollector()
+	var failures *spawnFailureWatcher
+	if opts.TrackSpawnFailures {
+		failures = newSpawnFailureWatcher()
+		go failures.Start(ctx)
+		log.Info("daemon spawn failure watcher enabled", "source", "log stream")
+	}
+	churn := newChurnTracker(failures)
 	liveTelemetry := telemetry.NewLiveCollector()
 	history := livehistory.NewRing(livehistory.DefaultCapacity)
 	sampler := metrics.NewSampler(collector, time.Second, nil)
 	jvmSampler := jvm.NewTelemetrySampler(liveTelemetry, 5*time.Second, daemonJVMOptions(), nil)
 	go sampler.Run(ctx)
 	go jvmSampler.Run(ctx)
-	go flushMetricsLoop(ctx, collector, db)
+	go churnLoop(ctx, churn, time.Second, nil)
+	go flushMetricsLoop(ctx, collector, churn, db)
 	autoSnap := opts.AutoSnap.normalized()
 	if !autoSnap.Disabled {
 		go snapshotLoop(ctx, opts.SpectraVersion, db, history, autoSnap)
@@ -248,7 +257,7 @@ func runDaemon(ctx context.Context, log logger.Logger, opts Options, listeners [
 	}
 
 	d := rpc.NewDispatcher()
-	registerHandlers(d, opts.SpectraVersion, db, collector, liveTelemetry, history, cacheReg, opts.DetectStore, detectWriter, artifactRecorder, artifactPolicy, log, tsnetStatus, tsNode)
+	registerHandlersWithChurn(d, opts.SpectraVersion, db, collector, churn, liveTelemetry, history, cacheReg, opts.DetectStore, detectWriter, artifactRecorder, artifactPolicy, log, tsnetStatus, tsNode)
 	log.Info("daemon serving", "version", opts.SpectraVersion, "listeners", len(listeners), "artifact_policy", artifactPolicy.Mode)
 
 	go func() {
@@ -426,7 +435,7 @@ func samplesForRuntime(samples []telemetry.LiveSample, runtimeName string) []tel
 
 // flushMetricsLoop writes 1-minute aggregates from the ring buffer to SQLite
 // on a 1-minute tick until ctx is cancelled.
-func flushMetricsLoop(ctx context.Context, c *metrics.Collector, db *store.DB) {
+func flushMetricsLoop(ctx context.Context, c *metrics.Collector, churn *churnTracker, db *store.DB) {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 	for {
@@ -435,24 +444,40 @@ func flushMetricsLoop(ctx context.Context, c *metrics.Collector, db *store.DB) {
 			return
 		case <-ticker.C:
 			aggs := c.FlushAggregates(metrics.DefaultRetainWindow)
-			if len(aggs) == 0 {
-				continue
-			}
-			rows := make([]store.ProcessMetricRow, len(aggs))
-			for i, a := range aggs {
-				rows[i] = store.ProcessMetricRow{
-					PID:         a.PID,
-					MinuteAt:    a.MinuteAt,
-					AvgRSSKiB:   a.AvgRSSKiB,
-					MaxRSSKiB:   a.MaxRSSKiB,
-					AvgCPUPct:   a.AvgCPUPct,
-					MaxCPUPct:   a.MaxCPUPct,
-					SampleCount: a.SampleCount,
+			if len(aggs) > 0 {
+				rows := make([]store.ProcessMetricRow, len(aggs))
+				for i, a := range aggs {
+					rows[i] = store.ProcessMetricRow{
+						PID:         a.PID,
+						MinuteAt:    a.MinuteAt,
+						AvgRSSKiB:   a.AvgRSSKiB,
+						MaxRSSKiB:   a.MaxRSSKiB,
+						AvgCPUPct:   a.AvgCPUPct,
+						MaxCPUPct:   a.MaxCPUPct,
+						SampleCount: a.SampleCount,
+					}
 				}
+				_ = db.SaveProcessMetrics(ctx, rows)
 			}
-			_ = db.SaveProcessMetrics(ctx, rows)
+			if churn != nil {
+				_ = db.SaveAppChurn(ctx, appChurnRowsFromAggregates(churn.flushAggregates(metrics.DefaultRetainWindow)))
+			}
 		}
 	}
+}
+
+func appChurnRowsFromAggregates(aggs []appChurnAggregate) []store.AppChurnRow {
+	rows := make([]store.AppChurnRow, len(aggs))
+	for i, a := range aggs {
+		rows[i] = store.AppChurnRow{
+			MinuteAt:     a.MinuteAt,
+			AppPath:      a.AppPath,
+			Spawns:       a.Spawns,
+			Exits:        a.Exits,
+			FailedSpawns: a.FailedSpawns,
+		}
+	}
+	return rows
 }
 
 // snapshotLoop captures lightweight auto snapshots and prunes only the
@@ -488,6 +513,11 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB, history *li
 //
 //gocyclo:ignore
 func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, liveTelemetry *telemetry.LiveCollector, history *livehistory.Ring, cacheReg *cache.Registry, detectStore *cache.ShardedStore, detectWriter *cache.AsyncWriter, artifactRecorder artifact.Recorder, artifactPolicy artifact.Policy, log logger.Logger, tsnetStatus *TsnetStatus, tsnetNode TsnetNode) {
+	registerHandlersWithChurn(d, version, db, collector, nil, liveTelemetry, history, cacheReg, detectStore, detectWriter, artifactRecorder, artifactPolicy, log, tsnetStatus, tsnetNode)
+}
+
+//gocyclo:ignore
+func registerHandlersWithChurn(d *rpc.Dispatcher, version string, db *store.DB, collector *metrics.Collector, churn *churnTracker, liveTelemetry *telemetry.LiveCollector, history *livehistory.Ring, cacheReg *cache.Registry, detectStore *cache.ShardedStore, detectWriter *cache.AsyncWriter, artifactRecorder artifact.Recorder, artifactPolicy artifact.Policy, log logger.Logger, tsnetStatus *TsnetStatus, tsnetNode TsnetNode) {
 	if history == nil {
 		history = livehistory.NewRing(livehistory.DefaultCapacity)
 	}
@@ -589,6 +619,26 @@ func registerHandlers(d *rpc.Dispatcher, version string, db *store.DB, collector
 			return nil, fmt.Errorf("process.history requires {\"pid\": <pid>}")
 		}
 		return db.GetProcessMetrics(context.Background(), p.PID, p.Limit)
+	})
+
+	d.Register("process.churn", func(params json.RawMessage) (any, error) {
+		var p struct {
+			AppPath string `json:"app_path"`
+			Limit   int    `json:"limit"`
+			Top     int    `json:"top"`
+		}
+		_ = json.Unmarshal(params, &p)
+		if churn == nil {
+			return []AppChurnSample{}, nil
+		}
+		if p.AppPath != "" {
+			return churn.recent(p.AppPath, p.Limit), nil
+		}
+		limit := p.Top
+		if limit <= 0 {
+			limit = p.Limit
+		}
+		return churn.current(limit), nil
 	})
 
 	d.Register("live.current", func(_ json.RawMessage) (any, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -243,6 +243,17 @@ CREATE TABLE IF NOT EXISTS process_metrics (
 
 CREATE INDEX IF NOT EXISTS idx_process_metrics_pid ON process_metrics(pid, minute_at DESC);
 
+CREATE TABLE IF NOT EXISTS app_churn (
+    ts            DATETIME NOT NULL,
+    app_path      TEXT NOT NULL,
+    spawns        INTEGER NOT NULL DEFAULT 0,
+    exits         INTEGER NOT NULL DEFAULT 0,
+    failed_spawns INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (ts, app_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_churn_app ON app_churn(app_path, ts DESC);
+
 CREATE TABLE IF NOT EXISTS jvm_samples (
     pid          INTEGER NOT NULL,
     at_nano      INTEGER NOT NULL,
@@ -857,6 +868,90 @@ type ProcessMetricRow struct {
 	AvgCPUPct   float64
 	MaxCPUPct   float64
 	SampleCount int
+}
+
+// AppChurnRow is a 1-minute per-app process churn aggregate.
+type AppChurnRow struct {
+	MinuteAt     time.Time `json:"minute_at"`
+	AppPath      string    `json:"app_path"`
+	Spawns       int       `json:"spawns"`
+	Exits        int       `json:"exits"`
+	FailedSpawns int       `json:"failed_spawns"`
+}
+
+// SaveAppChurn upserts 1-minute app churn aggregates.
+func (s *DB) SaveAppChurn(ctx context.Context, rows []AppChurnRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	for _, r := range rows {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO app_churn (ts, app_path, spawns, exits, failed_spawns)
+			VALUES (?,?,?,?,?)
+			ON CONFLICT(ts, app_path) DO UPDATE SET
+			    spawns=excluded.spawns,
+			    exits=excluded.exits,
+			    failed_spawns=excluded.failed_spawns`,
+			r.MinuteAt.UTC().Format(time.RFC3339), r.AppPath, r.Spawns, r.Exits, r.FailedSpawns,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetAppChurn returns newest app churn aggregate rows for appPath.
+func (s *DB) GetAppChurn(ctx context.Context, appPath string, limit int) ([]AppChurnRow, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT ts, app_path, spawns, exits, failed_spawns
+		FROM app_churn WHERE app_path=?
+		ORDER BY ts DESC LIMIT ?`, appPath, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanAppChurnRows(rows)
+}
+
+// GetAllAppChurn returns newest app churn aggregate rows across apps.
+func (s *DB) GetAllAppChurn(ctx context.Context, limit int) ([]AppChurnRow, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT ts, app_path, spawns, exits, failed_spawns
+		FROM app_churn
+		ORDER BY ts DESC LIMIT ?`, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanAppChurnRows(rows)
+}
+
+func scanAppChurnRows(rows *sql.Rows) ([]AppChurnRow, error) {
+	var out []AppChurnRow
+	for rows.Next() {
+		var r AppChurnRow
+		var minuteAt string
+		if err := rows.Scan(&minuteAt, &r.AppPath, &r.Spawns, &r.Exits, &r.FailedSpawns); err != nil {
+			return nil, err
+		}
+		r.MinuteAt, _ = time.Parse(time.RFC3339, minuteAt)
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }
 
 // SaveJVMSamples upserts compact per-PID JVM samples used by trend-aware

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -824,6 +824,51 @@ func TestSaveProcessMetricsUpsertsDuplicateMinute(t *testing.T) {
 	}
 }
 
+func TestSaveAndReadAppChurn(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	minute := time.Date(2026, 5, 6, 15, 4, 0, 0, time.UTC)
+	rows := []AppChurnRow{
+		{MinuteAt: minute, AppPath: "/Applications/Foo.app", Spawns: 3, Exits: 1},
+		{MinuteAt: minute.Add(time.Minute), AppPath: "/Applications/Foo.app", Spawns: 1, Exits: 2, FailedSpawns: 1},
+		{MinuteAt: minute, AppPath: "/Applications/Bar.app", Spawns: 5, Exits: 4, FailedSpawns: 2},
+	}
+	if err := db.SaveAppChurn(ctx, rows); err != nil {
+		t.Fatalf("SaveAppChurn: %v", err)
+	}
+
+	got, err := db.GetAppChurn(ctx, "/Applications/Foo.app", 10)
+	if err != nil {
+		t.Fatalf("GetAppChurn: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("GetAppChurn rows = %d, want 2", len(got))
+	}
+	if got[0].Spawns != 1 || got[0].FailedSpawns != 1 {
+		t.Fatalf("newest Foo row = %+v", got[0])
+	}
+
+	all, err := db.GetAllAppChurn(ctx, 10)
+	if err != nil {
+		t.Fatalf("GetAllAppChurn: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("GetAllAppChurn rows = %d, want 3", len(all))
+	}
+
+	rows[0].Spawns = 7
+	if err := db.SaveAppChurn(ctx, rows[:1]); err != nil {
+		t.Fatalf("SaveAppChurn upsert: %v", err)
+	}
+	got, err = db.GetAppChurn(ctx, "/Applications/Foo.app", 10)
+	if err != nil {
+		t.Fatalf("GetAppChurn after upsert: %v", err)
+	}
+	if got[1].Spawns != 7 {
+		t.Fatalf("upserted row = %+v, want spawns 7", got[1])
+	}
+}
+
 func TestSaveAndGetLoginItems(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
Closes #250

## Summary
- add daemon-side per-app process churn tracking with spawn/exit rolling windows and PID start-time reuse handling
- add opt-in `--track-spawn-failures` unified-log watcher and expose `process.churn` over RPC/connect
- persist 1-minute `app_churn` aggregates and add `spectra metrics churn` local views
- document churn workflows and the `log stream` data source

## Validation
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `gocyclo -over 15 -ignore '_test\\.go$' .`\n- `golangci-lint run`\n- `make docs-validate`\n- `go test ./internal/serve -run '^$' -bench BenchmarkChurnTick -benchmem` (`23136 ns/op`, `18739 B/op`, `7 allocs/op`)\n