### PR TITLE
snapshot: surface degraded collection instead of silent partial snapshots

### DIFF
--- a/cmd/spectra/rules.go
+++ b/cmd/spectra/rules.go
@@ -88,6 +88,8 @@ func runRules(args []string) int {
 		return 0
 	}
 
+	printSnapshotWarnings(os.Stderr, snap.Warnings)
+
 	if len(findings) == 0 {
 		fmt.Println("no findings — all rules passed")
 		return 0
@@ -95,6 +97,15 @@ func runRules(args []string) int {
 
 	printFindings(findings)
 	return 0
+}
+
+// printSnapshotWarnings surfaces degraded-collection warnings so a partial
+// snapshot ("no findings — all rules passed") is not mistaken for a clean
+// machine. Warnings go to stderr to keep stdout parseable.
+func printSnapshotWarnings(w io.Writer, warnings []string) {
+	for _, warning := range warnings {
+		fmt.Fprintf(w, "warning: %s\n", warning)
+	}
 }
 
 func loadRuleCatalog(configPath string, stderr io.Writer) ([]rules.Rule, error) {

--- a/cmd/spectra/rules_warnings_test.go
+++ b/cmd/spectra/rules_warnings_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrintSnapshotWarnings(t *testing.T) {
+	var buf bytes.Buffer
+	printSnapshotWarnings(&buf, []string{"jvm: jps not found in PATH"})
+	if !strings.Contains(buf.String(), "warning: jvm: jps not found in PATH") {
+		t.Fatalf("render = %q", buf.String())
+	}
+
+	buf.Reset()
+	printSnapshotWarnings(&buf, nil)
+	if buf.Len() != 0 {
+		t.Fatalf("no warnings should print nothing, got %q", buf.String())
+	}
+}

--- a/internal/jvm/collect.go
+++ b/internal/jvm/collect.go
@@ -22,14 +22,23 @@ type CollectOptions struct {
 // metadata via jcmd. Returns nil if jps is not on PATH (no JDK installed).
 // Any per-process collection failure is silently absorbed.
 func CollectAll(ctx context.Context, opts CollectOptions) []Info {
+	infos, _ := CollectAllStatus(ctx, opts)
+	return infos
+}
+
+// CollectAllStatus is CollectAll plus whether jps was available. A false
+// availability means JVM discovery could not run (jps missing), so an empty
+// result does not imply no JVMs are present — callers can surface that as a
+// degraded-collection warning.
+func CollectAllStatus(ctx context.Context, opts CollectOptions) (infos []Info, jpsAvailable bool) {
 	run := opts.CmdRunner
 	if run == nil {
 		run = DefaultRunner
 	}
 
-	pids := discoverPIDs(run)
+	pids, available := discoverPIDs(run)
 	if len(pids) == 0 {
-		return nil
+		return nil, available
 	}
 
 	results := make([]Info, 0, len(pids))
@@ -48,7 +57,7 @@ func CollectAll(ctx context.Context, opts CollectOptions) []Info {
 		}()
 	}
 	wg.Wait()
-	return results
+	return results, available
 }
 
 // InspectPID collects Info for a specific PID without running jps.

--- a/internal/jvm/jps.go
+++ b/internal/jvm/jps.go
@@ -11,14 +11,16 @@ func DefaultRunner(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).Output()
 }
 
-// discoverPIDs runs `jps -l` and returns a map of PID → main class.
-// Returns nil if jps is not found or returns an error (no JDK in PATH).
-func discoverPIDs(run CmdRunner) map[int]string {
+// discoverPIDs runs `jps -l` and returns a map of PID → main class, plus
+// whether jps was available (ran without error). available is false when jps
+// is not on PATH or errored, which is distinct from jps running and finding no
+// JVMs (empty map, available true).
+func discoverPIDs(run CmdRunner) (pids map[int]string, available bool) {
 	out, err := run("jps", "-l")
 	if err != nil {
-		return nil
+		return nil, false
 	}
-	return parseJPS(string(out))
+	return parseJPS(string(out)), true
 }
 
 // parseJPS parses `jps -l` output into a PID → main-class map.

--- a/internal/jvm/jps_status_test.go
+++ b/internal/jvm/jps_status_test.go
@@ -1,0 +1,27 @@
+package jvm
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestCollectAllStatusReportsJPSAvailability(t *testing.T) {
+	// jps errors (not on PATH) => unavailable.
+	if _, avail := CollectAllStatus(context.Background(), CollectOptions{
+		CmdRunner: func(string, ...string) ([]byte, error) { return nil, fmt.Errorf("jps: not found") },
+	}); avail {
+		t.Fatal("jpsAvailable = true, want false when jps errors")
+	}
+
+	// jps runs but reports no JVMs => available, empty result.
+	infos, avail := CollectAllStatus(context.Background(), CollectOptions{
+		CmdRunner: func(string, ...string) ([]byte, error) { return []byte(""), nil },
+	})
+	if !avail {
+		t.Fatal("jpsAvailable = false, want true when jps runs cleanly")
+	}
+	if len(infos) != 0 {
+		t.Fatalf("infos = %d, want 0", len(infos))
+	}
+}

--- a/internal/snapshot/degradation_test.go
+++ b/internal/snapshot/degradation_test.go
@@ -1,0 +1,66 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+func buildWithJPSRunner(run jvm.CmdRunner) Snapshot {
+	return Build(context.Background(), Options{
+		SpectraVersion: "test",
+		AppPaths:       []string{"/dev/null/__skip__"},
+		SkipApps:       true,
+		SkipProcesses:  true,
+		SkipStorage:    true,
+		SkipServices:   true,
+		SkipUpdates:    true,
+		JVMOpts:        jvm.CollectOptions{CmdRunner: run},
+	})
+}
+
+func hasJVMWarning(warnings []string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, "jps") {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildWarnsWhenJPSUnavailable(t *testing.T) {
+	snap := buildWithJPSRunner(func(string, ...string) ([]byte, error) {
+		return nil, fmt.Errorf("jps: not found")
+	})
+	if !hasJVMWarning(snap.Warnings) {
+		t.Fatalf("expected a jps degradation warning, got %v", snap.Warnings)
+	}
+}
+
+func TestBuildNoWarnWhenJPSAvailable(t *testing.T) {
+	snap := buildWithJPSRunner(func(string, ...string) ([]byte, error) {
+		return []byte(""), nil // jps ran, no JVMs
+	})
+	if hasJVMWarning(snap.Warnings) {
+		t.Fatalf("unexpected jps warning when jps is available: %v", snap.Warnings)
+	}
+}
+
+func TestBuildNoWarnWhenJVMsSkipped(t *testing.T) {
+	snap := Build(context.Background(), Options{
+		SpectraVersion: "test",
+		AppPaths:       []string{"/dev/null/__skip__"},
+		SkipApps:       true,
+		SkipProcesses:  true,
+		SkipStorage:    true,
+		SkipServices:   true,
+		SkipUpdates:    true,
+		SkipJVMs:       true,
+	})
+	if hasJVMWarning(snap.Warnings) {
+		t.Fatalf("no jvm warning expected when JVMs are skipped: %v", snap.Warnings)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -65,6 +65,11 @@ type Snapshot struct {
 	// populated by callers that have access to a snapshot store. Optional:
 	// rules that don't see history fall back to point-in-time checks.
 	FDHistory FDHistory `json:"fd_history,omitempty"`
+
+	// Warnings records collectors that could not run (e.g. a required tool was
+	// missing), so a partial snapshot is not mistaken for a clean machine.
+	// Empty when every requested collector produced trustworthy data.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // Options configure a snapshot Build.
@@ -203,6 +208,16 @@ func Build(ctx context.Context, opts Options) Snapshot {
 		netRun = netstate.DefaultRunner
 	}
 
+	// Collectors run concurrently; warnings about degraded collection are
+	// appended under this mutex and attached to the snapshot after Wait.
+	var warnMu sync.Mutex
+	var warnings []string
+	addWarning := func(w string) {
+		warnMu.Lock()
+		warnings = append(warnings, w)
+		warnMu.Unlock()
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(snapshotCollectorCount(opts))
 
@@ -277,7 +292,11 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	if !opts.SkipJVMs {
 		go func() {
 			defer wg.Done()
-			s.JVMs = jvm.CollectAll(ctx, opts.JVMOpts)
+			infos, jpsAvailable := jvm.CollectAllStatus(ctx, opts.JVMOpts)
+			s.JVMs = infos
+			if !jpsAvailable {
+				addWarning("jvm: jps not found in PATH — JVM discovery unavailable; JVM findings may be incomplete")
+			}
 		}()
 	}
 	if len(opts.RuntimeTelemetryCollectors) > 0 {
@@ -288,6 +307,7 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	}
 
 	wg.Wait()
+	s.Warnings = warnings
 	jvm.AttributeJDKs(s.JVMs, s.Toolchains.JDKs)
 	if !opts.SkipJVMs {
 		s.RuntimeTelemetry = append(s.RuntimeTelemetry, collectJVMTelemetry(ctx, s.JVMs, opts)...)


### PR DESCRIPTION
Closes #340

`snapshot.Build` silently absorbed collector failures, so `spectra rules` printed `no findings — all rules passed` even when it couldn't inspect (e.g. `jps` missing → no JVM discovery).

## What changed
- `Snapshot.Warnings []string` (thread-safe accumulator in `Build`, `omitempty`).
- `jvm.CollectAllStatus` returns whether `jps` was available (distinct from "ran, no JVMs"). `CollectAll` now delegates to it — behaviour preserved.
- `Build` records a warning when JVM discovery is requested but `jps` is unavailable.
- `spectra rules` prints warnings to stderr; stdout unchanged.

## Tests
- `internal/jvm/jps_status_test.go`: availability true/false.
- `internal/snapshot/degradation_test.go`: warning when jps missing; none when available or skipped.
- `cmd/spectra/rules_warnings_test.go`: renderer.
- Local: `go vet`, `go test ./...` (48 pkg), `gocyclo -over 15 -ignore _test` clean.

## Follow-up
Thread warnings through the `issues`/`playbook` output (issueflow service), and add warnings for other collectors as their failure signals become detectable.