### PR TITLE
spectra jvm heap-histogram: --json, --suspects ranking, and compare

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/diag"
+	"github.com/kaeawc/spectra/internal/heap"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
@@ -214,19 +215,47 @@ func printThreadSummary(w io.Writer, pid int, sum jvm.ThreadSummary, deadlocks [
 }
 
 func runJVMHeapHistogram(args []string) int {
+	if len(args) > 0 && args[0] == "compare" {
+		return runJVMHeapHistogramCompare(args[1:])
+	}
+
 	fs := flag.NewFlagSet("spectra jvm heap-histogram", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit the parsed histogram and ranked suspects as JSON")
+	suspects := fs.Int("suspects", 0, "Print the top-N largest classes (leak suspects); 0 disables")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() != 1 {
-		fmt.Fprintln(os.Stderr, "usage: spectra jvm heap-histogram <pid>")
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm heap-histogram [--json] [--suspects N] <pid>")
+		fmt.Fprintln(os.Stderr, "       spectra jvm heap-histogram compare [--json] [--suspects N] <before-file> <after-file>")
 		return 2
 	}
 	pid, err := strconv.Atoi(fs.Arg(0))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "invalid PID %q\n", fs.Arg(0))
 		return 2
+	}
+
+	if *asJSON || *suspects > 0 {
+		hist, err := jvm.HeapHistogramSnapshot(pid, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "heap-histogram failed for PID %d: %v\n", pid, err)
+			return 1
+		}
+		limit := *suspects
+		if limit <= 0 {
+			limit = 20
+		}
+		ranked := heap.RankHistogramSuspects(hist, limit)
+		if *asJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(heapHistogramReport{Histogram: hist, Suspects: ranked})
+			return 0
+		}
+		printHeapSuspects(os.Stdout, pid, ranked, hist.Total)
+		return 0
 	}
 
 	data, err := jvm.HeapHistogram(pid, nil)
@@ -237,6 +266,81 @@ func runJVMHeapHistogram(args []string) int {
 
 	os.Stdout.Write(data)
 	return 0
+}
+
+// runJVMHeapHistogramCompare diffs two saved `jcmd GC.class_histogram` captures
+// and ranks the classes that grew the most between them.
+func runJVMHeapHistogramCompare(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm heap-histogram compare", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit deltas and growth suspects as JSON")
+	limit := fs.Int("suspects", 20, "Number of growth suspects to rank")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm heap-histogram compare [--json] [--suspects N] <before-file> <after-file>")
+		return 2
+	}
+	before, err := readHistogramFile(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading %q: %v\n", fs.Arg(0), err)
+		return 1
+	}
+	after, err := readHistogramFile(fs.Arg(1))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading %q: %v\n", fs.Arg(1), err)
+		return 1
+	}
+
+	growth := heap.RankGrowthSuspects(before, after, *limit)
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(heapCompareReport{Deltas: heap.CompareHistograms(before, after), Growth: growth})
+		return 0
+	}
+	printGrowthSuspects(os.Stdout, growth)
+	return 0
+}
+
+func readHistogramFile(path string) (heap.Histogram, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return heap.Histogram{}, err
+	}
+	return heap.ParseHistogram(string(data))
+}
+
+// heapHistogramReport is the JSON shape emitted by `heap-histogram --json`.
+type heapHistogramReport struct {
+	Histogram heap.Histogram `json:"histogram"`
+	Suspects  []heap.Suspect `json:"suspects,omitempty"`
+}
+
+// heapCompareReport is the JSON shape emitted by `heap-histogram compare --json`.
+type heapCompareReport struct {
+	Deltas []heap.HistogramDelta `json:"deltas"`
+	Growth []heap.Suspect        `json:"growth_suspects"`
+}
+
+func printHeapSuspects(w io.Writer, pid int, suspects []heap.Suspect, total heap.ClassEntry) {
+	fmt.Fprintf(w, "Heap histogram for PID %d — %d classes, %d bytes total live\n", pid, total.Instances, total.Bytes)
+	fmt.Fprintf(w, "Top %d largest classes:\n", len(suspects))
+	for i, s := range suspects {
+		fmt.Fprintf(w, "  %2d. %-50s %12d bytes  %10d instances\n", i+1, s.ClassName, s.Bytes, s.Instances)
+	}
+}
+
+func printGrowthSuspects(w io.Writer, suspects []heap.Suspect) {
+	if len(suspects) == 0 {
+		fmt.Fprintln(w, "No positive class growth between the two histograms.")
+		return
+	}
+	fmt.Fprintf(w, "Top %d growth suspects (before -> after):\n", len(suspects))
+	for i, s := range suspects {
+		fmt.Fprintf(w, "  %2d. %-50s +%d bytes  (+%d instances)\n", i+1, s.ClassName, s.DeltaBytes, s.DeltaCount)
+	}
 }
 
 func runJVMHeapDump(args []string) int {

--- a/cmd/spectra/jvm_heap_histogram_test.go
+++ b/cmd/spectra/jvm_heap_histogram_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/heap"
+)
+
+const histBefore = ` num     #instances         #bytes  class name (module)
+-------------------------------------------------------
+   1:            10            1000  [B (java.base@21)
+   2:             5             200  java.lang.String (java.base@21)
+Total           15            1200
+`
+
+const histAfter = ` num     #instances         #bytes  class name (module)
+-------------------------------------------------------
+   1:           100           50000  [B (java.base@21)
+   2:             5             200  java.lang.String (java.base@21)
+Total          105           50200
+`
+
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+func TestHeapHistogramCompareRanksGrowth(t *testing.T) {
+	before, err := readHistogramFile(writeTemp(t, "before.txt", histBefore))
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+	after, err := readHistogramFile(writeTemp(t, "after.txt", histAfter))
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+
+	growth := heap.RankGrowthSuspects(before, after, 10)
+	if len(growth) == 0 {
+		t.Fatalf("expected at least one growth suspect")
+	}
+	// The [B (byte array) class grew the most; it should rank first.
+	if !strings.Contains(growth[0].ClassName, "[B") {
+		t.Fatalf("top growth suspect = %q, want the byte-array class", growth[0].ClassName)
+	}
+	if growth[0].DeltaBytes != 49000 {
+		t.Fatalf("top growth delta bytes = %d, want 49000", growth[0].DeltaBytes)
+	}
+
+	var buf bytes.Buffer
+	printGrowthSuspects(&buf, growth)
+	if !strings.Contains(buf.String(), "growth suspects") {
+		t.Fatalf("render missing header:\n%s", buf.String())
+	}
+}
+
+func TestHeapSuspectsRender(t *testing.T) {
+	hist, err := heap.ParseHistogram(histAfter)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	ranked := heap.RankHistogramSuspects(hist, 5)
+	var buf bytes.Buffer
+	printHeapSuspects(&buf, 4012, ranked, hist.Total)
+	out := buf.String()
+	if !strings.Contains(out, "Heap histogram for PID 4012") {
+		t.Fatalf("missing header:\n%s", out)
+	}
+	if !strings.Contains(out, "largest classes") {
+		t.Fatalf("missing suspects section:\n%s", out)
+	}
+}

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -33,7 +33,8 @@ spectra jvm --json
 spectra jvm <pid>
 spectra jvm explain [--samples 1] [--interval 1s] <pid>
 spectra jvm thread-dump [--json] [--summary] <pid>
-spectra jvm heap-histogram <pid>
+spectra jvm heap-histogram [--json] [--suspects N] <pid>
+spectra jvm heap-histogram compare [--json] [--suspects N] <before-file> <after-file>
 spectra jvm heap-dump [--out <path>] <pid>
 spectra jvm gc-stats [--json] <pid>
 spectra jvm vm-memory [--json] <pid>

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -298,7 +298,7 @@ spectra jvm --json
 spectra jvm 4012
 spectra jvm explain --samples 6 --interval 10s 4012
 spectra jvm thread-dump --summary 4012
-spectra jvm heap-histogram 4012
+spectra jvm heap-histogram --suspects 20 4012
 spectra jvm heap-dump --out /tmp/app.hprof 4012
 spectra jvm gc-stats --json 4012
 spectra jvm vm-memory --json 4012


### PR DESCRIPTION
Closes #299

Wires the tested `internal/heap` engine into the CLI. Previously `heap-histogram` streamed only raw `jcmd GC.class_histogram` text.

## What changed
- `--suspects N <pid>`: top-N largest live classes (leak suspects).
- `--json <pid>`: parsed histogram + ranked suspects.
- `compare [--json] [--suspects N] <before-file> <after-file>`: diff two saved captures and rank growth suspects (`RankGrowthSuspects` / `CompareHistograms`).
- Default `heap-histogram <pid>` unchanged: raw passthrough — no regression.
- Renderers take `io.Writer` for unit testing.

## Tests
- New `cmd/spectra/jvm_heap_histogram_test.go`: growth ranking on a class that grew 49k bytes, plus renderer coverage.
- Local: `go vet`, `go test ./...` (46 pkg), gocyclo -over 15 all clean.