### PR TITLE
crash: address review feedback on crash resource/inspect (flavor fallback, arg validation, injectable reads)

### DIFF
--- a/cmd/spectra/crash.go
+++ b/cmd/spectra/crash.go
@@ -29,16 +29,16 @@ func runCrashWithIO(args []string, stdout, stderr io.Writer, inspect func(string
 	case "", "readiness":
 		return runCrashReadiness(rest, stdout, stderr, inspect)
 	case "inspect":
-		return runCrashInspect(rest, stdout, stderr)
+		return runCrashInspect(rest, stdout, stderr, os.ReadFile)
 	case "resource":
-		return runCrashResource(rest, stdout, stderr)
+		return runCrashResource(rest, stdout, stderr, os.ReadFile)
 	default:
 		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource)\n", sub)
 		return 2
 	}
 }
 
-func runCrashResource(args []string, stdout, stderr io.Writer) int {
+func runCrashResource(args []string, stdout, stderr io.Writer, readFile func(string) ([]byte, error)) int {
 	fs := flag.NewFlagSet("crash resource", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "output JSON")
@@ -49,24 +49,14 @@ func runCrashResource(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	path := fs.Arg(0)
-	if path == "" {
+	if fs.NArg() != 1 {
 		fs.Usage()
 		return 2
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		fmt.Fprintf(stderr, "read %s: %v\n", path, err)
-		return 1
-	}
-	report, err := crashreport.Parse(data)
-	if err != nil {
-		if errors.Is(err, crashreport.ErrLegacyFormat) {
-			fmt.Fprintf(stderr, "%s is a legacy plain-text report; spectra decodes modern .ips reports.\n", path)
-			return 1
-		}
-		fmt.Fprintf(stderr, "parse %s: %v\n", path, err)
-		return 1
+	path := fs.Arg(0)
+	report, code := loadCrashReport(path, readFile, stderr)
+	if code != 0 {
+		return code
 	}
 	if *asJSON {
 		enc := json.NewEncoder(stdout)
@@ -122,7 +112,7 @@ func orDash(s string) string {
 	return s
 }
 
-func runCrashInspect(args []string, stdout, stderr io.Writer) int {
+func runCrashInspect(args []string, stdout, stderr io.Writer, readFile func(string) ([]byte, error)) int {
 	fs := flag.NewFlagSet("crash inspect", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "output JSON")
@@ -134,24 +124,13 @@ func runCrashInspect(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	path := fs.Arg(0)
-	if path == "" {
+	if fs.NArg() != 1 {
 		fs.Usage()
 		return 2
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		fmt.Fprintf(stderr, "read %s: %v\n", path, err)
-		return 1
-	}
-	report, err := crashreport.Parse(data)
-	if err != nil {
-		if errors.Is(err, crashreport.ErrLegacyFormat) {
-			fmt.Fprintf(stderr, "%s is a legacy plain-text crash report; spectra decodes modern .ips JSON reports.\n", path)
-			return 1
-		}
-		fmt.Fprintf(stderr, "parse %s: %v\n", path, err)
-		return 1
+	report, code := loadCrashReport(fs.Arg(0), readFile, stderr)
+	if code != 0 {
+		return code
 	}
 	if *asJSON {
 		enc := json.NewEncoder(stdout)
@@ -164,6 +143,26 @@ func runCrashInspect(args []string, stdout, stderr io.Writer) int {
 	}
 	renderCrashReport(stdout, report, *all)
 	return 0
+}
+
+// loadCrashReport reads and parses one .ips report, mapping failures to a
+// process exit code (0 on success). readFile is injected for testability.
+func loadCrashReport(path string, readFile func(string) ([]byte, error), stderr io.Writer) (*crashreport.Report, int) {
+	data, err := readFile(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "read %s: %v\n", path, err)
+		return nil, 1
+	}
+	report, err := crashreport.Parse(data)
+	if err != nil {
+		if errors.Is(err, crashreport.ErrLegacyFormat) {
+			fmt.Fprintf(stderr, "%s is a legacy plain-text crash report; spectra decodes modern .ips JSON reports.\n", path)
+			return nil, 1
+		}
+		fmt.Fprintf(stderr, "parse %s: %v\n", path, err)
+		return nil, 1
+	}
+	return report, 0
 }
 
 func renderCrashReport(w io.Writer, r *crashreport.Report, allThreads bool) {

--- a/cmd/spectra/crash_argval_test.go
+++ b/cmd/spectra/crash_argval_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func okRead(string) ([]byte, error) { return []byte("{}\n{}"), nil }
+
+func TestCrashInspectRejectsExtraPaths(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runCrashInspect([]string{"a.ips", "b.ips"}, &out, &errBuf, okRead); code != 2 {
+		t.Fatalf("exit = %d, want 2 for two positional paths", code)
+	}
+}
+
+func TestCrashResourceRejectsExtraPaths(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runCrashResource([]string{"a.ips", "b.ips"}, &out, &errBuf, okRead); code != 2 {
+		t.Fatalf("exit = %d, want 2 for two positional paths", code)
+	}
+}
+
+func TestCrashInspectReadFailure(t *testing.T) {
+	fail := func(string) ([]byte, error) { return nil, errors.New("boom") }
+	var out, errBuf bytes.Buffer
+	code := runCrashInspect([]string{"missing.ips"}, &out, &errBuf, fail)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 on read failure", code)
+	}
+	if !strings.Contains(errBuf.String(), "boom") {
+		t.Errorf("stderr = %q, want the read error surfaced", errBuf.String())
+	}
+}
+
+func TestCrashResourceReadFailure(t *testing.T) {
+	fail := func(string) ([]byte, error) { return nil, errors.New("boom") }
+	var out, errBuf bytes.Buffer
+	if code := runCrashResource([]string{"missing.ips"}, &out, &errBuf, fail); code != 1 {
+		t.Fatalf("exit = %d, want 1 on read failure", code)
+	}
+}

--- a/internal/crashreport/crashreport.go
+++ b/internal/crashreport/crashreport.go
@@ -259,7 +259,11 @@ var (
 // limit/observed/window numbers out of the human strings best-effort, so it is
 // robust to per-flavor schema drift across macOS releases.
 func decodeResource(exc ipsException, term ipsTerm) *ResourceKill {
-	flavor := resourceFlavor(exc.Subtype)
+	flavorSrc := exc.Subtype
+	if strings.TrimSpace(flavorSrc) == "" {
+		flavorSrc = term.Indicator
+	}
+	flavor := resourceFlavor(flavorSrc)
 	detail := strings.TrimSpace(exc.Subtype)
 	if detail == "" {
 		detail = strings.TrimSpace(term.Indicator)

--- a/internal/crashreport/crashreport_resource_test.go
+++ b/internal/crashreport/crashreport_resource_test.go
@@ -61,6 +61,17 @@ func TestResourceUnknownFlavor(t *testing.T) {
 	}
 }
 
+func TestResourceFlavorFallbackToIndicator(t *testing.T) {
+	// Empty subtype, but the termination indicator names the flavor.
+	r, err := Parse([]byte(resourceIPS("", "CPU")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Resource == nil || r.Resource.Flavor != "CPU" {
+		t.Fatalf("resource = %+v, want flavor CPU derived from the indicator", r.Resource)
+	}
+}
+
 func TestNonResourceHasNoResource(t *testing.T) {
 	r, err := Parse([]byte(sampleIPS)) // EXC_BAD_ACCESS fixture from crashreport_test.go
 	if err != nil {


### PR DESCRIPTION
## What

Follow-up addressing the three CodeRabbit findings on #333, plus the same two that latently applied to `crash inspect` (#329).

1. **Resource flavor fallback (correctness).** `decodeResource` now derives the flavor from `termination.indicator` when `exception.subtype` is empty — an `EXC_RESOURCE` report with `indicator: "CPU"` and no subtype decodes as `CPU` instead of `UNKNOWN`.
2. **Reject extra positional args.** `crash inspect` and `crash resource` now require exactly one path (`fs.NArg() == 1`); extra paths print usage and exit `2` rather than silently analyzing only the first.
3. **Injectable file reads.** Both handlers take a `readFile func(string) ([]byte, error)` (per AGENTS.md — no raw `os.ReadFile` in testable paths), wired to `os.ReadFile` at dispatch, and share one `loadCrashReport` helper. The read-failure branch is now unit-tested.

## Testing

- `crashreport`: flavor-fallback-from-indicator test.
- CLI: two-positional-paths → exit 2 (both subcommands), and injected read-failure → exit 1 with the error surfaced.
- `make vet complexity lint security docs-validate test` green locally (48 pkgs).

## Note

These fixes correct code already merged in #333/#329. The originating review threads on #333 are resolved with a pointer to this PR.

Closes #336
