### PR TITLE
power: internal/powerlog + spectra power log — sleep/wake history & sleep-blocker attribution

### DIFF
--- a/cmd/spectra/power.go
+++ b/cmd/spectra/power.go
@@ -14,11 +14,15 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/helperclient"
+	"github.com/kaeawc/spectra/internal/powerlog"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/sysinfo"
 )
 
 func runPower(args []string) int {
+	if len(args) > 0 && args[0] == "log" {
+		return runPowerLog(args[1:], os.Stdout, os.Stderr, powerlog.DefaultRunner)
+	}
 	return runPowerWithIO(args, os.Stdout, os.Stderr, defaultPowerDeps())
 }
 

--- a/cmd/spectra/power_log.go
+++ b/cmd/spectra/power_log.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/kaeawc/spectra/internal/powerlog"
+)
+
+func runPowerLog(args []string, stdout, stderr io.Writer, run powerlog.Runner) int {
+	fs := flag.NewFlagSet("power log", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	limit := fs.Int("n", 20, "show at most N most-recent sleep/wake events")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra power log [--json] [-n N]")
+		fmt.Fprintln(stderr, "Show recent sleep/wake history and what is currently keeping this Mac awake.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	report, err := powerlog.Collect(run)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	renderPowerLog(stdout, report, *limit)
+	return 0
+}
+
+func renderPowerLog(w io.Writer, r *powerlog.Report, limit int) {
+	events := r.Events
+	if limit > 0 && len(events) > limit {
+		events = events[len(events)-limit:]
+	}
+	fmt.Fprintf(w, "Sleep/Wake events (showing %d of %d):\n", len(events), len(r.Events))
+	for _, e := range events {
+		fmt.Fprintf(w, "  %s  %-9s %s\n", e.RawTime, e.Type, e.Detail)
+	}
+	fmt.Fprintln(w, "")
+	if len(r.SleepBlockers) == 0 {
+		fmt.Fprintln(w, "Nothing is currently blocking sleep.")
+		return
+	}
+	fmt.Fprintln(w, "Currently blocking sleep:")
+	for _, b := range r.SleepBlockers {
+		fmt.Fprintf(w, "  %s (pid %d) %s, held %s — %q\n", b.Process, b.PID, b.Type, b.Held, b.Reason)
+	}
+}

--- a/cmd/spectra/power_log_test.go
+++ b/cmd/spectra/power_log_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const plLogFixture = `2026-08-06 00:15:03 -0500 Sleep               	Entering Sleep state
+2026-08-06 02:00:00 -0500 Wake                	Wake from Deep Idle due to EC.LidOpen`
+
+const plAssertFixture = `   pid 335(powerd): [0x00043c8200019fc7] 05:14:01 PreventUserIdleSystemSleep named: "keep display on"`
+
+func plRunner(logOut, assertOut string, fail bool) func(string, ...string) ([]byte, error) {
+	return func(name string, args ...string) ([]byte, error) {
+		if fail {
+			return nil, errors.New("boom")
+		}
+		if len(args) >= 2 && args[1] == "log" {
+			return []byte(logOut), nil
+		}
+		return []byte(assertOut), nil
+	}
+}
+
+func TestRunPowerLogRenders(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runPowerLog(nil, &out, &errBuf, plRunner(plLogFixture, plAssertFixture, false)); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	for _, want := range []string{"Sleep/Wake events", "Wake", "Currently blocking sleep", "powerd"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+func TestRunPowerLogNoBlockers(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	runPowerLog(nil, &out, &errBuf, plRunner(plLogFixture, "", false))
+	if !strings.Contains(out.String(), "Nothing is currently blocking sleep") {
+		t.Errorf("expected no-blockers message; got:\n%s", out.String())
+	}
+}
+
+func TestRunPowerLogJSON(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runPowerLog([]string{"--json"}, &out, &errBuf, plRunner(plLogFixture, plAssertFixture, false)); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"type": "PreventUserIdleSystemSleep"`) {
+		t.Errorf("json missing blocker; got:\n%s", out.String())
+	}
+}
+
+func TestRunPowerLogError(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runPowerLog(nil, &out, &errBuf, plRunner("", "", true)); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -334,6 +334,21 @@ spectra fan --hosts work-mac,alice-laptop power
 
 See [../inspection/power-thermal.md](../inspection/power-thermal.md).
 
+### `spectra power log`
+
+Where `spectra power` shows the instantaneous state, `spectra power log`
+shows power *history*: recent sleep / wake / dark-wake events (with the
+wake reason) from `pmset -g log`, and which process is currently holding a
+sleep-preventing assertion (`pmset -g assertions`) — the answer to "what
+kept my Mac awake / drained it overnight?". Both reads are unprivileged.
+`-n` caps the number of events shown; `--json` emits the structured report.
+
+```bash
+spectra power log
+spectra power log -n 40
+spectra power log --json
+```
+
 ## `spectra network`
 
 Shows unprivileged network state by default, including current routes,

--- a/internal/powerlog/powerlog.go
+++ b/internal/powerlog/powerlog.go
@@ -1,0 +1,124 @@
+// Package powerlog parses macOS power history from pmset. It reads the
+// sleep/wake log (pmset -g log) and the current sleep-blocking assertions
+// (pmset -g assertions) — both without root — to answer "why did my Mac wake,
+// not sleep, or run hot overnight?" The parsers are deliberately tolerant: they
+// key on the entry type and skip lines they don't recognize rather than failing.
+package powerlog
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Runner runs a command and returns combined stdout. Injected for testability.
+type Runner func(name string, args ...string) ([]byte, error)
+
+// DefaultRunner runs the real command.
+func DefaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// Event is one sleep/wake power event.
+type Event struct {
+	Time    time.Time `json:"time,omitempty"`
+	RawTime string    `json:"raw_time"`
+	Type    string    `json:"type"`
+	Detail  string    `json:"detail,omitempty"`
+}
+
+// SleepBlocker is a process currently holding a sleep-preventing assertion.
+type SleepBlocker struct {
+	PID     int    `json:"pid"`
+	Process string `json:"process"`
+	Type    string `json:"type"`
+	Held    string `json:"held,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// Report is the parsed power history.
+type Report struct {
+	Events        []Event        `json:"events"`
+	SleepBlockers []SleepBlocker `json:"sleep_blockers"`
+}
+
+var (
+	logLineRe   = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-+]\d{4})\s+(\S+)\s*(.*)$`)
+	assertionRe = regexp.MustCompile(`pid (\d+)\(([^)]+)\):\s+\[[^\]]+\]\s+(\S+)\s+(\S+)\s+named:\s+"([^"]*)"`)
+)
+
+// Collect runs pmset and parses the sleep/wake log and current sleep blockers.
+func Collect(run Runner) (*Report, error) {
+	logOut, err := run("pmset", "-g", "log")
+	if err != nil {
+		return nil, fmt.Errorf("pmset -g log: %w", err)
+	}
+	assertOut, err := run("pmset", "-g", "assertions")
+	if err != nil {
+		return nil, fmt.Errorf("pmset -g assertions: %w", err)
+	}
+	return &Report{
+		Events:        ParseLog(string(logOut)),
+		SleepBlockers: ParseAssertions(string(assertOut)),
+	}, nil
+}
+
+// ParseLog extracts sleep/wake/darkwake events from `pmset -g log` output.
+func ParseLog(text string) []Event {
+	var events []Event
+	for _, line := range strings.Split(text, "\n") {
+		m := logLineRe.FindStringSubmatch(line)
+		if m == nil || !isSleepWakeType(m[2]) {
+			continue
+		}
+		detail := strings.TrimSpace(m[3])
+		// "Wake Requests" lines list *scheduled* wake requests, not an actual
+		// wake — the leading token collides with real Wake events.
+		if m[2] == "Wake" && strings.HasPrefix(detail, "Requests") {
+			continue
+		}
+		e := Event{RawTime: m[1], Type: m[2], Detail: detail}
+		if t, err := time.Parse("2006-01-02 15:04:05 -0700", m[1]); err == nil {
+			e.Time = t
+		}
+		events = append(events, e)
+	}
+	return events
+}
+
+// ParseAssertions extracts current sleep-blocking assertion holders from
+// `pmset -g assertions` output.
+func ParseAssertions(text string) []SleepBlocker {
+	var out []SleepBlocker
+	for _, line := range strings.Split(text, "\n") {
+		m := assertionRe.FindStringSubmatch(line)
+		if m == nil || !isSleepBlocking(m[4]) {
+			continue
+		}
+		pid, _ := strconv.Atoi(m[1])
+		out = append(out, SleepBlocker{
+			PID:     pid,
+			Process: m[2],
+			Held:    m[3],
+			Type:    m[4],
+			Reason:  m[5],
+		})
+	}
+	return out
+}
+
+func isSleepWakeType(t string) bool {
+	switch t {
+	case "Sleep", "Wake", "DarkWake":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSleepBlocking(t string) bool {
+	return t == "PreventUserIdleSystemSleep" || t == "PreventSystemSleep"
+}

--- a/internal/powerlog/powerlog_test.go
+++ b/internal/powerlog/powerlog_test.go
@@ -1,0 +1,73 @@
+package powerlog
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const logFixture = `2026-08-06 00:15:03 -0500 Sleep               	Entering Sleep state due to 'Software Sleep pid=123':TCPKeepAlive=1
+2026-08-06 01:00:00 -0500 DarkWake            	DarkWake to FullWake from Deep Idle [CDNVA] due to HID Activity
+2026-08-06 01:15:00 -0500 Wake Requests       	[*process=dasd request=SleepService]
+2026-08-06 01:30:03 -0500 Assertions          	PID 335(powerd) Summary PreventUserIdleSystemSleep "x" 04:46:14 id:0x1
+2026-08-06 02:00:00 -0500 Wake                	Wake from Deep Idle [CDNVA] due to EC.LidOpen/HID Activity
+some junk line that should be skipped
+Total Sleep/Wakes since boot at 2026-07-31 04:04:49 -0500 :172`
+
+const assertFixture = `Assertion status system-wide:
+   PreventUserIdleSystemSleep     1
+   pid 335(powerd): [0x00043c8200019fc7] 05:14:01 PreventUserIdleSystemSleep named: "Powerd - Prevent sleep while display is on"
+   pid 400(WindowServer): [0x00040ef900099a91] 01:18:24 UserIsActive named: "keyboard tickle"  `
+
+func TestParseLog(t *testing.T) {
+	events := ParseLog(logFixture)
+	if len(events) != 3 {
+		t.Fatalf("events = %d, want 3 (Sleep, DarkWake, Wake): %+v", len(events), events)
+	}
+	if events[0].Type != "Sleep" || events[1].Type != "DarkWake" || events[2].Type != "Wake" {
+		t.Errorf("types = %s,%s,%s", events[0].Type, events[1].Type, events[2].Type)
+	}
+	if !strings.Contains(events[2].Detail, "due to") {
+		t.Errorf("wake detail = %q, want a 'due to' reason", events[2].Detail)
+	}
+	if events[0].Time.IsZero() {
+		t.Error("timestamp should parse to a non-zero time")
+	}
+}
+
+func TestParseAssertions(t *testing.T) {
+	blockers := ParseAssertions(assertFixture)
+	if len(blockers) != 1 {
+		t.Fatalf("blockers = %d, want 1 (only the Prevent* holder): %+v", len(blockers), blockers)
+	}
+	b := blockers[0]
+	if b.PID != 335 || b.Process != "powerd" || b.Type != "PreventUserIdleSystemSleep" {
+		t.Errorf("blocker = %+v", b)
+	}
+	if !strings.Contains(b.Reason, "Powerd") || b.Held != "05:14:01" {
+		t.Errorf("blocker reason/held = %q / %q", b.Reason, b.Held)
+	}
+}
+
+func TestCollect(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[1] == "log" {
+			return []byte(logFixture), nil
+		}
+		return []byte(assertFixture), nil
+	}
+	r, err := Collect(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Events) != 3 || len(r.SleepBlockers) != 1 {
+		t.Errorf("report = %d events, %d blockers", len(r.Events), len(r.SleepBlockers))
+	}
+}
+
+func TestCollectError(t *testing.T) {
+	run := func(name string, args ...string) ([]byte, error) { return nil, errors.New("boom") }
+	if _, err := Collect(run); err == nil {
+		t.Fatal("expected error when pmset fails")
+	}
+}


### PR DESCRIPTION
## What

Adds **`internal/powerlog`** + **`spectra power log`** — power *history*. `spectra power` shows instantaneous state; this answers "why did my Mac wake, not sleep, or run hot overnight?" by reading the sleep/wake log and the current sleep-blocking assertions. Both `pmset` reads are unprivileged.

## How

Verified against real `pmset` output:
- `ParseLog` extracts `Sleep` / `Wake` / `DarkWake` events (with the wake "due to" reason) from `pmset -g log`. It's a tolerant, line-oriented parser keyed on the event-type column; unrecognized lines are skipped, and **`Wake Requests`** listings (scheduled requests, not actual wakes — they share the leading token) are excluded.
- `ParseAssertions` extracts the current `PreventUserIdleSystemSleep` / `PreventSystemSleep` holders (PID, process, held-duration, reason) from `pmset -g assertions`.
- `spectra power log` prints recent sleep/wake events + what's currently blocking sleep. `-n` caps events; `--json` structured. Added as a `power log` subcommand (doesn't disturb the existing `power` flag handling).

## Scope (v1)

Parsing + CLI. Feeding a "power" lane into a future unified timeline and a `sleep-blocked-by-process` rule are natural follow-ups.

## Testing

- `powerlog`: synthetic `pmset -g log` + `pmset -g assertions` fixtures — sleep/wake extraction, `Wake Requests` exclusion, timestamp parse, sleep-blocker fields, `Collect` happy path + error; malformed/junk lines skipped.
- CLI: render, no-blockers message, `--json`, error path — via an injected runner.
- Validated end-to-end against live `pmset` (547 events, 1 sleep blocker parsed correctly).
- `make vet complexity lint security docs-validate test` green locally (52 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #356
