### PR TITLE
fd debugging (2/3): fd-pressure rule

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -205,6 +205,7 @@ Implemented rules:
 - `permission-mismatch`
 - `sparse-file-inflation`
 - `app-gatekeeper-rejected`
+- `fd-pressure`
 
 ## Out of scope for v1
 

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -40,6 +40,7 @@ func V1Catalog() []Rule {
 		rulePermissionMismatch(),
 		ruleSparseFileInflation(),
 		ruleGatekeeperRejected(),
+		ruleFDPressure(),
 	}
 }
 

--- a/internal/rules/fd_pressure.go
+++ b/internal/rules/fd_pressure.go
@@ -1,0 +1,129 @@
+package rules
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+// fd-pressure thresholds, expressed as a percentage of the relevant limit.
+const (
+	// fdWarnPct is the per-process open-fd usage (of the soft limit) at or
+	// above which a medium finding is emitted.
+	fdWarnPct = 80
+	// fdCriticalPct is the per-process usage at or above which the finding is
+	// escalated to high severity.
+	fdCriticalPct = 95
+	// fdSystemPct is the system-wide open-fd usage (of kern.maxfiles) at or
+	// above which a single high finding is emitted.
+	fdSystemPct = 80
+)
+
+// ruleFDPressure fires when a process is approaching its file-descriptor soft
+// limit, or when the aggregate open-fd count across all processes approaches
+// the system-wide file table limit (kern.maxfiles). Both signals depend on
+// per-process OpenFDs, which is only populated in --deep mode; in shallow mode
+// OpenFDs is 0 and the rule stays silent.
+func ruleFDPressure() Rule {
+	return Rule{
+		ID:       "fd-pressure",
+		Severity: SeverityMedium,
+		MatchFn:  matchFDPressure,
+	}
+}
+
+func matchFDPressure(s snapshot.Snapshot) []Finding {
+	var findings []Finding
+	var total int
+	for _, proc := range s.Processes {
+		if proc.OpenFDs > 0 {
+			total += proc.OpenFDs
+		}
+		if f, ok := fdProcessFinding(proc, s.FDLimit.Soft); ok {
+			findings = append(findings, f)
+		}
+	}
+	if f, ok := fdSystemFinding(total, s.Sysctls); ok {
+		findings = append(findings, f)
+	}
+	return findings
+}
+
+// fdProcessFinding evaluates one process against its soft fd limit. It returns
+// no finding when the process reports no open descriptors, when the soft limit
+// is unknown (<= 0), or when usage is below fdWarnPct.
+func fdProcessFinding(proc process.Info, soft int) (Finding, bool) {
+	if proc.OpenFDs <= 0 || soft <= 0 {
+		return Finding{}, false
+	}
+	pct := proc.OpenFDs * 100 / soft
+	if pct < fdWarnPct {
+		return Finding{}, false
+	}
+	severity := SeverityMedium
+	if pct >= fdCriticalPct {
+		severity = SeverityHigh
+	}
+	return Finding{
+		RuleID:   "fd-pressure",
+		Severity: severity,
+		Subject:  fmt.Sprintf("PID %d (%s)", proc.PID, fdProcessName(proc)),
+		Message: fmt.Sprintf("open_fds=%d is %d%% of the default fd soft limit (%d); process may be approaching descriptor exhaustion.",
+			proc.OpenFDs, pct, soft),
+		Fix: "Raise the descriptor limit for this process (`launchctl limit maxfiles` or `ulimit -n`), or investigate a possible file-descriptor leak.",
+	}, true
+}
+
+// fdSystemFinding evaluates the aggregate open-fd count against the system-wide
+// file table limit (kern.maxfiles). It stays silent when nothing has open
+// descriptors, or when kern.maxfiles is absent or unparseable.
+func fdSystemFinding(total int, sysctls map[string]string) (Finding, bool) {
+	if total <= 0 {
+		return Finding{}, false
+	}
+	maxfiles, ok := parseMaxfiles(sysctls)
+	if !ok {
+		return Finding{}, false
+	}
+	pct := total * 100 / maxfiles
+	if pct < fdSystemPct {
+		return Finding{}, false
+	}
+	return Finding{
+		RuleID:   "fd-pressure",
+		Severity: SeverityHigh,
+		Subject:  "system file table",
+		Message: fmt.Sprintf("open file descriptors across all processes total %d, which is %d%% of kern.maxfiles (%d); the system file table may be approaching exhaustion.",
+			total, pct, maxfiles),
+		Fix: "Raise kern.maxfiles (`sudo sysctl -w kern.maxfiles=...` and a matching /etc/sysctl.conf entry), or investigate processes leaking descriptors with `spectra process --deep`.",
+	}, true
+}
+
+// parseMaxfiles returns the positive integer value of kern.maxfiles from the
+// sysctl map, or ok=false when it is missing, empty, or not a positive int.
+func parseMaxfiles(sysctls map[string]string) (int, bool) {
+	raw, present := sysctls["kern.maxfiles"]
+	if !present {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// fdProcessName returns the best available human-readable name for a process,
+// matching the "PID <pid> (<name>)" subject style used by neighboring rules.
+func fdProcessName(proc process.Info) string {
+	if proc.Command != "" {
+		return proc.Command
+	}
+	if proc.BSDName != "" {
+		return proc.BSDName
+	}
+	return "unknown"
+}

--- a/internal/rules/fd_pressure_test.go
+++ b/internal/rules/fd_pressure_test.go
@@ -1,0 +1,135 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/sysinfo"
+)
+
+// fdSnap builds a snapshot with the given soft fd limit, kern.maxfiles sysctl
+// (omitted when empty), and processes.
+func fdSnap(soft int, maxfiles string, procs ...process.Info) snapshot.Snapshot {
+	s := baseSnap()
+	s.FDLimit = sysinfo.FDLimit{Soft: soft}
+	s.Processes = procs
+	if maxfiles != "" {
+		s.Sysctls = map[string]string{"kern.maxfiles": maxfiles}
+	}
+	return s
+}
+
+func fdProc(pid int, name string, openFDs int) process.Info {
+	return process.Info{PID: pid, Command: name, OpenFDs: openFDs}
+}
+
+func findingsFor(s snapshot.Snapshot) []Finding {
+	return ruleFDPressure().MatchFn(s)
+}
+
+func TestFDPressurePerProcess(t *testing.T) {
+	cases := []struct {
+		name         string
+		soft         int
+		openFDs      int
+		wantFinding  bool
+		wantSeverity Severity
+	}{
+		{"below warn threshold", 1000, 799, false, ""},
+		{"exactly at warn threshold", 1000, 800, true, SeverityMedium},
+		{"mid warn band", 256, 240, true, SeverityMedium}, // 93%
+		{"just below critical", 1000, 949, true, SeverityMedium},
+		{"exactly at critical", 1000, 950, true, SeverityHigh},
+		{"above critical", 256, 256, true, SeverityHigh}, // 100%
+		{"soft limit zero", 0, 100000, false, ""},
+		{"open fds zero", 1000, 0, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := fdSnap(tc.soft, "", fdProc(42, "leaky", tc.openFDs))
+			findings := findingsFor(s)
+			if !tc.wantFinding {
+				if len(findings) != 0 {
+					t.Fatalf("expected no findings, got %+v", findings)
+				}
+				return
+			}
+			if len(findings) != 1 {
+				t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+			}
+			if findings[0].Severity != tc.wantSeverity {
+				t.Errorf("severity = %q, want %q", findings[0].Severity, tc.wantSeverity)
+			}
+			if findings[0].Subject != "PID 42 (leaky)" {
+				t.Errorf("subject = %q, want %q", findings[0].Subject, "PID 42 (leaky)")
+			}
+			if findings[0].RuleID != "fd-pressure" {
+				t.Errorf("rule id = %q, want fd-pressure", findings[0].RuleID)
+			}
+		})
+	}
+}
+
+func TestFDPressureSystemWide(t *testing.T) {
+	cases := []struct {
+		name         string
+		maxfiles     string
+		openFDs      []int
+		wantSystem   bool
+		wantSeverity Severity
+	}{
+		{"sum at 80% of maxfiles", "1000", []int{500, 300}, true, SeverityHigh},
+		{"sum above maxfiles", "1000", []int{700, 500}, true, SeverityHigh},
+		{"sum below 80%", "1000", []int{400, 300}, false, ""},
+		{"maxfiles missing", "", []int{5000, 5000}, false, ""},
+		{"maxfiles unparseable", "unlimited", []int{5000, 5000}, false, ""},
+		{"maxfiles zero", "0", []int{5000, 5000}, false, ""},
+		{"no open fds", "1000", []int{0, 0}, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Soft = 0 so per-process findings never fire; isolate the system rule.
+			procs := make([]process.Info, len(tc.openFDs))
+			for i, fd := range tc.openFDs {
+				procs[i] = fdProc(100+i, "proc", fd)
+			}
+			s := fdSnap(0, tc.maxfiles, procs...)
+			findings := findingsFor(s)
+			if !tc.wantSystem {
+				if len(findings) != 0 {
+					t.Fatalf("expected no findings, got %+v", findings)
+				}
+				return
+			}
+			if len(findings) != 1 {
+				t.Fatalf("expected 1 system finding, got %d: %+v", len(findings), findings)
+			}
+			if findings[0].Subject != "system file table" {
+				t.Errorf("subject = %q, want %q", findings[0].Subject, "system file table")
+			}
+			if findings[0].Severity != tc.wantSeverity {
+				t.Errorf("severity = %q, want %q", findings[0].Severity, tc.wantSeverity)
+			}
+		})
+	}
+}
+
+// TestFDPressureBothFindings verifies per-process and system findings coexist.
+func TestFDPressureBothFindings(t *testing.T) {
+	s := fdSnap(1000, "2000", fdProc(1, "a", 990), fdProc(2, "b", 900))
+	findings := findingsFor(s)
+	// PID 1 at 99% (high), PID 2 at 90% (medium), plus system 1890/2000=94% (high).
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 findings, got %d: %+v", len(findings), findings)
+	}
+	var sawSystem bool
+	for _, f := range findings {
+		if f.Subject == "system file table" {
+			sawSystem = true
+		}
+	}
+	if !sawSystem {
+		t.Errorf("expected a system-wide finding among %+v", findings)
+	}
+}


### PR DESCRIPTION
Closes #313.

Second of three fd-debugging PRs. Builds on #307 (the `fd_limit` data source) to turn the fd facts into an actual diagnostic.

## What

New rule `fd-pressure` (`internal/rules/fd_pressure.go`, registered in the catalog):

- **Per-process** — when a process's `open_fds` reaches **≥80%** of the default fd soft limit (`FDLimit.Soft`) → Medium; **≥95%** → High. Silent when the soft limit is unknown or `open_fds == 0` (i.e. non-`--deep` snapshots).
- **System-wide** — when the sum of `open_fds` across processes reaches **≥80%** of `kern.maxfiles` → one High finding. Silent when `kern.maxfiles` is absent/unparseable.

Thresholds are named constants (`fdWarnPct`, `fdCriticalPct`, `fdSystemPct`). Helpers factored and unit-tested (`fd_pressure_test.go`, table-driven across all threshold/skip cases).

## Honesty note

`launchctl limit maxfiles` reports the *default inherited* soft limit; a process can raise its own via `setrlimit`, so the per-process message is worded as "…% of the default fd soft limit" rather than claiming the exact per-process ceiling. This keeps the finding a useful heuristic without overclaiming.

## Follow-up

The third PR adds fd-leak trend detection (monotonic `open_fds` growth across samples), which will let the per-process signal distinguish a steady high-water mark from an actual leak.
