### PR TITLE
spectra core: auto-resolve the crashed executable from the core image

### DIFF
--- a/cmd/spectra/core.go
+++ b/cmd/spectra/core.go
@@ -54,7 +54,11 @@ func runCoreInspect(args []string) int {
 func printCoreReport(report corefile.Report) {
 	fmt.Printf("core:          %s\n", report.Artifact.Path)
 	if report.Artifact.ExecutablePath != "" {
-		fmt.Printf("executable:    %s\n", report.Artifact.ExecutablePath)
+		suffix := ""
+		if report.Artifact.ExecutableResolved {
+			suffix = " (auto-resolved from core image; override with --exe)"
+		}
+		fmt.Printf("executable:    %s%s\n", report.Artifact.ExecutablePath, suffix)
 	}
 	fmt.Printf("format:        %s\n", valueOrUnknown(report.Artifact.Format))
 	if report.Artifact.Architecture != "" {

--- a/internal/corefile/inspect.go
+++ b/internal/corefile/inspect.go
@@ -68,7 +68,74 @@ func (i Inspector) describe(path, executablePath string) (Artifact, []byte, erro
 	if artifact.Format == "" {
 		artifact.Format = identifyProbe(probe)
 	}
+	if artifact.ExecutablePath == "" {
+		if resolved := resolveExecutableFromProbe(probe, statExecutable); resolved != "" {
+			artifact.ExecutablePath = resolved
+			artifact.ExecutableResolved = true
+		}
+	}
 	return artifact, probe, nil
+}
+
+// statExecutable reports whether path is a regular file with an executable bit.
+// It is the default on-disk check used to validate an auto-resolved executable.
+func statExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
+}
+
+// resolveExecutableFromProbe scans a core's readable prefix for an absolute
+// executable path embedded in the image (typically argv[0] or a dyld image
+// path) and returns the first candidate that exists on disk as an executable.
+//
+// This is best-effort: a core does not guarantee the main executable's path is
+// present in the probed prefix, and shared libraries are deliberately excluded
+// so the result is biased toward the crashed program rather than a loaded dylib.
+// Callers must treat the result as a suggestion the user can override with --exe.
+func resolveExecutableFromProbe(probe []byte, exists func(string) bool) string {
+	for _, cand := range absolutePathTokens(probe) {
+		if isSharedLibraryPath(cand) {
+			continue
+		}
+		if exists(cand) {
+			return cand
+		}
+	}
+	return ""
+}
+
+// absolutePathTokens extracts NUL/whitespace-delimited absolute paths ("/...")
+// made of printable, non-space bytes from a byte buffer.
+func absolutePathTokens(buf []byte) []string {
+	var tokens []string
+	start := -1
+	flush := func(end int) {
+		if start >= 0 && buf[start] == '/' && end-start > 1 && end-start < 4096 {
+			tokens = append(tokens, string(buf[start:end]))
+		}
+		start = -1
+	}
+	for i, b := range buf {
+		if b > 0x20 && b < 0x7f {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		flush(i)
+	}
+	flush(len(buf))
+	return tokens
+}
+
+func isSharedLibraryPath(path string) bool {
+	if strings.HasSuffix(path, ".dylib") || strings.HasSuffix(path, ".so") {
+		return true
+	}
+	return strings.HasPrefix(path, "/usr/lib/") || strings.HasPrefix(path, "/System/")
 }
 
 func readPrefix(path string, limit int64) ([]byte, error) {

--- a/internal/corefile/resolve_test.go
+++ b/internal/corefile/resolve_test.go
@@ -1,0 +1,92 @@
+package corefile
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAbsolutePathTokens(t *testing.T) {
+	probe := []byte("junk\x00/Library/Java/temurin.jdk/Contents/Home/bin/java\x00 more /usr/lib/system/libx.dylib\n/tmp/app")
+	got := absolutePathTokens(probe)
+	want := map[string]bool{
+		"/Library/Java/temurin.jdk/Contents/Home/bin/java": true,
+		"/usr/lib/system/libx.dylib":                       true,
+		"/tmp/app":                                         true,
+	}
+	for _, g := range got {
+		delete(want, g)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing tokens %v in %v", want, got)
+	}
+}
+
+func TestResolveExecutableSkipsSharedLibsAndMissing(t *testing.T) {
+	// Only /usr/lib and .dylib paths, plus a non-existent binary: nothing resolves.
+	probe := []byte("/usr/lib/dyld\x00/opt/foo/libbar.dylib\x00/does/not/exist/java")
+	if got := resolveExecutableFromProbe(probe, statExecutable); got != "" {
+		t.Fatalf("resolved %q, want empty", got)
+	}
+}
+
+func TestResolveExecutablePicksOnDiskExecutable(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "java")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A dylib appears first but must be skipped in favour of the executable.
+	probe := []byte("/some/lib.dylib\x00" + exe + "\x00")
+	if got := resolveExecutableFromProbe(probe, statExecutable); got != exe {
+		t.Fatalf("resolved %q, want %q", got, exe)
+	}
+}
+
+func TestInspectorAutoResolvesExecutable(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "java")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	corePath := filepath.Join(dir, "java.core")
+	// HotSpot marker makes JVMAnalyzer support it; embedded java path is resolvable.
+	content := "HotSpot java.lang.Thread\x00" + exe + "\x00"
+	if err := os.WriteFile(corePath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := (Inspector{Analyzers: []Analyzer{JVMAnalyzer{}}}).Inspect(context.Background(), corePath, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Artifact.ExecutablePath != exe {
+		t.Fatalf("executable = %q, want %q (auto-resolved)", report.Artifact.ExecutablePath, exe)
+	}
+	if !report.Artifact.ExecutableResolved {
+		t.Fatal("ExecutableResolved = false, want true")
+	}
+	// With the executable resolved, the JVM analyzer should now emit jhsdb commands.
+	if len(report.Commands) != 3 {
+		t.Fatalf("commands = %d, want 3", len(report.Commands))
+	}
+}
+
+func TestInspectorKeepsExplicitExecutable(t *testing.T) {
+	dir := t.TempDir()
+	corePath := filepath.Join(dir, "core")
+	if err := os.WriteFile(corePath, []byte("HotSpot\x00/embedded/java\x00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	report, err := (Inspector{Analyzers: []Analyzer{JVMAnalyzer{}}}).Inspect(context.Background(), corePath, "/explicit/bin/java")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Artifact.ExecutablePath != "/explicit/bin/java" {
+		t.Fatalf("executable = %q, want the explicit path", report.Artifact.ExecutablePath)
+	}
+	if report.Artifact.ExecutableResolved {
+		t.Fatal("ExecutableResolved = true, want false for an explicit --exe")
+	}
+}

--- a/internal/corefile/types.go
+++ b/internal/corefile/types.go
@@ -12,9 +12,12 @@ import "context"
 type Artifact struct {
 	Path           string `json:"path"`
 	ExecutablePath string `json:"executable_path,omitempty"`
-	Format         string `json:"format,omitempty"`
-	Architecture   string `json:"architecture,omitempty"`
-	SizeBytes      int64  `json:"size_bytes,omitempty"`
+	// ExecutableResolved is true when ExecutablePath was auto-resolved from the
+	// core image rather than supplied by the caller (via --exe).
+	ExecutableResolved bool   `json:"executable_resolved,omitempty"`
+	Format             string `json:"format,omitempty"`
+	Architecture       string `json:"architecture,omitempty"`
+	SizeBytes          int64  `json:"size_bytes,omitempty"`
 }
 
 // Command is a suggested offline inspection command for an artifact.


### PR DESCRIPTION
Closes #303

`spectra core inspect` previously emitted no `jhsdb` commands unless the user passed `--exe`. This auto-resolves the executable from the core image.

## What changed
- Scan the core's readable prefix for absolute path tokens; exclude `*.dylib`/`*.so`/`/usr/lib`/`/System`.
- Accept only a candidate that exists on disk as a regular executable — never fabricates a path.
- Mark it `executable_resolved` and label it in the CLI (override with `--exe`). Explicit `--exe` always wins.

## Tests
- `internal/corefile/resolve_test.go`: token extraction, on-disk gating, dylib exclusion, end-to-end auto-fill enabling jhsdb commands, and explicit-`--exe` preservation.
- Local: `go vet`, `go test ./...` (46 pkg), gocyclo -over 15 clean.

## Follow-up (separate issue)
Full Mach-O `LC_NOTE` / dyld `all_image_infos` traversal to resolve the main binary by virtual address when its path is not in the probed prefix.