### PR TITLE
diag: internal/sysload + spectra whatswrong — ranked whole-system slowness triage

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -67,6 +67,7 @@ func subcommandList() []subcommand {
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},
 		{"crash", "Audit post-mortem readiness (can this machine produce a debuggable crash?)", runCrash},
 		{"web", "Diff an Electron app's app.asar payload between two versions", runWeb},
+		{"whatswrong", "Ranked whole-system triage: why is this Mac slow right now?", runWhatswrong},
 		{"cache", "Manage the local blob cache (stats, clear)", runCache},
 		{"version", "Print Spectra version and exit", runVersion},
 		{"help", "Show this help text", runHelpCmd},

--- a/cmd/spectra/whatswrong.go
+++ b/cmd/spectra/whatswrong.go
@@ -55,11 +55,22 @@ func runWhatswrongWithIO(args []string, stdout, stderr io.Writer, deps slowDeps)
 	causes := rankSlowCauses(sig)
 	if *asJSON {
 		out := struct {
-			Causes           []slowCause  `json:"causes"`
-			Load             sysload.Load `json:"load"`
-			ThermalPressure  string       `json:"thermal_pressure,omitempty"`
-			ThermalThrottled bool         `json:"thermal_throttled"`
-		}{causes, sig.Load, sig.Power.ThermalPressure, sig.Power.ThermalThrottled}
+			Causes  []slowCause `json:"causes"`
+			Signals struct {
+				Load   sysload.Load       `json:"load"`
+				Power  sysinfo.PowerState `json:"power"`
+				TopCPU *process.Info      `json:"top_cpu,omitempty"`
+				TopRSS *process.Info      `json:"top_rss,omitempty"`
+			} `json:"signals"`
+		}{Causes: causes}
+		out.Signals.Load = sig.Load
+		out.Signals.Power = sig.Power
+		if p, ok := topByCPU(sig.Procs); ok {
+			out.Signals.TopCPU = &p
+		}
+		if p, ok := topByRSS(sig.Procs); ok {
+			out.Signals.TopRSS = &p
+		}
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(out); err != nil {

--- a/cmd/spectra/whatswrong.go
+++ b/cmd/spectra/whatswrong.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/sysinfo"
+	"github.com/kaeawc/spectra/internal/sysload"
+)
+
+type slowSignals struct {
+	Load  sysload.Load
+	Power sysinfo.PowerState
+	Procs []process.Info
+}
+
+type slowCause struct {
+	Severity string `json:"severity"` // high, medium, low
+	Title    string `json:"title"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+type slowDeps struct {
+	load  func() sysload.Load
+	power func() sysinfo.PowerState
+	procs func() []process.Info
+}
+
+func defaultSlowDeps() slowDeps {
+	return slowDeps{
+		load:  func() sysload.Load { return sysload.Collect(sysload.DefaultRunner) },
+		power: func() sysinfo.PowerState { return sysinfo.CollectPower(sysinfo.DefaultRunner) },
+		procs: func() []process.Info { return process.CollectAll(context.Background(), process.CollectOptions{}) },
+	}
+}
+
+func runWhatswrong(args []string) int {
+	return runWhatswrongWithIO(args, os.Stdout, os.Stderr, defaultSlowDeps())
+}
+
+func runWhatswrongWithIO(args []string, stdout, stderr io.Writer, deps slowDeps) int {
+	fs := flag.NewFlagSet("whatswrong", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	sig := slowSignals{Load: deps.load(), Power: deps.power(), Procs: deps.procs()}
+	causes := rankSlowCauses(sig)
+	if *asJSON {
+		out := struct {
+			Causes           []slowCause  `json:"causes"`
+			Load             sysload.Load `json:"load"`
+			ThermalPressure  string       `json:"thermal_pressure,omitempty"`
+			ThermalThrottled bool         `json:"thermal_throttled"`
+		}{causes, sig.Load, sig.Power.ThermalPressure, sig.Power.ThermalThrottled}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		return 0
+	}
+	renderWhatswrong(stdout, causes)
+	return 0
+}
+
+func rankSlowCauses(s slowSignals) []slowCause {
+	var causes []slowCause
+	causes = appendMemoryCauses(causes, s.Load)
+	causes = appendThermalCauses(causes, s.Power)
+	causes = appendProcessCauses(causes, s.Procs)
+	sort.SliceStable(causes, func(i, j int) bool {
+		return severityRank(causes[i].Severity) < severityRank(causes[j].Severity)
+	})
+	return causes
+}
+
+func appendMemoryCauses(causes []slowCause, l sysload.Load) []slowCause {
+	switch l.MemoryPressure {
+	case "critical":
+		causes = append(causes, slowCause{"high", "Memory pressure is critical",
+			fmt.Sprintf("swap in use: %.0f MB of %.0f MB — the machine is out of RAM headroom", l.SwapUsedMB, l.SwapTotalMB)})
+	case "warn":
+		causes = append(causes, slowCause{"medium", "Memory pressure is elevated",
+			fmt.Sprintf("swap in use: %.0f MB", l.SwapUsedMB)})
+	default:
+		if l.SwapUsedMB >= 2048 {
+			causes = append(causes, slowCause{"medium", "Heavy swap usage",
+				fmt.Sprintf("%.0f MB swapped — the machine is over-committed on RAM", l.SwapUsedMB)})
+		}
+	}
+	return causes
+}
+
+func appendThermalCauses(causes []slowCause, p sysinfo.PowerState) []slowCause {
+	if p.ThermalThrottled {
+		return append(causes, slowCause{"high", "CPU is thermally throttled",
+			fmt.Sprintf("%d%% of recent samples were speed-limited (thermal state: %s)", p.PercentThermalThrottled, p.ThermalPressure)})
+	}
+	if p.ThermalPressure == "serious" || p.ThermalPressure == "critical" {
+		return append(causes, slowCause{"medium", "Thermal pressure is " + p.ThermalPressure,
+			"the system may begin throttling"})
+	}
+	return causes
+}
+
+func appendProcessCauses(causes []slowCause, procs []process.Info) []slowCause {
+	if p, ok := topByCPU(procs); ok && p.CPUPct >= 80 {
+		causes = append(causes, slowCause{"medium", "A process is using heavy CPU",
+			fmt.Sprintf("%s (pid %d) at %.0f%% CPU", p.Command, p.PID, p.CPUPct)})
+	}
+	if p, ok := topByRSS(procs); ok && p.RSSKiB >= 4*1024*1024 {
+		causes = append(causes, slowCause{"low", "A process is holding a lot of memory",
+			fmt.Sprintf("%s (pid %d) at %.1f GB RSS", p.Command, p.PID, float64(p.RSSKiB)/1024/1024)})
+	}
+	return causes
+}
+
+func topByCPU(procs []process.Info) (process.Info, bool) {
+	var top process.Info
+	found := false
+	for _, p := range procs {
+		if !found || p.CPUPct > top.CPUPct {
+			top, found = p, true
+		}
+	}
+	return top, found
+}
+
+func topByRSS(procs []process.Info) (process.Info, bool) {
+	var top process.Info
+	found := false
+	for _, p := range procs {
+		if !found || p.RSSKiB > top.RSSKiB {
+			top, found = p, true
+		}
+	}
+	return top, found
+}
+
+func severityRank(s string) int {
+	switch s {
+	case "high":
+		return 0
+	case "medium":
+		return 1
+	default:
+		return 2
+	}
+}
+
+func renderWhatswrong(w io.Writer, causes []slowCause) {
+	if len(causes) == 0 {
+		fmt.Fprintln(w, "Nothing obviously wrong: memory, thermal, CPU, and swap all look nominal.")
+		return
+	}
+	fmt.Fprintln(w, "Why this Mac may be slow right now:")
+	for i, c := range causes {
+		fmt.Fprintf(w, "%d) [%s] %s\n", i+1, c.Severity, c.Title)
+		if c.Detail != "" {
+			fmt.Fprintf(w, "     %s\n", c.Detail)
+		}
+	}
+}

--- a/cmd/spectra/whatswrong_test.go
+++ b/cmd/spectra/whatswrong_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/sysinfo"
+	"github.com/kaeawc/spectra/internal/sysload"
+)
+
+func TestRankCriticalMemoryFirst(t *testing.T) {
+	sig := slowSignals{
+		Load: sysload.Load{MemoryPressure: "critical", SwapUsedMB: 9200, SwapTotalMB: 10240},
+		Procs: []process.Info{
+			{PID: 5, Command: "hog", CPUPct: 95},
+		},
+	}
+	causes := rankSlowCauses(sig)
+	if len(causes) < 2 {
+		t.Fatalf("expected >=2 causes, got %d: %+v", len(causes), causes)
+	}
+	if causes[0].Severity != "high" || !strings.Contains(causes[0].Title, "Memory pressure is critical") {
+		t.Errorf("first cause = %+v, want high memory pressure", causes[0])
+	}
+}
+
+func TestRankThermalThrottle(t *testing.T) {
+	sig := slowSignals{
+		Power: sysinfo.PowerState{ThermalThrottled: true, PercentThermalThrottled: 42, ThermalPressure: "serious"},
+	}
+	causes := rankSlowCauses(sig)
+	if len(causes) != 1 || causes[0].Severity != "high" || !strings.Contains(causes[0].Title, "throttled") {
+		t.Errorf("causes = %+v, want one high thermal-throttle cause", causes)
+	}
+}
+
+func TestRankCPUHog(t *testing.T) {
+	sig := slowSignals{
+		Procs: []process.Info{
+			{PID: 1, Command: "idle", CPUPct: 2},
+			{PID: 2, Command: "busy", CPUPct: 190},
+		},
+	}
+	causes := rankSlowCauses(sig)
+	if len(causes) != 1 || !strings.Contains(causes[0].Detail, "busy (pid 2)") {
+		t.Errorf("causes = %+v, want a CPU-hog cause naming busy", causes)
+	}
+}
+
+func TestRankHealthyIsEmpty(t *testing.T) {
+	sig := slowSignals{
+		Load:  sysload.Load{MemoryPressure: "normal", SwapUsedMB: 100},
+		Power: sysinfo.PowerState{ThermalPressure: "nominal"},
+		Procs: []process.Info{{PID: 1, Command: "chill", CPUPct: 3, RSSKiB: 50000}},
+	}
+	if c := rankSlowCauses(sig); len(c) != 0 {
+		t.Errorf("healthy machine should have no causes, got %+v", c)
+	}
+}
+
+func TestRunWhatswrongRenders(t *testing.T) {
+	deps := slowDeps{
+		load: func() sysload.Load {
+			return sysload.Load{MemoryPressure: "critical", SwapUsedMB: 9000, SwapTotalMB: 10000}
+		},
+		power: func() sysinfo.PowerState { return sysinfo.PowerState{ThermalPressure: "nominal"} },
+		procs: func() []process.Info { return nil },
+	}
+	var out, errBuf bytes.Buffer
+	if code := runWhatswrongWithIO(nil, &out, &errBuf, deps); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), "Memory pressure is critical") {
+		t.Errorf("output = %q", out.String())
+	}
+}
+
+func TestRunWhatswrongHealthy(t *testing.T) {
+	deps := slowDeps{
+		load:  func() sysload.Load { return sysload.Load{MemoryPressure: "normal"} },
+		power: func() sysinfo.PowerState { return sysinfo.PowerState{} },
+		procs: func() []process.Info { return nil },
+	}
+	var out, errBuf bytes.Buffer
+	runWhatswrongWithIO(nil, &out, &errBuf, deps)
+	if !strings.Contains(out.String(), "Nothing obviously wrong") {
+		t.Errorf("healthy output = %q", out.String())
+	}
+}
+
+func TestRunWhatswrongJSON(t *testing.T) {
+	deps := slowDeps{
+		load:  func() sysload.Load { return sysload.Load{MemoryPressure: "warn", SwapUsedMB: 500} },
+		power: func() sysinfo.PowerState { return sysinfo.PowerState{} },
+		procs: func() []process.Info { return nil },
+	}
+	var out, errBuf bytes.Buffer
+	runWhatswrongWithIO([]string{"--json"}, &out, &errBuf, deps)
+	if !strings.Contains(out.String(), `"severity": "medium"`) {
+		t.Errorf("json = %q", out.String())
+	}
+}

--- a/cmd/spectra/whatswrong_test.go
+++ b/cmd/spectra/whatswrong_test.go
@@ -98,7 +98,11 @@ func TestRunWhatswrongJSON(t *testing.T) {
 	}
 	var out, errBuf bytes.Buffer
 	runWhatswrongWithIO([]string{"--json"}, &out, &errBuf, deps)
-	if !strings.Contains(out.String(), `"severity": "medium"`) {
-		t.Errorf("json = %q", out.String())
+	s := out.String()
+	// causes plus the full raw signals (load + power) so the ranking is auditable
+	for _, want := range []string{`"severity": "medium"`, `"signals"`, `"load"`, `"power"`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("json missing %q; got:\n%s", want, s)
+		}
 	}
 }

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -44,6 +44,7 @@ The short `-v` is unaffected: it still means "show detection signals" for
 | `process` | List running processes sorted by memory |
 | `crash` | Audit post-mortem readiness before a crash happens |
 | `web` | Diff an Electron app's `app.asar` payload between versions |
+| `whatswrong` | Ranked whole-system triage: why is this Mac slow right now? |
 | `playbook` | Show diagnostic playbooks and command plans |
 | `serve` | Run the local Unix-socket JSON-RPC daemon |
 | `connect` | Call a Spectra daemon over Unix socket or TCP JSON-RPC |
@@ -509,6 +510,22 @@ structured results.
 ```bash
 spectra web symbolicate app.js.map 1:284620
 spectra web symbolicate --json app.js.map 1:284620 1:9931
+```
+
+## `spectra whatswrong`
+
+A single whole-system triage: samples memory pressure and swap
+(`kern.memorystatus_vm_pressure_level`, `vm.swapusage`), thermal state, and
+the top CPU/RSS processes, then returns a **ranked, plain-language** list of
+likely causes instead of a raw table — the whole-machine counterpart to the
+app/PID-scoped `rules`/`issues`. A healthy machine says so. `--json` keeps
+the structured signals alongside the ranking so it's auditable.
+
+### Examples
+
+```bash
+spectra whatswrong
+spectra whatswrong --json
 ```
 
 ## `spectra playbook`

--- a/internal/sysload/sysload.go
+++ b/internal/sysload/sysload.go
@@ -1,0 +1,79 @@
+// Package sysload reads the whole-machine memory-pressure and swap signals
+// macOS exposes without root. It complements the per-process and thermal
+// collectors so a single "why is this Mac slow?" triage can rank causes.
+package sysload
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Runner runs a command and returns combined stdout. Injected for testability.
+type Runner func(name string, args ...string) ([]byte, error)
+
+// DefaultRunner runs the real command.
+func DefaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// Load is the machine's current memory-pressure and swap state.
+type Load struct {
+	MemoryPressure string  `json:"memory_pressure"` // normal, warn, critical, unknown
+	PressureLevel  int     `json:"pressure_level"`
+	SwapUsedMB     float64 `json:"swap_used_mb"`
+	SwapTotalMB    float64 `json:"swap_total_mb"`
+}
+
+var (
+	swapUsedRe  = regexp.MustCompile(`used\s*=\s*([0-9.]+)([MG]?)`)
+	swapTotalRe = regexp.MustCompile(`total\s*=\s*([0-9.]+)([MG]?)`)
+)
+
+// Collect reads memory pressure and swap usage.
+func Collect(run Runner) Load {
+	l := Load{MemoryPressure: "unknown"}
+	if out, err := run("sysctl", "-n", "kern.memorystatus_vm_pressure_level"); err == nil {
+		if lvl, aerr := strconv.Atoi(strings.TrimSpace(string(out))); aerr == nil {
+			l.PressureLevel = lvl
+			l.MemoryPressure = pressureLabel(lvl)
+		}
+	}
+	if out, err := run("sysctl", "-n", "vm.swapusage"); err == nil {
+		l.SwapUsedMB = parseSwapField(swapUsedRe, string(out))
+		l.SwapTotalMB = parseSwapField(swapTotalRe, string(out))
+	}
+	return l
+}
+
+func pressureLabel(lvl int) string {
+	switch lvl {
+	case 1:
+		return "normal"
+	case 2:
+		return "warn"
+	case 4:
+		return "critical"
+	default:
+		return fmt.Sprintf("level-%d", lvl)
+	}
+}
+
+// parseSwapField pulls a megabyte value out of a `vm.swapusage` string like
+// "total = 2048.00M  used = 669.88M  free = 1378.12M".
+func parseSwapField(re *regexp.Regexp, s string) float64 {
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		return 0
+	}
+	v, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0
+	}
+	if m[2] == "G" {
+		v *= 1024
+	}
+	return v
+}

--- a/internal/sysload/sysload_test.go
+++ b/internal/sysload/sysload_test.go
@@ -1,0 +1,49 @@
+package sysload
+
+import "testing"
+
+func fakeRunner(pressure, swap string) Runner {
+	return func(name string, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[1] == "kern.memorystatus_vm_pressure_level" {
+			return []byte(pressure), nil
+		}
+		return []byte(swap), nil
+	}
+}
+
+func TestCollect(t *testing.T) {
+	l := Collect(fakeRunner("4\n", "total = 2048.00M  used = 669.88M  free = 1378.12M  (encrypted)"))
+	if l.MemoryPressure != "critical" || l.PressureLevel != 4 {
+		t.Errorf("pressure = %q (%d), want critical (4)", l.MemoryPressure, l.PressureLevel)
+	}
+	if l.SwapUsedMB != 669.88 || l.SwapTotalMB != 2048.00 {
+		t.Errorf("swap used/total = %v/%v", l.SwapUsedMB, l.SwapTotalMB)
+	}
+}
+
+func TestPressureLabels(t *testing.T) {
+	cases := map[string]string{"1": "normal", "2": "warn", "4": "critical"}
+	for in, want := range cases {
+		l := Collect(fakeRunner(in, ""))
+		if l.MemoryPressure != want {
+			t.Errorf("level %s -> %q, want %q", in, l.MemoryPressure, want)
+		}
+	}
+}
+
+func TestSwapGigabytes(t *testing.T) {
+	l := Collect(fakeRunner("1", "total = 4.00G  used = 2.50G  free = 1.50G"))
+	if l.SwapUsedMB != 2560 { // 2.5 * 1024
+		t.Errorf("swap used = %v MB, want 2560", l.SwapUsedMB)
+	}
+}
+
+func TestMalformedGraceful(t *testing.T) {
+	l := Collect(fakeRunner("not-a-number", "garbage"))
+	if l.MemoryPressure != "unknown" {
+		t.Errorf("malformed pressure -> %q, want unknown", l.MemoryPressure)
+	}
+	if l.SwapUsedMB != 0 {
+		t.Errorf("malformed swap -> %v, want 0", l.SwapUsedMB)
+	}
+}


### PR DESCRIPTION
## What

Adds **`internal/sysload`** + **`spectra whatswrong`** — a single whole-system triage that answers "why is this Mac slow right now?" with a ranked, plain-language cause list, instead of making the user open Activity Monitor and guess. It's the whole-machine counterpart to today's app/PID-scoped `rules`/`issues`.

## How

- `internal/sysload` reads two root-free signals via an injected runner: memory pressure (`sysctl -n kern.memorystatus_vm_pressure_level` → normal/warn/critical) and swap (`sysctl -n vm.swapusage`, MB — handles the `M`/`G` suffixes). Malformed output degrades to `unknown`/0.
- `spectra whatswrong` composes that with the existing top-CPU/RSS processes (`process.CollectAll`) and thermal state (`sysinfo` `ThermalPressure`/`ThermalThrottled`), then **ranks causes by severity**: critical/elevated memory pressure + swap, thermal throttling, the top CPU hog (≥80%), and a large RSS holder (≥4 GB). Sorted high → low. A healthy machine reports "nothing obviously wrong". `--json` keeps the raw signals alongside the ranking so it's auditable, not a black box.

The ranking is a pure function over gathered signals; the collectors are injected for testability.

## Scope (v1)

CPU/RSS/memory/swap/thermal, ranked. Network top-talkers, a rules pass, and an MCP `system-slow` prompt are natural follow-ups — the structured output is designed to accept more lanes.

## Testing

- `sysload`: pressure-level labels, swap MB and GB parsing, `Collect`, malformed-graceful.
- Ranking: critical-memory-first ordering, thermal-throttle, CPU-hog naming, healthy-is-empty; CLI render, healthy message, `--json` — all over synthetic signals via injected collectors.
- Validated the two sysctl reads live (pressure level `1`, swap `used = 669.88M`).
- `make vet complexity lint security docs-validate test` green locally (53 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #358
