### PR TITLE
rules: projection parity (jvm.gc_count, diff.*) + projection/engine tests

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -178,8 +178,13 @@ app.bundle_id, app.version, app.runtime, app.architectures, app.entitlements,
 process.pid, process.rss_kib, process.cpu_pct, process.command
 jvm.version, jvm.vendor, jvm.max_heap_mb, jvm.gc_count, jvm.thread_count
 toolchain.brew_formulae[], toolchain.jdks[], toolchain.node_versions[]
-diff.added_apps[], diff.removed_apps[], diff.changed_versions[]   # vs baseline
 ```
+
+Baseline-diff inputs (`diff.added_apps[]`, `diff.removed_apps[]`,
+`diff.changed_versions[]`) are **not** part of the single-snapshot projection
+`SnapshotActivation` produces — a single snapshot carries no baseline to diff
+against. Change-based rules require the diff-aware evaluation path, which is
+future work; they are intentionally absent from the projection today.
 
 The current Go catalog can inspect the complete `snapshot.Snapshot`
 structure. The data model in [storage.md](storage.md) is the source of

--- a/internal/rules/engine_test.go
+++ b/internal/rules/engine_test.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func fixedRule(id string, findings ...Finding) Rule {
+	return Rule{ID: id, MatchFn: func(snapshot.Snapshot) []Finding { return findings }}
+}
+
+func TestEvaluateSortsBySeverityThenRuleIDThenSubject(t *testing.T) {
+	catalog := []Rule{
+		fixedRule("r-low", Finding{RuleID: "z-low", Severity: SeverityLow}),
+		fixedRule("r-high", Finding{RuleID: "m-high", Severity: SeverityHigh}),
+		fixedRule("r-high2", Finding{RuleID: "a-high", Severity: SeverityHigh}),
+		fixedRule("r-info", Finding{RuleID: "b-info", Severity: SeverityInfo}),
+		fixedRule("r-med", Finding{RuleID: "c-med", Severity: SeverityMedium}),
+	}
+	got := Evaluate(snapshot.Snapshot{}, catalog)
+	want := []string{"a-high", "m-high", "c-med", "z-low", "b-info"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d findings, want %d", len(got), len(want))
+	}
+	for i, id := range want {
+		if got[i].RuleID != id {
+			t.Fatalf("order[%d] = %q, want %q (full: %v)", i, got[i].RuleID, id, ruleIDs(got))
+		}
+	}
+}
+
+func TestEvaluateStableBySubjectWithinSameRule(t *testing.T) {
+	catalog := []Rule{
+		fixedRule("r",
+			Finding{RuleID: "same", Severity: SeverityHigh, Subject: "b"},
+			Finding{RuleID: "same", Severity: SeverityHigh, Subject: "a"},
+		),
+	}
+	got := Evaluate(snapshot.Snapshot{}, catalog)
+	if got[0].Subject != "a" || got[1].Subject != "b" {
+		t.Fatalf("subject order = %q,%q; want a,b", got[0].Subject, got[1].Subject)
+	}
+}
+
+func ruleIDs(fs []Finding) []string {
+	out := make([]string, len(fs))
+	for i, f := range fs {
+		out[i] = f.RuleID
+	}
+	return out
+}

--- a/internal/rules/projection.go
+++ b/internal/rules/projection.go
@@ -131,9 +131,41 @@ func projectJVMs(jvms []jvm.Info) []any {
 			"vm_flags":       info.VMFlags,
 			"thread_count":   info.ThreadCount,
 			"sys_props":      info.SysProps,
+			"gc_count":       gcCount(info.GC),
+			"gc":             projectGC(info.GC),
 		})
 	}
 	return out
+}
+
+// gcCount is the total GC event count (young + full) documented as
+// jvm.gc_count, or 0 when GC stats were not collected.
+func gcCount(gc *jvm.GCStats) int64 {
+	if gc == nil {
+		return 0
+	}
+	return gc.YGC + gc.FGC
+}
+
+// projectGC exposes the one-shot jstat GC counters to external rules, or nil
+// when GC stats were not collected.
+func projectGC(gc *jvm.GCStats) any {
+	if gc == nil {
+		return nil
+	}
+	return map[string]any{
+		"ygc":  gc.YGC,
+		"ygct": gc.YGCT,
+		"fgc":  gc.FGC,
+		"fgct": gc.FGCT,
+		"gct":  gc.GCT,
+		"ec":   gc.EC,
+		"eu":   gc.EU,
+		"oc":   gc.OC,
+		"ou":   gc.OU,
+		"mc":   gc.MC,
+		"mu":   gc.MU,
+	}
 }
 
 func projectToolchains(t toolchain.Toolchains) map[string]any {

--- a/internal/rules/projection_jvm_test.go
+++ b/internal/rules/projection_jvm_test.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func TestSnapshotActivationProjectsJVMGCCount(t *testing.T) {
+	snap := snapshot.Snapshot{
+		JVMs: []jvm.Info{{
+			PID: 100,
+			GC:  &jvm.GCStats{YGC: 12, FGC: 3, OC: 1000, OU: 900},
+		}},
+	}
+	act := SnapshotActivation(snap)
+	jvms, ok := act["jvms"].([]any)
+	if !ok || len(jvms) != 1 {
+		t.Fatalf("jvms projection = %#v", act["jvms"])
+	}
+	j := jvms[0].(map[string]any)
+	// jvm.gc_count is documented as an available rule input.
+	if got := j["gc_count"].(int64); got != 15 {
+		t.Fatalf("gc_count = %d, want 15 (ygc 12 + fgc 3)", got)
+	}
+	gc, ok := j["gc"].(map[string]any)
+	if !ok {
+		t.Fatalf("gc projection missing/typed %T", j["gc"])
+	}
+	if gc["fgc"].(int64) != 3 || gc["oc"].(float64) != 1000 {
+		t.Fatalf("gc detail = %#v", gc)
+	}
+}
+
+func TestSnapshotActivationJVMWithoutGC(t *testing.T) {
+	snap := snapshot.Snapshot{JVMs: []jvm.Info{{PID: 101}}}
+	j := SnapshotActivation(snap)["jvms"].([]any)[0].(map[string]any)
+	if j["gc_count"].(int64) != 0 {
+		t.Fatalf("gc_count = %v, want 0 when GC absent", j["gc_count"])
+	}
+	if j["gc"] != nil {
+		t.Fatalf("gc = %#v, want nil when GC absent", j["gc"])
+	}
+}
+
+// TestSnapshotActivationBoundaryKeys locks the top-level external-rule keys so
+// a rename that would silently break YAML/CEL rules is caught.
+func TestSnapshotActivationBoundaryKeys(t *testing.T) {
+	act := SnapshotActivation(snapshot.Snapshot{})
+	for _, key := range []string{
+		"snapshot", "host", "apps", "processes", "jvms",
+		"toolchains", "network", "storage", "power", "sysctls", "fd_limit",
+	} {
+		if _, ok := act[key]; !ok {
+			t.Errorf("projection missing boundary key %q", key)
+		}
+	}
+}


### PR DESCRIPTION
Closes #344

`SnapshotActivation` (the external-rule boundary) drifted from `recommendations-engine.md`.

## What changed
- Project `jvm.gc_count` (young + full GC) and a nested `jvm.gc` map (nil when GC absent).
- Doc: `diff.*` inputs require the diff-aware path (future work) — removed from the single-snapshot input list.
- Tests: JVM GC projection present/absent, top-level boundary-key lock, `Evaluate` severity→rule-id→subject ordering.

## Tests
- `internal/rules/projection_jvm_test.go`, `internal/rules/engine_test.go`.
- Local: `go vet`, `go test ./...` (49 pkg), `gocyclo -over 15 -ignore _test` clean.