### PR TITLE
web: spectra web processes — Chromium topology & per-role RSS attribution

### DIFF
--- a/cmd/spectra/web.go
+++ b/cmd/spectra/web.go
@@ -33,8 +33,10 @@ func runWebWithIO(args []string, stdout, stderr io.Writer, inspect detectFunc) i
 		return runAsarDiff(rest, stdout, stderr, inspect)
 	case "fuses":
 		return runWebFuses(rest, stdout, stderr, os.ReadFile)
+	case "processes":
+		return runWebProcesses(rest, stdout, stderr, defaultProcessCollector)
 	default:
-		fmt.Fprintf(stderr, "unknown web subcommand %q (want: asar-diff, fuses)\n", sub)
+		fmt.Fprintf(stderr, "unknown web subcommand %q (want: asar-diff, fuses, processes)\n", sub)
 		return 2
 	}
 }

--- a/cmd/spectra/web_processes.go
+++ b/cmd/spectra/web_processes.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+// chromiumRole is a process's decoded Chromium role.
+type chromiumRole struct {
+	Role     string `json:"role"`
+	SubType  string `json:"sub_type,omitempty"`
+	ClientID string `json:"client_id,omitempty"`
+}
+
+type roleGroup struct {
+	Role    string   `json:"role"`
+	Count   int      `json:"count"`
+	RSSKiB  int64    `json:"rss_kib"`
+	PIDs    []int    `json:"pids"`
+	Details []string `json:"details,omitempty"`
+}
+
+type rendererOutlier struct {
+	PID            int     `json:"pid"`
+	ClientID       string  `json:"client_id,omitempty"`
+	RSSKiB         int64   `json:"rss_kib"`
+	MedianMultiple float64 `json:"median_multiple"`
+}
+
+type webProcTopology struct {
+	App             string           `json:"app"`
+	Processes       int              `json:"processes"`
+	TotalRSSKiB     int64            `json:"total_rss_kib"`
+	Roles           []roleGroup      `json:"roles"`
+	OutlierRenderer *rendererOutlier `json:"outlier_renderer,omitempty"`
+}
+
+func defaultProcessCollector(app string) []process.Info {
+	return process.CollectAll(context.Background(), process.CollectOptions{BundlePaths: []string{app}})
+}
+
+func runWebProcesses(args []string, stdout, stderr io.Writer, collect func(string) []process.Info) int {
+	fs := flag.NewFlagSet("web processes", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra web processes [--json] <app.app>")
+		fmt.Fprintln(stderr, "Attribute a running Electron/Chromium app's memory to each helper role.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	app := fs.Arg(0)
+	procs := appProcesses(collect(app))
+	if len(procs) == 0 {
+		fmt.Fprintf(stderr, "%s: no running processes found for this app\n", app)
+		return 1
+	}
+	topo := buildTopology(strings.TrimSuffix(baseName(app), ".app"), procs)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(topo); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	renderTopology(stdout, topo)
+	return 0
+}
+
+func baseName(p string) string {
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+// appProcesses keeps only processes attributed to the target bundle.
+func appProcesses(all []process.Info) []process.Info {
+	var out []process.Info
+	for _, p := range all {
+		if p.AppPath != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// classifyChromiumRole decodes a Chromium child's role from its argv. A process
+// with no --type flag is the main (browser) process.
+func classifyChromiumRole(cmdline string) chromiumRole {
+	t := flagValue(cmdline, "--type=")
+	r := chromiumRole{
+		SubType:  flagValue(cmdline, "--utility-sub-type="),
+		ClientID: flagValue(cmdline, "--renderer-client-id="),
+	}
+	switch t {
+	case "":
+		r.Role = "browser"
+	case "renderer":
+		r.Role = "renderer"
+	case "gpu-process":
+		r.Role = "gpu"
+	case "utility":
+		r.Role = "utility"
+	case "zygote":
+		r.Role = "zygote"
+	default:
+		r.Role = t
+	}
+	return r
+}
+
+// flagValue returns the value of a "--flag=" occurrence in a command line.
+func flagValue(cmdline, prefix string) string {
+	for _, f := range strings.Fields(cmdline) {
+		if strings.HasPrefix(f, prefix) {
+			return strings.TrimPrefix(f, prefix)
+		}
+	}
+	return ""
+}
+
+func buildTopology(app string, procs []process.Info) webProcTopology {
+	groups := map[string]*roleGroup{}
+	order := []string{}
+	var total int64
+	var renderers []process.Info
+	for _, p := range procs {
+		role := classifyChromiumRole(p.FullCommandLine)
+		g, ok := groups[role.Role]
+		if !ok {
+			g = &roleGroup{Role: role.Role}
+			groups[role.Role] = g
+			order = append(order, role.Role)
+		}
+		g.Count++
+		g.RSSKiB += p.RSSKiB
+		g.PIDs = append(g.PIDs, p.PID)
+		if d := roleDetail(role); d != "" {
+			g.Details = append(g.Details, fmt.Sprintf("pid %d %s", p.PID, d))
+		}
+		total += p.RSSKiB
+		if role.Role == "renderer" {
+			renderers = append(renderers, p)
+		}
+	}
+	roles := make([]roleGroup, 0, len(order))
+	for _, name := range order {
+		roles = append(roles, *groups[name])
+	}
+	sort.Slice(roles, func(i, j int) bool { return roles[i].RSSKiB > roles[j].RSSKiB })
+	return webProcTopology{
+		App:             app,
+		Processes:       len(procs),
+		TotalRSSKiB:     total,
+		Roles:           roles,
+		OutlierRenderer: findRendererOutlier(renderers),
+	}
+}
+
+func roleDetail(r chromiumRole) string {
+	switch {
+	case r.SubType != "":
+		return r.SubType
+	case r.ClientID != "":
+		return "client-id " + r.ClientID
+	default:
+		return ""
+	}
+}
+
+// findRendererOutlier flags the renderer whose RSS most exceeds the renderer
+// median, when there are enough renderers to have a meaningful median and the
+// top one is at least 2.5x it.
+func findRendererOutlier(renderers []process.Info) *rendererOutlier {
+	if len(renderers) < 3 {
+		return nil
+	}
+	rss := make([]int64, len(renderers))
+	for i, p := range renderers {
+		rss[i] = p.RSSKiB
+	}
+	sort.Slice(rss, func(i, j int) bool { return rss[i] < rss[j] })
+	median := rss[len(rss)/2]
+	if median == 0 {
+		return nil
+	}
+	top := renderers[0]
+	for _, p := range renderers {
+		if p.RSSKiB > top.RSSKiB {
+			top = p
+		}
+	}
+	mult := float64(top.RSSKiB) / float64(median)
+	if mult < 2.5 {
+		return nil
+	}
+	return &rendererOutlier{
+		PID:            top.PID,
+		ClientID:       flagValue(top.FullCommandLine, "--renderer-client-id="),
+		RSSKiB:         top.RSSKiB,
+		MedianMultiple: mult,
+	}
+}
+
+func renderTopology(w io.Writer, t webProcTopology) {
+	fmt.Fprintf(w, "%s — Chromium process topology (%d processes, %s)\n", t.App, t.Processes, mib(t.TotalRSSKiB))
+	for _, g := range t.Roles {
+		fmt.Fprintf(w, "  %-9s %2d proc  %10s\n", g.Role, g.Count, mib(g.RSSKiB))
+		for _, d := range g.Details {
+			fmt.Fprintf(w, "                          %s\n", d)
+		}
+	}
+	if o := t.OutlierRenderer; o != nil {
+		id := ""
+		if o.ClientID != "" {
+			id = " (client-id " + o.ClientID + ")"
+		}
+		fmt.Fprintf(w, "\noutlier renderer: pid %d%s %s = %.1fx the renderer median\n", o.PID, id, mib(o.RSSKiB), o.MedianMultiple)
+	}
+}
+
+func mib(kib int64) string {
+	return fmt.Sprintf("%d MB", kib/1024)
+}

--- a/cmd/spectra/web_processes_test.go
+++ b/cmd/spectra/web_processes_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+func TestClassifyChromiumRole(t *testing.T) {
+	cases := []struct {
+		cmdline string
+		role    string
+		sub     string
+		client  string
+	}{
+		{"/Applications/Slack.app/.../Slack", "browser", "", ""},
+		{"Slack Helper --type=renderer --renderer-client-id=7", "renderer", "", "7"},
+		{"Slack Helper (GPU) --type=gpu-process", "gpu", "", ""},
+		{"Slack Helper --type=utility --utility-sub-type=network.mojom.NetworkService", "utility", "network.mojom.NetworkService", ""},
+		{"proc --type=zygote", "zygote", "", ""},
+	}
+	for _, c := range cases {
+		got := classifyChromiumRole(c.cmdline)
+		if got.Role != c.role || got.SubType != c.sub || got.ClientID != c.client {
+			t.Errorf("classify(%q) = %+v, want role=%s sub=%s client=%s", c.cmdline, got, c.role, c.sub, c.client)
+		}
+	}
+}
+
+func rendererProc(pid int, clientID string, rssMiB int64) process.Info {
+	return process.Info{
+		PID:             pid,
+		AppPath:         "/Applications/Slack.app",
+		RSSKiB:          rssMiB * 1024,
+		FullCommandLine: "Slack Helper --type=renderer --renderer-client-id=" + clientID,
+	}
+}
+
+func TestBuildTopologyRolesAndTotals(t *testing.T) {
+	procs := []process.Info{
+		{PID: 1, AppPath: "/Applications/Slack.app", RSSKiB: 120 * 1024, FullCommandLine: "/Applications/Slack.app/Contents/MacOS/Slack"},
+		{PID: 2, AppPath: "/Applications/Slack.app", RSSKiB: 380 * 1024, FullCommandLine: "Slack Helper (GPU) --type=gpu-process"},
+		rendererProc(3, "1", 200),
+		rendererProc(4, "2", 210),
+		rendererProc(5, "3", 190),
+	}
+	topo := buildTopology("Slack", procs)
+	if topo.Processes != 5 {
+		t.Errorf("processes = %d, want 5", topo.Processes)
+	}
+	if topo.TotalRSSKiB != (120+380+200+210+190)*1024 {
+		t.Errorf("total = %d", topo.TotalRSSKiB)
+	}
+	// roles sorted by RSS desc; renderer group (600MB) should be first
+	if topo.Roles[0].Role != "renderer" || topo.Roles[0].Count != 3 {
+		t.Errorf("top role = %+v, want renderer x3", topo.Roles[0])
+	}
+	if topo.OutlierRenderer != nil {
+		t.Errorf("balanced renderers should have no outlier, got %+v", topo.OutlierRenderer)
+	}
+}
+
+func TestBuildTopologyOutlier(t *testing.T) {
+	procs := []process.Info{
+		rendererProc(3, "1", 200),
+		rendererProc(4, "2", 210),
+		rendererProc(5, "7", 1200), // ~6x median
+		rendererProc(6, "3", 190),
+		rendererProc(7, "4", 205),
+	}
+	topo := buildTopology("Slack", procs)
+	if topo.OutlierRenderer == nil {
+		t.Fatal("expected an outlier renderer")
+	}
+	if topo.OutlierRenderer.PID != 5 || topo.OutlierRenderer.ClientID != "7" {
+		t.Errorf("outlier = %+v, want pid 5 client 7", topo.OutlierRenderer)
+	}
+	if topo.OutlierRenderer.MedianMultiple < 2.5 {
+		t.Errorf("median multiple = %v, want >= 2.5", topo.OutlierRenderer.MedianMultiple)
+	}
+}
+
+func TestRunWebProcessesRenders(t *testing.T) {
+	collect := func(string) []process.Info {
+		return []process.Info{
+			{PID: 1, AppPath: "/Applications/Slack.app", RSSKiB: 120 * 1024, FullCommandLine: "/Applications/Slack.app/Contents/MacOS/Slack"},
+			rendererProc(3, "1", 200),
+		}
+	}
+	var out, errBuf bytes.Buffer
+	if code := runWebProcesses([]string{"/Applications/Slack.app"}, &out, &errBuf, collect); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	for _, want := range []string{"Slack", "browser", "renderer", "topology"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+func TestRunWebProcessesNone(t *testing.T) {
+	collect := func(string) []process.Info { return nil }
+	var out, errBuf bytes.Buffer
+	if code := runWebProcesses([]string{"/Applications/Slack.app"}, &out, &errBuf, collect); code != 1 {
+		t.Fatalf("exit = %d, want 1 when no processes", code)
+	}
+}
+
+func TestRunWebProcessesWrongArgc(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runWebProcesses([]string{}, &out, &errBuf, func(string) []process.Info { return nil }); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -456,6 +456,23 @@ spectra web fuses /Applications/SomeChatApp.app
 spectra web fuses --json /Applications/SomeChatApp.app
 ```
 
+## `spectra web processes`
+
+Attributes a running Electron/Chromium app's memory to each helper role.
+Activity Monitor shows a dozen identically named "Helper (Renderer)"
+processes; this decodes each one's Chromium role from its command line
+(`--type=renderer|gpu-process|utility`, `--utility-sub-type`,
+`--renderer-client-id`) and rolls up RSS per role — browser, renderer, GPU,
+utility — flagging the renderer whose memory most exceeds the renderer
+median. `--json` emits the structured topology.
+
+### Examples
+
+```bash
+spectra web processes /Applications/Slack.app
+spectra web processes --json /Applications/Slack.app
+```
+
 ## `spectra playbook`
 
 Shows problem-first diagnostic workflows over existing collectors. Use it


### PR DESCRIPTION
## What

Adds **`spectra web processes <app>`** — attributes a running Electron/Chromium app's memory to each helper role. Activity Monitor shows a dozen identically named "Helper (Renderer)" processes with no way to know which is the 1.2 GB one or what role it plays; this decodes each process's Chromium role and rolls up RSS per role, flagging the outlier renderer.

## How

- Reuses `process.CollectAll` with `BundlePaths` (already sets `AppPath` and captures `FullCommandLine`); keeps the processes attributed to the target bundle.
- `classifyChromiumRole` decodes the role from argv: no `--type=` → **browser** (main), `--type=renderer` (+ `--renderer-client-id`), `--type=gpu-process`, `--type=utility` (+ `--utility-sub-type=network.mojom.NetworkService`/…), zygote.
- `buildTopology` groups by role (count, summed RSS, PIDs), sorts by RSS, and `findRendererOutlier` flags the renderer whose RSS exceeds the renderer median by ≥2.5x (only when there are ≥3 renderers). `--json` for the structured topology.

The collector is injected and all classify/aggregate/outlier logic is pure.

## Scope (v1)

RSS-based attribution over collected argv — no attach. `phys_footprint` via `vmmap -summary` and enriching `snapshot.RunningProcesses` for over-time diffs are natural follow-ups.

## Testing

- `classifyChromiumRole` table (browser/renderer/gpu/utility+subtype/zygote), `buildTopology` totals + role sort, outlier detection (present and absent), and the CLI render/no-processes/wrong-argc paths — all over synthetic `process.Info` slices via the injected collector.
- `make vet complexity lint security docs-validate test` green locally (50 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #346
