### PR TITLE
spectra core: run jhsdb jstack/jmap directly

### DIFF
--- a/cmd/spectra/core.go
+++ b/cmd/spectra/core.go
@@ -28,11 +28,18 @@ func runCore(args []string) int {
 	return 2
 }
 
-// coreRunner executes an external inspection command and returns its combined output.
-type coreRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+// coreRunner executes an external inspection command, streaming its output to
+// the provided writers as it is produced. It stays injectable for testing.
+type coreRunner func(ctx context.Context, stdout, stderr io.Writer, name string, args ...string) error
 
-func defaultCoreRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+func defaultCoreRunner(ctx context.Context, stdout, stderr io.Writer, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("jhsdb: %w", err)
+	}
+	return nil
 }
 
 // runCoreRun executes a specific jhsdb inspection (jstack or jmap-histo) against
@@ -69,11 +76,7 @@ func coreRun(ctx context.Context, stdout, stderr io.Writer, action, corePath, ex
 		fmt.Fprintf(stderr, "unsupported action %q (want jstack or jmap-histo)\n", action)
 		return 2
 	}
-	out, err := run(ctx, cmd.Tool, cmd.Args...)
-	if len(out) > 0 {
-		_, _ = stdout.Write(out)
-	}
-	if err != nil {
+	if err := run(ctx, stdout, stderr, cmd.Tool, cmd.Args...); err != nil {
 		fmt.Fprintf(stderr, "%s %s failed: %v\n", cmd.Tool, action, err)
 		return 1
 	}

--- a/cmd/spectra/core.go
+++ b/cmd/spectra/core.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 
@@ -13,11 +15,69 @@ import (
 )
 
 func runCore(args []string) int {
-	if len(args) > 0 && args[0] == "inspect" {
-		return runCoreInspect(args[1:])
+	if len(args) > 0 {
+		switch args[0] {
+		case "inspect":
+			return runCoreInspect(args[1:])
+		case "run":
+			return runCoreRun(args[1:])
+		}
 	}
 	fmt.Fprintln(os.Stderr, "usage: spectra core inspect [--json] [--exe <path>] <core-file>")
+	fmt.Fprintln(os.Stderr, "       spectra core run [--exe <path>] <jstack|jmap-histo> <core-file>")
 	return 2
+}
+
+// coreRunner executes an external inspection command and returns its combined output.
+type coreRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func defaultCoreRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+// runCoreRun executes a specific jhsdb inspection (jstack or jmap-histo) against
+// a core, resolving the executable automatically when --exe is not supplied.
+func runCoreRun(args []string) int {
+	fs := flag.NewFlagSet("spectra core run", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	exePath := fs.String("exe", "", "Executable path for the crashed process")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "usage: spectra core run [--exe <path>] <jstack|jmap-histo> <core-file>")
+		return 2
+	}
+	return coreRun(context.Background(), os.Stdout, os.Stderr, fs.Arg(0), fs.Arg(1), *exePath, defaultCoreRunner)
+}
+
+// coreRun is the testable core of `spectra core run`: it inspects the core,
+// selects the requested command, and executes it through run.
+func coreRun(ctx context.Context, stdout, stderr io.Writer, action, corePath, exePath string, run coreRunner) int {
+	inspector := corefile.Inspector{Analyzers: []corefile.Analyzer{corefile.JVMAnalyzer{}}}
+	report, err := inspector.Inspect(ctx, corePath, exePath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if report.Artifact.ExecutablePath == "" {
+		fmt.Fprintln(stderr, "no executable resolved from the core; pass --exe <path>")
+		return 1
+	}
+	cmd, ok := corefile.SelectCommand(report, action)
+	if !ok {
+		fmt.Fprintf(stderr, "unsupported action %q (want jstack or jmap-histo)\n", action)
+		return 2
+	}
+	out, err := run(ctx, cmd.Tool, cmd.Args...)
+	if len(out) > 0 {
+		_, _ = stdout.Write(out)
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "%s %s failed: %v\n", cmd.Tool, action, err)
+		return 1
+	}
+	return 0
 }
 
 func runCoreInspect(args []string) int {

--- a/cmd/spectra/core_run_test.go
+++ b/cmd/spectra/core_run_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// jvmCoreFixture writes an on-disk java executable and a synthetic core that
+// embeds its path plus a HotSpot marker, so the inspector auto-resolves the exe.
+func jvmCoreFixture(t *testing.T) (corePath, exe string) {
+	t.Helper()
+	dir := t.TempDir()
+	exe = filepath.Join(dir, "java")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	corePath = filepath.Join(dir, "java.core")
+	if err := os.WriteFile(corePath, []byte("HotSpot java.lang.Thread\x00"+exe+"\x00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return corePath, exe
+}
+
+func TestCoreRunExecutesJstack(t *testing.T) {
+	corePath, exe := jvmCoreFixture(t)
+
+	var gotName string
+	var gotArgs []string
+	fake := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotName, gotArgs = name, args
+		return []byte("thread state output\n"), nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := coreRun(context.Background(), &stdout, &stderr, "jstack", corePath, "", fake)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	if gotName != "jhsdb" {
+		t.Fatalf("tool = %q, want jhsdb", gotName)
+	}
+	joined := strings.Join(gotArgs, " ")
+	if !strings.HasPrefix(joined, "jstack ") || !strings.Contains(joined, "--exe "+exe) || !strings.Contains(joined, "--core "+corePath) {
+		t.Fatalf("args = %q", joined)
+	}
+	if !strings.Contains(stdout.String(), "thread state output") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestCoreRunUnsupportedAction(t *testing.T) {
+	corePath, _ := jvmCoreFixture(t)
+	var stdout, stderr bytes.Buffer
+	called := false
+	fake := func(_ context.Context, _ string, _ ...string) ([]byte, error) { called = true; return nil, nil }
+	code := coreRun(context.Background(), &stdout, &stderr, "jstat", corePath, "", fake)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if called {
+		t.Fatal("runner should not be called for an unsupported action")
+	}
+}
+
+func TestCoreRunNoExecutable(t *testing.T) {
+	// Core with no embedded on-disk executable and no --exe: refuse to run.
+	dir := t.TempDir()
+	corePath := filepath.Join(dir, "core")
+	if err := os.WriteFile(corePath, []byte("HotSpot java.lang.Thread\x00/nope/java\x00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := coreRun(context.Background(), &stdout, &stderr, "jstack", corePath, "", func(context.Context, string, ...string) ([]byte, error) { return nil, nil })
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "no executable resolved") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}

--- a/cmd/spectra/core_run_test.go
+++ b/cmd/spectra/core_run_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,9 +31,10 @@ func TestCoreRunExecutesJstack(t *testing.T) {
 
 	var gotName string
 	var gotArgs []string
-	fake := func(_ context.Context, name string, args ...string) ([]byte, error) {
+	fake := func(_ context.Context, stdout, _ io.Writer, name string, args ...string) error {
 		gotName, gotArgs = name, args
-		return []byte("thread state output\n"), nil
+		_, _ = io.WriteString(stdout, "thread state output\n")
+		return nil
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -56,7 +58,7 @@ func TestCoreRunUnsupportedAction(t *testing.T) {
 	corePath, _ := jvmCoreFixture(t)
 	var stdout, stderr bytes.Buffer
 	called := false
-	fake := func(_ context.Context, _ string, _ ...string) ([]byte, error) { called = true; return nil, nil }
+	fake := func(_ context.Context, _, _ io.Writer, _ string, _ ...string) error { called = true; return nil }
 	code := coreRun(context.Background(), &stdout, &stderr, "jstat", corePath, "", fake)
 	if code != 2 {
 		t.Fatalf("exit = %d, want 2", code)
@@ -74,7 +76,7 @@ func TestCoreRunNoExecutable(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	code := coreRun(context.Background(), &stdout, &stderr, "jstack", corePath, "", func(context.Context, string, ...string) ([]byte, error) { return nil, nil })
+	code := coreRun(context.Background(), &stdout, &stderr, "jstack", corePath, "", func(context.Context, io.Writer, io.Writer, string, ...string) error { return nil })
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}

--- a/internal/corefile/run.go
+++ b/internal/corefile/run.go
@@ -1,0 +1,20 @@
+package corefile
+
+// SelectCommand returns the suggested Command matching a short action name
+// ("jstack" or "jmap-histo"), letting callers execute a specific offline
+// inspection instead of only printing the whole suggestion list.
+func SelectCommand(report Report, action string) (Command, bool) {
+	for _, c := range report.Commands {
+		switch action {
+		case "jstack":
+			if len(c.Args) > 0 && c.Args[0] == "jstack" {
+				return c, true
+			}
+		case "jmap-histo":
+			if len(c.Args) >= 2 && c.Args[0] == "jmap" && c.Args[1] == "--histo" {
+				return c, true
+			}
+		}
+	}
+	return Command{}, false
+}

--- a/internal/corefile/run_test.go
+++ b/internal/corefile/run_test.go
@@ -1,0 +1,24 @@
+package corefile
+
+import "testing"
+
+func TestSelectCommand(t *testing.T) {
+	report := Report{Commands: []Command{
+		{Tool: "jhsdb", Args: []string{"jstack", "--exe", "/j", "--core", "/c"}},
+		{Tool: "jhsdb", Args: []string{"jmap", "--histo", "--exe", "/j", "--core", "/c"}},
+		{Tool: "jhsdb", Args: []string{"jmap", "--binaryheap", "--dumpfile", "<heap.hprof>"}},
+	}}
+
+	if c, ok := SelectCommand(report, "jstack"); !ok || c.Args[0] != "jstack" {
+		t.Fatalf("jstack select = %+v ok=%v", c, ok)
+	}
+	if c, ok := SelectCommand(report, "jmap-histo"); !ok || c.Args[1] != "--histo" {
+		t.Fatalf("jmap-histo select = %+v ok=%v", c, ok)
+	}
+	if _, ok := SelectCommand(report, "jstat"); ok {
+		t.Fatal("jstat should not select any command")
+	}
+	if _, ok := SelectCommand(Report{}, "jstack"); ok {
+		t.Fatal("empty report should not select")
+	}
+}


### PR DESCRIPTION
Closes #305

Builds on #304. `spectra core inspect` only printed suggested `jhsdb` commands; this executes them.

## What changed
- `spectra core run [--exe <path>] <jstack|jmap-histo> <core-file>`: inspect (auto-resolving the exe), select the matching command, run `jhsdb`, stream output.
- Runner injected (`coreRunner`) → selection + wiring unit-tested without a JDK. `core inspect` unchanged.

## Tests
- `cmd/spectra/core_run_test.go`: jstack execution with arg assertions, unsupported-action guard, no-executable refusal.
- `internal/corefile/run_test.go`: `SelectCommand` coverage.
- Local: `go vet`, `go test ./...` (46 pkg), gocyclo -over 15 clean.

## Follow-up
`core run jmap-dump --out <file>` for the HPROF binary-heap command.