### PR TITLE
crash: decode EXC_RESOURCE / watchdog resource-limit kills (spectra crash resource)

### DIFF
--- a/cmd/spectra/crash.go
+++ b/cmd/spectra/crash.go
@@ -30,10 +30,96 @@ func runCrashWithIO(args []string, stdout, stderr io.Writer, inspect func(string
 		return runCrashReadiness(rest, stdout, stderr, inspect)
 	case "inspect":
 		return runCrashInspect(rest, stdout, stderr)
+	case "resource":
+		return runCrashResource(rest, stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect)\n", sub)
+		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource)\n", sub)
 		return 2
 	}
+}
+
+func runCrashResource(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("crash resource", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra crash resource [--json] <report.ips>")
+		fmt.Fprintln(stderr, "Decode an EXC_RESOURCE / watchdog resource-limit kill (CPU, wakeups, I/O, memory).")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	path := fs.Arg(0)
+	if path == "" {
+		fs.Usage()
+		return 2
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "read %s: %v\n", path, err)
+		return 1
+	}
+	report, err := crashreport.Parse(data)
+	if err != nil {
+		if errors.Is(err, crashreport.ErrLegacyFormat) {
+			fmt.Fprintf(stderr, "%s is a legacy plain-text report; spectra decodes modern .ips reports.\n", path)
+			return 1
+		}
+		fmt.Fprintf(stderr, "parse %s: %v\n", path, err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	renderCrashResource(stdout, report)
+	return 0
+}
+
+func renderCrashResource(w io.Writer, r *crashreport.Report) {
+	if r.Resource == nil {
+		fmt.Fprintf(w, "%s is not a resource-limit kill", r.Process)
+		if r.Exception != "" {
+			fmt.Fprintf(w, " (exception %s)", r.Exception)
+		}
+		fmt.Fprintln(w, ".")
+		fmt.Fprintln(w, "Use `spectra crash inspect` for a full decode.")
+		return
+	}
+	res := r.Resource
+	fmt.Fprintf(w, "%s — resource-limit kill: %s\n", r.Process, res.Flavor)
+	fmt.Fprintf(w, "  %s\n", res.Explanation)
+	if res.Limit != "" || res.Observed != "" || res.Window != "" {
+		fmt.Fprintf(w, "  limit=%s  observed=%s  window=%s\n", orDash(res.Limit), orDash(res.Observed), orDash(res.Window))
+	}
+	if res.Detail != "" {
+		fmt.Fprintf(w, "  detail: %s\n", res.Detail)
+	}
+	for _, t := range r.Threads {
+		if !t.Triggered {
+			continue
+		}
+		fmt.Fprintf(w, "\noffending thread %d", t.Index)
+		if t.Queue != "" {
+			fmt.Fprintf(w, " (%s)", t.Queue)
+		}
+		fmt.Fprintln(w)
+		for i, f := range t.Frames {
+			fmt.Fprintf(w, "  %2d  %s\n", i, f)
+		}
+	}
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
 }
 
 func runCrashInspect(args []string, stdout, stderr io.Writer) int {

--- a/cmd/spectra/crash_resource_test.go
+++ b/cmd/spectra/crash_resource_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+const resourceSampleIPS = `{"app_name":"Helper","bug_type":"309","name":"Helper"}
+{"procName":"Helper","pid":900,"exception":{"type":"EXC_RESOURCE","subtype":"CPU (Limit 80% Was 95% over 60s)"},"termination":{"namespace":"RESOURCE","indicator":"CPU"},"faultingThread":0,"threads":[{"queue":"worker","triggered":true,"frames":[{"imageIndex":0,"imageOffset":10,"symbol":"busyLoop","symbolLocation":3}]}],"usedImages":[{"name":"Helper"}]}`
+
+func TestCrashResourceRenders(t *testing.T) {
+	p := writeCrashTemp(t, "Helper.ips", resourceSampleIPS)
+	var out, errBuf bytes.Buffer
+	if code := runCrashWithIO([]string{"resource", p}, &out, &errBuf, nil); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	for _, want := range []string{"resource-limit kill", "CPU", "offending thread", "busyLoop", "window=60s"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+func TestCrashResourceNonResource(t *testing.T) {
+	p := writeCrashTemp(t, "App.ips", inspectSampleIPS) // EXC_BAD_ACCESS fixture
+	var out, errBuf bytes.Buffer
+	if code := runCrashWithIO([]string{"resource", p}, &out, &errBuf, nil); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), "not a resource-limit kill") {
+		t.Errorf("output should note non-resource; got:\n%s", out.String())
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -402,6 +402,24 @@ spectra crash inspect --all report.ips
 spectra crash inspect --json report.ips
 ```
 
+## `spectra crash resource`
+
+Decodes an `EXC_RESOURCE` / watchdog-class kill — a `.cpu_resource` /
+`.wakeups_resource` report, or an `EXC_RESOURCE` termination inside an
+ordinary crash report. These read like mystery crashes but are the OS
+killing the process for exceeding a CPU-time, wakeups, I/O, or memory
+ledger limit. The command names the resource flavor, explains the cause in
+plain language, surfaces the limit/observed/window when the report carries
+them, and prints the offending thread's stack. `--json` emits the
+structured report.
+
+### Examples
+
+```bash
+spectra crash resource ~/Library/Logs/DiagnosticReports/Helper-2026-08-05.cpu_resource.ips
+spectra crash resource --json report.ips
+```
+
 ## `spectra playbook`
 
 Shows problem-first diagnostic workflows over existing collectors. Use it

--- a/internal/crashreport/crashreport.go
+++ b/internal/crashreport/crashreport.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/kaeawc/spectra/internal/threadinspect"
 )
@@ -21,23 +23,36 @@ var ErrLegacyFormat = errors.New("legacy plain-text crash report (not .ips JSON)
 
 // Report is a decoded crash report.
 type Report struct {
-	Process         string   `json:"process"`
-	Version         string   `json:"version,omitempty"`
-	BundleID        string   `json:"bundle_id,omitempty"`
-	Path            string   `json:"path,omitempty"`
-	OSVersion       string   `json:"os_version,omitempty"`
-	Time            string   `json:"time,omitempty"`
-	IncidentID      string   `json:"incident_id,omitempty"`
-	PID             int      `json:"pid,omitempty"`
-	Kind            string   `json:"kind"`
-	BugType         string   `json:"bug_type,omitempty"`
-	Exception       string   `json:"exception,omitempty"`
-	ExceptionDetail string   `json:"exception_detail,omitempty"`
-	Signal          string   `json:"signal,omitempty"`
-	Codes           string   `json:"codes,omitempty"`
-	Termination     string   `json:"termination,omitempty"`
-	FaultingThread  int      `json:"faulting_thread"`
-	Threads         []Thread `json:"threads"`
+	Process         string        `json:"process"`
+	Version         string        `json:"version,omitempty"`
+	BundleID        string        `json:"bundle_id,omitempty"`
+	Path            string        `json:"path,omitempty"`
+	OSVersion       string        `json:"os_version,omitempty"`
+	Time            string        `json:"time,omitempty"`
+	IncidentID      string        `json:"incident_id,omitempty"`
+	PID             int           `json:"pid,omitempty"`
+	Kind            string        `json:"kind"`
+	BugType         string        `json:"bug_type,omitempty"`
+	Exception       string        `json:"exception,omitempty"`
+	ExceptionDetail string        `json:"exception_detail,omitempty"`
+	Signal          string        `json:"signal,omitempty"`
+	Codes           string        `json:"codes,omitempty"`
+	Termination     string        `json:"termination,omitempty"`
+	Resource        *ResourceKill `json:"resource,omitempty"`
+	FaultingThread  int           `json:"faulting_thread"`
+	Threads         []Thread      `json:"threads"`
+}
+
+// ResourceKill describes an EXC_RESOURCE / watchdog-class termination: the OS
+// killed the process for exceeding a CPU-time, wakeups, memory, or I/O ledger
+// limit rather than for a fault. These read like mystery crashes but aren't.
+type ResourceKill struct {
+	Flavor      string `json:"flavor"`      // CPU, CPU_FATAL, WAKEUPS, IO, MEMORY, PORTS, THREADS, ...
+	Explanation string `json:"explanation"` // plain-language cause
+	Limit       string `json:"limit,omitempty"`
+	Observed    string `json:"observed,omitempty"`
+	Window      string `json:"window,omitempty"`
+	Detail      string `json:"detail,omitempty"` // raw subtype/indicator text
 }
 
 // Thread is one thread's decoded frames.
@@ -161,6 +176,9 @@ func build(h ipsHeader, b ipsBody) *Report {
 		}
 		r.ExceptionDetail = explainException(b.Exception.Type)
 	}
+	if b.Exception.Type == "EXC_RESOURCE" {
+		r.Resource = decodeResource(b.Exception, b.Termination)
+	}
 	for i, t := range b.Threads {
 		th := Thread{
 			Index:     i,
@@ -227,6 +245,72 @@ func crashKind(bugType string) string {
 		return "crash report"
 	default:
 		return "crash report (bug_type " + bugType + ")"
+	}
+}
+
+var (
+	reResourceWindow   = regexp.MustCompile(`(\d+)\s*s\b`)
+	reResourceLimit    = regexp.MustCompile(`(?i)limit[:\s]*([0-9]+%?)`)
+	reResourceObserved = regexp.MustCompile(`(?i)(?:was|observed|used)[:\s]*([0-9]+%?)`)
+)
+
+// decodeResource turns an EXC_RESOURCE exception into a plain-language kill
+// description. It reads the flavor from the exception subtype and pulls any
+// limit/observed/window numbers out of the human strings best-effort, so it is
+// robust to per-flavor schema drift across macOS releases.
+func decodeResource(exc ipsException, term ipsTerm) *ResourceKill {
+	flavor := resourceFlavor(exc.Subtype)
+	detail := strings.TrimSpace(exc.Subtype)
+	if detail == "" {
+		detail = strings.TrimSpace(term.Indicator)
+	}
+	rk := &ResourceKill{
+		Flavor:      flavor,
+		Explanation: explainResource(flavor),
+		Detail:      detail,
+	}
+	blob := exc.Subtype + " " + term.Indicator + " " + exc.Codes
+	if m := reResourceWindow.FindStringSubmatch(blob); m != nil {
+		rk.Window = m[1] + "s"
+	}
+	if m := reResourceLimit.FindStringSubmatch(blob); m != nil {
+		rk.Limit = m[1]
+	}
+	if m := reResourceObserved.FindStringSubmatch(blob); m != nil {
+		rk.Observed = m[1]
+	}
+	return rk
+}
+
+// resourceFlavor extracts the leading resource-type word from an EXC_RESOURCE
+// subtype (e.g. "WAKEUPS (Value=...)" -> "WAKEUPS").
+func resourceFlavor(subtype string) string {
+	f := strings.ToUpper(strings.TrimSpace(subtype))
+	if f == "" {
+		return "UNKNOWN"
+	}
+	if i := strings.IndexAny(f, " ("); i > 0 {
+		f = f[:i]
+	}
+	return f
+}
+
+func explainResource(flavor string) string {
+	switch flavor {
+	case "CPU", "CPU_FATAL":
+		return "sustained CPU use tripped the OS CPU-time watchdog over a rolling window (a busy loop or runaway thread), not a fault"
+	case "WAKEUPS":
+		return "excessive timer/interrupt wakeups tripped the power watchdog (typically a tight polling loop)"
+	case "IO":
+		return "sustained disk I/O exceeded the process I/O ledger limit"
+	case "MEMORY":
+		return "resident memory crossed a high-watermark limit"
+	case "PORTS":
+		return "the process exhausted its Mach port allocation"
+	case "THREADS":
+		return "the process exceeded its thread-count limit"
+	default:
+		return "a resource ledger limit was exceeded"
 	}
 }
 

--- a/internal/crashreport/crashreport_resource_test.go
+++ b/internal/crashreport/crashreport_resource_test.go
@@ -1,0 +1,72 @@
+package crashreport
+
+import (
+	"strings"
+	"testing"
+)
+
+func resourceIPS(subtype, indicator string) string {
+	return `{"app_name":"Helper","bug_type":"309","name":"Helper"}
+{"procName":"Helper","pid":900,"exception":{"type":"EXC_RESOURCE","subtype":"` + subtype + `","codes":"0x0"},"termination":{"namespace":"RESOURCE","indicator":"` + indicator + `"},"faultingThread":0,"threads":[{"queue":"busy","triggered":true,"frames":[{"imageIndex":0,"imageOffset":10,"symbol":"loop","symbolLocation":5}]}],"usedImages":[{"name":"Helper"}]}`
+}
+
+func TestResourceCPUFatal(t *testing.T) {
+	r, err := Parse([]byte(resourceIPS("CPU (Limit 80% Was 91% over 180s)", "")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Resource == nil {
+		t.Fatal("expected a resource kill")
+	}
+	if r.Resource.Flavor != "CPU" {
+		t.Errorf("flavor = %q, want CPU", r.Resource.Flavor)
+	}
+	if r.Resource.Limit != "80%" {
+		t.Errorf("limit = %q, want 80%%", r.Resource.Limit)
+	}
+	if r.Resource.Observed != "91%" {
+		t.Errorf("observed = %q, want 91%%", r.Resource.Observed)
+	}
+	if r.Resource.Window != "180s" {
+		t.Errorf("window = %q, want 180s", r.Resource.Window)
+	}
+	if !strings.Contains(r.Resource.Explanation, "CPU") {
+		t.Errorf("explanation = %q", r.Resource.Explanation)
+	}
+}
+
+func TestResourceWakeups(t *testing.T) {
+	r, err := Parse([]byte(resourceIPS("WAKEUPS", "")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Resource == nil || r.Resource.Flavor != "WAKEUPS" {
+		t.Fatalf("resource = %+v, want flavor WAKEUPS", r.Resource)
+	}
+	if !strings.Contains(r.Resource.Explanation, "wakeups") {
+		t.Errorf("explanation = %q, want wakeups mention", r.Resource.Explanation)
+	}
+}
+
+func TestResourceUnknownFlavor(t *testing.T) {
+	r, err := Parse([]byte(resourceIPS("", "")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Resource == nil || r.Resource.Flavor != "UNKNOWN" {
+		t.Fatalf("resource = %+v, want flavor UNKNOWN", r.Resource)
+	}
+	if r.Resource.Explanation == "" {
+		t.Error("unknown flavor should still carry a generic explanation")
+	}
+}
+
+func TestNonResourceHasNoResource(t *testing.T) {
+	r, err := Parse([]byte(sampleIPS)) // EXC_BAD_ACCESS fixture from crashreport_test.go
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Resource != nil {
+		t.Errorf("expected nil Resource for a segfault, got %+v", r.Resource)
+	}
+}


### PR DESCRIPTION
## What

Decodes `EXC_RESOURCE` / watchdog-class kills — the OS terminating a process for exceeding a CPU-time, wakeups, I/O, or memory ledger limit. These read like mystery crashes but aren't faults. Adds **`spectra crash resource <file>`**. Builds on the `.ips` parser from #329.

## How

- `internal/crashreport` now decodes an `EXC_RESOURCE` exception into a `ResourceKill`: flavor (CPU/CPU_FATAL/WAKEUPS/IO/MEMORY/PORTS/THREADS), a plain-language explanation, and limit/observed/window pulled **best-effort from the report's human strings** (regex over subtype/indicator/codes). This is deliberately string-driven so it survives per-flavor JSON schema drift across macOS releases; unknown flavors degrade to a generic explanation without erroring.
- `spectra crash resource` handles both entry points — a dedicated `.cpu_resource`/`.wakeups_resource` report and an inline `EXC_RESOURCE` termination in an ordinary crash report — and prints the offending (triggered) thread's stack. Non-resource reports get a clear "not a resource-limit kill, use `crash inspect`" message.

## Scope / honesty

- Decoding + CLI. A `resource-limit-kill` rule + hang-playbook wiring need the facts in a snapshot; deferred as a follow-up.
- This machine has no resource-kill `.ips` to sample, so the numeric limit/observed/window extraction is driven by the stable human indicator strings rather than an assumed per-flavor field schema. Flavor + explanation (the headline value) are reliable; the numbers populate when the report carries them and are omitted otherwise.

## Testing

- `crashreport` tests over synthetic `EXC_RESOURCE` fixtures: CPU_FATAL with limit/observed/window extraction, WAKEUPS, unknown-flavor fallback, and a segfault report producing no `Resource`.
- CLI tests: resource render (flavor, offending thread, window) and the non-resource path.
- `make vet complexity lint security docs-validate test` all green locally (48 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #332
