### PR TITLE
cli: add a global --verbose/--debug flag routing the logger to stderr

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -84,6 +84,10 @@ func main() {
 // args fall through to `inspect` for backward compatibility with the
 // flag-only CLI shape.
 func dispatch(args []string) int {
+	args, verbose := stripVerboseFlags(args)
+	if verbose {
+		enableVerbose()
+	}
 	if remote, ok, err := parseGlobalRemoteArgs(args); ok {
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -228,6 +232,9 @@ func runHelp(w *os.File) {
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Usage: spectra <subcommand> [flags] [args]")
 	fmt.Fprintln(w, "       spectra --remote <target> <subcommand> [args]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Global flags:")
+	fmt.Fprintln(w, "  --verbose, --debug   Log enhancement/collection failures to stderr (or set SPECTRA_DEBUG)")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Subcommands:")
 	for _, sc := range subcommandList() {

--- a/cmd/spectra/rules.go
+++ b/cmd/spectra/rules.go
@@ -265,10 +265,12 @@ func attachCLIHistory(snap *snapshot.Snapshot) {
 	}
 	dbPath, err := store.DefaultPath()
 	if err != nil {
+		cliLogger.Debug("rules: history unavailable, cannot resolve store path", "error", err)
 		return
 	}
 	db, err := store.Open(dbPath)
 	if err != nil {
+		cliLogger.Debug("rules: history unavailable, cannot open store", "path", dbPath, "error", err)
 		return
 	}
 	defer db.Close()

--- a/cmd/spectra/verbose.go
+++ b/cmd/spectra/verbose.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/kaeawc/spectra/internal/logger"
+)
+
+// cliLogger is the CLI's debug logger. By default it discards everything, so
+// one-shot commands stay quiet. When --verbose / --debug (or SPECTRA_DEBUG) is
+// set it writes debug records to stderr, making otherwise-silent enhancement
+// failures (history attach, cache writes, degraded collectors) observable.
+var cliLogger logger.Logger = logger.Discard()
+
+// enableVerbose routes cliLogger to stderr at debug level.
+func enableVerbose() {
+	cliLogger = logger.New(logger.Config{
+		Writer: os.Stderr,
+		Format: logger.FormatText,
+		Level:  slog.LevelDebug,
+	})
+}
+
+// stripVerboseFlags removes the global --verbose/--debug flags from args (they
+// may appear before or after the subcommand) and reports whether verbose output
+// was requested, also honouring the SPECTRA_DEBUG environment variable. The
+// short -v is intentionally left alone: `spectra inspect -v` already means
+// "show detection signals".
+func stripVerboseFlags(args []string) (rest []string, verbose bool) {
+	verbose = os.Getenv("SPECTRA_DEBUG") != ""
+	rest = make([]string, 0, len(args))
+	for _, a := range args {
+		switch a {
+		case "--verbose", "-verbose", "--debug", "-debug":
+			verbose = true
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return rest, verbose
+}

--- a/cmd/spectra/verbose_test.go
+++ b/cmd/spectra/verbose_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"reflect"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/logger"
+)
+
+func TestStripVerboseFlags(t *testing.T) {
+	t.Setenv("SPECTRA_DEBUG", "")
+	cases := []struct {
+		name        string
+		in          []string
+		wantRest    []string
+		wantVerbose bool
+	}{
+		{"none", []string{"rules", "--json"}, []string{"rules", "--json"}, false},
+		{"long verbose after subcommand", []string{"rules", "--verbose"}, []string{"rules"}, true},
+		{"debug before subcommand", []string{"--debug", "rules"}, []string{"rules"}, true},
+		{"preserves inspect -v", []string{"inspect", "-v", "/App"}, []string{"inspect", "-v", "/App"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rest, verbose := stripVerboseFlags(tc.in)
+			if verbose != tc.wantVerbose {
+				t.Fatalf("verbose = %v, want %v", verbose, tc.wantVerbose)
+			}
+			if !reflect.DeepEqual(rest, tc.wantRest) {
+				t.Fatalf("rest = %v, want %v", rest, tc.wantRest)
+			}
+		})
+	}
+}
+
+func TestStripVerboseFlagsHonoursEnv(t *testing.T) {
+	t.Setenv("SPECTRA_DEBUG", "1")
+	if _, verbose := stripVerboseFlags([]string{"rules"}); !verbose {
+		t.Fatal("SPECTRA_DEBUG should enable verbose")
+	}
+}
+
+func TestEnableVerboseTogglesDebugLevel(t *testing.T) {
+	orig := cliLogger
+	t.Cleanup(func() { cliLogger = orig })
+
+	cliLogger = logger.Discard()
+	if cliLogger.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("discard logger unexpectedly enables debug")
+	}
+	enableVerbose()
+	if !cliLogger.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("verbose logger should enable debug level")
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -18,6 +18,13 @@ is present before the subcommand, Spectra translates the command to a daemon
 JSON-RPC call and prints indented JSON. Without one of those flags, commands
 run in-process on the local machine.
 
+`--verbose` (alias `--debug`, or the `SPECTRA_DEBUG` environment variable) is a
+global flag that routes otherwise-silent enhancement and collection failures —
+such as history-attach or cache errors — to stderr. It can appear before or
+after the subcommand and does not affect stdout, so JSON output stays parseable.
+The short `-v` is unaffected: it still means "show detection signals" for
+`inspect`.
+
 ## Subcommands
 
 | Name | Description |


### PR DESCRIPTION
Closes #354

The structured logger was daemon-only; one-shot CLI commands swallowed enhancement/collection failures silently.

## What changed
- Global `--verbose` (alias `--debug`, env `SPECTRA_DEBUG`) routes a CLI debug logger to stderr; stripped from args before dispatch; works before/after the subcommand; stdout untouched.
- `inspect -v` (detection signals) is unaffected — short `-v` is left alone.
- Wired the history-attach silent failure in `spectra rules`; help + cli.md document the flag.

## Tests
- `cmd/spectra/verbose_test.go`: flag stripping (variants, env, -v preservation), enable→debug-level toggle.
- Local: `go vet`, `go test ./...` (50 pkg), `gofmt -l` clean, `gocyclo -over 15 -ignore _test` clean.

## Follow-up
Route the remaining silent sites (cache writes, collector degradation) through `cliLogger`.