### PR TITLE
web: internal/electronfuse + spectra web fuses — audit Electron fuses & asar-integrity

### DIFF
--- a/cmd/spectra/web.go
+++ b/cmd/spectra/web.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/asar"
 	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/electronfuse"
 )
 
 func runWeb(args []string) int {
@@ -29,9 +31,78 @@ func runWebWithIO(args []string, stdout, stderr io.Writer, inspect detectFunc) i
 	switch sub {
 	case "asar-diff":
 		return runAsarDiff(rest, stdout, stderr, inspect)
+	case "fuses":
+		return runWebFuses(rest, stdout, stderr, os.ReadFile)
 	default:
-		fmt.Fprintf(stderr, "unknown web subcommand %q (want: asar-diff)\n", sub)
+		fmt.Fprintf(stderr, "unknown web subcommand %q (want: asar-diff, fuses)\n", sub)
 		return 2
+	}
+}
+
+type webFusesOutput struct {
+	App      string                 `json:"app"`
+	Config   *electronfuse.Config   `json:"config"`
+	Findings []electronfuse.Finding `json:"findings,omitempty"`
+}
+
+func runWebFuses(args []string, stdout, stderr io.Writer, readFile func(string) ([]byte, error)) int {
+	fs := flag.NewFlagSet("web fuses", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra web fuses [--json] <app.app>")
+		fmt.Fprintln(stderr, "Audit an Electron app's build-time security fuses (RunAsNode, inspect args, asar integrity).")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	app := fs.Arg(0)
+	bin := filepath.Join(app, "Contents", "Frameworks", "Electron Framework.framework", "Electron Framework")
+	data, err := readFile(bin)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: not an Electron app or no Electron Framework binary: %v\n", app, err)
+		return 1
+	}
+	cfg, err := electronfuse.Parse(data)
+	if err != nil {
+		if errors.Is(err, electronfuse.ErrNoSentinel) {
+			fmt.Fprintf(stderr, "%s: no Electron fuse wire found in the framework binary\n", app)
+			return 1
+		}
+		fmt.Fprintf(stderr, "%s: %v\n", app, err)
+		return 1
+	}
+	name := strings.TrimSuffix(filepath.Base(app), ".app")
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(webFusesOutput{App: name, Config: cfg, Findings: cfg.Audit()}); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	renderWebFuses(stdout, name, cfg)
+	return 0
+}
+
+func renderWebFuses(w io.Writer, app string, cfg *electronfuse.Config) {
+	fmt.Fprintf(w, "%s — Electron fuses (schema v%d)\n", app, cfg.Version)
+	for _, f := range cfg.Fuses {
+		fmt.Fprintf(w, "  %-40s %s\n", f.Name, f.Status)
+	}
+	findings := cfg.Audit()
+	if len(findings) == 0 {
+		fmt.Fprintln(w, "\nno dangerous fuse configuration detected")
+		return
+	}
+	fmt.Fprintln(w, "")
+	for _, fd := range findings {
+		fmt.Fprintf(w, "  [%s] %s: %s\n", fd.Severity, fd.Fuse, fd.Message)
 	}
 }
 

--- a/cmd/spectra/web_fuses_test.go
+++ b/cmd/spectra/web_fuses_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fuseSentinel mirrors the literal sentinel electronfuse scans for, so the test
+// can synthesize a wire without exporting internals.
+const fuseSentinel = "dL7pKGdnNz796PbbjQWNKmHXBZaB9tsX"
+
+func buildFuseWire(statuses string) []byte {
+	w := []byte("preceding")
+	w = append(w, []byte(fuseSentinel)...)
+	w = append(w, 1, byte(len(statuses)))
+	w = append(w, []byte(statuses)...)
+	return w
+}
+
+func TestWebFusesInsecure(t *testing.T) {
+	read := func(string) ([]byte, error) { return buildFuseWire("100000000"), nil }
+	var out, errBuf bytes.Buffer
+	if code := runWebFuses([]string{"/Applications/Foo.app"}, &out, &errBuf, read); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	for _, want := range []string{"RunAsNode", "critical"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+func TestWebFusesHardened(t *testing.T) {
+	read := func(string) ([]byte, error) { return buildFuseWire("000011011"), nil }
+	var out, errBuf bytes.Buffer
+	if code := runWebFuses([]string{"/Applications/Foo.app"}, &out, &errBuf, read); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), "no dangerous fuse configuration") {
+		t.Errorf("hardened app should report clean; got:\n%s", out.String())
+	}
+}
+
+func TestWebFusesJSON(t *testing.T) {
+	read := func(string) ([]byte, error) { return buildFuseWire("100000000"), nil }
+	var out, errBuf bytes.Buffer
+	if code := runWebFuses([]string{"--json", "/Applications/Foo.app"}, &out, &errBuf, read); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"severity": "critical"`) {
+		t.Errorf("json missing critical finding; got:\n%s", out.String())
+	}
+}
+
+func TestWebFusesReadError(t *testing.T) {
+	read := func(string) ([]byte, error) { return nil, errors.New("nope") }
+	var out, errBuf bytes.Buffer
+	if code := runWebFuses([]string{"/Applications/Foo.app"}, &out, &errBuf, read); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestWebFusesNoSentinel(t *testing.T) {
+	read := func(string) ([]byte, error) { return []byte("not an electron binary"), nil }
+	var out, errBuf bytes.Buffer
+	if code := runWebFuses([]string{"/Applications/Foo.app"}, &out, &errBuf, read); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "no Electron fuse wire") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestWebFusesWrongArgc(t *testing.T) {
+	read := func(string) ([]byte, error) { return nil, nil }
+	var out, errBuf bytes.Buffer
+	if code := runWebFuses([]string{}, &out, &errBuf, read); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -438,6 +438,24 @@ spectra web asar-diff /Volumes/backup/Slack.app /Applications/Slack.app
 spectra web asar-diff --json ./old/App.app ./new/App.app
 ```
 
+## `spectra web fuses`
+
+Audits an Electron app's build-time security **fuses** — toggles baked into
+the framework binary. An app that ships with `RunAsNode` or
+`EnableNodeCliInspectArguments` enabled, or `EnableEmbeddedAsarIntegrityValidation`
+disabled, is a local code-injection surface: any process can relaunch the
+signed app as an arbitrary Node interpreter or attach a debugger. The command
+decodes the fuse wire and reports a security posture (`critical` / `warn` /
+`info`) per dangerous setting. `--json` emits the structured config. Reads
+binary bytes only; runs nothing.
+
+### Examples
+
+```bash
+spectra web fuses /Applications/SomeChatApp.app
+spectra web fuses --json /Applications/SomeChatApp.app
+```
+
 ## `spectra playbook`
 
 Shows problem-first diagnostic workflows over existing collectors. Use it

--- a/internal/electronfuse/electronfuse.go
+++ b/internal/electronfuse/electronfuse.go
@@ -1,0 +1,163 @@
+// Package electronfuse reads the "fuse" configuration Electron bakes into its
+// framework binary. Fuses are build-time security toggles (RunAsNode, Node CLI
+// inspect arguments, asar integrity validation, …). They are encoded as a
+// sentinel string followed by a version byte, a fuse-count byte, and one ASCII
+// status byte per fuse ('0' disabled, '1' enabled, else removed/inert). A
+// dangerous fuse left enabled turns a signed app into a local code-injection
+// surface. This package decodes the wire and assesses the security posture; it
+// reads bytes only and never executes anything.
+package electronfuse
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// sentinel precedes the fuse wire in the Electron Framework binary.
+var sentinel = []byte("dL7pKGdnNz796PbbjQWNKmHXBZaB9tsX")
+
+// ErrNoSentinel means the fuse wire was not found (not an Electron binary, or a
+// build without the fuse sentinel).
+var ErrNoSentinel = errors.New("electronfuse: fuse sentinel not found")
+
+// Status is one fuse's decoded state.
+type Status string
+
+const (
+	StatusDisabled Status = "disabled"
+	StatusEnabled  Status = "enabled"
+	StatusRemoved  Status = "removed"
+)
+
+// Fuse is one decoded fuse.
+type Fuse struct {
+	Index  int    `json:"index"`
+	Name   string `json:"name"`
+	Status Status `json:"status"`
+}
+
+// Config is the decoded fuse wire.
+type Config struct {
+	Version int    `json:"version"`
+	Fuses   []Fuse `json:"fuses"`
+}
+
+// v1Names are the schema-v1 fuse names in wire order (part of Electron's fuse
+// ABI). Indices beyond this list are labeled generically.
+var v1Names = []string{
+	"RunAsNode",
+	"EnableCookieEncryption",
+	"EnableNodeOptionsEnvironmentVariable",
+	"EnableNodeCliInspectArguments",
+	"EnableEmbeddedAsarIntegrityValidation",
+	"OnlyLoadAppFromAsar",
+	"LoadBrowserProcessSpecificV8Snapshot",
+	"GrantFileProtocolExtraPrivileges",
+}
+
+// ParseFile reads an Electron Framework binary and decodes its fuse wire.
+func ParseFile(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return Parse(data)
+}
+
+// Parse decodes the fuse wire from a binary's bytes.
+func Parse(data []byte) (*Config, error) {
+	i := bytes.Index(data, sentinel)
+	if i < 0 {
+		return nil, ErrNoSentinel
+	}
+	p := i + len(sentinel)
+	if p+2 > len(data) {
+		return nil, fmt.Errorf("electronfuse: truncated wire after sentinel")
+	}
+	version := int(data[p])
+	count := int(data[p+1])
+	start := p + 2
+	if start+count > len(data) {
+		return nil, fmt.Errorf("electronfuse: fuse count %d exceeds data", count)
+	}
+	cfg := &Config{Version: version}
+	for idx := 0; idx < count; idx++ {
+		cfg.Fuses = append(cfg.Fuses, Fuse{
+			Index:  idx,
+			Name:   fuseName(idx),
+			Status: statusFromByte(data[start+idx]),
+		})
+	}
+	return cfg, nil
+}
+
+func fuseName(idx int) string {
+	if idx >= 0 && idx < len(v1Names) {
+		return v1Names[idx]
+	}
+	return fmt.Sprintf("Fuse%d", idx)
+}
+
+func statusFromByte(b byte) Status {
+	switch b {
+	case '0':
+		return StatusDisabled
+	case '1':
+		return StatusEnabled
+	default:
+		return StatusRemoved
+	}
+}
+
+// Get returns the status of a named fuse.
+func (c *Config) Get(name string) (Status, bool) {
+	for _, f := range c.Fuses {
+		if f.Name == name {
+			return f.Status, true
+		}
+	}
+	return "", false
+}
+
+// Finding is one security observation about a fuse configuration.
+type Finding struct {
+	Fuse     string `json:"fuse"`
+	Severity string `json:"severity"` // critical, warn, info
+	Message  string `json:"message"`
+}
+
+// Audit assesses the fuse configuration for local code-injection risk.
+func (c *Config) Audit() []Finding {
+	var out []Finding
+	enabled := func(name string) bool {
+		s, ok := c.Get(name)
+		return ok && s == StatusEnabled
+	}
+	disabled := func(name string) bool {
+		s, ok := c.Get(name)
+		return ok && s == StatusDisabled
+	}
+	if enabled("RunAsNode") {
+		out = append(out, Finding{"RunAsNode", "critical",
+			"RunAsNode is enabled — any local process can set ELECTRON_RUN_AS_NODE and execute arbitrary JavaScript as this signed app."})
+	}
+	if enabled("EnableNodeCliInspectArguments") {
+		out = append(out, Finding{"EnableNodeCliInspectArguments", "warn",
+			"Node CLI --inspect arguments are honored — a local process can attach a debugger and run code in the app's context."})
+	}
+	if enabled("EnableNodeOptionsEnvironmentVariable") {
+		out = append(out, Finding{"EnableNodeOptionsEnvironmentVariable", "warn",
+			"NODE_OPTIONS is honored — a local process can inject Node flags or preload modules into the app."})
+	}
+	if disabled("EnableEmbeddedAsarIntegrityValidation") {
+		out = append(out, Finding{"EnableEmbeddedAsarIntegrityValidation", "warn",
+			"Embedded asar integrity validation is off — the app.asar payload can be swapped without detection."})
+	}
+	if disabled("OnlyLoadAppFromAsar") {
+		out = append(out, Finding{"OnlyLoadAppFromAsar", "info",
+			"OnlyLoadAppFromAsar is off — the app may load code from an unpacked directory, not just the signed asar."})
+	}
+	return out
+}

--- a/internal/electronfuse/electronfuse_test.go
+++ b/internal/electronfuse/electronfuse_test.go
@@ -1,0 +1,105 @@
+package electronfuse
+
+import (
+	"errors"
+	"testing"
+)
+
+// buildWire embeds a fuse status string in a synthetic binary: junk, then the
+// sentinel, version, count, the ASCII status bytes, then trailing junk.
+func buildWire(version byte, statuses string) []byte {
+	w := []byte("some-preceding-bytes-")
+	w = append(w, sentinel...)
+	w = append(w, version, byte(len(statuses)))
+	w = append(w, []byte(statuses)...)
+	w = append(w, []byte("-trailing")...)
+	return w
+}
+
+func TestParseHardened(t *testing.T) {
+	// 1Password's real vector: RunAsNode off, inspect off, integrity on.
+	cfg, err := Parse(buildWire(1, "000011011"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("version = %d, want 1", cfg.Version)
+	}
+	if len(cfg.Fuses) != 9 {
+		t.Fatalf("fuses = %d, want 9", len(cfg.Fuses))
+	}
+	if s, _ := cfg.Get("RunAsNode"); s != StatusDisabled {
+		t.Errorf("RunAsNode = %q, want disabled", s)
+	}
+	if s, _ := cfg.Get("EnableEmbeddedAsarIntegrityValidation"); s != StatusEnabled {
+		t.Errorf("integrity = %q, want enabled", s)
+	}
+	if f := cfg.Audit(); len(f) != 0 {
+		t.Errorf("hardened config should have no findings, got %+v", f)
+	}
+}
+
+func TestParseInsecure(t *testing.T) {
+	// RunAsNode on, node-options on, integrity off, only-load-from-asar off.
+	cfg, err := Parse(buildWire(1, "101000000"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := cfg.Audit()
+	bySev := map[string]int{}
+	names := map[string]bool{}
+	for _, f := range findings {
+		bySev[f.Severity]++
+		names[f.Fuse] = true
+	}
+	if bySev["critical"] != 1 || !names["RunAsNode"] {
+		t.Errorf("expected a critical RunAsNode finding, got %+v", findings)
+	}
+	if !names["EnableNodeOptionsEnvironmentVariable"] {
+		t.Errorf("expected NODE_OPTIONS finding, got %+v", findings)
+	}
+	if !names["EnableEmbeddedAsarIntegrityValidation"] {
+		t.Errorf("expected integrity-off finding, got %+v", findings)
+	}
+}
+
+func TestParseNoSentinel(t *testing.T) {
+	if _, err := Parse([]byte("nothing to see here")); !errors.Is(err, ErrNoSentinel) {
+		t.Fatalf("err = %v, want ErrNoSentinel", err)
+	}
+}
+
+func TestParseTruncated(t *testing.T) {
+	w := append([]byte("x"), sentinel...) // sentinel but no version/count
+	if _, err := Parse(w); err == nil {
+		t.Fatal("expected error for truncated wire")
+	}
+}
+
+func TestParseCountExceedsData(t *testing.T) {
+	w := append([]byte{}, sentinel...)
+	w = append(w, 1, 20)           // count 20
+	w = append(w, []byte("00")...) // but only 2 status bytes
+	if _, err := Parse(w); err == nil {
+		t.Fatal("expected error when count exceeds data")
+	}
+}
+
+func TestUnknownFuseIndexNamed(t *testing.T) {
+	cfg, err := Parse(buildWire(1, "0000000000")) // 10 fuses; index 8,9 beyond v1 names
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Fuses[8].Name != "Fuse8" || cfg.Fuses[9].Name != "Fuse9" {
+		t.Errorf("unknown fuse names = %q,%q", cfg.Fuses[8].Name, cfg.Fuses[9].Name)
+	}
+}
+
+func TestStatusFromByte(t *testing.T) {
+	cases := map[byte]Status{'0': StatusDisabled, '1': StatusEnabled, '2': StatusRemoved, 'x': StatusRemoved}
+	for b, want := range cases {
+		if got := statusFromByte(b); got != want {
+			t.Errorf("statusFromByte(%q) = %q, want %q", b, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds **`internal/electronfuse`** + **`spectra web fuses <app>`** — audits the build-time security **fuses** an Electron app ships with. An app with `RunAsNode` or `EnableNodeCliInspectArguments` enabled, or `EnableEmbeddedAsarIntegrityValidation` disabled, is a local code-injection surface: any process can relaunch the signed app as an arbitrary Node interpreter, attach a debugger, or swap its `app.asar`. Spectra inspected neither before. Builds on `internal/asar` (#339).

## How

- The fuse wire was confirmed **empirically** against a real Electron Framework binary: sentinel `dL7pKGdnNz…`, then a version byte, a fuse-count byte, then one **ASCII** status byte per fuse (`'0'` disabled, `'1'` enabled, else removed). 1Password decodes as `v1, 9 fuses, RunAsNode off / inspect off / integrity on` — a hardened config with zero findings.
- `electronfuse.Parse` scans for the sentinel (`bytes.Index`, stdlib only), decodes the version/count/status vector, and maps indices to the v1 fuse names (indices beyond the known set are labeled generically). `Config.Audit` produces `critical`/`warn`/`info` findings.
- `spectra web fuses` locates the app's `Electron Framework` binary, decodes, and reports the posture (`--json` for structured output). Reads bytes only; runs nothing.

The `EnableNodeCliInspectArguments` fuse also gates `--inspect`/CDP, so this is the prerequisite that tells the later CDP items which apps are even attachable.

## Scope (v1)

Fuse decode + security posture. Recomputing the `ElectronAsarIntegrity` header hash for cross-snapshot tamper detection is a natural follow-up.

## Testing

- `electronfuse`: synthetic wire — hardened vector (no findings), insecure vector (critical RunAsNode + NODE_OPTIONS + integrity-off), missing sentinel (`ErrNoSentinel`), truncated wire, count-exceeds-data, unknown-index naming, `statusFromByte` table.
- Validated the parser against a real Electron binary during development.
- CLI: insecure/hardened/JSON render, read error, no-sentinel, wrong-argc — all with an injected read func.
- `make vet complexity lint security docs-validate test` green locally (50 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #342
