### PR TITLE
netcap: decode IPv6 flows

### DIFF
--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -71,7 +71,7 @@ mode (see [../design/privileged-helper.md](../design/privileged-helper.md)).
 | `tcpdump -i <iface>` | raw packet capture to helper-generated pcap path | helper | streaming, high | `helper.net_capture.start` / `helper.net_capture.stop` |
 | `internal/netcap` tcpdump builder | validated interface/output/filter argv for bounded captures | helper | no capture cost itself | shared plumbing for targeted capture |
 | `internal/netcap` pcap reader | classic pcap packet records and link type | user | streaming, low | shared plumbing for future capture summaries |
-| `internal/netcap` packet decoder | IPv4 TCP/UDP flow endpoints, TCP sequence metadata, and transport payload from Ethernet, raw IPv4, loopback, and Linux cooked pcap packets | user | low per packet | shared plumbing for future capture summaries |
+| `internal/netcap` packet decoder | IPv4/IPv6 TCP/UDP flow endpoints, TCP sequence metadata, and transport payload from Ethernet, raw IP, loopback, and Linux cooked pcap packets | user | low per packet | shared plumbing for future capture summaries |
 | `internal/netcap` pcap summarizer | bounded DNS, TLS ClientHello, HTTP/1 header, and WebSocket upgrade metadata from pcap streams with small TCP reassembly buffers | user | streaming, low; handles contiguous and directly preceding out-of-order TCP payloads | shared plumbing for capture summaries |
 
 The current unprivileged path uses `lsof`, `scutil`, `route`, `ifconfig`,
@@ -85,7 +85,7 @@ capture workflows.
 summarize packet metadata without storing request or response bodies. The
 initial parsers handle plaintext HTTP/1 headers, DNS messages, and TLS
 ClientHello records. `internal/netcap` wires those parsers to bounded pcap
-summaries after link-layer and IPv4 TCP/UDP decoding. HTTP parsing redacts
+summaries after link-layer and IPv4/IPv6 TCP/UDP decoding. HTTP parsing redacts
 sensitive headers by default. TLS parsing exposes SNI and ALPN when the client
 sends them in cleartext; it cannot decrypt HTTPS traffic.
 

--- a/internal/netcap/packet.go
+++ b/internal/netcap/packet.go
@@ -8,12 +8,25 @@ import (
 
 const (
 	etherTypeIPv4  = 0x0800
+	etherTypeIPv6  = 0x86dd
 	loopFamilyIPv4 = 2
 	ipProtoTCP     = 6
 	ipProtoUDP     = 17
+
+	ipv6HeaderLen     = 40
+	ipProtoIPv6Frag   = 44
+	maxIPv6ExtHeaders = 8
+
+	ipv6ExtHopByHop = 0
+	ipv6ExtRouting  = 43
+	ipv6ExtDestOpts = 60
 )
 
-// FlowPacket is a decoded IPv4 TCP/UDP packet and its transport payload.
+// loopFamiliesIPv6 are the AF_INET6 values seen in DLT_NULL/DLT_LOOP link
+// headers across platforms (macOS 30, FreeBSD 28, Linux 10).
+var loopFamiliesIPv6 = [...]uint32{30, 28, 10}
+
+// FlowPacket is a decoded IPv4/IPv6 TCP/UDP packet and its transport payload.
 type FlowPacket struct {
 	NetworkProto   string
 	TransportProto string
@@ -34,12 +47,16 @@ func DecodeFlowPacket(linkType uint32, data []byte) (FlowPacket, error) {
 		if len(data) < 14 {
 			return FlowPacket{}, fmt.Errorf("ethernet packet too short")
 		}
-		if binary.BigEndian.Uint16(data[12:14]) != etherTypeIPv4 {
+		switch binary.BigEndian.Uint16(data[12:14]) {
+		case etherTypeIPv4:
+			return decodeIPv4Flow(data[14:])
+		case etherTypeIPv6:
+			return decodeIPv6Flow(data[14:])
+		default:
 			return FlowPacket{}, fmt.Errorf("unsupported ethernet ethertype")
 		}
-		return decodeIPv4Flow(data[14:])
 	case LinkTypeRaw:
-		return decodeIPv4Flow(data)
+		return decodeRawIPFlow(data)
 	case LinkTypeNull, LinkTypeLoop:
 		return decodeLoopbackFlow(data)
 	case LinkTypeLinuxSLL:
@@ -53,10 +70,14 @@ func decodeLinuxSLLFlow(data []byte) (FlowPacket, error) {
 	if len(data) < 16 {
 		return FlowPacket{}, fmt.Errorf("linux sll packet too short")
 	}
-	if binary.BigEndian.Uint16(data[14:16]) != etherTypeIPv4 {
+	switch binary.BigEndian.Uint16(data[14:16]) {
+	case etherTypeIPv4:
+		return decodeIPv4Flow(data[16:])
+	case etherTypeIPv6:
+		return decodeIPv6Flow(data[16:])
+	default:
 		return FlowPacket{}, fmt.Errorf("unsupported linux sll protocol")
 	}
-	return decodeIPv4Flow(data[16:])
 }
 
 func decodeLoopbackFlow(data []byte) (FlowPacket, error) {
@@ -65,10 +86,37 @@ func decodeLoopbackFlow(data []byte) (FlowPacket, error) {
 	}
 	familyBE := binary.BigEndian.Uint32(data[:4])
 	familyLE := binary.LittleEndian.Uint32(data[:4])
-	if familyBE != loopFamilyIPv4 && familyLE != loopFamilyIPv4 {
-		return FlowPacket{}, fmt.Errorf("unsupported loopback family")
+	if familyBE == loopFamilyIPv4 || familyLE == loopFamilyIPv4 {
+		return decodeIPv4Flow(data[4:])
 	}
-	return decodeIPv4Flow(data[4:])
+	if isIPv6LoopFamily(familyBE) || isIPv6LoopFamily(familyLE) {
+		return decodeIPv6Flow(data[4:])
+	}
+	return FlowPacket{}, fmt.Errorf("unsupported loopback family")
+}
+
+func isIPv6LoopFamily(family uint32) bool {
+	for _, f := range loopFamiliesIPv6 {
+		if family == f {
+			return true
+		}
+	}
+	return false
+}
+
+// decodeRawIPFlow dispatches a raw IP packet (no link header) by IP version.
+func decodeRawIPFlow(data []byte) (FlowPacket, error) {
+	if len(data) < 1 {
+		return FlowPacket{}, fmt.Errorf("empty ip packet")
+	}
+	switch data[0] >> 4 {
+	case 4:
+		return decodeIPv4Flow(data)
+	case 6:
+		return decodeIPv6Flow(data)
+	default:
+		return FlowPacket{}, fmt.Errorf("unsupported ip version %d", data[0]>>4)
+	}
 }
 
 func decodeIPv4Flow(data []byte) (FlowPacket, error) {
@@ -103,6 +151,59 @@ func decodeIPv4Flow(data []byte) (FlowPacket, error) {
 	default:
 		return FlowPacket{}, fmt.Errorf("unsupported ip protocol %d", data[9])
 	}
+}
+
+func decodeIPv6Flow(data []byte) (FlowPacket, error) {
+	if len(data) < ipv6HeaderLen {
+		return FlowPacket{}, fmt.Errorf("ipv6 packet too short")
+	}
+	if version := data[0] >> 4; version != 6 {
+		return FlowPacket{}, fmt.Errorf("unsupported ip version %d", version)
+	}
+	// PayloadLength covers extension headers + transport. Bound the transport
+	// region by it, but tolerate a zero value (jumbogram) or truncated capture
+	// by falling back to the captured length.
+	end := ipv6HeaderLen + int(binary.BigEndian.Uint16(data[4:6]))
+	if end <= ipv6HeaderLen || end > len(data) {
+		end = len(data)
+	}
+	var src, dst [16]byte
+	copy(src[:], data[8:24])
+	copy(dst[:], data[24:40])
+	out := FlowPacket{
+		NetworkProto: "ipv6",
+		SrcAddr:      netip.AddrFrom16(src),
+		DstAddr:      netip.AddrFrom16(dst),
+	}
+
+	nextHeader := data[6]
+	offset := ipv6HeaderLen
+	for hops := 0; hops < maxIPv6ExtHeaders; hops++ {
+		switch nextHeader {
+		case ipProtoTCP:
+			return decodeTCPFlow(out, data[offset:end])
+		case ipProtoUDP:
+			return decodeUDPFlow(out, data[offset:end])
+		case ipv6ExtHopByHop, ipv6ExtRouting, ipv6ExtDestOpts:
+			// Option-style extension header: [next(1)][hdr_ext_len(1)][...],
+			// length = (hdr_ext_len + 1) * 8 bytes.
+			if offset+2 > end {
+				return FlowPacket{}, fmt.Errorf("truncated ipv6 extension header")
+			}
+			next := data[offset]
+			extLen := (int(data[offset+1]) + 1) * 8
+			offset += extLen
+			nextHeader = next
+			if offset > end {
+				return FlowPacket{}, fmt.Errorf("invalid ipv6 extension header length")
+			}
+		case ipProtoIPv6Frag:
+			return FlowPacket{}, fmt.Errorf("fragmented ipv6 packet unsupported")
+		default:
+			return FlowPacket{}, fmt.Errorf("unsupported ipv6 next header %d", nextHeader)
+		}
+	}
+	return FlowPacket{}, fmt.Errorf("too many ipv6 extension headers")
 }
 
 func decodeTCPFlow(out FlowPacket, data []byte) (FlowPacket, error) {

--- a/internal/netcap/packet_ipv6_test.go
+++ b/internal/netcap/packet_ipv6_test.go
@@ -1,0 +1,88 @@
+package netcap
+
+import (
+	"encoding/binary"
+	"net/netip"
+	"testing"
+)
+
+// ipv6Packet builds a 40-byte IPv6 header (optionally followed by extension
+// headers already prepended to body) carrying `next` as the next-header value.
+func ipv6Packet(next byte, body []byte) []byte {
+	packet := make([]byte, ipv6HeaderLen+len(body))
+	packet[0] = 0x60 // version 6
+	binary.BigEndian.PutUint16(packet[4:6], uint16(len(body)))
+	packet[6] = next
+	packet[7] = 64 // hop limit
+	copy(packet[8:24], netip.MustParseAddr("2001:db8::1").AsSlice())
+	copy(packet[24:40], netip.MustParseAddr("2001:db8::2").AsSlice())
+	copy(packet[40:], body)
+	return packet
+}
+
+func ethernetFrameV6(ip []byte) []byte {
+	frame := make([]byte, 14+len(ip))
+	binary.BigEndian.PutUint16(frame[12:14], etherTypeIPv6)
+	copy(frame[14:], ip)
+	return frame
+}
+
+func TestDecodeEthernetIPv6TCP(t *testing.T) {
+	frame := ethernetFrameV6(ipv6Packet(ipProtoTCP, tcpSegment(51000, 443, []byte("hi"))))
+	flow, err := DecodeFlowPacket(LinkTypeEthernet, frame)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if flow.NetworkProto != "ipv6" || flow.TransportProto != "tcp" {
+		t.Fatalf("protos = %s/%s", flow.NetworkProto, flow.TransportProto)
+	}
+	if flow.SrcAddr != netip.MustParseAddr("2001:db8::1") || flow.DstAddr != netip.MustParseAddr("2001:db8::2") {
+		t.Fatalf("addrs = %s -> %s", flow.SrcAddr, flow.DstAddr)
+	}
+	if flow.SrcPort != 51000 || flow.DstPort != 443 {
+		t.Fatalf("ports = %d -> %d", flow.SrcPort, flow.DstPort)
+	}
+	if string(flow.Payload) != "hi" {
+		t.Fatalf("payload = %q", flow.Payload)
+	}
+}
+
+func TestDecodeLoopbackIPv6UDP(t *testing.T) {
+	// macOS DLT_NULL loopback uses AF_INET6 = 30.
+	ip := ipv6Packet(ipProtoUDP, udpDatagram(5353, 53, []byte("q")))
+	packet := make([]byte, 4+len(ip))
+	binary.LittleEndian.PutUint32(packet[:4], 30)
+	copy(packet[4:], ip)
+
+	flow, err := DecodeFlowPacket(LinkTypeNull, packet)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if flow.NetworkProto != "ipv6" || flow.TransportProto != "udp" || flow.DstPort != 53 {
+		t.Fatalf("flow = %+v", flow)
+	}
+}
+
+func TestDecodeIPv6WithHopByHopExtension(t *testing.T) {
+	// One 8-byte Hop-by-Hop extension header (next=TCP) before the TCP segment.
+	ext := make([]byte, 8)
+	ext[0] = ipProtoTCP // next header
+	ext[1] = 0          // hdr ext len => (0+1)*8 = 8 bytes
+	body := append(ext, tcpSegment(4000, 8080, []byte("x"))...)
+	frame := ethernetFrameV6(ipv6Packet(ipv6ExtHopByHop, body))
+
+	flow, err := DecodeFlowPacket(LinkTypeEthernet, frame)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if flow.TransportProto != "tcp" || flow.DstPort != 8080 {
+		t.Fatalf("flow = %+v", flow)
+	}
+}
+
+func TestDecodeIPv6FragmentUnsupported(t *testing.T) {
+	frame := ethernetFrameV6(ipv6Packet(ipProtoIPv6Frag, make([]byte, 8)))
+	if _, err := DecodeFlowPacket(LinkTypeEthernet, frame); err == nil {
+		t.Fatal("expected fragmented ipv6 to be unsupported")
+	}
+}


### PR DESCRIPTION
Closes #330

The packet decoder was IPv4-only — every IPv6 packet became a `DecodeErrors` and its DNS/TLS/HTTP was dropped from capture summaries.

## What changed
- Ethernet / Linux-SLL: handle ethertype `0x86DD`.
- Loopback: handle `AF_INET6` families (macOS 30, FreeBSD 28, Linux 10).
- Raw IP: dispatch by version.
- Parse the 40-byte IPv6 header, walk a bounded Hop-by-Hop/Routing/Dest-Options extension chain, reject Fragment headers, hand TCP/UDP to the existing transport decoders (already version-agnostic).

## Tests
- `internal/netcap/packet_ipv6_test.go`: Ethernet IPv6/TCP, loopback IPv6/UDP, Hop-by-Hop extension, fragment rejection.
- Local: `go vet`, `go test ./...` (47 pkg), `gocyclo -over 15 -ignore _test` clean.