### PR TITLE
fleet: spectra fleet symptom/drift — cross-host rollup & version-drift matrix

### DIFF
--- a/cmd/spectra/fleet.go
+++ b/cmd/spectra/fleet.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kaeawc/spectra/internal/fleet"
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+type fleetLoader func() ([]fleet.HostSnapshot, error)
+
+func runFleet(args []string) int {
+	return runFleetWithIO(args, os.Stdout, os.Stderr, defaultFleetLoader)
+}
+
+func runFleetWithIO(args []string, stdout, stderr io.Writer, load fleetLoader) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fmt.Fprintln(stderr, "usage: spectra fleet <symptom <rule-id> | drift (--jdk | --app <bundleID>)> [--json]")
+		return 2
+	}
+	switch args[0] {
+	case "symptom":
+		return runFleetSymptom(args[1:], stdout, stderr, load)
+	case "drift":
+		return runFleetDrift(args[1:], stdout, stderr, load)
+	default:
+		fmt.Fprintf(stderr, "unknown fleet subcommand %q (want: symptom, drift)\n", args[0])
+		return 2
+	}
+}
+
+// defaultFleetLoader loads each host's latest snapshot from the local store.
+func defaultFleetLoader() ([]fleet.HostSnapshot, error) {
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		return nil, err
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	ctx := context.Background()
+	hostRows, err := db.ListHosts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]fleet.HostSnapshot, 0, len(hostRows))
+	for _, hr := range hostRows {
+		out = append(out, loadHostSnapshot(ctx, db, hr))
+	}
+	return out, nil
+}
+
+func loadHostSnapshot(ctx context.Context, db *store.DB, hr store.HostRow) fleet.HostSnapshot {
+	hs := fleet.HostSnapshot{Hostname: hr.Hostname, MachineUUID: hr.MachineUUID}
+	snaps, err := db.ListSnapshots(ctx, hr.MachineUUID)
+	if err != nil || len(snaps) == 0 {
+		hs.Empty = true
+		return hs
+	}
+	data, err := db.GetSnapshotJSON(ctx, snaps[0].ID)
+	if err != nil {
+		hs.Empty = true
+		return hs
+	}
+	var snap snapshot.Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		hs.Empty = true
+		return hs
+	}
+	hs.Snap = snap
+	return hs
+}
+
+func runFleetSymptom(args []string, stdout, stderr io.Writer, load fleetLoader) int {
+	fs := flag.NewFlagSet("fleet symptom", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "usage: spectra fleet symptom [--json] <rule-id>")
+		return 2
+	}
+	hosts, code := loadFleet(load, stderr)
+	if code != 0 {
+		return code
+	}
+	rollup := fleet.RollupSymptom(hosts, fs.Arg(0), rules.V1Catalog())
+	if *asJSON {
+		return encodeJSON(stdout, stderr, rollup)
+	}
+	fmt.Fprintf(stdout, "symptom %s across %d host(s):\n", rollup.RuleID, len(hosts))
+	fmt.Fprintf(stdout, "  firing (%d): %s\n", len(rollup.Firing), joinOrDash(rollup.Firing))
+	fmt.Fprintf(stdout, "  clear  (%d): %s\n", len(rollup.Clear), joinOrDash(rollup.Clear))
+	if len(rollup.Unknown) > 0 {
+		fmt.Fprintf(stdout, "  unknown (%d): %s\n", len(rollup.Unknown), joinOrDash(rollup.Unknown))
+	}
+	return 0
+}
+
+func runFleetDrift(args []string, stdout, stderr io.Writer, load fleetLoader) int {
+	fs := flag.NewFlagSet("fleet drift", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	jdk := fs.Bool("jdk", false, "JDK version drift")
+	app := fs.String("app", "", "app bundle ID version drift")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if !*jdk && *app == "" {
+		fmt.Fprintln(stderr, "usage: spectra fleet drift (--jdk | --app <bundleID>) [--json]")
+		return 2
+	}
+	hosts, code := loadFleet(load, stderr)
+	if code != 0 {
+		return code
+	}
+	var cells []fleet.DriftCell
+	dim := "jdk"
+	if *jdk {
+		cells = fleet.DriftJDK(hosts)
+	} else {
+		cells = fleet.DriftApp(hosts, *app)
+		dim = *app
+	}
+	if *asJSON {
+		return encodeJSON(stdout, stderr, cells)
+	}
+	fmt.Fprintf(stdout, "%s drift across %d host(s):\n", dim, len(cells))
+	for _, c := range cells {
+		fmt.Fprintf(stdout, "  %-24s %s\n", c.Host, c.Value)
+	}
+	return 0
+}
+
+func loadFleet(load fleetLoader, stderr io.Writer) ([]fleet.HostSnapshot, int) {
+	hosts, err := load()
+	if err != nil {
+		fmt.Fprintf(stderr, "load fleet: %v\n", err)
+		return nil, 1
+	}
+	if len(hosts) == 0 {
+		fmt.Fprintln(stderr, "no hosts in the store — run `spectra snapshot` (and fan-out to peers) first")
+		return nil, 1
+	}
+	return hosts, 0
+}
+
+func encodeJSON(stdout, stderr io.Writer, v any) int {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func joinOrDash(xs []string) string {
+	if len(xs) == 0 {
+		return "-"
+	}
+	out := xs[0]
+	for _, x := range xs[1:] {
+		out += ", " + x
+	}
+	return out
+}

--- a/cmd/spectra/fleet.go
+++ b/cmd/spectra/fleet.go
@@ -40,17 +40,17 @@ func runFleetWithIO(args []string, stdout, stderr io.Writer, load fleetLoader) i
 func defaultFleetLoader() ([]fleet.HostSnapshot, error) {
 	dbPath, err := store.DefaultPath()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolve store path: %w", err)
 	}
 	db, err := store.Open(dbPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open store %s: %w", dbPath, err)
 	}
 	defer db.Close()
 	ctx := context.Background()
 	hostRows, err := db.ListHosts(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list hosts: %w", err)
 	}
 	out := make([]fleet.HostSnapshot, 0, len(hostRows))
 	for _, hr := range hostRows {
@@ -91,11 +91,16 @@ func runFleetSymptom(args []string, stdout, stderr io.Writer, load fleetLoader) 
 		fmt.Fprintln(stderr, "usage: spectra fleet symptom [--json] <rule-id>")
 		return 2
 	}
+	ruleID := fs.Arg(0)
+	if !ruleInCatalog(ruleID) {
+		fmt.Fprintf(stderr, "unknown rule id %q — run `spectra rules` to see available rules\n", ruleID)
+		return 2
+	}
 	hosts, code := loadFleet(load, stderr)
 	if code != 0 {
 		return code
 	}
-	rollup := fleet.RollupSymptom(hosts, fs.Arg(0), rules.V1Catalog())
+	rollup := fleet.RollupSymptom(hosts, ruleID, rules.V1Catalog())
 	if *asJSON {
 		return encodeJSON(stdout, stderr, rollup)
 	}
@@ -117,8 +122,16 @@ func runFleetDrift(args []string, stdout, stderr io.Writer, load fleetLoader) in
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	if *jdk && *app != "" {
+		fmt.Fprintln(stderr, "specify only one of --jdk or --app <bundleID>")
+		return 2
+	}
 	if !*jdk && *app == "" {
 		fmt.Fprintln(stderr, "usage: spectra fleet drift (--jdk | --app <bundleID>) [--json]")
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "unexpected arguments; drift takes only --jdk or --app <bundleID>")
 		return 2
 	}
 	hosts, code := loadFleet(load, stderr)
@@ -164,6 +177,15 @@ func encodeJSON(stdout, stderr io.Writer, v any) int {
 		return 1
 	}
 	return 0
+}
+
+func ruleInCatalog(id string) bool {
+	for _, r := range rules.V1Catalog() {
+		if r.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func joinOrDash(xs []string) string {

--- a/cmd/spectra/fleet_test.go
+++ b/cmd/spectra/fleet_test.go
@@ -96,6 +96,30 @@ func TestRunFleetLoadError(t *testing.T) {
 	}
 }
 
+func TestRunFleetSymptomUnknownRule(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"symptom", "no-such-rule"}, &out, &errBuf, okLoader); code != 2 {
+		t.Fatalf("exit = %d, want 2 for unknown rule id", code)
+	}
+	if !strings.Contains(errBuf.String(), "unknown rule id") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestRunFleetDriftBothDimensions(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"drift", "--jdk", "--app", "com.x"}, &out, &errBuf, okLoader); code != 2 {
+		t.Fatalf("exit = %d, want 2 when both dimensions given", code)
+	}
+}
+
+func TestRunFleetDriftStrayArgs(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"drift", "--jdk", "extra"}, &out, &errBuf, okLoader); code != 2 {
+		t.Fatalf("exit = %d, want 2 for stray operands", code)
+	}
+}
+
 func TestRunFleetUnknownSub(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	if code := runFleetWithIO([]string{"bogus"}, &out, &errBuf, okLoader); code != 2 {

--- a/cmd/spectra/fleet_test.go
+++ b/cmd/spectra/fleet_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/fleet"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+func fakeFleet() []fleet.HostSnapshot {
+	return []fleet.HostSnapshot{
+		{Hostname: "laptop", Snap: snapshot.Snapshot{
+			Apps:       []detect.Result{{Path: "/Applications/Unsigned.app", TeamID: "", BundleID: "com.x.app", AppVersion: "2.1"}},
+			Toolchains: toolchain.Toolchains{JDKs: []toolchain.JDKInstall{{VersionMajor: 21, ReleaseString: "21.0.6"}}},
+		}},
+		{Hostname: "ci-mac", Snap: snapshot.Snapshot{
+			Apps:       []detect.Result{{Path: "/Applications/Signed.app", TeamID: "TEAM1"}},
+			Toolchains: toolchain.Toolchains{JDKs: []toolchain.JDKInstall{{VersionMajor: 17, ReleaseString: "17.0.10"}}},
+		}},
+	}
+}
+
+func okLoader() ([]fleet.HostSnapshot, error) { return fakeFleet(), nil }
+
+func TestRunFleetNoArgs(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO(nil, &out, &errBuf, okLoader); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}
+
+func TestRunFleetSymptom(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"symptom", "app-unsigned"}, &out, &errBuf, okLoader); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "firing (1): laptop") {
+		t.Errorf("symptom output = %q", s)
+	}
+	if !strings.Contains(s, "clear  (1): ci-mac") {
+		t.Errorf("symptom output = %q", s)
+	}
+}
+
+func TestRunFleetDriftJDK(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"drift", "--jdk"}, &out, &errBuf, okLoader); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	s := out.String()
+	if !strings.Contains(s, "21.0.6") || !strings.Contains(s, "17.0.10") {
+		t.Errorf("jdk drift output = %q", s)
+	}
+}
+
+func TestRunFleetDriftApp(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"drift", "--app", "com.x.app"}, &out, &errBuf, okLoader); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	s := out.String()
+	if !strings.Contains(s, "laptop") || !strings.Contains(s, "2.1") || !strings.Contains(s, "absent") {
+		t.Errorf("app drift output = %q", s)
+	}
+}
+
+func TestRunFleetDriftNoDimension(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"drift"}, &out, &errBuf, okLoader); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}
+
+func TestRunFleetEmptyStore(t *testing.T) {
+	empty := func() ([]fleet.HostSnapshot, error) { return nil, nil }
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"symptom", "app-unsigned"}, &out, &errBuf, empty); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "no hosts") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestRunFleetLoadError(t *testing.T) {
+	failing := func() ([]fleet.HostSnapshot, error) { return nil, errors.New("db locked") }
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"drift", "--jdk"}, &out, &errBuf, failing); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestRunFleetUnknownSub(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"bogus"}, &out, &errBuf, okLoader); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -59,6 +59,7 @@ func subcommandList() []subcommand {
 		{"connect", "Call a Spectra daemon over Unix socket, TCP, or MagicDNS", runConnect},
 		{"fan", "Run one daemon RPC call against multiple targets", runFan},
 		{"hosts", "List hosts known from stored snapshots", runHosts},
+		{"fleet", "Cross-host rollups: which hosts trip a rule, and version-drift matrices", runFleet},
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -50,6 +50,7 @@ The short `-v` is unaffected: it still means "show detection signals" for
 | `connect` | Call a Spectra daemon over Unix socket or TCP JSON-RPC |
 | `fan` | Run one daemon RPC call against multiple explicit targets |
 | `hosts` | List hosts known from stored snapshots |
+| `fleet` | Cross-host symptom rollups and version-drift matrices |
 | `status` | Check whether the local daemon is running |
 | `metrics` | Show stored process metrics from daemon sampling |
 | `sample` | Collect a user-space CPU sample of a process |
@@ -757,6 +758,28 @@ spectra hosts --probe --json
 spectra hosts --discover
 spectra hosts --discover-daemons
 ``` 
+
+## `spectra fleet`
+
+Aggregates the snapshots already in the local store (keyed by machine UUID,
+so it can hold multiple hosts from `snapshot` + fan-out) into cross-host
+answers — the grouped result fan-out set up but never closed.
+
+- `spectra fleet symptom <rule-id>` groups hosts by whether that rule fires
+  against their latest snapshot ("which Macs trip `app-no-hardened-runtime`?").
+- `spectra fleet drift --jdk` / `--app <bundleID>` prints a per-host version
+  matrix ("why does it repro on CI only?" — `laptop=21.0.6, ci-mac=17.0.10`).
+
+A host with no usable snapshot shows as `unknown` for a dimension rather
+than a false "missing". `--json` emits the structured result.
+
+### Examples
+
+```bash
+spectra fleet symptom app-no-hardened-runtime
+spectra fleet drift --jdk
+spectra fleet drift --app com.tinyapp.jvm --json
+```
 
 ## `spectra fan`
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -763,7 +763,7 @@ spectra hosts --discover-daemons
 
 Aggregates the snapshots already in the local store (keyed by machine UUID,
 so it can hold multiple hosts from `snapshot` + fan-out) into cross-host
-answers — the grouped result fan-out set up but never closed.
+answers — the grouped result that fan-out enabled but never produced.
 
 - `spectra fleet symptom <rule-id>` groups hosts by whether that rule fires
   against their latest snapshot ("which Macs trip `app-no-hardened-runtime`?").

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -23,14 +23,42 @@ type HostSnapshot struct {
 	Empty       bool
 }
 
-func hostLabel(h HostSnapshot) string {
-	if h.Hostname != "" {
-		return h.Hostname
+// displayLabels returns a stable display label per host, keyed on the unique
+// MachineUUID identity but showing the friendlier hostname. When two hosts
+// share a hostname, the label is disambiguated with a short UUID prefix so the
+// rollup and drift matrix never emit an ambiguous identity.
+func displayLabels(hosts []HostSnapshot) []string {
+	counts := map[string]int{}
+	for _, h := range hosts {
+		if h.Hostname != "" {
+			counts[h.Hostname]++
+		}
 	}
-	if h.MachineUUID != "" {
-		return h.MachineUUID
+	labels := make([]string, len(hosts))
+	for i, h := range hosts {
+		labels[i] = hostLabel(h, counts[h.Hostname] > 1)
 	}
-	return "unknown-host"
+	return labels
+}
+
+func hostLabel(h HostSnapshot, ambiguous bool) string {
+	if h.Hostname == "" {
+		if h.MachineUUID != "" {
+			return h.MachineUUID
+		}
+		return "unknown-host"
+	}
+	if ambiguous && h.MachineUUID != "" {
+		return fmt.Sprintf("%s (%s)", h.Hostname, shortUUID(h.MachineUUID))
+	}
+	return h.Hostname
+}
+
+func shortUUID(u string) string {
+	if len(u) > 8 {
+		return u[:8]
+	}
+	return u
 }
 
 // SymptomRollup groups hosts by whether a rule fires against their snapshot.
@@ -45,8 +73,9 @@ type SymptomRollup struct {
 // by whether ruleID fired. Hosts without a usable snapshot are Unknown.
 func RollupSymptom(hosts []HostSnapshot, ruleID string, catalog []rules.Rule) SymptomRollup {
 	r := SymptomRollup{RuleID: ruleID}
-	for _, h := range hosts {
-		name := hostLabel(h)
+	labels := displayLabels(hosts)
+	for i, h := range hosts {
+		name := labels[i]
 		switch {
 		case h.Empty:
 			r.Unknown = append(r.Unknown, name)
@@ -88,9 +117,10 @@ func DriftApp(hosts []HostSnapshot, bundleID string) []DriftCell {
 }
 
 func driftMatrix(hosts []HostSnapshot, value func(HostSnapshot) string) []DriftCell {
+	labels := displayLabels(hosts)
 	cells := make([]DriftCell, 0, len(hosts))
-	for _, h := range hosts {
-		cells = append(cells, DriftCell{Host: hostLabel(h), Value: value(h)})
+	for i, h := range hosts {
+		cells = append(cells, DriftCell{Host: labels[i], Value: value(h)})
 	}
 	sort.Slice(cells, func(i, j int) bool { return cells[i].Host < cells[j].Host })
 	return cells

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -1,0 +1,139 @@
+// Package fleet aggregates per-host snapshots into cross-host answers: which
+// hosts trip a given rule (symptom rollup), and how a dimension (JDK or an app)
+// varies across the tailnet (drift matrix). The reducers are pure over loaded
+// snapshots and deliberately tolerant: a host with no usable snapshot is marked
+// "unknown" for a dimension rather than mislabeled as "missing X".
+package fleet
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+// HostSnapshot pairs a host identity with its latest snapshot. Empty is true
+// when no snapshot could be loaded for the host.
+type HostSnapshot struct {
+	Hostname    string
+	MachineUUID string
+	Snap        snapshot.Snapshot
+	Empty       bool
+}
+
+func hostLabel(h HostSnapshot) string {
+	if h.Hostname != "" {
+		return h.Hostname
+	}
+	if h.MachineUUID != "" {
+		return h.MachineUUID
+	}
+	return "unknown-host"
+}
+
+// SymptomRollup groups hosts by whether a rule fires against their snapshot.
+type SymptomRollup struct {
+	RuleID  string   `json:"rule_id"`
+	Firing  []string `json:"firing"`
+	Clear   []string `json:"clear"`
+	Unknown []string `json:"unknown,omitempty"`
+}
+
+// RollupSymptom evaluates catalog against each host's snapshot and groups hosts
+// by whether ruleID fired. Hosts without a usable snapshot are Unknown.
+func RollupSymptom(hosts []HostSnapshot, ruleID string, catalog []rules.Rule) SymptomRollup {
+	r := SymptomRollup{RuleID: ruleID}
+	for _, h := range hosts {
+		name := hostLabel(h)
+		switch {
+		case h.Empty:
+			r.Unknown = append(r.Unknown, name)
+		case ruleFires(h.Snap, ruleID, catalog):
+			r.Firing = append(r.Firing, name)
+		default:
+			r.Clear = append(r.Clear, name)
+		}
+	}
+	sort.Strings(r.Firing)
+	sort.Strings(r.Clear)
+	sort.Strings(r.Unknown)
+	return r
+}
+
+func ruleFires(snap snapshot.Snapshot, ruleID string, catalog []rules.Rule) bool {
+	for _, f := range rules.Evaluate(snap, catalog) {
+		if f.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+// DriftCell is one host's value for a drift dimension.
+type DriftCell struct {
+	Host  string `json:"host"`
+	Value string `json:"value"`
+}
+
+// DriftJDK builds a per-host JDK-version matrix.
+func DriftJDK(hosts []HostSnapshot) []DriftCell {
+	return driftMatrix(hosts, jdkValue)
+}
+
+// DriftApp builds a per-host version matrix for one app bundle ID.
+func DriftApp(hosts []HostSnapshot, bundleID string) []DriftCell {
+	return driftMatrix(hosts, func(h HostSnapshot) string { return appValue(h, bundleID) })
+}
+
+func driftMatrix(hosts []HostSnapshot, value func(HostSnapshot) string) []DriftCell {
+	cells := make([]DriftCell, 0, len(hosts))
+	for _, h := range hosts {
+		cells = append(cells, DriftCell{Host: hostLabel(h), Value: value(h)})
+	}
+	sort.Slice(cells, func(i, j int) bool { return cells[i].Host < cells[j].Host })
+	return cells
+}
+
+func jdkValue(h HostSnapshot) string {
+	if h.Empty {
+		return "unknown"
+	}
+	jdks := h.Snap.Toolchains.JDKs
+	if len(jdks) == 0 {
+		return "none"
+	}
+	seen := map[string]bool{}
+	var vs []string
+	for _, j := range jdks {
+		v := fmt.Sprintf("%d", j.VersionMajor)
+		if j.ReleaseString != "" {
+			v = j.ReleaseString
+		}
+		if j.Vendor != "" {
+			v += " (" + j.Vendor + ")"
+		}
+		if !seen[v] {
+			seen[v] = true
+			vs = append(vs, v)
+		}
+	}
+	sort.Strings(vs)
+	return strings.Join(vs, ", ")
+}
+
+func appValue(h HostSnapshot, bundleID string) string {
+	if h.Empty {
+		return "unknown"
+	}
+	for _, a := range h.Snap.Apps {
+		if a.BundleID == bundleID {
+			if a.AppVersion != "" {
+				return a.AppVersion
+			}
+			return "installed"
+		}
+	}
+	return "absent"
+}

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -1,0 +1,87 @@
+package fleet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+func host(name string, apps []detect.Result, jdks []toolchain.JDKInstall) HostSnapshot {
+	return HostSnapshot{
+		Hostname: name,
+		Snap: snapshot.Snapshot{
+			Apps:       apps,
+			Toolchains: toolchain.Toolchains{JDKs: jdks},
+		},
+	}
+}
+
+func TestRollupSymptom(t *testing.T) {
+	hosts := []HostSnapshot{
+		host("laptop", []detect.Result{{Path: "/Applications/Unsigned.app", TeamID: ""}}, nil),
+		host("work-mac", []detect.Result{{Path: "/Applications/Signed.app", TeamID: "TEAM1"}}, nil),
+		{Hostname: "offline", Empty: true},
+	}
+	r := RollupSymptom(hosts, "app-unsigned", rules.V1Catalog())
+	if strings.Join(r.Firing, ",") != "laptop" {
+		t.Errorf("firing = %v, want [laptop]", r.Firing)
+	}
+	if strings.Join(r.Clear, ",") != "work-mac" {
+		t.Errorf("clear = %v, want [work-mac]", r.Clear)
+	}
+	if strings.Join(r.Unknown, ",") != "offline" {
+		t.Errorf("unknown = %v, want [offline]", r.Unknown)
+	}
+}
+
+func TestDriftJDK(t *testing.T) {
+	hosts := []HostSnapshot{
+		host("laptop", nil, []toolchain.JDKInstall{{VersionMajor: 21, ReleaseString: "21.0.6", Vendor: "Temurin"}}),
+		host("ci-mac", nil, []toolchain.JDKInstall{{VersionMajor: 17, ReleaseString: "17.0.10", Vendor: "Zulu"}}),
+		host("bare", nil, nil),
+		{Hostname: "offline", Empty: true},
+	}
+	cells := DriftJDK(hosts)
+	got := map[string]string{}
+	for _, c := range cells {
+		got[c.Host] = c.Value
+	}
+	if got["laptop"] != "21.0.6 (Temurin)" {
+		t.Errorf("laptop jdk = %q", got["laptop"])
+	}
+	if got["ci-mac"] != "17.0.10 (Zulu)" {
+		t.Errorf("ci-mac jdk = %q", got["ci-mac"])
+	}
+	if got["bare"] != "none" {
+		t.Errorf("bare jdk = %q, want none", got["bare"])
+	}
+	if got["offline"] != "unknown" {
+		t.Errorf("offline jdk = %q, want unknown", got["offline"])
+	}
+}
+
+func TestDriftApp(t *testing.T) {
+	hosts := []HostSnapshot{
+		host("laptop", []detect.Result{{BundleID: "com.example.app", AppVersion: "2.1"}}, nil),
+		host("ci-mac", []detect.Result{{BundleID: "com.other", AppVersion: "9"}}, nil),
+		{Hostname: "offline", Empty: true},
+	}
+	cells := DriftApp(hosts, "com.example.app")
+	got := map[string]string{}
+	for _, c := range cells {
+		got[c.Host] = c.Value
+	}
+	if got["laptop"] != "2.1" {
+		t.Errorf("laptop app = %q, want 2.1", got["laptop"])
+	}
+	if got["ci-mac"] != "absent" {
+		t.Errorf("ci-mac app = %q, want absent", got["ci-mac"])
+	}
+	if got["offline"] != "unknown" {
+		t.Errorf("offline app = %q, want unknown", got["offline"])
+	}
+}

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -64,6 +64,23 @@ func TestDriftJDK(t *testing.T) {
 	}
 }
 
+func TestDuplicateHostnamesDisambiguated(t *testing.T) {
+	// Two machines share a hostname; the labels must stay distinct.
+	hosts := []HostSnapshot{
+		{Hostname: "MacBook-Pro", MachineUUID: "AAAAAAAA-1111", Snap: snapshot.Snapshot{Toolchains: toolchain.Toolchains{JDKs: []toolchain.JDKInstall{{VersionMajor: 21, ReleaseString: "21"}}}}},
+		{Hostname: "MacBook-Pro", MachineUUID: "BBBBBBBB-2222", Snap: snapshot.Snapshot{Toolchains: toolchain.Toolchains{JDKs: []toolchain.JDKInstall{{VersionMajor: 17, ReleaseString: "17"}}}}},
+	}
+	cells := DriftJDK(hosts)
+	if len(cells) != 2 || cells[0].Host == cells[1].Host {
+		t.Fatalf("labels must be distinct for same-hostname machines, got %+v", cells)
+	}
+	for _, c := range cells {
+		if !strings.HasPrefix(c.Host, "MacBook-Pro (") {
+			t.Errorf("expected uuid-disambiguated label, got %q", c.Host)
+		}
+	}
+}
+
 func TestDriftApp(t *testing.T) {
 	hosts := []HostSnapshot{
 		host("laptop", []detect.Result{{BundleID: "com.example.app", AppVersion: "2.1"}}, nil),


### PR DESCRIPTION
## What

Adds **`internal/fleet`** + **`spectra fleet`** — cross-host aggregation, the grouped answer fan-out set up but never closed. It answers "which Macs trip `app-no-hardened-runtime`?" and "why does it repro on CI only?" (a JDK/app version matrix) as a single result instead of N raw JSON blobs.

## How

- `internal/fleet` is a **pure reducer** over `[]HostSnapshot`:
  - `RollupSymptom(hosts, ruleID, catalog)` runs `rules.Evaluate` against each host's latest snapshot and groups hosts into **firing / clear / unknown**.
  - `DriftJDK` / `DriftApp(bundleID)` build a per-host version matrix.
  - Per the vetting hazard, a host with no usable snapshot is marked **`unknown`** for a dimension rather than mislabeled "missing X".
- `spectra fleet symptom <rule-id>` and `spectra fleet drift (--jdk | --app <bundleID>)` load each host's latest snapshot from the local store (`ListHosts` → latest `ListSnapshots` → `GetSnapshotJSON` → unmarshal), then aggregate. `--json` structured.
- The store loader is injected, so the command and the reducers are tested without a live DB.

## Scope (v1)

Aggregation over the **local store** (snapshots present from prior `snapshot`/fan-out runs). Live fan-out aggregation and MCP exposure are natural follow-ups — the reducer accepts host→snapshot pairs from either source. Foundation for the regression-bisection item.

## Testing

- `fleet`: `RollupSymptom` (firing/clear/unknown via the real `app-unsigned` rule), `DriftJDK` (version, `none`, `unknown`), `DriftApp` (version, `absent`, `unknown`) over synthetic multi-host snapshots.
- CLI: symptom/drift-jdk/drift-app render, no-dimension/unknown-subcommand/no-args exits, empty-store and load-error paths — via an injected loader.
- `make vet complexity lint security docs-validate test` green locally (54 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #360
