### PR TITLE
fd debugging (1/3): capture per-process fd limit as a data source

### DIFF
--- a/docs/design/system-inventory.md
+++ b/docs/design/system-inventory.md
@@ -301,6 +301,20 @@ sysctls {
 A small allowlist. Adding to this is a deliberate decision; we don't
 dump the entire `sysctl -a` because it's massive and noisy.
 
+## fd_limit
+
+The per-process file-descriptor limit processes actually launch under,
+read from `launchctl limit maxfiles`. Complements the system-wide
+`kern.maxfiles` sysctl and per-process `open_fds` counts.
+
+```
+fd_limit {
+  soft            # current per-process limit
+  hard            # ceiling (0 when unlimited)
+  hard_unlimited  # true when the hard limit is "unlimited"
+}
+```
+
 ## Diff semantics
 
 `spectra diff <a> <b>` computes a structural diff. Per category, the

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -166,6 +166,7 @@ inspection. All preinstalled — no install-time dependencies.
 | Source | Output | Privilege | Cost | Used by |
 |---|---|---|---|---|
 | `sysctl -n <key>` | single tunable | user | <10ms | `sysctls` map (allowlisted keys) |
+| `launchctl limit maxfiles` | per-process fd limit (soft/hard) | user | <10ms | `fd_limit` (soft, hard, hard_unlimited) |
 | `system_profiler SPHardwareDataType` | hardware specs | user | ~500ms | `HostInfo.cpu_brand`, `ram_bytes` |
 | `sw_vers` | macOS version + build | user | <10ms | `HostInfo.os_*` |
 

--- a/internal/rules/projection.go
+++ b/internal/rules/projection.go
@@ -27,6 +27,11 @@ func SnapshotActivation(s snapshot.Snapshot) map[string]any {
 		"storage":    s.Storage,
 		"power":      s.Power,
 		"sysctls":    s.Sysctls,
+		"fd_limit": map[string]any{
+			"soft":           s.FDLimit.Soft,
+			"hard":           s.FDLimit.Hard,
+			"hard_unlimited": s.FDLimit.HardUnlimited,
+		},
 	}
 }
 

--- a/internal/rules/projection_test.go
+++ b/internal/rules/projection_test.go
@@ -1,0 +1,46 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/sysinfo"
+)
+
+func TestSnapshotActivationFDLimit(t *testing.T) {
+	s := snapshot.Snapshot{
+		FDLimit: sysinfo.FDLimit{Soft: 256, HardUnlimited: true},
+	}
+	act := SnapshotActivation(s)
+
+	raw, ok := act["fd_limit"]
+	if !ok {
+		t.Fatal("fd_limit key missing from activation")
+	}
+	fd, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("fd_limit is %T, want map[string]any", raw)
+	}
+	if fd["soft"] != 256 {
+		t.Errorf("soft = %v, want 256", fd["soft"])
+	}
+	if fd["hard"] != 0 {
+		t.Errorf("hard = %v, want 0", fd["hard"])
+	}
+	if fd["hard_unlimited"] != true {
+		t.Errorf("hard_unlimited = %v, want true", fd["hard_unlimited"])
+	}
+}
+
+func TestSnapshotActivationFDLimitBothNumeric(t *testing.T) {
+	s := snapshot.Snapshot{
+		FDLimit: sysinfo.FDLimit{Soft: 10240, Hard: 12288},
+	}
+	fd, ok := SnapshotActivation(s)["fd_limit"].(map[string]any)
+	if !ok {
+		t.Fatal("fd_limit missing or wrong type")
+	}
+	if fd["soft"] != 10240 || fd["hard"] != 12288 || fd["hard_unlimited"] != false {
+		t.Errorf("fd_limit = %+v, want soft=10240 hard=12288 hard_unlimited=false", fd)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -47,6 +47,7 @@ type Snapshot struct {
 	Power        sysinfo.PowerState       `json:"power"`
 	SystemLimits syslimits.SystemLimits   `json:"system_limits"`
 	Sysctls      map[string]string        `json:"sysctls,omitempty"`
+	FDLimit      sysinfo.FDLimit          `json:"fd_limit,omitempty"`
 	Network      netstate.State           `json:"network"`
 	Storage      storagestate.State       `json:"storage"`
 	Services     services.LaunchInventory `json:"services,omitempty"`
@@ -231,6 +232,10 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	}()
 	go func() {
 		defer wg.Done()
+		s.FDLimit = sysinfo.CollectFDLimit(siRun)
+	}()
+	go func() {
+		defer wg.Done()
 		s.Network = netstate.Collect(netRun)
 	}()
 	if !opts.SkipStorage {
@@ -287,7 +292,7 @@ func Build(ctx context.Context, opts Options) Snapshot {
 }
 
 func snapshotCollectorCount(opts Options) int {
-	collectors := 6 // host, toolchains, power, system limits, sysctls, network
+	collectors := 7 // host, toolchains, power, system limits, sysctls, fd limit, network
 	if !opts.SkipApps {
 		collectors++
 	}

--- a/internal/sysinfo/fdlimit.go
+++ b/internal/sysinfo/fdlimit.go
@@ -1,0 +1,65 @@
+package sysinfo
+
+import (
+	"strconv"
+	"strings"
+)
+
+// FDLimit is the per-process file-descriptor limit macOS launches processes
+// under (soft = current, hard = ceiling). It complements the system-wide
+// kern.maxfiles sysctl and per-process open_fds counts.
+type FDLimit struct {
+	Soft          int  `json:"soft,omitempty"`
+	Hard          int  `json:"hard,omitempty"`
+	HardUnlimited bool `json:"hard_unlimited,omitempty"`
+}
+
+// CollectFDLimit runs `launchctl limit maxfiles` and parses the soft/hard
+// file-descriptor limits. Output looks like:
+//
+//	maxfiles    256            unlimited
+//
+// The collector is defensive: missing/empty/error output, a line that does
+// not start with "maxfiles", or unparseable columns yield the zero value.
+// A soft or hard column of "unlimited" leaves the numeric field 0; the hard
+// case additionally sets HardUnlimited.
+func CollectFDLimit(run CmdRunner) FDLimit {
+	out, err := run("launchctl", "limit", "maxfiles")
+	if err != nil {
+		return FDLimit{}
+	}
+	return parseFDLimit(string(out))
+}
+
+func parseFDLimit(out string) FDLimit {
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 || fields[0] != "maxfiles" {
+			continue
+		}
+		var fd FDLimit
+		if v, ok := parseLimitValue(fields[1]); ok {
+			fd.Soft = v
+		}
+		if fields[2] == "unlimited" {
+			fd.HardUnlimited = true
+		} else if v, ok := parseLimitValue(fields[2]); ok {
+			fd.Hard = v
+		}
+		return fd
+	}
+	return FDLimit{}
+}
+
+// parseLimitValue returns the numeric value of a limit column, reporting
+// false for "unlimited" or anything that isn't a non-negative integer.
+func parseLimitValue(s string) (int, bool) {
+	if s == "unlimited" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/sysinfo/fdlimit_test.go
+++ b/internal/sysinfo/fdlimit_test.go
@@ -1,0 +1,87 @@
+package sysinfo
+
+import (
+	"errors"
+	"testing"
+)
+
+func stubFDLimit(out string, err error) CmdRunner {
+	return func(name string, args ...string) ([]byte, error) {
+		if name != "launchctl" || len(args) != 2 || args[0] != "limit" || args[1] != "maxfiles" {
+			return nil, errors.New("unexpected command")
+		}
+		if err != nil {
+			return nil, err
+		}
+		return []byte(out), nil
+	}
+}
+
+func TestCollectFDLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		err  error
+		want FDLimit
+	}{
+		{
+			name: "soft numeric, hard unlimited",
+			out:  "\tmaxfiles    256            unlimited\n",
+			want: FDLimit{Soft: 256, HardUnlimited: true},
+		},
+		{
+			name: "both numeric",
+			out:  "\tmaxfiles    10240          12288\n",
+			want: FDLimit{Soft: 10240, Hard: 12288},
+		},
+		{
+			name: "both unlimited",
+			out:  "\tmaxfiles    unlimited      unlimited\n",
+			want: FDLimit{HardUnlimited: true},
+		},
+		{
+			name: "empty output",
+			out:  "",
+			want: FDLimit{},
+		},
+		{
+			name: "runner error",
+			err:  errors.New("permission denied"),
+			want: FDLimit{},
+		},
+		{
+			name: "irregular whitespace",
+			out:  "   maxfiles\t 200 \t 400 \n",
+			want: FDLimit{Soft: 200, Hard: 400},
+		},
+		{
+			name: "line does not start with maxfiles",
+			out:  "\tmaxproc     2000           4000\n",
+			want: FDLimit{},
+		},
+		{
+			name: "too few columns",
+			out:  "\tmaxfiles    256\n",
+			want: FDLimit{},
+		},
+		{
+			name: "non-numeric column",
+			out:  "\tmaxfiles    abc            def\n",
+			want: FDLimit{},
+		},
+		{
+			name: "multi-line, header ignored",
+			out:  "Some header line\n\tmaxfiles    512            1024\n",
+			want: FDLimit{Soft: 512, Hard: 1024},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CollectFDLimit(stubFDLimit(tt.out, tt.err))
+			if got != tt.want {
+				t.Errorf("CollectFDLimit() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #307.

First of three PRs adding file-descriptor debugging to Spectra. This one lands the **data source** only — the fd-pressure rule and fd-leak trend build on it in follow-ups.

## What

Spectra already captures per-process `open_fds` (`--deep`) and the system-wide `kern.maxfiles`, but never the per-process fd limit those descriptors count against. This adds it.

- `internal/sysinfo/fdlimit.go` — `CollectFDLimit(CmdRunner)` runs `launchctl limit maxfiles` and parses soft/hard into `FDLimit{ Soft, Hard, HardUnlimited }`. Defensive: `unlimited`, numeric, missing/empty/error output, wrong-prefix lines, and irregular whitespace all handled (zero value when unavailable).
- `internal/snapshot/snapshot.go` — new `Snapshot.FDLimit` field, collected in its own goroutine like `Sysctls` (collector count bumped 6→7).
- `internal/rules/projection.go` — stable `fd_limit` fact → `{ soft, hard, hard_unlimited }` for rules to consume.
- Tests: `fdlimit_test.go` (table-driven parser) and `projection_test.go` (fact present + populated).
- Docs: `fd_limit` noted alongside existing fd/sysctl facts.

## Notes

- Per-arbitrary-pid `getrlimit` isn't reliably available for other processes on macOS; the inherited default from `launchctl limit maxfiles` is the pragmatic source.
- No behavior change to existing output beyond the additive `fd_limit` field.
