### PR TITLE
web: internal/sourcemap + spectra web symbolicate — Source Map v3 position decoder

### DIFF
--- a/cmd/spectra/web.go
+++ b/cmd/spectra/web.go
@@ -35,8 +35,10 @@ func runWebWithIO(args []string, stdout, stderr io.Writer, inspect detectFunc) i
 		return runWebFuses(rest, stdout, stderr, os.ReadFile)
 	case "processes":
 		return runWebProcesses(rest, stdout, stderr, defaultProcessCollector)
+	case "symbolicate":
+		return runWebSymbolicate(rest, stdout, stderr, os.ReadFile)
 	default:
-		fmt.Fprintf(stderr, "unknown web subcommand %q (want: asar-diff, fuses, processes)\n", sub)
+		fmt.Fprintf(stderr, "unknown web subcommand %q (want: asar-diff, fuses, processes, symbolicate)\n", sub)
 		return 2
 	}
 }

--- a/cmd/spectra/web_symbolicate.go
+++ b/cmd/spectra/web_symbolicate.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/sourcemap"
+)
+
+type symResult struct {
+	Input  string `json:"input"`
+	Mapped bool   `json:"mapped"`
+	Source string `json:"source,omitempty"`
+	Line   int    `json:"line,omitempty"`
+	Column int    `json:"column,omitempty"`
+	Name   string `json:"name,omitempty"`
+}
+
+func runWebSymbolicate(args []string, stdout, stderr io.Writer, readFile func(string) ([]byte, error)) int {
+	fs := flag.NewFlagSet("web symbolicate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra web symbolicate [--json] <map.js.map> <line>:<col> [<line>:<col> ...]")
+		fmt.Fprintln(stderr, "Resolve minified generated positions to their original source locations.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() < 2 {
+		fs.Usage()
+		return 2
+	}
+	data, err := readFile(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(stderr, "read %s: %v\n", fs.Arg(0), err)
+		return 1
+	}
+	sm, err := sourcemap.Parse(data)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	results := make([]symResult, 0, fs.NArg()-1)
+	for _, posArg := range fs.Args()[1:] {
+		r, err := symbolicateOne(sm, posArg)
+		if err != nil {
+			fmt.Fprintf(stderr, "%v\n", err)
+			return 2
+		}
+		results = append(results, r)
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(results); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	for _, r := range results {
+		fmt.Fprintln(stdout, formatSym(r))
+	}
+	return 0
+}
+
+func symbolicateOne(sm *sourcemap.SourceMap, posArg string) (symResult, error) {
+	line, col, err := parsePosition(posArg)
+	if err != nil {
+		return symResult{}, err
+	}
+	r := symResult{Input: posArg}
+	if p, ok := sm.Lookup(line, col); ok {
+		r.Mapped = true
+		r.Source, r.Line, r.Column, r.Name = p.Source, p.Line, p.Column, p.Name
+	}
+	return r, nil
+}
+
+func parsePosition(s string) (line, col int, err error) {
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("bad position %q, want line:col", s)
+	}
+	line, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("bad line in %q: %w", s, err)
+	}
+	col, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("bad column in %q: %w", s, err)
+	}
+	return line, col, nil
+}
+
+func formatSym(r symResult) string {
+	if !r.Mapped {
+		return r.Input + " -> no mapping"
+	}
+	out := fmt.Sprintf("%s -> %s:%d:%d", r.Input, r.Source, r.Line, r.Column)
+	if r.Name != "" {
+		out += " (" + r.Name + ")"
+	}
+	return out
+}

--- a/cmd/spectra/web_symbolicate_test.go
+++ b/cmd/spectra/web_symbolicate_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+const sampleMap = `{"version":3,"sources":["orig.js"],"names":["boom"],"mappings":"AAAAA"}`
+
+func TestParsePosition(t *testing.T) {
+	line, col, err := parsePosition("12:340")
+	if err != nil || line != 12 || col != 340 {
+		t.Fatalf("parsePosition = %d,%d,%v", line, col, err)
+	}
+	if _, _, err := parsePosition("nope"); err == nil {
+		t.Error("expected error for bad position")
+	}
+	if _, _, err := parsePosition("x:1"); err == nil {
+		t.Error("expected error for non-numeric line")
+	}
+}
+
+func TestFormatSym(t *testing.T) {
+	got := formatSym(symResult{Input: "1:0", Mapped: true, Source: "orig.js", Line: 1, Column: 0, Name: "boom"})
+	if got != "1:0 -> orig.js:1:0 (boom)" {
+		t.Errorf("formatSym = %q", got)
+	}
+	if formatSym(symResult{Input: "9:9"}) != "9:9 -> no mapping" {
+		t.Errorf("unmapped format wrong")
+	}
+}
+
+func TestRunWebSymbolicate(t *testing.T) {
+	read := func(string) ([]byte, error) { return []byte(sampleMap), nil }
+	var out, errBuf bytes.Buffer
+	if code := runWebSymbolicate([]string{"map.js.map", "1:0"}, &out, &errBuf, read); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "orig.js:1:0 (boom)") {
+		t.Errorf("output = %q", out.String())
+	}
+}
+
+func TestRunWebSymbolicateJSON(t *testing.T) {
+	read := func(string) ([]byte, error) { return []byte(sampleMap), nil }
+	var out, errBuf bytes.Buffer
+	if code := runWebSymbolicate([]string{"--json", "map.js.map", "1:0"}, &out, &errBuf, read); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"name": "boom"`) {
+		t.Errorf("json = %q", out.String())
+	}
+}
+
+func TestRunWebSymbolicateReadError(t *testing.T) {
+	read := func(string) ([]byte, error) { return nil, bytesErr("nope") }
+	var out, errBuf bytes.Buffer
+	if code := runWebSymbolicate([]string{"missing.map", "1:0"}, &out, &errBuf, read); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestRunWebSymbolicateWrongArgc(t *testing.T) {
+	read := func(string) ([]byte, error) { return []byte(sampleMap), nil }
+	var out, errBuf bytes.Buffer
+	if code := runWebSymbolicate([]string{"only-map.map"}, &out, &errBuf, read); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}
+
+type bytesErr string
+
+func (e bytesErr) Error() string { return string(e) }

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -473,6 +473,22 @@ spectra web processes /Applications/Slack.app
 spectra web processes --json /Applications/Slack.app
 ```
 
+## `spectra web symbolicate`
+
+Resolves minified generated positions back to their original source
+locations using a Source Map v3 file — the primitive that turns
+`app.js:1:284620` in a crash report or JS stack into
+`src/sync/engine.ts:214:9 (flush)`. Pass the `.js.map` and one or more
+`line:col` positions (1-based line, 0-based column). `--json` emits
+structured results.
+
+### Examples
+
+```bash
+spectra web symbolicate app.js.map 1:284620
+spectra web symbolicate --json app.js.map 1:284620 1:9931
+```
+
 ## `spectra playbook`
 
 Shows problem-first diagnostic workflows over existing collectors. Use it

--- a/internal/sourcemap/sourcemap.go
+++ b/internal/sourcemap/sourcemap.go
@@ -1,0 +1,175 @@
+// Package sourcemap decodes Source Map v3 files and resolves a generated
+// (minified) position back to its original source location. It implements the
+// base64-VLQ mappings format with the standard library only — no third-party
+// dependency — so minified JS stack frames can be symbolicated.
+package sourcemap
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const base64Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+// Position is a resolved original source location.
+type Position struct {
+	Source string `json:"source"`
+	Line   int    `json:"line"`   // 1-based original line
+	Column int    `json:"column"` // 0-based original column
+	Name   string `json:"name,omitempty"`
+}
+
+// SourceMap is a parsed, queryable source map.
+type SourceMap struct {
+	sources []string
+	names   []string
+	root    string
+	lines   [][]segment // per 0-based generated line, sorted by generated column
+}
+
+type segment struct {
+	genCol    int
+	sourceIdx int
+	srcLine   int
+	srcCol    int
+	nameIdx   int
+	hasSource bool
+	hasName   bool
+}
+
+type rawMap struct {
+	Version    int      `json:"version"`
+	Sources    []string `json:"sources"`
+	Names      []string `json:"names"`
+	Mappings   string   `json:"mappings"`
+	SourceRoot string   `json:"sourceRoot"`
+}
+
+// Parse decodes a Source Map v3 document.
+func Parse(data []byte) (*SourceMap, error) {
+	var r rawMap
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("sourcemap: %w", err)
+	}
+	if r.Version != 0 && r.Version != 3 {
+		return nil, fmt.Errorf("sourcemap: unsupported version %d", r.Version)
+	}
+	sm := &SourceMap{sources: r.Sources, names: r.Names, root: r.SourceRoot}
+	if err := sm.decodeMappings(r.Mappings); err != nil {
+		return nil, err
+	}
+	return sm, nil
+}
+
+// accum holds the cross-line running values the VLQ deltas accumulate against.
+type accum struct{ sourceIdx, srcLine, srcCol, nameIdx int }
+
+func (sm *SourceMap) decodeMappings(mappings string) error {
+	lines := strings.Split(mappings, ";")
+	sm.lines = make([][]segment, len(lines))
+	var a accum
+	for li, line := range lines {
+		if line == "" {
+			continue
+		}
+		genCol := 0
+		for _, raw := range strings.Split(line, ",") {
+			if raw == "" {
+				continue
+			}
+			vals, err := decodeVLQ(raw)
+			if err != nil {
+				return err
+			}
+			seg, err := buildSegment(vals, &genCol, &a)
+			if err != nil {
+				return err
+			}
+			sm.lines[li] = append(sm.lines[li], seg)
+		}
+		sort.Slice(sm.lines[li], func(i, j int) bool { return sm.lines[li][i].genCol < sm.lines[li][j].genCol })
+	}
+	return nil
+}
+
+func buildSegment(vals []int, genCol *int, a *accum) (segment, error) {
+	if len(vals) != 1 && len(vals) != 4 && len(vals) != 5 {
+		return segment{}, fmt.Errorf("sourcemap: segment has %d fields, want 1, 4, or 5", len(vals))
+	}
+	*genCol += vals[0]
+	s := segment{genCol: *genCol, nameIdx: -1}
+	if len(vals) >= 4 {
+		a.sourceIdx += vals[1]
+		a.srcLine += vals[2]
+		a.srcCol += vals[3]
+		s.sourceIdx, s.srcLine, s.srcCol, s.hasSource = a.sourceIdx, a.srcLine, a.srcCol, true
+	}
+	if len(vals) == 5 {
+		a.nameIdx += vals[4]
+		s.nameIdx, s.hasName = a.nameIdx, true
+	}
+	return s, nil
+}
+
+// decodeVLQ decodes one comma-free mapping segment into its integer fields.
+func decodeVLQ(seg string) ([]int, error) {
+	var out []int
+	var shift uint
+	var value int
+	for i := 0; i < len(seg); i++ {
+		d := strings.IndexByte(base64Alphabet, seg[i])
+		if d < 0 {
+			return nil, fmt.Errorf("sourcemap: invalid base64 char %q", seg[i])
+		}
+		digit := d & 0x1f
+		value += digit << shift
+		if d&0x20 != 0 { // continuation bit set
+			shift += 5
+			continue
+		}
+		neg := value&1 != 0
+		v := value >> 1
+		if neg {
+			v = -v
+		}
+		out = append(out, v)
+		value, shift = 0, 0
+	}
+	if shift != 0 {
+		return nil, errors.New("sourcemap: truncated VLQ sequence")
+	}
+	return out, nil
+}
+
+// Lookup resolves a generated position (1-based line, 0-based column) to its
+// original source location. It returns false when no mapping covers it.
+func (sm *SourceMap) Lookup(genLine, genCol int) (Position, bool) {
+	li := genLine - 1
+	if li < 0 || li >= len(sm.lines) {
+		return Position{}, false
+	}
+	segs := sm.lines[li]
+	if len(segs) == 0 {
+		return Position{}, false
+	}
+	// greatest segment whose generated column is <= genCol
+	idx := sort.Search(len(segs), func(i int) bool { return segs[i].genCol > genCol }) - 1
+	if idx < 0 {
+		return Position{}, false
+	}
+	s := segs[idx]
+	if !s.hasSource {
+		return Position{}, false
+	}
+	pos := Position{Line: s.srcLine + 1, Column: s.srcCol}
+	if s.sourceIdx >= 0 && s.sourceIdx < len(sm.sources) {
+		pos.Source = sm.root + sm.sources[s.sourceIdx]
+	}
+	if s.hasName && s.nameIdx >= 0 && s.nameIdx < len(sm.names) {
+		pos.Name = sm.names[s.nameIdx]
+	}
+	return pos, true
+}

--- a/internal/sourcemap/sourcemap_test.go
+++ b/internal/sourcemap/sourcemap_test.go
@@ -1,0 +1,108 @@
+package sourcemap
+
+import "testing"
+
+func eqInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestDecodeVLQ(t *testing.T) {
+	cases := map[string][]int{
+		"A":    {0},
+		"C":    {1},
+		"D":    {-1},
+		"gB":   {16},
+		"AAAA": {0, 0, 0, 0},
+		"AACA": {0, 0, 1, 0},
+		"CAAC": {1, 0, 0, 1},
+	}
+	for in, want := range cases {
+		got, err := decodeVLQ(in)
+		if err != nil {
+			t.Fatalf("decodeVLQ(%q): %v", in, err)
+		}
+		if !eqInts(got, want) {
+			t.Errorf("decodeVLQ(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestDecodeVLQBadChar(t *testing.T) {
+	if _, err := decodeVLQ("A!"); err == nil {
+		t.Fatal("expected error for invalid base64 char")
+	}
+}
+
+func TestLookupBasic(t *testing.T) {
+	sm, err := Parse([]byte(`{"version":3,"sources":["orig.js"],"names":[],"mappings":"AAAA;AACA"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := sm.Lookup(1, 0)
+	if !ok || p.Source != "orig.js" || p.Line != 1 || p.Column != 0 {
+		t.Errorf("lookup(1,0) = %+v ok=%v", p, ok)
+	}
+	// second generated line maps to original line 2
+	p, ok = sm.Lookup(2, 5)
+	if !ok || p.Line != 2 {
+		t.Errorf("lookup(2,5) = %+v ok=%v, want line 2", p, ok)
+	}
+}
+
+func TestLookupColumnBinarySearch(t *testing.T) {
+	sm, err := Parse([]byte(`{"version":3,"sources":["a.js"],"names":[],"mappings":"AAAA,CAAC"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p, _ := sm.Lookup(1, 0); p.Column != 0 {
+		t.Errorf("col at gen 0 = %d, want 0", p.Column)
+	}
+	if p, _ := sm.Lookup(1, 1); p.Column != 1 {
+		t.Errorf("col at gen 1 = %d, want 1", p.Column)
+	}
+	if p, _ := sm.Lookup(1, 9); p.Column != 1 {
+		t.Errorf("col at gen 9 = %d, want 1 (nearest preceding segment)", p.Column)
+	}
+}
+
+func TestLookupName(t *testing.T) {
+	sm, err := Parse([]byte(`{"version":3,"sources":["a.js"],"names":["myFunc"],"mappings":"AAAAA"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := sm.Lookup(1, 0)
+	if !ok || p.Name != "myFunc" {
+		t.Errorf("lookup = %+v ok=%v, want name myFunc", p, ok)
+	}
+}
+
+func TestLookupMisses(t *testing.T) {
+	sm, _ := Parse([]byte(`{"version":3,"sources":["a.js"],"names":[],"mappings":"AAAA"}`))
+	if _, ok := sm.Lookup(5, 0); ok {
+		t.Error("lookup on a nonexistent line should miss")
+	}
+}
+
+func TestSourceRootPrefixed(t *testing.T) {
+	sm, _ := Parse([]byte(`{"version":3,"sourceRoot":"src/","sources":["a.js"],"names":[],"mappings":"AAAA"}`))
+	if p, _ := sm.Lookup(1, 0); p.Source != "src/a.js" {
+		t.Errorf("source = %q, want src/a.js", p.Source)
+	}
+}
+
+func TestParseErrors(t *testing.T) {
+	if _, err := Parse([]byte("not json")); err == nil {
+		t.Error("expected error for bad json")
+	}
+	if _, err := Parse([]byte(`{"version":2,"mappings":""}`)); err == nil {
+		t.Error("expected error for unsupported version")
+	}
+}


### PR DESCRIPTION
## What

Adds **`internal/sourcemap`** (a stdlib-only Source Map v3 decoder) + **`spectra web symbolicate <map> <line>:<col> ...`**. This turns a minified generated position — `app.js:1:284620` in a crash report or JS stack — into its original source location, the primitive every later web-stack decode (crash symbolication, CDP profiles) needs.

## How

- Parses the v3 JSON and decodes the **base64-VLQ `mappings`**: per generated line, comma-separated segments of `[genCol, sourceIdx, srcLine, srcCol, nameIdx]` — `genCol` resets each line, the rest accumulate across the whole map. Segments of 1/4/5 fields are all handled; malformed VLQ / bad chars / truncated sequences error.
- `Lookup(genLine, genCol)` (1-based line, 0-based column) binary-searches the line's segments for the greatest one whose generated column ≤ the query and returns `{source, line, column, name}` (with `sourceRoot` prefixed).
- `spectra web symbolicate` resolves one or more positions against a `.js.map`; `--json` structured.

## Scope (v1)

Single-map position lookup. Consuming inline `//# sourceMappingURL=` data-URIs and symbolicating a whole `.ips`/CDP stack in one call are natural follow-ups on this primitive.

## Testing

- VLQ decode over computed values (`A`=0, `C`=1, `D`=-1, `gB`=16, multi-field segments), bad-char error.
- `Lookup`: basic mapping, second-line → original line 2, column binary-search (picks nearest preceding segment), name resolution, `sourceRoot` prefix, line-miss, and parse errors (bad JSON, unsupported version).
- CLI: position parsing, render + `--json`, read error, wrong-argc — via an injected read func.
- `make vet complexity lint security docs-validate test` green locally (51 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #350
