### PR TITLE
crash: add spectra crash readiness — audit post-mortem readiness before a crash

### DIFF
--- a/cmd/spectra/crash.go
+++ b/cmd/spectra/crash.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/crashready"
+	"github.com/kaeawc/spectra/internal/detect"
+)
+
+func runCrash(args []string) int {
+	return runCrashWithIO(args, os.Stdout, os.Stderr, detect.Detect)
+}
+
+func runCrashWithIO(args []string, stdout, stderr io.Writer, inspect func(string) (detect.Result, error)) int {
+	sub := "readiness"
+	rest := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		sub, rest = args[0], args[1:]
+	}
+	if sub != "readiness" {
+		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness)\n", sub)
+		return 2
+	}
+	return runCrashReadiness(rest, stdout, stderr, inspect)
+}
+
+func runCrashReadiness(args []string, stdout, stderr io.Writer, inspect func(string) (detect.Result, error)) int {
+	fs := flag.NewFlagSet("crash readiness", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra crash readiness [--json] [/path/to/App.app]")
+		fmt.Fprintln(stderr, "Audit whether this machine (and optionally one app) can produce a debuggable crash.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	var app *crashready.AppDebug
+	if p := fs.Arg(0); p != "" {
+		res, err := inspect(p)
+		if err != nil {
+			fmt.Fprintf(stderr, "inspect %s: %v\n", p, err)
+			return 1
+		}
+		app = &crashready.AppDebug{
+			Name:            strings.TrimSuffix(filepath.Base(res.Path), ".app"),
+			HardenedRuntime: res.HardenedRuntime,
+			GetTaskAllow:    hasEntitlement(res.Entitlements, "get-task-allow"),
+		}
+	}
+
+	report := crashready.Evaluate(crashready.NewLiveHost(), app)
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	renderCrashReadiness(stdout, report)
+	return 0
+}
+
+func hasEntitlement(ents []string, want string) bool {
+	for _, e := range ents {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
+func crashStatusLabel(s crashready.Status) string {
+	switch s {
+	case crashready.StatusCritical:
+		return "CRIT"
+	case crashready.StatusWarn:
+		return "warn"
+	default:
+		return "ok"
+	}
+}
+
+func renderCrashReadiness(w io.Writer, r crashready.Report) {
+	header := "Post-mortem readiness"
+	if r.App != "" {
+		header += " — " + r.App
+	}
+	fmt.Fprintln(w, header)
+	fmt.Fprintln(w, strings.Repeat("-", len(header)))
+	for _, c := range r.Checks {
+		fmt.Fprintf(w, "[%-4s] %s\n", crashStatusLabel(c.Status), c.Name)
+		fmt.Fprintf(w, "        %s\n", c.Detail)
+		if c.Fix != "" {
+			fmt.Fprintf(w, "        fix: %s\n", c.Fix)
+		}
+	}
+	warn, crit := r.Counts()
+	verdict := "ready: a crash here should leave debuggable evidence"
+	if crit > 0 {
+		verdict = "NOT ready: a crash here may leave nothing debuggable"
+	}
+	fmt.Fprintf(w, "\n%s (%d warning(s), %d critical)\n", verdict, warn, crit)
+}

--- a/cmd/spectra/crash_test.go
+++ b/cmd/spectra/crash_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/crashready"
+	"github.com/kaeawc/spectra/internal/detect"
+)
+
+func TestRunCrashUnknownSubcommand(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runCrashWithIO([]string{"bogus"}, &out, &errBuf, detect.Detect)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "unknown crash subcommand") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestHasEntitlement(t *testing.T) {
+	ents := []string{"app-sandbox", "get-task-allow", "network.client"}
+	if !hasEntitlement(ents, "get-task-allow") {
+		t.Error("expected get-task-allow present")
+	}
+	if hasEntitlement(ents, "virtualization") {
+		t.Error("did not expect virtualization")
+	}
+}
+
+func TestCrashStatusLabel(t *testing.T) {
+	cases := map[crashready.Status]string{
+		crashready.StatusOK:       "ok",
+		crashready.StatusWarn:     "warn",
+		crashready.StatusCritical: "CRIT",
+	}
+	for s, want := range cases {
+		if got := crashStatusLabel(s); got != want {
+			t.Errorf("crashStatusLabel(%q) = %q, want %q", s, got, want)
+		}
+	}
+}
+
+func TestRenderCrashReadiness(t *testing.T) {
+	r := crashready.Report{
+		App: "MyApp",
+		Checks: []crashready.Check{
+			{Name: "kern.coredump", Status: crashready.StatusWarn, Detail: "disabled", Fix: "sudo sysctl kern.coredump=1"},
+			{Name: "app: MyApp", Status: crashready.StatusOK, Detail: "debuggable"},
+		},
+	}
+	var out bytes.Buffer
+	renderCrashReadiness(&out, r)
+	s := out.String()
+	for _, want := range []string{"MyApp", "warn", "kern.coredump", "fix: sudo sysctl", "ready:"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("render output missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+func TestRenderCrashReadinessCritical(t *testing.T) {
+	r := crashready.Report{Checks: []crashready.Check{
+		{Name: "/cores", Status: crashready.StatusCritical, Detail: "unwritable"},
+	}}
+	var out bytes.Buffer
+	renderCrashReadiness(&out, r)
+	if !strings.Contains(out.String(), "NOT ready") {
+		t.Errorf("critical report should say NOT ready; got:\n%s", out.String())
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -65,6 +65,7 @@ func subcommandList() []subcommand {
 		{"install-daemon", "Install the user LaunchAgent for spectra serve", runInstallDaemonCmd},
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},
+		{"crash", "Audit post-mortem readiness (can this machine produce a debuggable crash?)", runCrash},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -35,6 +35,7 @@ run in-process on the local machine.
 | `power` | Show current battery and thermal state |
 | `storage` | Show disk volumes and `~/Library` footprint |
 | `process` | List running processes sorted by memory |
+| `crash` | Audit post-mortem readiness before a crash happens |
 | `playbook` | Show diagnostic playbooks and command plans |
 | `serve` | Run the local Unix-socket JSON-RPC daemon |
 | `connect` | Call a Spectra daemon over Unix socket or TCP JSON-RPC |
@@ -362,6 +363,26 @@ spectra network capture stop --summarize netcap-1
 spectra network capture summarize --json /var/tmp/spectra-netcap/501/netcap-1.pcap
 spectra network firewall
 spectra network firewall --json
+```
+
+## `spectra crash readiness`
+
+Audits whether the machine can produce a debuggable crash *before* one
+happens, so you don't discover an unrecoverable configuration after the
+fact. Checks the host crash-capture prerequisites — `kern.coredump`,
+`kern.corefile`, the `RLIMIT_CORE` soft limit, whether `/cores` exists, and
+`com.apple.CrashReporter` `DialogType` — and, when given an app path, whether
+that app is attachable (hardened runtime plus the
+`com.apple.security.get-task-allow` entitlement). Each finding is `ok`,
+`warn`, or `critical` with a concrete fix. Purely diagnostic; it never
+changes system settings.
+
+### Examples
+
+```bash
+spectra crash readiness
+spectra crash readiness --json
+spectra crash readiness /Applications/MyApp.app
 ```
 
 ## `spectra playbook`

--- a/internal/crashready/crashready.go
+++ b/internal/crashready/crashready.go
@@ -1,0 +1,194 @@
+// Package crashready audits whether a machine — and optionally one app — can
+// produce a debuggable crash before one happens. It answers the question teams
+// usually ask too late: "if this crashes right now, will I get anything I can
+// debug?" The evaluation is pure over an injectable Host seam so it is testable
+// without touching the real machine.
+package crashready
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Status classifies a single readiness check.
+type Status string
+
+const (
+	StatusOK       Status = "ok"
+	StatusWarn     Status = "warn"
+	StatusCritical Status = "critical"
+)
+
+// Check is one readiness signal with a human explanation and, when it is not
+// ok, a concrete fix.
+type Check struct {
+	Name   string `json:"name"`
+	Status Status `json:"status"`
+	Detail string `json:"detail"`
+	Fix    string `json:"fix,omitempty"`
+}
+
+// Report is the outcome of a readiness audit.
+type Report struct {
+	App    string  `json:"app,omitempty"`
+	Checks []Check `json:"checks"`
+}
+
+// Ready is true when no check is critical.
+func (r Report) Ready() bool {
+	for _, c := range r.Checks {
+		if c.Status == StatusCritical {
+			return false
+		}
+	}
+	return true
+}
+
+// Counts returns how many checks are warnings and how many are critical.
+func (r Report) Counts() (warn, critical int) {
+	for _, c := range r.Checks {
+		switch c.Status {
+		case StatusWarn:
+			warn++
+		case StatusCritical:
+			critical++
+		}
+	}
+	return warn, critical
+}
+
+// AppDebug is the subset of an inspected app that crashready reasons about.
+// The caller builds it from a detect.Result so this package stays decoupled
+// from the detector.
+type AppDebug struct {
+	Name            string
+	HardenedRuntime bool
+	GetTaskAllow    bool
+}
+
+// Host abstracts the live machine facts crashready inspects.
+type Host interface {
+	// Sysctl returns the trimmed value of a sysctl key (e.g. "kern.coredump").
+	Sysctl(key string) (string, error)
+	// CoreRLimit returns the RLIMIT_CORE soft and hard limits.
+	CoreRLimit() (soft, hard uint64, err error)
+	// CoresDir reports whether /cores exists.
+	CoresDir() (exists bool)
+	// CrashReporterDialogType returns com.apple.CrashReporter DialogType, or
+	// "" when it is unset.
+	CrashReporterDialogType() string
+}
+
+// rlimInfinity is RLIM_INFINITY as an unsigned value (all bits set).
+const rlimInfinity = ^uint64(0)
+
+// Evaluate runs every readiness check against host. app is optional; when
+// non-nil its debuggability is checked too.
+func Evaluate(host Host, app *AppDebug) Report {
+	r := Report{}
+	if app != nil {
+		r.App = app.Name
+	}
+	r.Checks = append(r.Checks,
+		coredumpCheck(host),
+		coreLimitCheck(host),
+		coresDirCheck(host),
+		dialogTypeCheck(host),
+	)
+	if app != nil {
+		r.Checks = append(r.Checks, appDebugCheck(*app))
+	}
+	return r
+}
+
+func coredumpEnabled(host Host) bool {
+	v, err := host.Sysctl("kern.coredump")
+	return err == nil && strings.TrimSpace(v) == "1"
+}
+
+func coredumpCheck(host Host) Check {
+	v, err := host.Sysctl("kern.coredump")
+	if err != nil {
+		return Check{Name: "kern.coredump", Status: StatusWarn, Detail: "could not read sysctl kern.coredump: " + err.Error()}
+	}
+	if strings.TrimSpace(v) != "1" {
+		return Check{
+			Name:   "kern.coredump",
+			Status: StatusWarn,
+			Detail: "full core dumps are disabled (macOS default) — a crash leaves no core file. Crash reports (.ips) are still written to ~/Library/Logs/DiagnosticReports.",
+			Fix:    "Enable cores before you need them: sudo sysctl kern.coredump=1 and raise the size limit with `ulimit -c unlimited`.",
+		}
+	}
+	detail := "full core dumps are enabled"
+	if pattern, perr := host.Sysctl("kern.corefile"); perr == nil {
+		if p := strings.TrimSpace(pattern); p != "" {
+			detail += "; core file pattern " + p
+		}
+	}
+	return Check{Name: "kern.coredump", Status: StatusOK, Detail: detail}
+}
+
+func coreLimitCheck(host Host) Check {
+	soft, hard, err := host.CoreRLimit()
+	if err != nil {
+		return Check{Name: "core size limit", Status: StatusWarn, Detail: "could not read RLIMIT_CORE: " + err.Error()}
+	}
+	if soft == 0 {
+		return Check{
+			Name:   "core size limit",
+			Status: StatusWarn,
+			Detail: "RLIMIT_CORE soft limit is 0 — no core is written even when kern.coredump is enabled.",
+			Fix:    "Raise it in the launching context: `ulimit -c unlimited`, or set LimitCORE in the launchd job.",
+		}
+	}
+	return Check{Name: "core size limit", Status: StatusOK, Detail: fmt.Sprintf("RLIMIT_CORE soft=%s hard=%s", limitString(soft), limitString(hard))}
+}
+
+func coresDirCheck(host Host) Check {
+	if host.CoresDir() {
+		return Check{Name: "/cores", Status: StatusOK, Detail: "/cores exists — the kernel writes core files here as root"}
+	}
+	if coredumpEnabled(host) {
+		return Check{
+			Name:   "/cores",
+			Status: StatusWarn,
+			Detail: "/cores is absent while kern.coredump is enabled — confirm kern.corefile points at an existing, writable directory.",
+			Fix:    "Create it (`sudo mkdir -m 1777 /cores`) or point kern.corefile at a writable path.",
+		}
+	}
+	return Check{Name: "/cores", Status: StatusOK, Detail: "/cores is absent (moot while core dumps are disabled)"}
+}
+
+func dialogTypeCheck(host Host) Check {
+	dt := host.CrashReporterDialogType()
+	detail := "DialogType unset (default)"
+	if dt != "" {
+		detail = "DialogType=" + dt
+	}
+	detail += " — crash reports are written to ~/Library/Logs/DiagnosticReports regardless."
+	return Check{Name: "CrashReporter", Status: StatusOK, Detail: detail}
+}
+
+func appDebugCheck(a AppDebug) Check {
+	name := "app: " + a.Name
+	switch {
+	case a.GetTaskAllow:
+		return Check{Name: name, Status: StatusOK, Detail: "carries get-task-allow — a debugger can attach and read its memory, and cores are symbolicable."}
+	case a.HardenedRuntime:
+		return Check{
+			Name:   name,
+			Status: StatusWarn,
+			Detail: "hardened runtime without get-task-allow — task_for_pid is blocked, so lldb attach fails and cores may be unsymbolicable. Normal for release builds.",
+			Fix:    "To debug it, use a build signed with the com.apple.security.get-task-allow entitlement (an Xcode Debug build, or re-sign with it).",
+		}
+	default:
+		return Check{Name: name, Status: StatusOK, Detail: "no hardened runtime — a debugger can generally attach (system apps are still gated by SIP)."}
+	}
+}
+
+func limitString(v uint64) string {
+	if v == rlimInfinity {
+		return "unlimited"
+	}
+	return fmt.Sprintf("%d", v)
+}

--- a/internal/crashready/crashready_test.go
+++ b/internal/crashready/crashready_test.go
@@ -1,0 +1,136 @@
+package crashready
+
+import (
+	"strings"
+	"testing"
+)
+
+// fakeHost is a scripted Host for table tests.
+type fakeHost struct {
+	sysctls    map[string]string
+	sysctlErr  map[string]error
+	softLimit  uint64
+	hardLimit  uint64
+	limitErr   error
+	coresDir   bool
+	dialogType string
+}
+
+func (f fakeHost) Sysctl(key string) (string, error) {
+	if f.sysctlErr != nil {
+		if err := f.sysctlErr[key]; err != nil {
+			return "", err
+		}
+	}
+	return f.sysctls[key], nil
+}
+func (f fakeHost) CoreRLimit() (uint64, uint64, error) { return f.softLimit, f.hardLimit, f.limitErr }
+func (f fakeHost) CoresDir() bool                      { return f.coresDir }
+func (f fakeHost) CrashReporterDialogType() string     { return f.dialogType }
+
+func statusOf(r Report, name string) Status {
+	for _, c := range r.Checks {
+		if c.Name == name {
+			return c.Status
+		}
+	}
+	return Status("<missing>")
+}
+
+func TestCoredumpDisabledWarns(t *testing.T) {
+	h := fakeHost{sysctls: map[string]string{"kern.coredump": "0"}, softLimit: rlimInfinity, hardLimit: rlimInfinity, coresDir: true}
+	r := Evaluate(h, nil)
+	if got := statusOf(r, "kern.coredump"); got != StatusWarn {
+		t.Fatalf("kern.coredump status = %q, want warn", got)
+	}
+	if !r.Ready() {
+		t.Error("disabled cores are advisory (warn), report should still be Ready")
+	}
+}
+
+func TestCoredumpEnabledOK(t *testing.T) {
+	h := fakeHost{
+		sysctls:   map[string]string{"kern.coredump": "1", "kern.corefile": "/cores/core.%P"},
+		softLimit: rlimInfinity, hardLimit: rlimInfinity, coresDir: true,
+	}
+	r := Evaluate(h, nil)
+	if got := statusOf(r, "kern.coredump"); got != StatusOK {
+		t.Fatalf("kern.coredump status = %q, want ok", got)
+	}
+	var detail string
+	for _, c := range r.Checks {
+		if c.Name == "kern.coredump" {
+			detail = c.Detail
+		}
+	}
+	if want := "/cores/core.%P"; !strings.Contains(detail, want) {
+		t.Errorf("detail %q should mention corefile pattern %q", detail, want)
+	}
+}
+
+func TestCoreLimitZeroWarns(t *testing.T) {
+	h := fakeHost{sysctls: map[string]string{"kern.coredump": "1"}, softLimit: 0, hardLimit: rlimInfinity, coresDir: true}
+	r := Evaluate(h, nil)
+	if got := statusOf(r, "core size limit"); got != StatusWarn {
+		t.Fatalf("core size limit status = %q, want warn", got)
+	}
+}
+
+func TestCoresDirMissingWhileEnabledWarns(t *testing.T) {
+	h := fakeHost{sysctls: map[string]string{"kern.coredump": "1"}, softLimit: rlimInfinity, coresDir: false}
+	if got := statusOf(Evaluate(h, nil), "/cores"); got != StatusWarn {
+		t.Fatalf("/cores status = %q, want warn (enabled but absent)", got)
+	}
+}
+
+func TestCoresDirMissingWhileDisabledOK(t *testing.T) {
+	h := fakeHost{sysctls: map[string]string{"kern.coredump": "0"}, softLimit: rlimInfinity, coresDir: false}
+	if got := statusOf(Evaluate(h, nil), "/cores"); got != StatusOK {
+		t.Fatalf("/cores status = %q, want ok (moot while disabled)", got)
+	}
+}
+
+func TestAppHardenedWithoutGetTaskAllowWarns(t *testing.T) {
+	h := fakeHost{sysctls: map[string]string{"kern.coredump": "1"}, softLimit: rlimInfinity, coresDir: true}
+	app := &AppDebug{Name: "Locked", HardenedRuntime: true, GetTaskAllow: false}
+	r := Evaluate(h, app)
+	if r.App != "Locked" {
+		t.Errorf("report App = %q, want Locked", r.App)
+	}
+	if got := statusOf(r, "app: Locked"); got != StatusWarn {
+		t.Fatalf("app status = %q, want warn", got)
+	}
+}
+
+func TestAppDebuggableOK(t *testing.T) {
+	h := fakeHost{sysctls: map[string]string{"kern.coredump": "1"}, softLimit: rlimInfinity, coresDir: true}
+	app := &AppDebug{Name: "Debuggable", HardenedRuntime: true, GetTaskAllow: true}
+	if got := statusOf(Evaluate(h, app), "app: Debuggable"); got != StatusOK {
+		t.Fatalf("app status = %q, want ok", got)
+	}
+}
+
+func TestReadyAndCounts(t *testing.T) {
+	// cores enabled but /cores absent -> warn; nothing critical -> Ready.
+	h := fakeHost{sysctls: map[string]string{"kern.coredump": "1"}, softLimit: 0, coresDir: false}
+	r := Evaluate(h, nil)
+	warn, crit := r.Counts()
+	if crit != 0 {
+		t.Errorf("critical = %d, want 0", crit)
+	}
+	if warn < 2 {
+		t.Errorf("warn = %d, want >= 2 (rlimit 0 and /cores absent)", warn)
+	}
+	if !r.Ready() {
+		t.Error("Ready() should be true with no critical checks")
+	}
+}
+
+func TestLimitString(t *testing.T) {
+	if got := limitString(rlimInfinity); got != "unlimited" {
+		t.Errorf("limitString(inf) = %q, want unlimited", got)
+	}
+	if got := limitString(0); got != "0" {
+		t.Errorf("limitString(0) = %q, want 0", got)
+	}
+}

--- a/internal/crashready/host.go
+++ b/internal/crashready/host.go
@@ -1,0 +1,51 @@
+package crashready
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// liveHost reads crash-capture facts from the running machine.
+type liveHost struct {
+	run func(name string, args ...string) ([]byte, error)
+}
+
+// NewLiveHost returns a Host backed by the running machine (sysctl, defaults,
+// RLIMIT_CORE, and /cores).
+func NewLiveHost() Host {
+	return liveHost{run: func(name string, args ...string) ([]byte, error) {
+		return exec.Command(name, args...).Output()
+	}}
+}
+
+func (h liveHost) Sysctl(key string) (string, error) {
+	out, err := h.run("sysctl", "-n", key)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (h liveHost) CoreRLimit() (uint64, uint64, error) {
+	var rl syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_CORE, &rl); err != nil {
+		return 0, 0, err
+	}
+	return rl.Cur, rl.Max, nil
+}
+
+func (h liveHost) CoresDir() bool {
+	fi, err := os.Stat("/cores")
+	return err == nil && fi.IsDir()
+}
+
+func (h liveHost) CrashReporterDialogType() string {
+	// `defaults read` exits non-zero when the key is unset; treat that as "".
+	out, err := h.run("defaults", "read", "com.apple.CrashReporter", "DialogType")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -712,6 +712,7 @@ func (d detector) readEntitlementsDetail(appPath string) (sandboxed bool, notabl
 		"com.apple.security.cs.allow-unsigned-executable-memory": true,
 		"com.apple.security.automation.apple-events":             true,
 		"com.apple.security.virtualization":                      true,
+		"com.apple.security.get-task-allow":                      true,
 	}
 
 	for key := range notableKeys {


### PR DESCRIPTION
## What

Adds **`spectra crash readiness [app]`** — a proactive audit of whether this machine (and optionally one app) can produce a debuggable crash *before* one happens. Teams usually learn too late that cores were off or an app couldn't be attached; this answers "if this crashes right now, will I get anything I can debug?"

## How

- **`internal/crashready`** — a pure `Evaluate(Host, *AppDebug) Report` over an injectable `Host` seam, so all logic is unit-tested without touching the machine (`host.go` is the only impure file).
  - Host checks: `kern.coredump`, `kern.corefile`, `RLIMIT_CORE` soft limit (via `syscall.Getrlimit`), `/cores` presence, `com.apple.CrashReporter` `DialogType`.
  - App checks (when a path is given): hardened runtime + `get-task-allow` → is `task_for_pid`/lldb attach possible.
  - Each finding is `ok` / `warn` / `critical` with a concrete fix. Severities are deliberately measured — common/expected states (cores off by default, release app without `get-task-allow`) are advisory `warn`, not `critical`.
- **`internal/detect`** now surfaces `com.apple.security.get-task-allow` in `Result.Entitlements`; the CLI builds the decoupled `AppDebug` from that, so `crashready` never imports `detect`.
- New `crash` command in the CLI table; documented in `docs/operations/cli.md`.

## Scope (v1)

CLI + a self-contained evaluation package. Host crash-capture facts aren't in `snapshot.Snapshot` today, so this ships as a live audit; folding the app-debuggability checks into the rules engine once those facts are snapshot-carried is a natural follow-up.

## Example

```
$ spectra crash readiness /Applications/MyApp.app
Post-mortem readiness — MyApp
[warn] kern.coredump
        full core dumps are disabled (macOS default) — a crash leaves no core file. ...
        fix: sudo sysctl kern.coredump=1 and raise the size limit with `ulimit -c unlimited`.
[warn] app: MyApp
        hardened runtime without get-task-allow — task_for_pid is blocked, so lldb attach fails ...
```

## Testing

- Table-driven `crashready` tests: cores-off warns, cores-on is ok and echoes the corefile pattern, `RLIMIT_CORE=0` warns, `/cores` absent warns only while cores are enabled, hardened-without-`get-task-allow` warns, debuggable app is ok, `Ready()`/`Counts()`.
- Command tests: unknown-subcommand dispatch, `hasEntitlement`, status labels, and render output (incl. the `NOT ready` critical path).
- `detect` tests still green with the new entitlement.
- `make vet complexity lint security docs-validate test` all pass locally (47 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 stdlib quirk, unrelated to this change.

Closes #315
