### PR TITLE
web: internal/asar + spectra web asar-diff — diff app.asar between versions

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -66,6 +66,7 @@ func subcommandList() []subcommand {
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},
 		{"crash", "Audit post-mortem readiness (can this machine produce a debuggable crash?)", runCrash},
+		{"web", "Diff an Electron app's app.asar payload between two versions", runWeb},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},

--- a/cmd/spectra/web.go
+++ b/cmd/spectra/web.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/asar"
+	"github.com/kaeawc/spectra/internal/detect"
+)
+
+func runWeb(args []string) int {
+	return runWebWithIO(args, os.Stdout, os.Stderr, detect.DetectWith)
+}
+
+type detectFunc func(string, detect.Options) (detect.Result, error)
+
+func runWebWithIO(args []string, stdout, stderr io.Writer, inspect detectFunc) int {
+	sub := ""
+	rest := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		sub, rest = args[0], args[1:]
+	}
+	switch sub {
+	case "asar-diff":
+		return runAsarDiff(rest, stdout, stderr, inspect)
+	default:
+		fmt.Fprintf(stderr, "unknown web subcommand %q (want: asar-diff)\n", sub)
+		return 2
+	}
+}
+
+// asarPayload is the version-independent inventory of one Electron app.
+type asarPayload struct {
+	App       string
+	Archive   *asar.Archive
+	NPM       []string
+	Native    []string
+	Endpoints []string
+}
+
+type webAsarDiff struct {
+	AppA             string    `json:"app_a"`
+	AppB             string    `json:"app_b"`
+	Files            asar.Diff `json:"files"`
+	NPMAdded         []string  `json:"npm_added,omitempty"`
+	NPMRemoved       []string  `json:"npm_removed,omitempty"`
+	NativeAdded      []string  `json:"native_added,omitempty"`
+	NativeRemoved    []string  `json:"native_removed,omitempty"`
+	EndpointsAdded   []string  `json:"endpoints_added,omitempty"`
+	EndpointsRemoved []string  `json:"endpoints_removed,omitempty"`
+}
+
+func runAsarDiff(args []string, stdout, stderr io.Writer, inspect detectFunc) int {
+	fs := flag.NewFlagSet("web asar-diff", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra web asar-diff [--json] <oldApp.app> <newApp.app>")
+		fmt.Fprintln(stderr, "Diff two Electron apps' app.asar payloads: changed files and new npm/native/endpoint capabilities.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fs.Usage()
+		return 2
+	}
+	a, err := buildAsarPayload(fs.Arg(0), inspect)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	b, err := buildAsarPayload(fs.Arg(1), inspect)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	diff := computeWebAsarDiff(a, b)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(diff); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	renderWebAsarDiff(stdout, diff)
+	return 0
+}
+
+func buildAsarPayload(appPath string, inspect detectFunc) (asarPayload, error) {
+	asarPath := filepath.Join(appPath, "Contents", "Resources", "app.asar")
+	arch, err := asar.ParseFile(asarPath)
+	if err != nil {
+		return asarPayload{}, fmt.Errorf("%s: %w", appPath, err)
+	}
+	res, err := inspect(appPath, detect.Options{ScanNetwork: true})
+	if err != nil {
+		return asarPayload{}, fmt.Errorf("inspect %s: %w", appPath, err)
+	}
+	p := asarPayload{
+		App:       strings.TrimSuffix(filepath.Base(appPath), ".app"),
+		Archive:   arch,
+		Native:    arch.NativeModulePaths(),
+		Endpoints: res.NetworkEndpoints,
+	}
+	if res.Dependencies != nil {
+		p.NPM = res.Dependencies.NPMPackages
+	}
+	return p, nil
+}
+
+func computeWebAsarDiff(a, b asarPayload) webAsarDiff {
+	return webAsarDiff{
+		AppA:             a.App,
+		AppB:             b.App,
+		Files:            asar.DiffArchives(a.Archive, b.Archive),
+		NPMAdded:         setSubtract(b.NPM, a.NPM),
+		NPMRemoved:       setSubtract(a.NPM, b.NPM),
+		NativeAdded:      setSubtract(b.Native, a.Native),
+		NativeRemoved:    setSubtract(a.Native, b.Native),
+		EndpointsAdded:   setSubtract(b.Endpoints, a.Endpoints),
+		EndpointsRemoved: setSubtract(a.Endpoints, b.Endpoints),
+	}
+}
+
+// setSubtract returns the items in a that are not in b, sorted and de-duped.
+func setSubtract(a, b []string) []string {
+	inB := make(map[string]bool, len(b))
+	for _, x := range b {
+		inB[x] = true
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, x := range a {
+		if inB[x] || seen[x] {
+			continue
+		}
+		seen[x] = true
+		out = append(out, x)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func renderWebAsarDiff(w io.Writer, d webAsarDiff) {
+	fmt.Fprintf(w, "asar-diff %s -> %s\n", d.AppA, d.AppB)
+	fmt.Fprintf(w, "files: +%d added, -%d removed, ~%d changed\n",
+		len(d.Files.Added), len(d.Files.Removed), len(d.Files.Changed))
+	renderDriftList(w, "+ npm", d.NPMAdded)
+	renderDriftList(w, "- npm", d.NPMRemoved)
+	renderDriftList(w, "+ native", d.NativeAdded)
+	renderDriftList(w, "- native", d.NativeRemoved)
+	renderDriftList(w, "+ endpoint", d.EndpointsAdded)
+	renderDriftList(w, "- endpoint", d.EndpointsRemoved)
+	if len(d.NPMAdded)+len(d.NativeAdded)+len(d.EndpointsAdded) == 0 && d.Files.Empty() {
+		fmt.Fprintln(w, "no changes")
+	}
+}
+
+func renderDriftList(w io.Writer, label string, items []string) {
+	for _, it := range items {
+		fmt.Fprintf(w, "  %s %s\n", label, it)
+	}
+}

--- a/cmd/spectra/web_test.go
+++ b/cmd/spectra/web_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/asar"
+)
+
+func TestSetSubtract(t *testing.T) {
+	got := setSubtract([]string{"b", "a", "c", "a"}, []string{"c"})
+	if strings.Join(got, ",") != "a,b" {
+		t.Errorf("setSubtract = %v, want [a b]", got)
+	}
+}
+
+func TestComputeWebAsarDiff(t *testing.T) {
+	a := asarPayload{
+		App:       "Slack-old",
+		Archive:   &asar.Archive{Files: []asar.FileEntry{{Path: "main.js", SHA256: "aaa"}}},
+		NPM:       []string{"react", "lodash"},
+		Native:    []string{"node_modules/a/a.node"},
+		Endpoints: []string{"api.slack.com"},
+	}
+	b := asarPayload{
+		App:       "Slack-new",
+		Archive:   &asar.Archive{Files: []asar.FileEntry{{Path: "main.js", SHA256: "bbb"}, {Path: "boot.js", SHA256: "ccc"}}},
+		NPM:       []string{"react", "lodash", "node-pty"},
+		Native:    []string{"node_modules/a/a.node", "node_modules/keytar/keytar.node"},
+		Endpoints: []string{"api.slack.com", "telemetry.vendor.io"},
+	}
+	d := computeWebAsarDiff(a, b)
+	if len(d.Files.Added) != 1 || d.Files.Added[0].Path != "boot.js" {
+		t.Errorf("files added = %+v", d.Files.Added)
+	}
+	if len(d.Files.Changed) != 1 || d.Files.Changed[0].Path != "main.js" {
+		t.Errorf("files changed = %+v", d.Files.Changed)
+	}
+	if strings.Join(d.NPMAdded, ",") != "node-pty" {
+		t.Errorf("npm added = %v", d.NPMAdded)
+	}
+	if strings.Join(d.NativeAdded, ",") != "node_modules/keytar/keytar.node" {
+		t.Errorf("native added = %v", d.NativeAdded)
+	}
+	if strings.Join(d.EndpointsAdded, ",") != "telemetry.vendor.io" {
+		t.Errorf("endpoints added = %v", d.EndpointsAdded)
+	}
+}
+
+func TestRenderWebAsarDiff(t *testing.T) {
+	d := webAsarDiff{
+		AppA: "old", AppB: "new",
+		NPMAdded:       []string{"node-pty"},
+		NativeAdded:    []string{"keytar.node"},
+		EndpointsAdded: []string{"telemetry.vendor.io"},
+	}
+	var out bytes.Buffer
+	renderWebAsarDiff(&out, d)
+	s := out.String()
+	for _, want := range []string{"asar-diff old -> new", "+ npm node-pty", "+ native keytar.node", "+ endpoint telemetry.vendor.io"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("render missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+func TestRunWebUnknownSub(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runWebWithIO([]string{"bogus"}, &out, &errBuf, nil); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}
+
+func TestRunAsarDiffWrongArgc(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runWebWithIO([]string{"asar-diff", "only-one.app"}, &out, &errBuf, nil); code != 2 {
+		t.Fatalf("exit = %d, want 2 for one path", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -36,6 +36,7 @@ run in-process on the local machine.
 | `storage` | Show disk volumes and `~/Library` footprint |
 | `process` | List running processes sorted by memory |
 | `crash` | Audit post-mortem readiness before a crash happens |
+| `web` | Diff an Electron app's `app.asar` payload between versions |
 | `playbook` | Show diagnostic playbooks and command plans |
 | `serve` | Run the local Unix-socket JSON-RPC daemon |
 | `connect` | Call a Spectra daemon over Unix socket or TCP JSON-RPC |
@@ -418,6 +419,23 @@ structured report.
 ```bash
 spectra crash resource ~/Library/Logs/DiagnosticReports/Helper-2026-08-05.cpu_resource.ips
 spectra crash resource --json report.ips
+```
+
+## `spectra web asar-diff`
+
+Diffs two Electron apps' `app.asar` payloads to answer "what changed in
+this app's JavaScript when it auto-updated?" — a question Activity Monitor
+and the extract-only `asar` CLI cannot. It parses each archive's header
+(read-only; no extraction) into a file inventory with per-file SHA256, then
+reports added/removed/changed files plus the capability drift that matters:
+new npm packages, new native `.node` add-ons, and new embedded endpoint
+hosts introduced by the update. `--json` emits the structured diff.
+
+### Examples
+
+```bash
+spectra web asar-diff /Volumes/backup/Slack.app /Applications/Slack.app
+spectra web asar-diff --json ./old/App.app ./new/App.app
 ```
 
 ## `spectra playbook`

--- a/internal/asar/asar.go
+++ b/internal/asar/asar.go
@@ -1,0 +1,193 @@
+// Package asar reads the header of an Electron app.asar archive without
+// extracting it. An asar file begins with a Chromium "pickle" header — a small
+// run of little-endian uint32 fields followed by a JSON directory that lists
+// every logical file with its size and (in modern archives) a SHA256 integrity
+// hash. This package parses that directory into a flat file inventory so two
+// versions of an app can be diffed. It reads header bytes only and never
+// executes or fully extracts the archive.
+package asar
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// maxHeaderBytes caps the JSON directory size we will read, as a sanity guard
+// against a corrupt or hostile length field.
+const maxHeaderBytes = 128 << 20 // 128 MiB
+
+// FileEntry is one logical file inside an asar archive.
+type FileEntry struct {
+	Path     string `json:"path"`
+	Size     int64  `json:"size"`
+	SHA256   string `json:"sha256,omitempty"`
+	Unpacked bool   `json:"unpacked,omitempty"`
+}
+
+// Archive is the parsed file inventory of an asar header, sorted by path.
+type Archive struct {
+	Files []FileEntry `json:"files"`
+}
+
+type rawHeader struct {
+	Files map[string]rawNode `json:"files"`
+}
+
+type rawNode struct {
+	Size      *int64             `json:"size"`
+	Offset    string             `json:"offset"`
+	Unpacked  bool               `json:"unpacked"`
+	Integrity *rawIntegrity      `json:"integrity"`
+	Files     map[string]rawNode `json:"files"`
+}
+
+type rawIntegrity struct {
+	Algorithm string `json:"algorithm"`
+	Hash      string `json:"hash"`
+}
+
+// ParseFile reads and parses the asar header at path.
+func ParseFile(path string) (*Archive, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	prefix := make([]byte, 16)
+	if _, err := io.ReadFull(f, prefix); err != nil {
+		return nil, fmt.Errorf("asar: read header prefix: %w", err)
+	}
+	jsonLen := binary.LittleEndian.Uint32(prefix[12:16])
+	if jsonLen == 0 || jsonLen > maxHeaderBytes {
+		return nil, fmt.Errorf("asar: implausible header size %d", jsonLen)
+	}
+	jsonBuf := make([]byte, jsonLen)
+	if _, err := io.ReadFull(f, jsonBuf); err != nil {
+		return nil, fmt.Errorf("asar: read header json: %w", err)
+	}
+	return parseHeaderJSON(jsonBuf)
+}
+
+// Parse parses an asar archive already held in memory.
+func Parse(data []byte) (*Archive, error) {
+	if len(data) < 16 {
+		return nil, fmt.Errorf("asar: too short (%d bytes)", len(data))
+	}
+	jsonLen := binary.LittleEndian.Uint32(data[12:16])
+	if jsonLen == 0 || jsonLen > maxHeaderBytes {
+		return nil, fmt.Errorf("asar: implausible header size %d", jsonLen)
+	}
+	if int64(16)+int64(jsonLen) > int64(len(data)) {
+		return nil, fmt.Errorf("asar: header size %d exceeds data (%d bytes)", jsonLen, len(data))
+	}
+	return parseHeaderJSON(data[16 : 16+jsonLen])
+}
+
+func parseHeaderJSON(jsonBuf []byte) (*Archive, error) {
+	var h rawHeader
+	if err := json.Unmarshal(jsonBuf, &h); err != nil {
+		return nil, fmt.Errorf("asar: parse header json: %w", err)
+	}
+	a := &Archive{}
+	walk("", h.Files, a)
+	sort.Slice(a.Files, func(i, j int) bool { return a.Files[i].Path < a.Files[j].Path })
+	return a, nil
+}
+
+func walk(prefix string, nodes map[string]rawNode, a *Archive) {
+	for name, node := range nodes {
+		path := name
+		if prefix != "" {
+			path = prefix + "/" + name
+		}
+		if node.Size != nil { // a file has a size; a directory does not
+			entry := FileEntry{Path: path, Size: *node.Size, Unpacked: node.Unpacked}
+			if node.Integrity != nil {
+				entry.SHA256 = node.Integrity.Hash
+			}
+			a.Files = append(a.Files, entry)
+			continue
+		}
+		walk(path, node.Files, a) // directory: recurse
+	}
+}
+
+// Diff is the file-level difference between two archives.
+type Diff struct {
+	Added   []FileEntry `json:"added,omitempty"`
+	Removed []FileEntry `json:"removed,omitempty"`
+	Changed []FileEntry `json:"changed,omitempty"`
+}
+
+// Empty reports whether the two archives are identical at the file level.
+func (d Diff) Empty() bool {
+	return len(d.Added) == 0 && len(d.Removed) == 0 && len(d.Changed) == 0
+}
+
+// DiffArchives compares archive a (older) with b (newer): files only in b are
+// Added, files only in a are Removed, files present in both whose SHA256
+// differs are Changed. Results are sorted by path.
+func DiffArchives(a, b *Archive) Diff {
+	oldByPath := indexByPath(a)
+	newByPath := indexByPath(b)
+	var d Diff
+	for path, ne := range newByPath {
+		oe, ok := oldByPath[path]
+		if !ok {
+			d.Added = append(d.Added, ne)
+			continue
+		}
+		if changed(oe, ne) {
+			d.Changed = append(d.Changed, ne)
+		}
+	}
+	for path, oe := range oldByPath {
+		if _, ok := newByPath[path]; !ok {
+			d.Removed = append(d.Removed, oe)
+		}
+	}
+	sortEntries(d.Added)
+	sortEntries(d.Removed)
+	sortEntries(d.Changed)
+	return d
+}
+
+// changed reports whether two entries for the same path differ. When both
+// carry a SHA256 we trust it; otherwise we fall back to size.
+func changed(oldE, newE FileEntry) bool {
+	if oldE.SHA256 != "" && newE.SHA256 != "" {
+		return oldE.SHA256 != newE.SHA256
+	}
+	return oldE.Size != newE.Size
+}
+
+func indexByPath(a *Archive) map[string]FileEntry {
+	m := make(map[string]FileEntry, len(a.Files))
+	for _, e := range a.Files {
+		m[e.Path] = e
+	}
+	return m
+}
+
+func sortEntries(es []FileEntry) {
+	sort.Slice(es, func(i, j int) bool { return es[i].Path < es[j].Path })
+}
+
+// NativeModulePaths returns the archive-relative paths of bundled native
+// add-ons (*.node), which are the highest-signal capability surface.
+func (a *Archive) NativeModulePaths() []string {
+	var out []string
+	for _, e := range a.Files {
+		if strings.HasSuffix(e.Path, ".node") {
+			out = append(out, e.Path)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/asar/asar_test.go
+++ b/internal/asar/asar_test.go
@@ -1,0 +1,110 @@
+package asar
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// buildASAR wraps a header-directory JSON string in the 16-byte Chromium
+// pickle prefix an asar file begins with (only the length at offset 12 is read
+// by the parser, but we fill the other fields to mirror the real layout).
+func buildASAR(headerJSON string) []byte {
+	jb := []byte(headerJSON)
+	buf := make([]byte, 16+len(jb))
+	binary.LittleEndian.PutUint32(buf[0:], 4)
+	binary.LittleEndian.PutUint32(buf[4:], uint32(len(jb)+8))
+	binary.LittleEndian.PutUint32(buf[8:], uint32(len(jb)+4))
+	binary.LittleEndian.PutUint32(buf[12:], uint32(len(jb)))
+	copy(buf[16:], jb)
+	return buf
+}
+
+const sampleHeader = `{"files":{
+  "main.js":{"size":100,"offset":"0","integrity":{"algorithm":"SHA256","hash":"aaa"}},
+  "node_modules":{"files":{"keytar":{"files":{"build":{"files":{
+    "keytar.node":{"size":2000,"offset":"100","unpacked":true,"integrity":{"algorithm":"SHA256","hash":"bbb"}}
+  }}}}}}
+}}`
+
+func TestParseInventory(t *testing.T) {
+	a, err := Parse(buildASAR(sampleHeader))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a.Files) != 2 {
+		t.Fatalf("files = %d, want 2: %+v", len(a.Files), a.Files)
+	}
+	// sorted by path: main.js first
+	if a.Files[0].Path != "main.js" || a.Files[0].SHA256 != "aaa" || a.Files[0].Size != 100 {
+		t.Errorf("entry0 = %+v", a.Files[0])
+	}
+	kt := a.Files[1]
+	if kt.Path != "node_modules/keytar/build/keytar.node" {
+		t.Errorf("entry1 path = %q", kt.Path)
+	}
+	if !kt.Unpacked || kt.SHA256 != "bbb" {
+		t.Errorf("keytar.node entry = %+v, want unpacked + sha bbb", kt)
+	}
+}
+
+func TestNativeModulePaths(t *testing.T) {
+	a, _ := Parse(buildASAR(sampleHeader))
+	nm := a.NativeModulePaths()
+	if len(nm) != 1 || nm[0] != "node_modules/keytar/build/keytar.node" {
+		t.Errorf("native modules = %v", nm)
+	}
+}
+
+func TestParseTooShort(t *testing.T) {
+	if _, err := Parse([]byte("tiny")); err == nil {
+		t.Fatal("expected error for short input")
+	}
+}
+
+func TestParseImplausibleLength(t *testing.T) {
+	buf := make([]byte, 16)
+	binary.LittleEndian.PutUint32(buf[12:], 0xFFFFFFFF)
+	if _, err := Parse(buf); err == nil {
+		t.Fatal("expected error for implausible header size")
+	}
+}
+
+func TestParseLengthExceedsData(t *testing.T) {
+	buf := make([]byte, 20)
+	binary.LittleEndian.PutUint32(buf[12:], 1000) // claims 1000 bytes of json but only 4 present
+	if _, err := Parse(buf); err == nil {
+		t.Fatal("expected error when header length exceeds data")
+	}
+}
+
+func TestDiffArchives(t *testing.T) {
+	oldA, _ := Parse(buildASAR(`{"files":{
+      "main.js":{"size":100,"integrity":{"hash":"aaa"}},
+      "gone.js":{"size":10,"integrity":{"hash":"xxx"}}
+    }}`))
+	newA, _ := Parse(buildASAR(`{"files":{
+      "main.js":{"size":120,"integrity":{"hash":"ccc"}},
+      "new.js":{"size":50,"integrity":{"hash":"ddd"}}
+    }}`))
+	d := DiffArchives(oldA, newA)
+	if d.Empty() {
+		t.Fatal("expected a non-empty diff")
+	}
+	if len(d.Added) != 1 || d.Added[0].Path != "new.js" {
+		t.Errorf("added = %+v", d.Added)
+	}
+	if len(d.Removed) != 1 || d.Removed[0].Path != "gone.js" {
+		t.Errorf("removed = %+v", d.Removed)
+	}
+	if len(d.Changed) != 1 || d.Changed[0].Path != "main.js" {
+		t.Errorf("changed = %+v", d.Changed)
+	}
+}
+
+func TestDiffIdentical(t *testing.T) {
+	a, _ := Parse(buildASAR(sampleHeader))
+	b, _ := Parse(buildASAR(sampleHeader))
+	if !DiffArchives(a, b).Empty() {
+		t.Error("identical archives should diff empty")
+	}
+}


### PR DESCRIPTION
## What

Adds **`internal/asar`** + **`spectra web asar-diff <oldApp> <newApp>`** — Spectra can now answer "what changed in this Electron app's JavaScript payload when it auto-updated?" (a new dependency, a newly bundled native bridge like node-pty/keytar, a new telemetry host). That's structurally unanswerable by Activity Monitor or the extract-only `asar` CLI.

## How

- `internal/asar` parses the `app.asar` **Chromium-pickle header** (verified empirically against a real archive: `uint32` fields, JSON directory length at byte offset 12, JSON string at 16). Each file entry already carries an `integrity.hash` (SHA256), so the inventory (path → size + SHA256 + unpacked) comes straight from the header — **stdlib `encoding/json`/`encoding/binary` only, no extraction, no third-party asar lib**. Length fields are sanity-capped. `DiffArchives` compares two inventories into added/removed/changed (by SHA256, size fallback).
- `spectra web asar-diff` parses both apps' archives and reuses `detect`'s `NPMPackages` / native-module / `NetworkEndpoints` scans, diffing them into a capability-drift summary (`--json` for structured output). The diff/render logic is factored into pure functions for testing.

## Scope (v1)

Two-path diff. `--since-snapshot` (against a stored snapshot artifact) and an MCP `web_asar_diff` tool are natural follow-ups.

## Testing

- `internal/asar`: parse a synthetic in-test archive (nested dirs, unpacked native module), `NativeModulePaths`, malformed/truncated/implausible-length errors, and `DiffArchives` (added/removed/changed + identical).
- Validated the parser against a **real 478-file `app.asar`** during development (correct SHA256s + native-module detection).
- CLI: `computeWebAsarDiff` set math, render output, unknown-subcommand and wrong-argc exits.
- `make vet complexity lint security docs-validate test` green locally (49 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #338
