### PR TITLE
rules: add network detectors (proxy configured, hosts override)

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -212,6 +212,8 @@ Implemented rules:
 - `app-gatekeeper-rejected`
 - `fd-pressure`
 - `process-memory-hog`
+- `network.proxy_configured`
+- `network.hosts_override`
 
 ## Out of scope for v1
 

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -42,6 +42,8 @@ func V1Catalog() []Rule {
 		ruleGatekeeperRejected(),
 		ruleFDPressure(),
 		ruleProcessMemoryHog(),
+		ruleNetworkProxyConfigured(),
+		ruleNetworkHostsOverride(),
 	}
 }
 

--- a/internal/rules/network.go
+++ b/internal/rules/network.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+// ruleNetworkProxyConfigured surfaces an active system web proxy. A forgotten
+// proxy is a common root cause of "TLS issuer is unexpected" or connectivity
+// failures — the network-failure playbook lists it as a manual signal, so the
+// engine flags it automatically (informational, not a defect).
+func ruleNetworkProxyConfigured() Rule {
+	return Rule{
+		ID:       "network.proxy_configured",
+		Severity: SeverityInfo,
+		MatchFn:  matchNetworkProxyConfigured,
+	}
+}
+
+func matchNetworkProxyConfigured(s snapshot.Snapshot) []Finding {
+	p := s.Network.Proxy
+	var parts []string
+	if p.HTTP != "" {
+		parts = append(parts, "http="+p.HTTP)
+	}
+	if p.HTTPS != "" {
+		parts = append(parts, "https="+p.HTTPS)
+	}
+	if p.SOCKS != "" {
+		parts = append(parts, "socks="+p.SOCKS)
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return []Finding{{
+		RuleID:   "network.proxy_configured",
+		Severity: SeverityInfo,
+		Message:  fmt.Sprintf("A system proxy is configured (%s). Proxy interception can explain unexpected TLS issuers or blocked endpoints.", strings.Join(parts, ", ")),
+		Fix:      "Confirm the proxy is intended for this network; clear it if it is stale.",
+	}}
+}
+
+// ruleNetworkHostsOverride surfaces /etc/hosts entries that pin a real
+// hostname to a non-loopback address, which silently overrides DNS and can
+// redirect or break connectivity. The default macOS loopback/broadcast entries
+// are ignored.
+func ruleNetworkHostsOverride() Rule {
+	return Rule{
+		ID:       "network.hosts_override",
+		Severity: SeverityInfo,
+		MatchFn:  matchNetworkHostsOverride,
+	}
+}
+
+func matchNetworkHostsOverride(s snapshot.Snapshot) []Finding {
+	var findings []Finding
+	for _, entry := range s.Network.HostsOverrides {
+		if isDefaultHostsIP(entry.IP) {
+			continue
+		}
+		names := realHostNames(entry.Names)
+		if len(names) == 0 {
+			continue
+		}
+		findings = append(findings, Finding{
+			RuleID:   "network.hosts_override",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("/etc/hosts pins %s to %s, overriding DNS. This can silently redirect or break connectivity.", strings.Join(names, ", "), entry.IP),
+			Subject:  entry.IP,
+			Fix:      "Remove the /etc/hosts entry if it is stale or unintended.",
+		})
+	}
+	return findings
+}
+
+func isDefaultHostsIP(ip string) bool {
+	if ip == "" || ip == "255.255.255.255" {
+		return true
+	}
+	parsed := net.ParseIP(ip)
+	return parsed != nil && parsed.IsLoopback()
+}
+
+func realHostNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		switch strings.ToLower(strings.TrimSpace(n)) {
+		case "", "localhost", "broadcasthost":
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/rules/network_test.go
+++ b/internal/rules/network_test.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/netstate"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func netSnap(state netstate.State) snapshot.Snapshot {
+	var s snapshot.Snapshot
+	s.Network = state
+	return s
+}
+
+func TestNetworkProxyConfiguredFires(t *testing.T) {
+	s := netSnap(netstate.State{Proxy: netstate.ProxyConfig{HTTPS: "proxy.corp:8080"}})
+	f := matchNetworkProxyConfigured(s)
+	if len(f) != 1 || !strings.Contains(f[0].Message, "proxy.corp:8080") {
+		t.Fatalf("proxy finding = %+v", f)
+	}
+	if none := matchNetworkProxyConfigured(netSnap(netstate.State{})); none != nil {
+		t.Fatalf("expected no finding without a proxy, got %+v", none)
+	}
+}
+
+func TestNetworkHostsOverrideFlagsRealHostOnly(t *testing.T) {
+	s := netSnap(netstate.State{HostsOverrides: []netstate.HostsEntry{
+		{IP: "127.0.0.1", Names: []string{"localhost"}},           // default, ignored
+		{IP: "255.255.255.255", Names: []string{"broadcasthost"}}, // default, ignored
+		{IP: "::1", Names: []string{"localhost"}},                 // loopback, ignored
+		{IP: "10.0.0.5", Names: []string{"api.example.com"}},      // real override
+	}})
+	f := matchNetworkHostsOverride(s)
+	if len(f) != 1 {
+		t.Fatalf("findings = %d, want 1 (only the real override): %+v", len(f), f)
+	}
+	if !strings.Contains(f[0].Message, "api.example.com") || f[0].Subject != "10.0.0.5" {
+		t.Fatalf("finding = %+v", f[0])
+	}
+}
+
+func TestNetworkHostsOverrideIgnoresLoopbackWithRealName(t *testing.T) {
+	// A real hostname pinned to loopback is still a local redirect, not a
+	// DNS-hijack; the default-IP filter skips it.
+	s := netSnap(netstate.State{HostsOverrides: []netstate.HostsEntry{
+		{IP: "127.0.0.1", Names: []string{"dev.local"}},
+	}})
+	if f := matchNetworkHostsOverride(s); f != nil {
+		t.Fatalf("expected no finding for loopback pin, got %+v", f)
+	}
+}

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1159,6 +1159,8 @@ func TestV1CatalogContainsExpectedRules(t *testing.T) {
 		"backup.destinationless_scheduler_leak",
 		"updates.stale_major_prepared",
 		"process-memory-hog",
+		"network.proxy_configured",
+		"network.hosts_override",
 	} {
 		if !ruleIDs[want] {
 			t.Errorf("V1Catalog missing rule %q", want)


### PR DESCRIPTION
Closes #351

The network-failure playbook flags proxy/DNS-override as manual signals and the state is projected, but no rule consumed it.

## What changed
- `network.proxy_configured` (Info): a system HTTP/HTTPS/SOCKS proxy is set.
- `network.hosts_override` (Info): `/etc/hosts` pins a real hostname to a non-loopback IP; default loopback/broadcast entries ignored.
- VPN-active left as a diagnosis input (always-on VPNs would make it noise).
- Registered in `V1Catalog`; documented.

## Tests
- `internal/rules/network_test.go`: proxy fire/no-fire, hosts real-vs-default filtering, loopback-pin skip; added to catalog presence test.
- Local: `go vet`, `go test ./...` (50 pkg), `gofmt -l` clean, `gocyclo -over 15 -ignore _test` clean.