### PR TITLE
spectra jvm jfr: add analyze and view commands

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -808,14 +808,123 @@ func runJVMExplain(args []string) int {
 }
 
 func runJVMJFR(args []string) int {
-	if len(args) > 0 && args[0] == "summary" {
-		return runJFRSummary(args[1:])
+	if len(args) > 0 {
+		switch args[0] {
+		case "summary":
+			return runJFRSummary(args[1:])
+		case "analyze":
+			return runJFRAnalyze(args[1:])
+		case "view":
+			return runJFRView(args[1:])
+		}
 	}
 	sub, pid, name, outPath, code := parseJFRArgs(args)
 	if code != 0 {
 		return code
 	}
 	return executeJFR(sub, pid, name, outPath)
+}
+
+// runJFRAnalyze runs the full JFR incident analysis (summary + event views +
+// derived narrative findings) over a recording on disk.
+func runJFRAnalyze(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm jfr analyze", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit the full analysis as JSON")
+	var views stringListFlag
+	fs.Var(&views, "view", "Restrict to a specific jfr view (repeatable); default is the standard incident set")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm jfr analyze [--json] [--view <name>]... <recording.jfr>")
+		return 2
+	}
+	analysis, err := jvm.AnalyzeJFR(fs.Arg(0), jvm.JFRAnalysisOptions{Views: views}, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jfr analyze failed for %s: %v\n", fs.Arg(0), err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(analysis)
+		return 0
+	}
+	printJFRAnalysis(os.Stdout, analysis)
+	return 0
+}
+
+// runJFRView runs one `jfr view <view> <recording>` and renders the parsed table.
+func runJFRView(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm jfr view", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit the parsed view as JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm jfr view [--json] <view> <recording.jfr>")
+		return 2
+	}
+	result, err := jvm.ViewJFR(fs.Arg(1), fs.Arg(0), nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jfr view %s failed for %s: %v\n", fs.Arg(0), fs.Arg(1), err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return 0
+	}
+	printJFRView(os.Stdout, result)
+	return 0
+}
+
+func printJFRAnalysis(w io.Writer, a jvm.JFRAnalysis) {
+	fmt.Fprintf(w, "JFR analysis: %s\n", a.Artifact.Path)
+	if len(a.Narrative) == 0 {
+		fmt.Fprintln(w, "  No incident findings.")
+	} else {
+		fmt.Fprintf(w, "  Findings (%d):\n", len(a.Narrative))
+		for _, f := range a.Narrative {
+			fmt.Fprintf(w, "    [%s] %s: %s\n", f.Severity, f.Area, f.Summary)
+			if f.Detail != "" {
+				fmt.Fprintf(w, "      %s\n", f.Detail)
+			}
+		}
+	}
+	if len(a.Views) > 0 {
+		names := make([]string, 0, len(a.Views))
+		for _, v := range a.Views {
+			names = append(names, v.View)
+		}
+		fmt.Fprintf(w, "  Views: %s\n", strings.Join(names, ", "))
+	}
+}
+
+func printJFRView(w io.Writer, v jvm.JFRViewResult) {
+	fmt.Fprintf(w, "JFR view %q (%s)\n", v.View, v.Path)
+	if len(v.Tables) == 0 {
+		fmt.Fprintln(w, "  (no tables parsed)")
+		return
+	}
+	for _, tbl := range v.Tables {
+		if tbl.Title != "" {
+			fmt.Fprintf(w, "  %s\n", tbl.Title)
+		}
+		if len(tbl.Columns) > 0 {
+			fmt.Fprintf(w, "    %s\n", strings.Join(tbl.Columns, " | "))
+		}
+		for _, row := range tbl.Rows {
+			vals := make([]string, 0, len(tbl.Columns))
+			for _, c := range tbl.Columns {
+				vals = append(vals, row[c])
+			}
+			fmt.Fprintf(w, "    %s\n", strings.Join(vals, " | "))
+		}
+	}
 }
 
 func runJFRSummary(args []string) int {

--- a/cmd/spectra/jvm_jfr_test.go
+++ b/cmd/spectra/jvm_jfr_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+const sampleJFRView = `
+Longest GC Pauses
+
+Start Time                 Duration  GC Cause
+------------------------------------------------
+21:00:01.123               45.1 ms   Allocation Failure
+21:00:15.002               12.3 ms   Metadata GC Threshold
+`
+
+func TestPrintJFRViewRendersTable(t *testing.T) {
+	view := jvm.ParseJFRView("/tmp/rec.jfr", jvm.JFRViewGCPauses, sampleJFRView)
+	if len(view.Tables) == 0 {
+		t.Fatalf("expected a parsed table")
+	}
+	var buf bytes.Buffer
+	printJFRView(&buf, view)
+	out := buf.String()
+	if !strings.Contains(out, "Longest GC Pauses") {
+		t.Fatalf("missing table title:\n%s", out)
+	}
+	if !strings.Contains(out, "Allocation Failure") {
+		t.Fatalf("missing row data:\n%s", out)
+	}
+}
+
+func TestPrintJFRAnalysisRendersFindings(t *testing.T) {
+	a := jvm.JFRAnalysis{}
+	a.Artifact.Path = "/tmp/rec.jfr"
+	a.Narrative = []jvm.JFRFinding{
+		{Area: "gc", Severity: "warn", Summary: "long GC pause observed", Detail: "45.1 ms allocation failure"},
+	}
+	a.Views = []jvm.JFRViewResult{{View: jvm.JFRViewGCPauses}}
+
+	var buf bytes.Buffer
+	printJFRAnalysis(&buf, a)
+	out := buf.String()
+	if !strings.Contains(out, "JFR analysis: /tmp/rec.jfr") {
+		t.Fatalf("missing header:\n%s", out)
+	}
+	if !strings.Contains(out, "long GC pause observed") {
+		t.Fatalf("missing finding:\n%s", out)
+	}
+}
+
+func TestPrintJFRAnalysisNoFindings(t *testing.T) {
+	var buf bytes.Buffer
+	printJFRAnalysis(&buf, jvm.JFRAnalysis{})
+	if !strings.Contains(buf.String(), "No incident findings.") {
+		t.Fatalf("expected empty-findings message, got:\n%s", buf.String())
+	}
+}

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -50,6 +50,8 @@ spectra jvm jfr start <pid> [--name spectra]
 spectra jvm jfr dump <pid> [--name spectra] [--out <path>]
 spectra jvm jfr stop <pid> [--name spectra] [--out <path>]
 spectra jvm jfr summary [--json] <recording.jfr>
+spectra jvm jfr view [--json] <view> <recording.jfr>
+spectra jvm jfr analyze [--json] [--view <name>]... <recording.jfr>
 ```
 
 Daemon methods:

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -308,6 +308,8 @@ spectra jvm flamegraph --event wall --duration 30 --out /tmp/app.html 4012
 spectra jvm jfr start 4012 --name spectra
 spectra jvm jfr dump 4012 --name spectra --out /tmp/app.jfr
 spectra jvm jfr summary --json /tmp/app.jfr
+spectra jvm jfr analyze /tmp/app.jfr
+spectra jvm jfr view gc-pauses /tmp/app.jfr
 spectra jvm jfr stop 4012 --name spectra
 ```
 


### PR DESCRIPTION
Closes #301

Wires the previously-unused JFR analysis engine (`AnalyzeJFR` / `ViewJFR` / `ParseJFRView`, backed by `internal/recording`) into the CLI.

## What changed
- `jfr view [--json] <view> <recording.jfr>`: run one `jfr view` and render the parsed table.
- `jfr analyze [--json] [--view <name>]... <recording.jfr>`: full incident analysis — summary + event views + derived narrative findings.
- `start`/`dump`/`stop`/`summary` unchanged. Renderers take `io.Writer`.

## Tests
- `cmd/spectra/jvm_jfr_test.go`: renderers over a parsed GC-pauses view and a hand-built analysis; no `jfr` binary needed.
- Local: `go vet`, `go test ./...` (46 pkg), gocyclo -over 15 all clean.