### PR TITLE
fd debugging (3/3): fd sample history + leak-trend detection

### DIFF
--- a/cmd/spectra/rules.go
+++ b/cmd/spectra/rules.go
@@ -245,10 +245,11 @@ func resolveRulesConfigPath(configPath string) (path string, explicit bool) {
 }
 
 // attachCLIHistory opens the local samples store, persists the current
-// JVM samples and loads recent history so trend-aware rules engage when
-// `spectra rules` is invoked. Failure is silent: history is an enhancement.
+// JVM and fd samples and loads recent history so trend-aware rules engage
+// when `spectra rules` is invoked. Failure is silent: history is an
+// enhancement.
 func attachCLIHistory(snap *snapshot.Snapshot) {
-	if len(snap.JVMs) == 0 {
+	if len(snap.JVMs) == 0 && !hasOpenFDs(snap) {
 		return
 	}
 	dbPath, err := store.DefaultPath()
@@ -261,6 +262,18 @@ func attachCLIHistory(snap *snapshot.Snapshot) {
 	}
 	defer db.Close()
 	db.AttachJVMHistory(context.Background(), snap)
+	db.AttachFDHistory(context.Background(), snap)
+}
+
+// hasOpenFDs reports whether any process in the snapshot has a positive
+// open-fd count, i.e. deep-mode data that fd trend history can use.
+func hasOpenFDs(snap *snapshot.Snapshot) bool {
+	for _, p := range snap.Processes {
+		if p.OpenFDs > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func loadStoredSnapshot(id string) (*snapshot.Snapshot, error) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1575,11 +1575,11 @@ func (s *Server) evaluateRules(snapshotID, config string) (snapshot.Snapshot, []
 	return snap, rules.Evaluate(snap, catalog), nil
 }
 
-// attachJVMHistory opens the local samples store, calls AttachJVMHistory,
-// and closes the connection. Failure is silent — history is an enhancement,
-// not a contract.
+// attachJVMHistory opens the local samples store, calls AttachJVMHistory and
+// AttachFDHistory, and closes the connection. Failure is silent — history is
+// an enhancement, not a contract.
 func attachJVMHistory(snap *snapshot.Snapshot) {
-	if len(snap.JVMs) == 0 {
+	if len(snap.JVMs) == 0 && !snapHasOpenFDs(snap) {
 		return
 	}
 	db, err := openStore()
@@ -1588,6 +1588,18 @@ func attachJVMHistory(snap *snapshot.Snapshot) {
 	}
 	defer db.Close()
 	db.AttachJVMHistory(context.Background(), snap)
+	db.AttachFDHistory(context.Background(), snap)
+}
+
+// snapHasOpenFDs reports whether any process in the snapshot has a positive
+// open-fd count, i.e. deep-mode data that fd trend history can use.
+func snapHasOpenFDs(snap *snapshot.Snapshot) bool {
+	for _, p := range snap.Processes {
+		if p.OpenFDs > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func persistFindings(snap snapshot.Snapshot, findings []rules.Finding) ([]string, error) {

--- a/internal/rules/fd_pressure.go
+++ b/internal/rules/fd_pressure.go
@@ -94,20 +94,20 @@ func escalateFDLeak(base Finding, proc process.Info, soft int) Finding {
 // is climbing across the sample window but has not yet reached fdWarnPct. It
 // catches a leak early — before descriptor exhaustion — and is only ever
 // reached behind HasFDTrendFor, so no-history snapshots never see it.
+//
+// Like fdProcessFinding, it stays silent when the soft limit is unknown
+// (soft <= 0): "below the limit" is meaningless without a limit, and the rule
+// as a whole reports nothing when the fd limit could not be collected.
 func fdEarlyLeakFinding(proc process.Info, soft int) (Finding, bool) {
-	if proc.OpenFDs <= 0 {
+	if proc.OpenFDs <= 0 || soft <= 0 {
 		return Finding{}, false
-	}
-	limitClause := "the fd soft limit"
-	if soft > 0 {
-		limitClause = fmt.Sprintf("the fd soft limit (%d)", soft)
 	}
 	return Finding{
 		RuleID:   "fd-pressure",
 		Severity: SeverityMedium,
 		Subject:  fmt.Sprintf("PID %d (%s)", proc.PID, fdProcessName(proc)),
-		Message: fmt.Sprintf("open_fds=%d is rising across recent samples while still below %s; this looks like an early file-descriptor leak.",
-			proc.OpenFDs, limitClause),
+		Message: fmt.Sprintf("open_fds=%d is rising across recent samples while still below the fd soft limit (%d); this looks like an early file-descriptor leak.",
+			proc.OpenFDs, soft),
 		Fix: "Investigate a possible file-descriptor leak before the process approaches its limit (`lsof -p <pid>` to see what is accumulating).",
 	}, true
 }

--- a/internal/rules/fd_pressure.go
+++ b/internal/rules/fd_pressure.go
@@ -42,7 +42,7 @@ func matchFDPressure(s snapshot.Snapshot) []Finding {
 		if proc.OpenFDs > 0 {
 			total += proc.OpenFDs
 		}
-		if f, ok := fdProcessFinding(proc, s.FDLimit.Soft); ok {
+		if f, ok := fdProcessFindingWithHistory(proc, s.FDLimit.Soft, s.FDHistory); ok {
 			findings = append(findings, f)
 		}
 	}
@@ -50,6 +50,66 @@ func matchFDPressure(s snapshot.Snapshot) []Finding {
 		findings = append(findings, f)
 	}
 	return findings
+}
+
+// fdProcessFindingWithHistory layers trend awareness over the point-in-time
+// fdProcessFinding. It consults snapshot.FDHistory exactly the way
+// ruleJVMGCPressure consults JVMHistory:
+//
+//   - On the existing >=80% path: if fd usage is rising across the window
+//     (>=3 samples, non-decreasing, net climb) the finding is re-worded as a
+//     probable leak and escalated to High. If history exists but is steady
+//     (not rising) the original finding is kept without escalation.
+//   - Below 80%: a rising window still emits a distinct early-leak finding.
+//
+// When FDHistory is empty/nil, HasFDTrendFor is false, so this collapses to
+// exactly fdProcessFinding — the no-history one-shot case is byte-for-byte
+// unchanged.
+func fdProcessFindingWithHistory(proc process.Info, soft int, h snapshot.FDHistory) (Finding, bool) {
+	rising := HasFDTrendFor(h, proc.PID) && RisingFDsFor(h, proc.PID)
+	if f, ok := fdProcessFinding(proc, soft); ok {
+		if rising {
+			return escalateFDLeak(f, proc, soft), true
+		}
+		return f, true
+	}
+	if rising {
+		return fdEarlyLeakFinding(proc, soft)
+	}
+	return Finding{}, false
+}
+
+// escalateFDLeak re-words an at-threshold finding as a confirmed leak and
+// raises it to High severity. The rising slope removes the ambiguity between
+// a steady high-water mark and descriptor exhaustion in progress.
+func escalateFDLeak(base Finding, proc process.Info, soft int) Finding {
+	pct := proc.OpenFDs * 100 / soft
+	base.Severity = SeverityHigh
+	base.Message = fmt.Sprintf("open_fds=%d is %d%% of the default fd soft limit (%d) and rising across recent samples; this is a probable file-descriptor leak.",
+		proc.OpenFDs, pct, soft)
+	return base
+}
+
+// fdEarlyLeakFinding emits a Medium finding for a process whose open-fd count
+// is climbing across the sample window but has not yet reached fdWarnPct. It
+// catches a leak early — before descriptor exhaustion — and is only ever
+// reached behind HasFDTrendFor, so no-history snapshots never see it.
+func fdEarlyLeakFinding(proc process.Info, soft int) (Finding, bool) {
+	if proc.OpenFDs <= 0 {
+		return Finding{}, false
+	}
+	limitClause := "the fd soft limit"
+	if soft > 0 {
+		limitClause = fmt.Sprintf("the fd soft limit (%d)", soft)
+	}
+	return Finding{
+		RuleID:   "fd-pressure",
+		Severity: SeverityMedium,
+		Subject:  fmt.Sprintf("PID %d (%s)", proc.PID, fdProcessName(proc)),
+		Message: fmt.Sprintf("open_fds=%d is rising across recent samples while still below %s; this looks like an early file-descriptor leak.",
+			proc.OpenFDs, limitClause),
+		Fix: "Investigate a possible file-descriptor leak before the process approaches its limit (`lsof -p <pid>` to see what is accumulating).",
+	}, true
 }
 
 // fdProcessFinding evaluates one process against its soft fd limit. It returns

--- a/internal/rules/fd_pressure_test.go
+++ b/internal/rules/fd_pressure_test.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/kaeawc/spectra/internal/process"
@@ -113,6 +115,99 @@ func TestFDPressureSystemWide(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fdHist builds an FDHistory for one PID from an explicit sequence of counts.
+func fdHist(pid int, counts ...int) snapshot.FDHistory {
+	out := make(snapshot.FDHistory, len(counts))
+	for i, c := range counts {
+		out[i] = snapshot.FDSample{PID: pid, OpenFDs: c}
+	}
+	return out
+}
+
+// TestFDPressureRisingLeak: a process at >=80% whose fd count is rising across
+// the window is escalated to High and re-worded as a probable leak.
+func TestFDPressureRisingLeak(t *testing.T) {
+	s := fdSnap(1000, "", fdProc(42, "leaky", 850)) // 85% → Medium on the point-in-time path
+	s.FDHistory = fdHist(42, 600, 720, 850)         // rising
+	findings := findingsFor(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityHigh {
+		t.Errorf("rising leak should escalate to High, got %q", findings[0].Severity)
+	}
+	if !strings.Contains(findings[0].Message, "leak") {
+		t.Errorf("expected leak wording, got %q", findings[0].Message)
+	}
+}
+
+// TestFDPressureSteadyState: a process at >=80% with history that is NOT rising
+// keeps the original Medium finding without escalation.
+func TestFDPressureSteadyState(t *testing.T) {
+	s := fdSnap(1000, "", fdProc(42, "steady", 850)) // 85%
+	s.FDHistory = fdHist(42, 850, 850, 850)          // flat high-water mark
+	findings := findingsFor(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityMedium {
+		t.Errorf("steady state should NOT escalate, got %q", findings[0].Severity)
+	}
+	if strings.Contains(findings[0].Message, "probable file-descriptor leak") {
+		t.Errorf("steady state should keep the original message, got %q", findings[0].Message)
+	}
+}
+
+// TestFDPressureEarlyLeak: a process below 80% whose fd count is rising still
+// emits a distinct early-leak finding.
+func TestFDPressureEarlyLeak(t *testing.T) {
+	s := fdSnap(1000, "", fdProc(42, "early", 400)) // 40% → no point-in-time finding
+	s.FDHistory = fdHist(42, 100, 250, 400)         // rising
+	findings := findingsFor(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 early-leak finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityMedium {
+		t.Errorf("early leak should be Medium, got %q", findings[0].Severity)
+	}
+	if !strings.Contains(findings[0].Message, "early file-descriptor leak") {
+		t.Errorf("expected early-leak wording, got %q", findings[0].Message)
+	}
+}
+
+// TestFDPressureBelowThresholdSteadyNoFinding: below 80% and not rising → silent.
+func TestFDPressureBelowThresholdSteadyNoFinding(t *testing.T) {
+	s := fdSnap(1000, "", fdProc(42, "quiet", 400))
+	s.FDHistory = fdHist(42, 400, 400, 400) // flat, below threshold
+	if findings := findingsFor(s); len(findings) != 0 {
+		t.Fatalf("expected no findings for a flat below-threshold process, got %+v", findings)
+	}
+}
+
+// TestFDPressureNoHistoryUnchanged: with empty history, an at-threshold process
+// produces exactly the point-in-time finding (byte-for-byte behavior).
+func TestFDPressureNoHistoryUnchanged(t *testing.T) {
+	s := fdSnap(1000, "", fdProc(42, "leaky", 850)) // 85%, no FDHistory
+	findings := findingsFor(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityMedium {
+		t.Errorf("no history should stay Medium, got %q", findings[0].Severity)
+	}
+	want := fdProcessFindingMessage(850, 85, 1000)
+	if findings[0].Message != want {
+		t.Errorf("message = %q, want %q", findings[0].Message, want)
+	}
+}
+
+// fdProcessFindingMessage mirrors the point-in-time message format so the
+// no-history test can assert byte-for-byte equality.
+func fdProcessFindingMessage(openFDs, pct, soft int) string {
+	return fmt.Sprintf("open_fds=%d is %d%% of the default fd soft limit (%d); process may be approaching descriptor exhaustion.",
+		openFDs, pct, soft)
 }
 
 // TestFDPressureBothFindings verifies per-process and system findings coexist.

--- a/internal/rules/fd_pressure_test.go
+++ b/internal/rules/fd_pressure_test.go
@@ -186,6 +186,18 @@ func TestFDPressureBelowThresholdSteadyNoFinding(t *testing.T) {
 	}
 }
 
+// TestFDPressureRisingUnknownLimitNoFinding: a rising fd trend must NOT emit an
+// early-leak finding when the soft limit is unknown (soft <= 0). "Below the
+// limit" is meaningless without a limit, and the rule reports nothing when the
+// fd limit could not be collected.
+func TestFDPressureRisingUnknownLimitNoFinding(t *testing.T) {
+	s := fdSnap(0, "", fdProc(42, "leaky", 400)) // soft limit unknown
+	s.FDHistory = fdHist(42, 100, 250, 400)      // rising
+	if findings := findingsFor(s); len(findings) != 0 {
+		t.Fatalf("expected no findings when soft limit is unknown, got %+v", findings)
+	}
+}
+
 // TestFDPressureNoHistoryUnchanged: with empty history, an at-threshold process
 // produces exactly the point-in-time finding (byte-for-byte behavior).
 func TestFDPressureNoHistoryUnchanged(t *testing.T) {

--- a/internal/rules/history.go
+++ b/internal/rules/history.go
@@ -42,3 +42,34 @@ func RisingOldGenFor(h snapshot.JVMHistory, pid int) bool {
 func HasTrendFor(h snapshot.JVMHistory, pid int) bool {
 	return len(h.SamplesFor(pid)) >= MinTrendSamples
 }
+
+// HasFDTrendFor reports whether there are enough fd samples for trend
+// predicates to be meaningful. Rules use this to decide whether to apply a
+// trend gate or fall back to point-in-time checks. Mirrors HasTrendFor.
+func HasFDTrendFor(h snapshot.FDHistory, pid int) bool {
+	return len(h.SamplesFor(pid)) >= MinTrendSamples
+}
+
+// RisingFDsFor reports whether open-fd usage is climbing for pid in the given
+// history. Returns false when there is no history or fewer than
+// MinTrendSamples observations.
+//
+// Unlike the coarse first/last old-gen comparison, a descriptor leak shows as
+// a monotone climb: allocation without release. "Rising" therefore requires
+// the samples to be non-decreasing across the window AND the last sample to
+// exceed the first (a net climb, not a flat high-water mark). A single dip —
+// the process closing descriptors — is enough to disqualify the window, which
+// is the conservative choice: the cost of a missed leak is one delayed cycle,
+// the cost of a false leak signal is noise on healthy steady-state processes.
+func RisingFDsFor(h snapshot.FDHistory, pid int) bool {
+	samples := h.SamplesFor(pid)
+	if len(samples) < MinTrendSamples {
+		return false
+	}
+	for i := 1; i < len(samples); i++ {
+		if samples[i].OpenFDs < samples[i-1].OpenFDs {
+			return false
+		}
+	}
+	return samples[len(samples)-1].OpenFDs > samples[0].OpenFDs
+}

--- a/internal/rules/history_test.go
+++ b/internal/rules/history_test.go
@@ -77,3 +77,72 @@ func TestHasTrendFor(t *testing.T) {
 		t.Error("3 samples → enough")
 	}
 }
+
+// helper: build fd samples for one PID from an explicit sequence of counts.
+func fdSamples(pid int, counts ...int) snapshot.FDHistory {
+	out := make(snapshot.FDHistory, len(counts))
+	now := time.Now()
+	for i, c := range counts {
+		out[i] = snapshot.FDSample{
+			PID:     pid,
+			At:      now.Add(time.Duration(i-len(counts)) * time.Minute),
+			OpenFDs: c,
+		}
+	}
+	return out
+}
+
+func TestRisingFDsFor_NoHistory(t *testing.T) {
+	if RisingFDsFor(nil, 10) {
+		t.Error("nil history should not report rising")
+	}
+}
+
+func TestRisingFDsFor_TooFewSamples(t *testing.T) {
+	if RisingFDsFor(fdSamples(10, 100, 500), 10) { // big jump but only 2 samples
+		t.Error("only 2 samples should not be enough for trend")
+	}
+}
+
+func TestRisingFDsFor_RisingTrend(t *testing.T) {
+	if !RisingFDsFor(fdSamples(10, 100, 150, 220), 10) {
+		t.Error("100 -> 150 -> 220 should be rising")
+	}
+}
+
+func TestRisingFDsFor_FlatTrend(t *testing.T) {
+	if RisingFDsFor(fdSamples(10, 200, 200, 200), 10) {
+		t.Error("flat window should not be rising (no net climb)")
+	}
+}
+
+func TestRisingFDsFor_NonMonotonicNotRising(t *testing.T) {
+	// Net climb from first to last, but a mid-window dip disqualifies it.
+	if RisingFDsFor(fdSamples(10, 100, 90, 130), 10) {
+		t.Error("a mid-window dip should disqualify the rising trend")
+	}
+}
+
+func TestRisingFDsFor_FallingTrend(t *testing.T) {
+	if RisingFDsFor(fdSamples(10, 300, 200, 100), 10) {
+		t.Error("300 -> 100 should not be rising")
+	}
+}
+
+func TestRisingFDsFor_OtherPID(t *testing.T) {
+	if RisingFDsFor(fdSamples(10, 100, 150, 220), 99) {
+		t.Error("trend for another PID should not match")
+	}
+}
+
+func TestHasFDTrendFor(t *testing.T) {
+	if HasFDTrendFor(nil, 10) {
+		t.Error("nil history → no trend")
+	}
+	if HasFDTrendFor(fdSamples(10, 100, 200), 10) {
+		t.Error("2 samples → not enough")
+	}
+	if !HasFDTrendFor(fdSamples(10, 100, 150, 200), 10) {
+		t.Error("3 samples → enough")
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -505,6 +505,7 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB, history *li
 			_ = db.SaveGrantedPerms(ctx, snap.ID, store.GrantedPermsFromSnapshot(snap))
 			_, _ = db.PruneAutoSnapshots(ctx, cfg.Retain)
 			_, _ = db.PruneJVMSamples(ctx, 7)
+			_, _ = db.PruneFDSamples(ctx, 7)
 		}
 	}
 }

--- a/internal/snapshot/fd_history.go
+++ b/internal/snapshot/fd_history.go
@@ -1,0 +1,51 @@
+package snapshot
+
+import (
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+// FDSample is one historical point of file-descriptor usage for a single PID.
+// It is a deliberately compact subset of process.Info — enough to compute a
+// leak slope without re-deserializing whole snapshots.
+type FDSample struct {
+	PID     int       `json:"pid"`
+	At      time.Time `json:"at"`
+	OpenFDs int       `json:"open_fds"`
+}
+
+// FDSampleFrom builds a sample from a live process.Info reading. Returns
+// ok=false when the process reports no open descriptors (shallow mode, where
+// OpenFDs is 0, or a collection that never ran).
+func FDSampleFrom(p process.Info, at time.Time) (FDSample, bool) {
+	if p.OpenFDs <= 0 {
+		return FDSample{}, false
+	}
+	return FDSample{
+		PID:     p.PID,
+		At:      at.UTC(),
+		OpenFDs: p.OpenFDs,
+	}, true
+}
+
+// FDHistory is a slice of FDSamples in chronological order (oldest first).
+// Empty / nil is the legitimate "no history available" state — callers must
+// treat absence as "fall back to point-in-time rules", not as an error.
+type FDHistory []FDSample
+
+// SamplesFor returns just the samples for one PID, preserving order.
+// Returns nil (not empty slice) when there are zero matches so callers can
+// branch on `samples == nil` to mean "no history."
+func (h FDHistory) SamplesFor(pid int) []FDSample {
+	if len(h) == 0 {
+		return nil
+	}
+	var out []FDSample
+	for _, s := range h {
+		if s.PID == pid {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/snapshot/fd_history_test.go
+++ b/internal/snapshot/fd_history_test.go
@@ -1,0 +1,67 @@
+package snapshot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+func TestFDHistory_SamplesFor(t *testing.T) {
+	now := time.Now()
+	h := FDHistory{
+		{PID: 10, At: now.Add(-3 * time.Minute), OpenFDs: 100},
+		{PID: 11, At: now.Add(-3 * time.Minute), OpenFDs: 50},
+		{PID: 10, At: now.Add(-2 * time.Minute), OpenFDs: 120},
+		{PID: 10, At: now.Add(-1 * time.Minute), OpenFDs: 140},
+	}
+	got := h.SamplesFor(10)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 samples for PID 10, got %d", len(got))
+	}
+	for i, want := range []int{100, 120, 140} {
+		if got[i].OpenFDs != want {
+			t.Errorf("sample %d: OpenFDs = %v, want %v", i, got[i].OpenFDs, want)
+		}
+	}
+}
+
+func TestFDHistory_SamplesForNoMatch(t *testing.T) {
+	h := FDHistory{{PID: 10, OpenFDs: 50}}
+	if got := h.SamplesFor(99); got != nil {
+		t.Errorf("expected nil for missing PID, got %v", got)
+	}
+}
+
+func TestFDHistory_SamplesForEmpty(t *testing.T) {
+	var h FDHistory
+	if got := h.SamplesFor(10); got != nil {
+		t.Errorf("expected nil from empty history, got %v", got)
+	}
+}
+
+func TestFDSampleFrom(t *testing.T) {
+	at := time.Date(2026, 5, 8, 10, 0, 0, 0, time.Local)
+	sm, ok := FDSampleFrom(process.Info{PID: 42, OpenFDs: 128}, at)
+	if !ok {
+		t.Fatal("expected ok for a process with open descriptors")
+	}
+	if sm.PID != 42 || sm.OpenFDs != 128 {
+		t.Errorf("unexpected sample: %+v", sm)
+	}
+	if !sm.At.Equal(at) {
+		t.Errorf("At = %v, want %v", sm.At, at)
+	}
+	if sm.At.Location() != time.UTC {
+		t.Errorf("At should be normalized to UTC, got %v", sm.At.Location())
+	}
+}
+
+func TestFDSampleFrom_NoDescriptors(t *testing.T) {
+	if _, ok := FDSampleFrom(process.Info{PID: 42, OpenFDs: 0}, time.Now()); ok {
+		t.Error("expected ok=false when OpenFDs is 0 (shallow mode)")
+	}
+	if _, ok := FDSampleFrom(process.Info{PID: 42, OpenFDs: -1}, time.Now()); ok {
+		t.Error("expected ok=false when OpenFDs is negative")
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -60,6 +60,11 @@ type Snapshot struct {
 	// callers that have access to a snapshot store. Optional: rules that
 	// don't see history fall back to point-in-time checks.
 	JVMHistory JVMHistory `json:"jvm_history,omitempty"`
+
+	// FDHistory is recent per-PID file-descriptor samples (oldest first)
+	// populated by callers that have access to a snapshot store. Optional:
+	// rules that don't see history fall back to point-in-time checks.
+	FDHistory FDHistory `json:"fd_history,omitempty"`
 }
 
 // Options configure a snapshot Build.

--- a/internal/store/fd_samples_test.go
+++ b/internal/store/fd_samples_test.go
@@ -1,0 +1,162 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func TestSaveAndGetFDSamples(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	base := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	samples := []snapshot.FDSample{
+		{PID: 1127, At: base, OpenFDs: 100},
+		{PID: 1127, At: base.Add(time.Minute), OpenFDs: 130},
+		{PID: 1127, At: base.Add(2 * time.Minute), OpenFDs: 170},
+		{PID: 999, At: base.Add(time.Minute), OpenFDs: 30}, // unrelated PID
+	}
+	if err := db.SaveFDSamples(ctx, samples); err != nil {
+		t.Fatalf("SaveFDSamples: %v", err)
+	}
+
+	got, err := db.GetRecentFDSamples(ctx, 1127, 0)
+	if err != nil {
+		t.Fatalf("GetRecentFDSamples: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 samples for PID 1127, got %d", len(got))
+	}
+	for i, want := range []int{100, 130, 170} {
+		if got[i].OpenFDs != want {
+			t.Errorf("sample %d: OpenFDs = %v, want %v", i, got[i].OpenFDs, want)
+		}
+	}
+	if !got[0].At.Equal(base) {
+		t.Errorf("At roundtrip failed: got %v want %v", got[0].At, base)
+	}
+}
+
+func TestGetRecentFDSamples_Limit(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < 10; i++ {
+		if err := db.SaveFDSamples(ctx, []snapshot.FDSample{{
+			PID: 7, At: base.Add(time.Duration(i) * time.Minute), OpenFDs: i * 10,
+		}}); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+	}
+	got, err := db.GetRecentFDSamples(ctx, 7, 3)
+	if err != nil {
+		t.Fatalf("GetRecentFDSamples: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 samples, got %d", len(got))
+	}
+	// Should be the 3 newest, in oldest-first order: counts 70, 80, 90.
+	for i, want := range []int{70, 80, 90} {
+		if got[i].OpenFDs != want {
+			t.Errorf("sample %d: OpenFDs = %v, want %v", i, got[i].OpenFDs, want)
+		}
+	}
+}
+
+func TestGetRecentFDSamples_None(t *testing.T) {
+	db := openTestDB(t)
+	got, err := db.GetRecentFDSamples(context.Background(), 12345, 0)
+	if err != nil {
+		t.Fatalf("GetRecentFDSamples: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for PID with no samples, got %v", got)
+	}
+}
+
+func TestSaveFDSamples_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	at := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	first := snapshot.FDSample{PID: 1, At: at, OpenFDs: 50}
+	updated := snapshot.FDSample{PID: 1, At: at, OpenFDs: 95} // same key
+	if err := db.SaveFDSamples(ctx, []snapshot.FDSample{first}); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if err := db.SaveFDSamples(ctx, []snapshot.FDSample{updated}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, _ := db.GetRecentFDSamples(ctx, 1, 0)
+	if len(got) != 1 || got[0].OpenFDs != 95 {
+		t.Errorf("upsert should overwrite, got %v", got)
+	}
+}
+
+func TestPruneFDSamples(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	old1 := snapshot.FDSample{PID: 1, At: now.Add(-30 * 24 * time.Hour), OpenFDs: 10}
+	old2 := snapshot.FDSample{PID: 1, At: now.Add(-10 * 24 * time.Hour), OpenFDs: 20}
+	recent := snapshot.FDSample{PID: 1, At: now.Add(-1 * time.Hour), OpenFDs: 90}
+	if err := db.SaveFDSamples(ctx, []snapshot.FDSample{old1, old2, recent}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	deleted, err := db.PruneFDSamples(ctx, 7)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("expected 2 deleted, got %d", deleted)
+	}
+	got, _ := db.GetRecentFDSamples(ctx, 1, 0)
+	if len(got) != 1 || got[0].OpenFDs != 90 {
+		t.Errorf("only the recent row should survive, got %v", got)
+	}
+}
+
+func TestAttachFDHistory(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+
+	// Seed two prior samples for PID 42 so a window builds up.
+	if err := db.SaveFDSamples(ctx, []snapshot.FDSample{
+		{PID: 42, At: base, OpenFDs: 100},
+		{PID: 42, At: base.Add(time.Minute), OpenFDs: 130},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	snap := &snapshot.Snapshot{
+		TakenAt:   base.Add(2 * time.Minute),
+		Processes: []process.Info{{PID: 42, OpenFDs: 170}},
+	}
+	db.AttachFDHistory(ctx, snap)
+
+	got := snap.FDHistory.SamplesFor(42)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 samples attached for PID 42, got %d", len(got))
+	}
+	for i, want := range []int{100, 130, 170} {
+		if got[i].OpenFDs != want {
+			t.Errorf("sample %d: OpenFDs = %v, want %v", i, got[i].OpenFDs, want)
+		}
+	}
+}
+
+func TestAttachFDHistory_NoOpenFDs(t *testing.T) {
+	db := openTestDB(t)
+	snap := &snapshot.Snapshot{
+		TakenAt:   time.Now(),
+		Processes: []process.Info{{PID: 42, OpenFDs: 0}},
+	}
+	db.AttachFDHistory(context.Background(), snap)
+	if snap.FDHistory != nil {
+		t.Errorf("expected no history for a snapshot with no open descriptors, got %v", snap.FDHistory)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -266,6 +266,15 @@ CREATE TABLE IF NOT EXISTS jvm_samples (
 
 CREATE INDEX IF NOT EXISTS idx_jvm_samples_pid ON jvm_samples(pid, at_nano DESC);
 
+CREATE TABLE IF NOT EXISTS fd_samples (
+    pid          INTEGER NOT NULL,
+    at_nano      INTEGER NOT NULL,
+    open_fds     INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pid, at_nano)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fd_samples_pid ON fd_samples(pid, at_nano DESC);
+
 CREATE TABLE IF NOT EXISTS issues (
     id                     TEXT PRIMARY KEY,
     rule_id                TEXT NOT NULL,
@@ -1066,6 +1075,127 @@ func (s *DB) PruneJVMSamples(ctx context.Context, keepDays int) (int64, error) {
 	}
 	cutoff := time.Now().UTC().Add(-time.Duration(keepDays) * 24 * time.Hour).UnixNano()
 	res, err := s.db.ExecContext(ctx, `DELETE FROM jvm_samples WHERE at_nano < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// SaveFDSamples upserts compact per-PID file-descriptor samples used by
+// trend-aware rules. Timestamps are stored as nanoseconds so two parallel
+// diagnose calls within the same wall-clock second produce distinct rows; the
+// upsert clause keeps reruns at literally the same instant idempotent.
+func (s *DB) SaveFDSamples(ctx context.Context, samples []snapshot.FDSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	for _, sm := range samples {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO fd_samples (pid, at_nano, open_fds)
+			VALUES (?,?,?)
+			ON CONFLICT(pid, at_nano) DO UPDATE SET
+			    open_fds=excluded.open_fds`,
+			sm.PID, sm.At.UTC().UnixNano(), sm.OpenFDs,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetRecentFDSamples returns up to limit fd samples for pid, ordered
+// oldest-first so callers can hand the slice straight to trend predicates.
+// Pass limit=0 for the default cap (60 samples).
+func (s *DB) GetRecentFDSamples(ctx context.Context, pid, limit int) ([]snapshot.FDSample, error) {
+	if limit <= 0 {
+		limit = 60
+	}
+	// Pull newest-first so LIMIT applies to the most recent rows, then reverse.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT pid, at_nano, open_fds
+		FROM fd_samples WHERE pid=?
+		ORDER BY at_nano DESC LIMIT ?`, pid, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []snapshot.FDSample
+	for rows.Next() {
+		var sm snapshot.FDSample
+		var atNano int64
+		if err := rows.Scan(&sm.PID, &atNano, &sm.OpenFDs); err != nil {
+			return nil, err
+		}
+		sm.At = time.Unix(0, atNano).UTC()
+		out = append(out, sm)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Reverse to oldest-first.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out, nil
+}
+
+// AttachFDHistory persists the current snapshot's per-process open-fd counts
+// as samples and loads recent samples per PID into snap.FDHistory so
+// trend-aware rules see a multi-sample window. Errors are accumulated but
+// never abort the caller — history is an enhancement, not a contract; rules
+// degrade to point-in-time checks when nothing is loaded.
+//
+// The snapshot's TakenAt is used as the sample timestamp when set, so
+// historical snapshots replayed against the store don't get a time.Now()
+// stamp that would corrupt trend ordering.
+func (s *DB) AttachFDHistory(ctx context.Context, snap *snapshot.Snapshot) {
+	if snap == nil || len(snap.Processes) == 0 {
+		return
+	}
+	now := snap.TakenAt
+	if now.IsZero() {
+		now = time.Now()
+	}
+	current := make([]snapshot.FDSample, 0, len(snap.Processes))
+	for _, p := range snap.Processes {
+		if sm, ok := snapshot.FDSampleFrom(p, now); ok {
+			current = append(current, sm)
+		}
+	}
+	if len(current) == 0 {
+		return
+	}
+	_ = s.SaveFDSamples(ctx, current)
+
+	var history snapshot.FDHistory
+	for _, p := range snap.Processes {
+		if p.OpenFDs <= 0 {
+			continue
+		}
+		samples, err := s.GetRecentFDSamples(ctx, p.PID, 0)
+		if err != nil {
+			continue
+		}
+		history = append(history, samples...)
+	}
+	snap.FDHistory = history
+}
+
+// PruneFDSamples deletes fd_samples rows older than keepDays. Returns the
+// number of rows removed. keepDays <= 0 keeps the default of 7 days.
+func (s *DB) PruneFDSamples(ctx context.Context, keepDays int) (int64, error) {
+	if keepDays <= 0 {
+		keepDays = 7
+	}
+	cutoff := time.Now().UTC().Add(-time.Duration(keepDays) * 24 * time.Hour).UnixNano()
+	res, err := s.db.ExecContext(ctx, `DELETE FROM fd_samples WHERE at_nano < ?`, cutoff)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Closes #319.

Final fd-debugging PR. #307 added the `fd_limit` data source; #314 added the `fd-pressure` rule. A high fd count alone is ambiguous — a steady high-water mark is normal, a monotonic climb is a leak. This adds **fd sample history** so the rule can tell them apart, mirroring the existing JVM trend machinery.

## What

- **Sampling/history** (mirrors JVM): `snapshot.FDSample`/`FDHistory` (`fd_history.go`), a `fd_samples` table + index in the store, `Save/GetRecent/Prune FDSamples`, and `AttachFDHistory` (persist per-process `open_fds`, load recent per PID). Wired at every `AttachJVMHistory` site (`cmd/spectra/rules.go`, `internal/mcp/tools.go`) and `PruneFDSamples` next to `PruneJVMSamples` (`internal/serve/serve.go`).
- **Trend predicates** (`internal/rules/history.go`): `HasFDTrendFor` (≥3 samples) and `RisingFDsFor` (non-decreasing across the window **and** a net climb — one dip disqualifies, the conservative choice).
- **`fd-pressure` becomes trend-aware**: at ≥80% of the soft limit, a *rising* window escalates to High and re-words as a probable leak; a *steady* window keeps the original Medium finding (no escalation). Below 80%, a rising window emits a distinct early-leak finding — catching a leak before exhaustion.

## Safety

History is an enhancement, never a contract — every store error degrades silently to point-in-time behavior. When `FDHistory` is empty (the common one-shot CLI case) `HasFDTrendFor` is false and the rule collapses **byte-for-byte** to the #314 behavior; the pre-existing `fd-pressure` tests pass unchanged, and `TestFDPressureNoHistoryUnchanged` pins the exact message. The two attach wrappers' `len(snap.JVMs)==0` early-return was relaxed to also proceed when deep-mode fd data is present; `AttachJVMHistory`'s own internal no-JVM guard keeps its behavior a no-op, so JVM history is unaffected.

## Tests

Store round-trip + prune (`fd_samples_test.go`), predicate tests (rising/flat/decreasing/too-few), and rule cases for rising-leak (escalated), steady-state (no escalation), and below-threshold-but-rising (early leak).
