### PR TITLE
crash: parse & decode .ips crash reports (spectra crash inspect)

### DIFF
--- a/cmd/spectra/crash.go
+++ b/cmd/spectra/crash.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/kaeawc/spectra/internal/crashready"
+	"github.com/kaeawc/spectra/internal/crashreport"
 	"github.com/kaeawc/spectra/internal/detect"
 )
 
@@ -18,16 +20,118 @@ func runCrash(args []string) int {
 }
 
 func runCrashWithIO(args []string, stdout, stderr io.Writer, inspect func(string) (detect.Result, error)) int {
-	sub := "readiness"
+	sub := ""
 	rest := args
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		sub, rest = args[0], args[1:]
 	}
-	if sub != "readiness" {
-		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness)\n", sub)
+	switch sub {
+	case "", "readiness":
+		return runCrashReadiness(rest, stdout, stderr, inspect)
+	case "inspect":
+		return runCrashInspect(rest, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect)\n", sub)
 		return 2
 	}
-	return runCrashReadiness(rest, stdout, stderr, inspect)
+}
+
+func runCrashInspect(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("crash inspect", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	all := fs.Bool("all", false, "show every thread (default: the faulting thread only)")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra crash inspect [--json] [--all] <report.ips>")
+		fmt.Fprintln(stderr, "Decode a macOS .ips crash report into a readable summary.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	path := fs.Arg(0)
+	if path == "" {
+		fs.Usage()
+		return 2
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "read %s: %v\n", path, err)
+		return 1
+	}
+	report, err := crashreport.Parse(data)
+	if err != nil {
+		if errors.Is(err, crashreport.ErrLegacyFormat) {
+			fmt.Fprintf(stderr, "%s is a legacy plain-text crash report; spectra decodes modern .ips JSON reports.\n", path)
+			return 1
+		}
+		fmt.Fprintf(stderr, "parse %s: %v\n", path, err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	renderCrashReport(stdout, report, *all)
+	return 0
+}
+
+func renderCrashReport(w io.Writer, r *crashreport.Report, allThreads bool) {
+	renderCrashHeader(w, r)
+	renderCrashThreads(w, r, allThreads)
+}
+
+func renderCrashHeader(w io.Writer, r *crashreport.Report) {
+	fmt.Fprintf(w, "%s", r.Process)
+	if r.Version != "" {
+		fmt.Fprintf(w, " %s", r.Version)
+	}
+	fmt.Fprintf(w, "  [%s]\n", r.Kind)
+	if r.OSVersion != "" {
+		fmt.Fprintf(w, "  os:        %s\n", r.OSVersion)
+	}
+	if r.Time != "" {
+		fmt.Fprintf(w, "  time:      %s\n", r.Time)
+	}
+	if r.Exception != "" {
+		fmt.Fprintf(w, "  exception: %s", r.Exception)
+		if r.ExceptionDetail != "" {
+			fmt.Fprintf(w, " — %s", r.ExceptionDetail)
+		}
+		fmt.Fprintln(w)
+	}
+	if r.Termination != "" {
+		fmt.Fprintf(w, "  reason:    %s\n", r.Termination)
+	}
+	if r.Codes != "" {
+		fmt.Fprintf(w, "  codes:     %s\n", r.Codes)
+	}
+}
+
+func renderCrashThreads(w io.Writer, r *crashreport.Report, allThreads bool) {
+	for _, t := range r.Threads {
+		if !allThreads && !t.Triggered {
+			continue
+		}
+		label := fmt.Sprintf("Thread %d", t.Index)
+		if t.Queue != "" {
+			label += " (" + t.Queue + ")"
+		}
+		if t.Triggered {
+			label += "  <-- crashed"
+		}
+		fmt.Fprintf(w, "\n%s\n", label)
+		for i, f := range t.Frames {
+			fmt.Fprintf(w, "  %2d  %s\n", i, f)
+		}
+	}
+	if !allThreads && len(r.Threads) > 1 {
+		fmt.Fprintf(w, "\n(%d threads total; pass --all to show them)\n", len(r.Threads))
+	}
 }
 
 func runCrashReadiness(args []string, stdout, stderr io.Writer, inspect func(string) (detect.Result, error)) int {

--- a/cmd/spectra/crash_inspect_test.go
+++ b/cmd/spectra/crash_inspect_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const inspectSampleIPS = `{"app_name":"MyApp","app_version":"2.1","bug_type":"309","os_version":"macOS 15.6.1","incident_id":"ABC-123","name":"MyApp"}
+{"procName":"MyApp","pid":4012,"exception":{"type":"EXC_BAD_ACCESS","signal":"SIGSEGV","codes":"0x1, 0x0"},"termination":{"namespace":"SIGNAL","indicator":"Segmentation fault: 11"},"faultingThread":0,"threads":[{"queue":"com.apple.main-thread","triggered":true,"frames":[{"imageIndex":0,"imageOffset":1000,"symbol":"main","symbolLocation":42}]}],"usedImages":[{"name":"MyApp","arch":"arm64"}]}`
+
+func writeCrashTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestCrashInspectRenders(t *testing.T) {
+	p := writeCrashTemp(t, "MyApp.ips", inspectSampleIPS)
+	var out, errBuf bytes.Buffer
+	code := runCrashWithIO([]string{"inspect", p}, &out, &errBuf, nil)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	for _, want := range []string{"MyApp", "EXC_BAD_ACCESS", "crashed", "main + 42"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+func TestCrashInspectJSON(t *testing.T) {
+	p := writeCrashTemp(t, "MyApp.ips", inspectSampleIPS)
+	var out, errBuf bytes.Buffer
+	code := runCrashWithIO([]string{"inspect", "--json", p}, &out, &errBuf, nil)
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"exception": "EXC_BAD_ACCESS (SIGSEGV)"`) {
+		t.Errorf("json output missing decoded exception; got:\n%s", out.String())
+	}
+}
+
+func TestCrashInspectLegacy(t *testing.T) {
+	p := writeCrashTemp(t, "old.crash", "Process: Foo [1]\nIdentifier: com.example.foo\n")
+	var out, errBuf bytes.Buffer
+	code := runCrashWithIO([]string{"inspect", p}, &out, &errBuf, nil)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "legacy") {
+		t.Errorf("stderr = %q, want legacy notice", errBuf.String())
+	}
+}
+
+func TestCrashInspectNoPath(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runCrashWithIO([]string{"inspect"}, &out, &errBuf, nil); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -385,6 +385,23 @@ spectra crash readiness --json
 spectra crash readiness /Applications/MyApp.app
 ```
 
+## `spectra crash inspect`
+
+Decodes a modern macOS `.ips` crash report (the JSON reports written to
+`~/Library/Logs/DiagnosticReports`) into a readable summary — the decoded
+exception and termination reason, the faulting thread, and its stack with
+frames resolved to image + symbol — without opening Console.app. `--all`
+shows every thread; `--json` emits the structured report. Legacy pre-2020
+plain-text `.crash` reports are detected and reported as such.
+
+### Examples
+
+```bash
+spectra crash inspect ~/Library/Logs/DiagnosticReports/MyApp-2026-08-05-101500.ips
+spectra crash inspect --all report.ips
+spectra crash inspect --json report.ips
+```
+
 ## `spectra playbook`
 
 Shows problem-first diagnostic workflows over existing collectors. Use it

--- a/internal/crashreport/crashreport.go
+++ b/internal/crashreport/crashreport.go
@@ -1,0 +1,261 @@
+// Package crashreport parses modern macOS .ips crash reports into a structured,
+// decoded form. An .ips file is a one-line JSON header followed by a JSON body;
+// this package reads both, decodes the exception/termination reason and the
+// numeric bug_type, resolves stack frames against the report's image list, and
+// normalizes the threads into a threadinspect.Snapshot so the existing
+// summarize/filter/diff machinery is reused.
+package crashreport
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/kaeawc/spectra/internal/threadinspect"
+)
+
+// ErrLegacyFormat is returned by Parse for pre-2020 plain-text .crash/.spin
+// reports, which are not JSON. Callers can detect it with errors.Is.
+var ErrLegacyFormat = errors.New("legacy plain-text crash report (not .ips JSON)")
+
+// Report is a decoded crash report.
+type Report struct {
+	Process         string   `json:"process"`
+	Version         string   `json:"version,omitempty"`
+	BundleID        string   `json:"bundle_id,omitempty"`
+	Path            string   `json:"path,omitempty"`
+	OSVersion       string   `json:"os_version,omitempty"`
+	Time            string   `json:"time,omitempty"`
+	IncidentID      string   `json:"incident_id,omitempty"`
+	PID             int      `json:"pid,omitempty"`
+	Kind            string   `json:"kind"`
+	BugType         string   `json:"bug_type,omitempty"`
+	Exception       string   `json:"exception,omitempty"`
+	ExceptionDetail string   `json:"exception_detail,omitempty"`
+	Signal          string   `json:"signal,omitempty"`
+	Codes           string   `json:"codes,omitempty"`
+	Termination     string   `json:"termination,omitempty"`
+	FaultingThread  int      `json:"faulting_thread"`
+	Threads         []Thread `json:"threads"`
+}
+
+// Thread is one thread's decoded frames.
+type Thread struct {
+	Index     int      `json:"index"`
+	Name      string   `json:"name,omitempty"`
+	Queue     string   `json:"queue,omitempty"`
+	Triggered bool     `json:"triggered,omitempty"`
+	Frames    []string `json:"frames"`
+}
+
+// --- raw .ips shapes (best-effort; any field may be absent) ---
+
+type ipsHeader struct {
+	AppName    string `json:"app_name"`
+	AppVersion string `json:"app_version"`
+	BundleID   string `json:"bundleID"`
+	Timestamp  string `json:"timestamp"`
+	OSVersion  string `json:"os_version"`
+	BugType    string `json:"bug_type"`
+	IncidentID string `json:"incident_id"`
+	Name       string `json:"name"`
+}
+
+type ipsBody struct {
+	ProcName       string       `json:"procName"`
+	ProcPath       string       `json:"procPath"`
+	PID            int          `json:"pid"`
+	Exception      ipsException `json:"exception"`
+	Termination    ipsTerm      `json:"termination"`
+	FaultingThread int          `json:"faultingThread"`
+	Threads        []ipsThread  `json:"threads"`
+	UsedImages     []ipsImage   `json:"usedImages"`
+}
+
+type ipsException struct {
+	Type    string `json:"type"`
+	Signal  string `json:"signal"`
+	Codes   string `json:"codes"`
+	Subtype string `json:"subtype"`
+}
+
+type ipsTerm struct {
+	Namespace string `json:"namespace"`
+	Indicator string `json:"indicator"`
+	Code      int    `json:"code"`
+	ByProc    string `json:"byProc"`
+	ByPid     int    `json:"byPid"`
+}
+
+type ipsThread struct {
+	ID        int64      `json:"id"`
+	Queue     string     `json:"queue"`
+	Name      string     `json:"name"`
+	Triggered bool       `json:"triggered"`
+	Frames    []ipsFrame `json:"frames"`
+}
+
+type ipsFrame struct {
+	ImageIndex     int    `json:"imageIndex"`
+	ImageOffset    int64  `json:"imageOffset"`
+	Symbol         string `json:"symbol"`
+	SymbolLocation int64  `json:"symbolLocation"`
+}
+
+type ipsImage struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+	Base int64  `json:"base"`
+	UUID string `json:"uuid"`
+	Arch string `json:"arch"`
+}
+
+// Parse decodes a modern .ips crash report. It returns ErrLegacyFormat for
+// pre-2020 plain-text reports.
+func Parse(data []byte) (*Report, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, errors.New("empty crash report")
+	}
+	if trimmed[0] != '{' {
+		return nil, ErrLegacyFormat
+	}
+	nl := bytes.IndexByte(data, '\n')
+	if nl < 0 {
+		return nil, errors.New("malformed .ips: header line has no body")
+	}
+	var h ipsHeader
+	if err := json.Unmarshal(bytes.TrimSpace(data[:nl]), &h); err != nil {
+		return nil, fmt.Errorf("parse header: %w", err)
+	}
+	var b ipsBody
+	if err := json.Unmarshal(data[nl+1:], &b); err != nil {
+		return nil, fmt.Errorf("parse body: %w", err)
+	}
+	return build(h, b), nil
+}
+
+func build(h ipsHeader, b ipsBody) *Report {
+	process := firstNonEmpty(b.ProcName, h.AppName, h.Name)
+	r := &Report{
+		Process:        process,
+		Version:        h.AppVersion,
+		BundleID:       h.BundleID,
+		Path:           b.ProcPath,
+		OSVersion:      h.OSVersion,
+		Time:           h.Timestamp,
+		IncidentID:     h.IncidentID,
+		PID:            b.PID,
+		BugType:        h.BugType,
+		Kind:           crashKind(h.BugType),
+		Signal:         b.Exception.Signal,
+		Codes:          b.Exception.Codes,
+		Termination:    b.Termination.Indicator,
+		FaultingThread: b.FaultingThread,
+	}
+	if b.Exception.Type != "" {
+		r.Exception = b.Exception.Type
+		if b.Exception.Signal != "" {
+			r.Exception = fmt.Sprintf("%s (%s)", b.Exception.Type, b.Exception.Signal)
+		}
+		r.ExceptionDetail = explainException(b.Exception.Type)
+	}
+	for i, t := range b.Threads {
+		th := Thread{
+			Index:     i,
+			Name:      t.Name,
+			Queue:     t.Queue,
+			Triggered: t.Triggered || i == b.FaultingThread,
+		}
+		for _, f := range t.Frames {
+			th.Frames = append(th.Frames, formatFrame(f, b.UsedImages))
+		}
+		r.Threads = append(r.Threads, th)
+	}
+	return r
+}
+
+// Snapshot normalizes the report's threads into a threadinspect.Snapshot so the
+// shared summarize/filter/diff helpers apply to native crashes.
+func (r *Report) Snapshot() threadinspect.Snapshot {
+	s := threadinspect.Snapshot{Runtime: threadinspect.RuntimeNative, PID: r.PID}
+	for _, t := range r.Threads {
+		name := t.Name
+		if name == "" {
+			name = fmt.Sprintf("Thread %d", t.Index)
+		}
+		if t.Triggered {
+			name += " (faulting)"
+		}
+		th := threadinspect.Thread{
+			Name:      name,
+			NativeID:  fmt.Sprintf("%d", t.Index),
+			Detail:    t.Queue,
+			Stack:     t.Frames,
+			RuntimeID: t.Queue,
+		}
+		if len(t.Frames) > 0 {
+			th.TopFrame = t.Frames[0]
+		}
+		s.Threads = append(s.Threads, th)
+	}
+	return s
+}
+
+func formatFrame(f ipsFrame, images []ipsImage) string {
+	img := "???"
+	if f.ImageIndex >= 0 && f.ImageIndex < len(images) && images[f.ImageIndex].Name != "" {
+		img = images[f.ImageIndex].Name
+	}
+	if f.Symbol != "" {
+		return fmt.Sprintf("%s`%s + %d", img, f.Symbol, f.SymbolLocation)
+	}
+	return fmt.Sprintf("%s + 0x%x", img, f.ImageOffset)
+}
+
+// crashKind maps the numeric bug_type to a human kind. Modern reports use
+// numeric codes rather than the old crash/hang strings. Best-effort: unknown
+// codes fall back to a generic label that still names the raw code.
+func crashKind(bugType string) string {
+	switch bugType {
+	case "309", "385", "108", "109":
+		return "crash"
+	case "288":
+		return "hang"
+	case "":
+		return "crash report"
+	default:
+		return "crash report (bug_type " + bugType + ")"
+	}
+}
+
+func explainException(excType string) string {
+	switch excType {
+	case "EXC_BAD_ACCESS":
+		return "invalid memory access (segmentation fault / bad pointer)"
+	case "EXC_BAD_INSTRUCTION":
+		return "illegal instruction (often a Swift trap, assertion, or precondition failure)"
+	case "EXC_CRASH":
+		return "abnormal exit (abort() or an uncaught Objective-C/C++ exception)"
+	case "EXC_BREAKPOINT":
+		return "trap/breakpoint (Swift fatalError/precondition, or a debugger trap)"
+	case "EXC_ARITHMETIC":
+		return "arithmetic error (e.g. integer divide by zero)"
+	case "EXC_GUARD":
+		return "guarded-resource violation (e.g. illegal use of a guarded file descriptor)"
+	case "EXC_RESOURCE":
+		return "resource limit exceeded (CPU time, memory, or wakeups)"
+	default:
+		return ""
+	}
+}
+
+func firstNonEmpty(vs ...string) string {
+	for _, v := range vs {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/crashreport/crashreport_test.go
+++ b/internal/crashreport/crashreport_test.go
@@ -1,0 +1,126 @@
+package crashreport
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/threadinspect"
+)
+
+// synthetic .ips: a JSON header line + JSON body. No real user data.
+const sampleIPS = `{"app_name":"MyApp","app_version":"2.1","bundleID":"com.example.myapp","timestamp":"2026-08-05 10:15:00.00 -0500","os_version":"macOS 15.6.1 (24G90)","bug_type":"309","incident_id":"ABC-123","name":"MyApp"}
+{"procName":"MyApp","procPath":"/Applications/MyApp.app/Contents/MacOS/MyApp","pid":4012,"exception":{"type":"EXC_BAD_ACCESS","signal":"SIGSEGV","codes":"0x1, 0x0"},"termination":{"namespace":"SIGNAL","indicator":"Segmentation fault: 11","code":11},"faultingThread":1,"threads":[{"id":100,"queue":"com.apple.main-thread","frames":[{"imageIndex":0,"imageOffset":1000,"symbol":"main","symbolLocation":42}]},{"id":101,"queue":"sync.queue","triggered":true,"frames":[{"imageIndex":0,"imageOffset":171856,"symbol":"-[SyncEngine flush]","symbolLocation":214},{"imageIndex":1,"imageOffset":5000}]}],"usedImages":[{"name":"MyApp","base":4294967296,"arch":"arm64","path":"/Applications/MyApp.app/Contents/MacOS/MyApp"},{"name":"libdispatch.dylib","base":1,"arch":"arm64"}]}`
+
+func TestParseHeaderAndException(t *testing.T) {
+	r, err := Parse([]byte(sampleIPS))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if r.Process != "MyApp" {
+		t.Errorf("Process = %q, want MyApp", r.Process)
+	}
+	if r.Kind != "crash" {
+		t.Errorf("Kind = %q, want crash", r.Kind)
+	}
+	if r.Exception != "EXC_BAD_ACCESS (SIGSEGV)" {
+		t.Errorf("Exception = %q", r.Exception)
+	}
+	if !strings.Contains(r.ExceptionDetail, "segmentation") {
+		t.Errorf("ExceptionDetail = %q, want segmentation-fault explanation", r.ExceptionDetail)
+	}
+	if r.Termination != "Segmentation fault: 11" {
+		t.Errorf("Termination = %q", r.Termination)
+	}
+	if r.FaultingThread != 1 {
+		t.Errorf("FaultingThread = %d, want 1", r.FaultingThread)
+	}
+	if r.PID != 4012 {
+		t.Errorf("PID = %d, want 4012", r.PID)
+	}
+}
+
+func TestParseFrameResolution(t *testing.T) {
+	r, err := Parse([]byte(sampleIPS))
+	if err != nil {
+		t.Fatal(err)
+	}
+	faulting := r.Threads[1]
+	if !faulting.Triggered {
+		t.Error("thread 1 should be triggered")
+	}
+	// symbolized frame uses the embedded symbol + location
+	if got, want := faulting.Frames[0], "MyApp`-[SyncEngine flush] + 214"; got != want {
+		t.Errorf("frame[0] = %q, want %q", got, want)
+	}
+	// unsymbolized frame falls back to image + hex offset (5000 = 0x1388)
+	if got, want := faulting.Frames[1], "libdispatch.dylib + 0x1388"; got != want {
+		t.Errorf("frame[1] = %q, want %q", got, want)
+	}
+}
+
+func TestSnapshotNormalization(t *testing.T) {
+	r, err := Parse([]byte(sampleIPS))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := r.Snapshot()
+	if s.Runtime != threadinspect.RuntimeNative {
+		t.Errorf("Runtime = %q, want native", s.Runtime)
+	}
+	if s.PID != 4012 {
+		t.Errorf("PID = %d", s.PID)
+	}
+	if len(s.Threads) != 2 {
+		t.Fatalf("threads = %d, want 2", len(s.Threads))
+	}
+	if !strings.Contains(s.Threads[1].Name, "(faulting)") {
+		t.Errorf("faulting thread name = %q, want (faulting) marker", s.Threads[1].Name)
+	}
+	if s.Threads[1].TopFrame == "" {
+		t.Error("faulting thread should have a top frame")
+	}
+}
+
+func TestParseLegacyFormat(t *testing.T) {
+	legacy := []byte("Process:         Foo [123]\nIdentifier:      com.example.foo\n")
+	_, err := Parse(legacy)
+	if !errors.Is(err, ErrLegacyFormat) {
+		t.Fatalf("err = %v, want ErrLegacyFormat", err)
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	if _, err := Parse([]byte("   ")); err == nil {
+		t.Fatal("expected error for empty input")
+	}
+}
+
+func TestParseNoBody(t *testing.T) {
+	if _, err := Parse([]byte(`{"app_name":"X"}`)); err == nil {
+		t.Fatal("expected error for header with no body line")
+	}
+}
+
+func TestCrashKind(t *testing.T) {
+	cases := map[string]string{
+		"309": "crash",
+		"288": "hang",
+		"":    "crash report",
+		"999": "crash report (bug_type 999)",
+	}
+	for in, want := range cases {
+		if got := crashKind(in); got != want {
+			t.Errorf("crashKind(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestExplainException(t *testing.T) {
+	if explainException("EXC_BAD_ACCESS") == "" {
+		t.Error("EXC_BAD_ACCESS should have an explanation")
+	}
+	if explainException("EXC_TOTALLY_UNKNOWN") != "" {
+		t.Error("unknown exception types should return empty")
+	}
+}


### PR DESCRIPTION
## What

Adds **`internal/crashreport`** + **`spectra crash inspect <file.ips>`** — Spectra can now read the `.ips` crash reports macOS writes to `~/Library/Logs/DiagnosticReports` and answer "why did this app die?" without opening Console.app. This is the crash-domain keystone the resource-kill decoder and crash-signature aggregation build on.

## How

An `.ips` file is a one-line JSON header + a JSON body. `crashreport.Parse`:
- Decodes the numeric `bug_type` into a kind (crash / hang / …) — modern reports use numeric codes, not the old strings — with an honest fallback that still names unknown codes.
- Decodes `exception`/`termination` into a human explanation (EXC_BAD_ACCESS/SIGSEGV, EXC_BREAKPOINT, EXC_CRASH, EXC_BAD_INSTRUCTION, EXC_GUARD, EXC_RESOURCE, …).
- Resolves each frame using the report's embedded `symbol` when present, else `usedImages[imageIndex].name + imageOffset`.
- Normalizes threads into `threadinspect.Snapshot{Runtime: RuntimeNative}` so the existing summarize/filter/diff helpers apply to native crashes.
- Returns a sentinel `ErrLegacyFormat` for pre-2020 plain-text `.crash` reports so the CLI reports them clearly instead of erroring.

`spectra crash inspect` renders a readable summary (decoded exception, faulting thread + stack), with `--all` for every thread and `--json` for the structured report. Verified against real reports on macOS 15.6.

## Scope (v1)

Parser + CLI. An MCP `inspect_crash` tool is a natural fast-follow (deferred to keep this reviewable).

## Testing

- `crashreport` tests over a synthetic in-test `.ips` fixture (no real user data): header/exception decoding, frame resolution with embedded symbols *and* image+offset fallback, faulting-thread selection, `Snapshot()` normalization to `RuntimeNative`, legacy-format sentinel, empty/no-body errors, `crashKind` table.
- CLI tests: render, `--json`, legacy detection, missing-path usage.
- `make vet complexity lint security docs-validate test` all pass locally (48 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 stdlib quirk, unrelated to this change.

Closes #323
