### PR TITLE
spectra jvm thread-dump: --json + triage summary with deadlock detection

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -114,11 +115,13 @@ func jvmOptions(ctx context.Context) jvm.CollectOptions {
 func runJVMThreadDump(args []string) int {
 	fs := flag.NewFlagSet("spectra jvm thread-dump", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit the parsed dump and triage summary as JSON")
+	summary := fs.Bool("summary", false, "Print a triage summary (states, categories, deadlocks) instead of the raw dump")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "usage: spectra jvm thread-dump <pid>")
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm thread-dump [--json] [--summary] <pid>")
 		return 2
 	}
 	pid, err := strconv.Atoi(fs.Arg(0))
@@ -149,8 +152,65 @@ func runJVMThreadDump(args []string) int {
 		SizeBytes:   int64(len(data)),
 	})
 
+	if *asJSON || *summary {
+		dump := jvm.ParseThreadDump(string(data), time.Now())
+		sum := jvm.SummarizeThreads(dump)
+		if *asJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(threadDumpReport{Summary: sum, Dump: dump})
+			return 0
+		}
+		printThreadSummary(os.Stdout, pid, sum, dump.Deadlocks)
+		return 0
+	}
+
 	os.Stdout.Write(data)
 	return 0
+}
+
+// threadDumpReport is the JSON shape emitted by `spectra jvm thread-dump --json`.
+type threadDumpReport struct {
+	Summary jvm.ThreadSummary    `json:"summary"`
+	Dump    jvm.ParsedThreadDump `json:"dump"`
+}
+
+func printThreadSummary(w io.Writer, pid int, sum jvm.ThreadSummary, deadlocks []jvm.DeadlockCycle) {
+	fmt.Fprintf(w, "Thread dump for PID %d\n", pid)
+	fmt.Fprintf(w, "  Total:    %d threads (%d daemon, %d virtual)\n", sum.Total, sum.Daemon, sum.Virtual)
+	if len(sum.ByState) > 0 {
+		fmt.Fprintln(w, "  By state:")
+		states := make([]string, 0, len(sum.ByState))
+		for st := range sum.ByState {
+			states = append(states, string(st))
+		}
+		sort.Strings(states)
+		for _, st := range states {
+			fmt.Fprintf(w, "    %-14s %d\n", st, sum.ByState[jvm.ThreadState(st)])
+		}
+	}
+	if len(sum.ByCategory) > 0 {
+		fmt.Fprintln(w, "  By category:")
+		cats := make([]string, 0, len(sum.ByCategory))
+		for c := range sum.ByCategory {
+			cats = append(cats, string(c))
+		}
+		sort.Strings(cats)
+		for _, c := range cats {
+			fmt.Fprintf(w, "    %-14s %d\n", c, sum.ByCategory[jvm.WaitCategory(c)])
+		}
+	}
+	if len(deadlocks) > 0 {
+		fmt.Fprintf(w, "  DEADLOCKS: %d cycle(s) detected\n", len(deadlocks))
+		for i, dc := range deadlocks {
+			fmt.Fprintf(w, "    cycle %d: %s\n", i+1, strings.Join(dc.Threads, " -> "))
+			if len(dc.Locks) > 0 {
+				fmt.Fprintf(w, "      locks: %s\n", strings.Join(dc.Locks, ", "))
+			}
+		}
+	} else {
+		fmt.Fprintln(w, "  Deadlocks: none")
+	}
 }
 
 func runJVMHeapHistogram(args []string) int {

--- a/cmd/spectra/jvm_thread_dump_test.go
+++ b/cmd/spectra/jvm_thread_dump_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+// sampleThreadDump is a minimal jstack-style dump: two application threads plus
+// a Java-level deadlock section, enough to exercise parse -> summarize -> render.
+const sampleThreadDump = `2024-01-01 00:00:00
+Full thread dump OpenJDK 64-Bit Server VM:
+
+"worker-1" #12 daemon prio=5 os_prio=0 tid=0x1 nid=0xa waiting for monitor entry [0x1]
+   java.lang.Thread.State: BLOCKED (on object monitor)
+	at com.example.A.run(A.java:10)
+	- waiting to lock <0x0000000700000001> (a java.lang.Object)
+
+"worker-2" #13 daemon prio=5 os_prio=0 tid=0x2 nid=0xb waiting for monitor entry [0x2]
+   java.lang.Thread.State: BLOCKED (on object monitor)
+	at com.example.B.run(B.java:20)
+	- waiting to lock <0x0000000700000002> (a java.lang.Object)
+
+Found one Java-level deadlock:
+=============================
+"worker-1":
+  waiting to lock monitor 0x1 (object 0x0000000700000001, a java.lang.Object),
+  which is held by "worker-2"
+"worker-2":
+  waiting to lock monitor 0x2 (object 0x0000000700000002, a java.lang.Object),
+  which is held by "worker-1"
+`
+
+func TestThreadDumpSummaryRendersDeadlock(t *testing.T) {
+	dump := jvm.ParseThreadDump(sampleThreadDump, time.Unix(0, 0))
+	sum := jvm.SummarizeThreads(dump)
+
+	if len(dump.Deadlocks) == 0 {
+		t.Fatalf("expected a deadlock cycle to be parsed, got none")
+	}
+	if sum.Total < 2 {
+		t.Fatalf("expected >=2 threads summarized, got %d", sum.Total)
+	}
+
+	var buf bytes.Buffer
+	printThreadSummary(&buf, 4012, sum, dump.Deadlocks)
+	out := buf.String()
+	if !strings.Contains(out, "Thread dump for PID 4012") {
+		t.Fatalf("summary missing header:\n%s", out)
+	}
+	if !strings.Contains(out, "DEADLOCKS:") {
+		t.Fatalf("summary did not surface deadlocks:\n%s", out)
+	}
+}
+
+func TestThreadDumpReportJSONRoundTrip(t *testing.T) {
+	dump := jvm.ParseThreadDump(sampleThreadDump, time.Unix(0, 0))
+	sum := jvm.SummarizeThreads(dump)
+
+	data, err := json.Marshal(threadDumpReport{Summary: sum, Dump: dump})
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	var back threadDumpReport
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if back.Summary.Total != sum.Total {
+		t.Fatalf("round-trip total = %d, want %d", back.Summary.Total, sum.Total)
+	}
+	if len(back.Dump.Deadlocks) != len(dump.Deadlocks) {
+		t.Fatalf("round-trip deadlocks = %d, want %d", len(back.Dump.Deadlocks), len(dump.Deadlocks))
+	}
+}

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -32,7 +32,7 @@ spectra jvm
 spectra jvm --json
 spectra jvm <pid>
 spectra jvm explain [--samples 1] [--interval 1s] <pid>
-spectra jvm thread-dump <pid>
+spectra jvm thread-dump [--json] [--summary] <pid>
 spectra jvm heap-histogram <pid>
 spectra jvm heap-dump [--out <path>] <pid>
 spectra jvm gc-stats [--json] <pid>

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -297,7 +297,7 @@ spectra jvm
 spectra jvm --json
 spectra jvm 4012
 spectra jvm explain --samples 6 --interval 10s 4012
-spectra jvm thread-dump 4012
+spectra jvm thread-dump --summary 4012
 spectra jvm heap-histogram 4012
 spectra jvm heap-dump --out /tmp/app.hprof 4012
 spectra jvm gc-stats --json 4012


### PR DESCRIPTION
Closes #297

Wires the existing, tested thread-dump analysis engine (`ParseThreadDump` / `SummarizeThreads` / deadlock detection, backed by `internal/threadinspect`) into the CLI. Previously `spectra jvm thread-dump` only streamed raw `jcmd Thread.print` text.

## What changed
- `--summary`: triage view — total/daemon/virtual, by-state and by-category counts, and highlighted **deadlock cycles**.
- `--json`: emits `{summary, dump}` (parsed threads + deadlocks) for tooling.
- Default (no flags) is unchanged: raw dump still streamed and cached — no regression.
- `printThreadSummary` takes an `io.Writer` (writer-injection, per repo convention) so it's unit-tested.

## Tests
- New `cmd/spectra/jvm_thread_dump_test.go`: parse → summarize → render over a dump containing a Java-level deadlock, plus JSON round-trip.
- Full suite green locally: `go vet`, `go test ./...`, gocyclo -over 15 all clean.

## Out of scope (follow-ups)
`thread-dump --filter` and `thread-dump diff <a> <b>` / `--samples` timeline — the engine supports both; separate issues.