### PR TITLE
rules: add process-memory-hog detector

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -211,6 +211,7 @@ Implemented rules:
 - `sparse-file-inflation`
 - `app-gatekeeper-rejected`
 - `fd-pressure`
+- `process-memory-hog`
 
 ## Out of scope for v1
 

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -41,6 +41,7 @@ func V1Catalog() []Rule {
 		ruleSparseFileInflation(),
 		ruleGatekeeperRejected(),
 		ruleFDPressure(),
+		ruleProcessMemoryHog(),
 	}
 }
 

--- a/internal/rules/process_memory.go
+++ b/internal/rules/process_memory.go
@@ -1,0 +1,57 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+const (
+	// processMemoryHogRAMPercent is the share of system RAM above which a single
+	// process's resident set is flagged for investigation.
+	processMemoryHogRAMPercent = 25
+	// processMemoryHogFloorKiB is an absolute floor so the rule never fires on
+	// small machines where 25% is still a modest amount of memory (2 GiB).
+	processMemoryHogFloorKiB int64 = 2 * 1024 * 1024
+)
+
+// ruleProcessMemoryHog fires for a process whose resident set is both above an
+// absolute floor and a large share of system RAM — the "what is eating my RAM"
+// debugging question that Activity Monitor answers only after manual sorting.
+func ruleProcessMemoryHog() Rule {
+	return Rule{
+		ID:       "process-memory-hog",
+		Severity: SeverityMedium,
+		MatchFn:  matchProcessMemoryHog,
+	}
+}
+
+func matchProcessMemoryHog(s snapshot.Snapshot) []Finding {
+	ramBytes := s.Host.RAMBytes
+	if ramBytes == 0 {
+		return nil // unknown system RAM — cannot compute a share
+	}
+	var findings []Finding
+	for _, proc := range s.Processes {
+		if proc.RSSKiB < processMemoryHogFloorKiB {
+			continue
+		}
+		rssBytes := uint64(proc.RSSKiB) * 1024
+		pct := rssBytes * 100 / ramBytes
+		if pct < processMemoryHogRAMPercent {
+			continue
+		}
+		name := proc.Command
+		if name == "" {
+			name = "process"
+		}
+		findings = append(findings, Finding{
+			RuleID:   "process-memory-hog",
+			Severity: SeverityMedium,
+			Message:  fmt.Sprintf("%s (pid %d) is resident in %d MiB (%d%% of system RAM).", name, proc.PID, proc.RSSKiB/1024, pct),
+			Subject:  fmt.Sprintf("%s pid %d", name, proc.PID),
+			Fix:      "Investigate the process's memory growth; restart it or cap its heap/cache if this footprint is unexpected.",
+		})
+	}
+	return findings
+}

--- a/internal/rules/process_memory_test.go
+++ b/internal/rules/process_memory_test.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func memSnap(ramBytes uint64, procs ...process.Info) snapshot.Snapshot {
+	var s snapshot.Snapshot
+	s.Host.RAMBytes = ramBytes
+	s.Processes = procs
+	return s
+}
+
+func TestProcessMemoryHogFiresAboveThreshold(t *testing.T) {
+	const ram = 16 * 1024 * 1024 * 1024 // 16 GiB
+	// 6 GiB resident = 37% of RAM and above the 2 GiB floor.
+	s := memSnap(ram, process.Info{PID: 900, Command: "hungry", RSSKiB: 6 * 1024 * 1024})
+	findings := matchProcessMemoryHog(s)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1", len(findings))
+	}
+	if findings[0].RuleID != "process-memory-hog" || !strings.Contains(findings[0].Message, "hungry") {
+		t.Fatalf("finding = %+v", findings[0])
+	}
+}
+
+func TestProcessMemoryHogRespectsFloorAndShare(t *testing.T) {
+	const ram = 64 * 1024 * 1024 * 1024 // 64 GiB
+	s := memSnap(ram,
+		process.Info{PID: 1, Command: "small", RSSKiB: 500 * 1024},           // below 2 GiB floor
+		process.Info{PID: 2, Command: "modest", RSSKiB: 3 * 1024 * 1024},     // above floor but ~4.7% of RAM
+	)
+	if f := matchProcessMemoryHog(s); len(f) != 0 {
+		t.Fatalf("expected no findings, got %+v", f)
+	}
+}
+
+func TestProcessMemoryHogSkipsUnknownRAM(t *testing.T) {
+	s := memSnap(0, process.Info{PID: 3, Command: "x", RSSKiB: 100 * 1024 * 1024})
+	if f := matchProcessMemoryHog(s); f != nil {
+		t.Fatalf("expected nil when RAM unknown, got %+v", f)
+	}
+}

--- a/internal/rules/process_memory_test.go
+++ b/internal/rules/process_memory_test.go
@@ -31,8 +31,8 @@ func TestProcessMemoryHogFiresAboveThreshold(t *testing.T) {
 func TestProcessMemoryHogRespectsFloorAndShare(t *testing.T) {
 	const ram = 64 * 1024 * 1024 * 1024 // 64 GiB
 	s := memSnap(ram,
-		process.Info{PID: 1, Command: "small", RSSKiB: 500 * 1024},           // below 2 GiB floor
-		process.Info{PID: 2, Command: "modest", RSSKiB: 3 * 1024 * 1024},     // above floor but ~4.7% of RAM
+		process.Info{PID: 1, Command: "small", RSSKiB: 500 * 1024},       // below 2 GiB floor
+		process.Info{PID: 2, Command: "modest", RSSKiB: 3 * 1024 * 1024}, // above floor but ~4.7% of RAM
 	)
 	if f := matchProcessMemoryHog(s); len(f) != 0 {
 		t.Fatalf("expected no findings, got %+v", f)

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1158,6 +1158,7 @@ func TestV1CatalogContainsExpectedRules(t *testing.T) {
 		"spotlight.large_resident_indexer",
 		"backup.destinationless_scheduler_leak",
 		"updates.stale_major_prepared",
+		"process-memory-hog",
 	} {
 		if !ruleIDs[want] {
 			t.Errorf("V1Catalog missing rule %q", want)


### PR DESCRIPTION
Closes #347

The projection exposes rich process fields but only `fd-pressure` consumed them. Adds the missing memory detector.

## What changed
- `process-memory-hog`: Medium finding when a process's RSS is above a 2 GiB floor **and** >=25% of system RAM; skips when RAM is unknown; registered in `V1Catalog`; documented.

## Scope note
FD exhaustion is already covered by `fd-pressure` (with trend/leak escalation). A CPU-hog detector is deferred — snapshot `cpu_pct` is a lifetime average needing different thresholds (separate issue).

## Tests
- `internal/rules/process_memory_test.go`: above-threshold fire, floor/share negatives, unknown-RAM skip; added to the catalog presence test.
- Local: `go vet`, `go test ./...` (50 pkg), `gocyclo -over 15 -ignore _test` clean.