### PR TITLE
rpc: lift the silent 64 KiB request cap in the daemon read loop

### DIFF
--- a/internal/rpc/large_request_test.go
+++ b/internal/rpc/large_request_test.go
@@ -1,0 +1,72 @@
+package rpc
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestServeHandlesRequestLargerThan64KiB guards the fix for the silent 64 KiB
+// request cap: a default bufio.Scanner would stop reading and drop the
+// connection when a single request line exceeded 64 KiB. jsonrpc.ReadMessage
+// grows to the line length, so a large payload round-trips normally.
+func TestServeHandlesRequestLargerThan64KiB(t *testing.T) {
+	d := NewDispatcher()
+	d.Register("echo_len", func(params json.RawMessage) (any, error) {
+		var p struct {
+			Blob string `json:"blob"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, err
+		}
+		return len(p.Blob), nil
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go d.ServeListener(ln)
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	const blobLen = 256 * 1024 // 256 KiB, well past the old 64 KiB scanner cap
+	blob := strings.Repeat("a", blobLen)
+	req, err := json.Marshal(Request{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "echo_len",
+		Params:  json.RawMessage(`{"blob":"` + blob + `"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write(append(req, '\n')); err != nil {
+		t.Fatal(err)
+	}
+
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	var resp Response
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	got, ok := resp.Result.(float64) // JSON numbers decode to float64
+	if !ok || int(got) != blobLen {
+		t.Fatalf("result = %v, want %d", resp.Result, blobLen)
+	}
+}

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -12,6 +12,8 @@ import (
 	"io"
 	"net"
 	"sync"
+
+	"github.com/kaeawc/spectra/internal/jsonrpc"
 )
 
 // Request is a JSON-RPC 2.0 request object.
@@ -71,12 +73,20 @@ func (d *Dispatcher) Register(method string, fn HandlerFunc) {
 // Serve handles one connection. Each newline-delimited JSON request on
 // the connection produces a newline-delimited JSON response.
 // The function returns when the connection is closed.
+//
+// Requests are read with jsonrpc.ReadMessage, which grows its buffer to the
+// line length rather than capping it at bufio.Scanner's default 64 KiB. Large
+// debug requests (e.g. inspect.app.batch or jvm.mbean.invoke argument payloads)
+// would otherwise be silently dropped when the connection exceeded that limit.
 func (d *Dispatcher) Serve(conn net.Conn) {
 	defer conn.Close()
-	scanner := bufio.NewScanner(conn)
+	reader := bufio.NewReader(conn)
 	enc := json.NewEncoder(conn)
-	for scanner.Scan() {
-		line := scanner.Bytes()
+	for {
+		line, err := jsonrpc.ReadMessage(reader)
+		if err != nil {
+			return
+		}
 		resp := d.handle(line)
 		_ = enc.Encode(resp)
 	}


### PR DESCRIPTION
Closes #310

The daemon read loop used a default `bufio.Scanner` (64 KiB token cap, never raised). Requests over 64 KiB made `Scan()` return false and the connection dropped with **no** JSON-RPC error.

## What changed
- Read requests via `jsonrpc.ReadMessage(*bufio.Reader)` (already used elsewhere), which grows to the line length. Normal requests unchanged.

## Tests
- `internal/rpc/large_request_test.go`: sends a 256 KiB request over a TCP listener and asserts a correct response.
- Local: `go vet`, `go test ./...` (46 pkg), gocyclo -over 15 clean.