### PR TITLE
fleet: fleet.BisectSymptom + spectra bisect — regression bisection across snapshot history

### DIFF
--- a/cmd/spectra/bisect.go
+++ b/cmd/spectra/bisect.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kaeawc/spectra/internal/fleet"
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+// seriesLoader returns a host's snapshot series oldest→newest and the resolved
+// hostname.
+type seriesLoader func(hostname string) ([]snapshot.Snapshot, string, error)
+
+func runBisect(args []string) int {
+	return runBisectWithIO(args, os.Stdout, os.Stderr, defaultSeriesLoader)
+}
+
+func runBisectWithIO(args []string, stdout, stderr io.Writer, load seriesLoader) int {
+	fs := flag.NewFlagSet("bisect", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	host := fs.String("host", "", "host to bisect (defaults to the only stored host)")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra bisect [--json] [--host <hostname>] <rule-id>")
+		fmt.Fprintln(stderr, "Find the snapshot where a rule started firing, and what changed alongside it.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	ruleID := fs.Arg(0)
+	if !ruleInCatalog(ruleID) {
+		fmt.Fprintf(stderr, "unknown rule id %q — run `spectra rules` to see available rules\n", ruleID)
+		return 2
+	}
+	series, hostname, err := load(*host)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	if len(series) == 0 {
+		fmt.Fprintf(stderr, "no snapshots stored for host %q\n", hostname)
+		return 1
+	}
+	res := fleet.BisectSymptom(series, ruleID, rules.V1Catalog())
+	if *asJSON {
+		return encodeJSON(stdout, stderr, res)
+	}
+	renderBisect(stdout, res, hostname)
+	return 0
+}
+
+func defaultSeriesLoader(hostname string) ([]snapshot.Snapshot, string, error) {
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve store path: %w", err)
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("open store %s: %w", dbPath, err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	hostRows, err := db.ListHosts(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("list hosts: %w", err)
+	}
+	hr, err := resolveBisectHost(hostRows, hostname)
+	if err != nil {
+		return nil, "", err
+	}
+	snaps, err := db.ListSnapshots(ctx, hr.MachineUUID)
+	if err != nil {
+		return nil, "", fmt.Errorf("list snapshots: %w", err)
+	}
+	// ListSnapshots is newest-first; reverse into an oldest-first series.
+	series := make([]snapshot.Snapshot, 0, len(snaps))
+	for i := len(snaps) - 1; i >= 0; i-- {
+		data, gerr := db.GetSnapshotJSON(ctx, snaps[i].ID)
+		if gerr != nil {
+			continue
+		}
+		var s snapshot.Snapshot
+		if json.Unmarshal(data, &s) == nil {
+			series = append(series, s)
+		}
+	}
+	return series, hr.Hostname, nil
+}
+
+func resolveBisectHost(rows []store.HostRow, hostname string) (store.HostRow, error) {
+	if len(rows) == 0 {
+		return store.HostRow{}, errors.New("no hosts in the store — run `spectra snapshot` first")
+	}
+	if hostname != "" {
+		for _, r := range rows {
+			if r.Hostname == hostname {
+				return r, nil
+			}
+		}
+		return store.HostRow{}, fmt.Errorf("no stored host named %q", hostname)
+	}
+	if len(rows) == 1 {
+		return rows[0], nil
+	}
+	return store.HostRow{}, errors.New("multiple hosts stored — specify --host <hostname>")
+}
+
+func renderBisect(w io.Writer, r fleet.BisectResult, hostname string) {
+	switch r.Status {
+	case "clean":
+		fmt.Fprintf(w, "%s never fires across the %d snapshot(s) stored for %s.\n", r.RuleID, r.Snapshots, hostname)
+		return
+	case "already-firing":
+		fmt.Fprintf(w, "%s is already firing in the oldest of %d snapshot(s) for %s (%s, %s).\n",
+			r.RuleID, r.Snapshots, hostname, r.FirstBadID, r.FirstBadTime.Format("2006-01-02 15:04"))
+		fmt.Fprintln(w, "No earlier snapshot to bisect against — capture started after the symptom.")
+		return
+	}
+	fmt.Fprintf(w, "%s first tripped in %s (%s) on %s.\n",
+		r.RuleID, r.FirstBadID, r.FirstBadTime.Format("2006-01-02 15:04"), hostname)
+	fmt.Fprintf(w, "Changes that co-occurred in that snapshot vs the prior one (%s) — correlated, not necessarily the cause:\n", r.PrevID)
+	if len(r.Changes) == 0 {
+		fmt.Fprintln(w, "  (no other tracked changes in that snapshot)")
+	}
+	for _, c := range r.Changes {
+		fmt.Fprintf(w, "  [%s/%s] %s%s\n", c.Section, c.Kind, c.Key, beforeAfter(c))
+	}
+	fmt.Fprintln(w, "Note: snapshots are periodic, so timing is bounded by capture cadence.")
+}
+
+func beforeAfter(c fleet.CoChange) string {
+	switch {
+	case c.Before != "" && c.After != "":
+		return fmt.Sprintf(" %s -> %s", c.Before, c.After)
+	case c.After != "":
+		return " +" + c.After
+	case c.Before != "":
+		return " -" + c.Before
+	default:
+		return ""
+	}
+}

--- a/cmd/spectra/bisect_test.go
+++ b/cmd/spectra/bisect_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+func bsnap(id string, day int, teamID string) snapshot.Snapshot {
+	return snapshot.Snapshot{
+		ID:      id,
+		TakenAt: time.Date(2026, 8, day, 9, 0, 0, 0, time.UTC),
+		Apps:    []detect.Result{{Path: "/Applications/Foo.app", BundleID: "com.x.foo", TeamID: teamID, AppVersion: "2." + id}},
+	}
+}
+
+func bisectLoader() ([]snapshot.Snapshot, string, error) {
+	return []snapshot.Snapshot{bsnap("1", 1, "TEAM1"), bsnap("2", 2, ""), bsnap("3", 3, "")}, "work-mac", nil
+}
+
+func TestRunBisectFound(t *testing.T) {
+	load := func(string) ([]snapshot.Snapshot, string, error) { return bisectLoader() }
+	var out, errBuf bytes.Buffer
+	if code := runBisectWithIO([]string{"app-unsigned"}, &out, &errBuf, load); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "first tripped in 2") {
+		t.Errorf("output = %q", s)
+	}
+	if !strings.Contains(s, "correlated") || !strings.Contains(s, "capture cadence") {
+		t.Errorf("output should carry the correlation + cadence caveats; got:\n%s", s)
+	}
+}
+
+func TestRunBisectUnknownRule(t *testing.T) {
+	load := func(string) ([]snapshot.Snapshot, string, error) { return bisectLoader() }
+	var out, errBuf bytes.Buffer
+	if code := runBisectWithIO([]string{"no-such-rule"}, &out, &errBuf, load); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "unknown rule id") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestRunBisectNoArgs(t *testing.T) {
+	load := func(string) ([]snapshot.Snapshot, string, error) { return bisectLoader() }
+	var out, errBuf bytes.Buffer
+	if code := runBisectWithIO(nil, &out, &errBuf, load); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}
+
+func TestRunBisectLoadError(t *testing.T) {
+	load := func(string) ([]snapshot.Snapshot, string, error) { return nil, "", errors.New("db locked") }
+	var out, errBuf bytes.Buffer
+	if code := runBisectWithIO([]string{"app-unsigned"}, &out, &errBuf, load); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestRunBisectEmptySeries(t *testing.T) {
+	load := func(string) ([]snapshot.Snapshot, string, error) { return nil, "work-mac", nil }
+	var out, errBuf bytes.Buffer
+	if code := runBisectWithIO([]string{"app-unsigned"}, &out, &errBuf, load); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestResolveBisectHost(t *testing.T) {
+	rows := []store.HostRow{
+		{Hostname: "laptop", MachineUUID: "A"},
+		{Hostname: "work-mac", MachineUUID: "B"},
+	}
+	// explicit hostname selects it
+	if hr, err := resolveBisectHost(rows, "work-mac"); err != nil || hr.MachineUUID != "B" {
+		t.Errorf("resolve work-mac = %+v, %v", hr, err)
+	}
+	// unknown hostname errors
+	if _, err := resolveBisectHost(rows, "nope"); err == nil {
+		t.Error("expected error for unknown host")
+	}
+	// ambiguous default (>1 host, no --host) errors
+	if _, err := resolveBisectHost(rows, ""); err == nil {
+		t.Error("expected error when multiple hosts and no --host")
+	}
+	// single host defaults
+	if hr, err := resolveBisectHost(rows[:1], ""); err != nil || hr.MachineUUID != "A" {
+		t.Errorf("single-host default = %+v, %v", hr, err)
+	}
+	// empty store errors
+	if _, err := resolveBisectHost(nil, ""); err == nil {
+		t.Error("expected error for empty store")
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -60,6 +60,7 @@ func subcommandList() []subcommand {
 		{"fan", "Run one daemon RPC call against multiple targets", runFan},
 		{"hosts", "List hosts known from stored snapshots", runHosts},
 		{"fleet", "Cross-host rollups: which hosts trip a rule, and version-drift matrices", runFleet},
+		{"bisect", "Find the snapshot where a rule started firing, and what changed alongside it", runBisect},
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -51,6 +51,7 @@ The short `-v` is unaffected: it still means "show detection signals" for
 | `fan` | Run one daemon RPC call against multiple explicit targets |
 | `hosts` | List hosts known from stored snapshots |
 | `fleet` | Cross-host symptom rollups and version-drift matrices |
+| `bisect` | Find the snapshot where a rule started firing, and what changed alongside it |
 | `status` | Check whether the local daemon is running |
 | `metrics` | Show stored process metrics from daemon sampling |
 | `sample` | Collect a user-space CPU sample of a process |
@@ -758,6 +759,23 @@ spectra hosts --probe --json
 spectra hosts --discover
 spectra hosts --discover-daemons
 ``` 
+
+## `spectra bisect`
+
+Bisects one host's stored snapshot series to find the first snapshot where a
+rule started firing, then diffs it against its predecessor to surface the
+changes that co-occurred (an app version bump, a new login item, a JDK
+swap). Because snapshots are periodic, the timing is bounded by capture
+cadence, and the co-occurring changes are reported as **correlated, not
+the cause**. `--host` selects the host (defaults to the only stored one);
+`--json` emits the structured result.
+
+### Examples
+
+```bash
+spectra bisect app-no-hardened-runtime
+spectra bisect app-no-hardened-runtime --host work-mac --json
+```
 
 ## `spectra fleet`
 

--- a/internal/fleet/bisect.go
+++ b/internal/fleet/bisect.go
@@ -1,0 +1,70 @@
+package fleet
+
+import (
+	"time"
+
+	"github.com/kaeawc/spectra/internal/diff"
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+// CoChange is one change that co-occurred in the snapshot where a symptom first
+// appeared. It is correlational context, not an identified cause.
+type CoChange struct {
+	Section string `json:"section"`
+	Kind    string `json:"kind"`
+	Key     string `json:"key"`
+	Before  string `json:"before,omitempty"`
+	After   string `json:"after,omitempty"`
+}
+
+// BisectResult is the outcome of a symptom bisection over a snapshot series.
+type BisectResult struct {
+	Status       string     `json:"status"` // clean, already-firing, found
+	RuleID       string     `json:"rule_id"`
+	Snapshots    int        `json:"snapshots"`
+	FirstBadID   string     `json:"first_bad_id,omitempty"`
+	FirstBadTime time.Time  `json:"first_bad_time,omitempty"`
+	PrevID       string     `json:"prev_id,omitempty"`
+	Changes      []CoChange `json:"co_occurring_changes,omitempty"`
+}
+
+// BisectSymptom walks an oldest→newest snapshot series and finds the first
+// snapshot where ruleID starts firing, then (when there is a predecessor) the
+// changes that co-occurred in that snapshot. Because snapshots are periodic,
+// the result is bounded by capture cadence, and the co-occurring changes are
+// correlational only.
+func BisectSymptom(series []snapshot.Snapshot, ruleID string, catalog []rules.Rule) BisectResult {
+	r := BisectResult{RuleID: ruleID, Snapshots: len(series), Status: "clean"}
+	firstBad := -1
+	for i, s := range series {
+		if ruleFires(s, ruleID, catalog) {
+			firstBad = i
+			break
+		}
+	}
+	if firstBad < 0 {
+		return r // rule never fires across the series
+	}
+	r.FirstBadID = series[firstBad].ID
+	r.FirstBadTime = series[firstBad].TakenAt
+	if firstBad == 0 {
+		r.Status = "already-firing" // firing in the oldest snapshot; nothing earlier to compare
+		return r
+	}
+	r.Status = "found"
+	prev := series[firstBad-1]
+	r.PrevID = prev.ID
+	for _, sec := range diff.Compare(prev, series[firstBad]).Sections {
+		for _, c := range sec.Changes {
+			r.Changes = append(r.Changes, CoChange{
+				Section: sec.Name,
+				Kind:    string(c.Kind),
+				Key:     c.Key,
+				Before:  c.Before,
+				After:   c.After,
+			})
+		}
+	}
+	return r
+}

--- a/internal/fleet/bisect_test.go
+++ b/internal/fleet/bisect_test.go
@@ -1,0 +1,65 @@
+package fleet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/rules"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func snap(id string, day int, apps ...detect.Result) snapshot.Snapshot {
+	return snapshot.Snapshot{
+		ID:      id,
+		TakenAt: time.Date(2026, 8, day, 9, 0, 0, 0, time.UTC),
+		Apps:    apps,
+	}
+}
+
+func signed() detect.Result {
+	return detect.Result{Path: "/Applications/Foo.app", BundleID: "com.x.foo", TeamID: "TEAM1", AppVersion: "2.3"}
+}
+func unsigned() detect.Result {
+	return detect.Result{Path: "/Applications/Foo.app", BundleID: "com.x.foo", TeamID: "", AppVersion: "2.4"}
+}
+
+func TestBisectFound(t *testing.T) {
+	series := []snapshot.Snapshot{
+		snap("s1", 1, signed()),
+		snap("s2", 2, unsigned()), // app-unsigned starts firing here; team-id + version co-change
+		snap("s3", 3, unsigned()),
+	}
+	r := BisectSymptom(series, "app-unsigned", rules.V1Catalog())
+	if r.Status != "found" {
+		t.Fatalf("status = %q, want found", r.Status)
+	}
+	if r.FirstBadID != "s2" || r.PrevID != "s1" {
+		t.Errorf("first=%q prev=%q, want s2/s1", r.FirstBadID, r.PrevID)
+	}
+	if len(r.Changes) == 0 {
+		t.Error("expected co-occurring changes between s1 and s2")
+	}
+}
+
+func TestBisectClean(t *testing.T) {
+	series := []snapshot.Snapshot{snap("s1", 1, signed()), snap("s2", 2, signed())}
+	r := BisectSymptom(series, "app-unsigned", rules.V1Catalog())
+	if r.Status != "clean" {
+		t.Errorf("status = %q, want clean", r.Status)
+	}
+	if r.FirstBadID != "" {
+		t.Errorf("clean series should have no first-bad id, got %q", r.FirstBadID)
+	}
+}
+
+func TestBisectAlreadyFiring(t *testing.T) {
+	series := []snapshot.Snapshot{snap("s1", 1, unsigned()), snap("s2", 2, unsigned())}
+	r := BisectSymptom(series, "app-unsigned", rules.V1Catalog())
+	if r.Status != "already-firing" {
+		t.Errorf("status = %q, want already-firing", r.Status)
+	}
+	if r.FirstBadID != "s1" || r.PrevID != "" {
+		t.Errorf("first=%q prev=%q, want s1/'' (no earlier snapshot)", r.FirstBadID, r.PrevID)
+	}
+}


### PR DESCRIPTION
## What

Adds **`fleet.BisectSymptom`** + **`spectra bisect <rule-id> [--host <hostname>]`** — regression bisection over a host's snapshot history. `diff.Compare` handles two snapshots; this walks the *series* to answer "when did `app-no-hardened-runtime` start tripping, and what else changed in that snapshot?". Builds on the fleet/snapshot-series work from #361.

## How

- `fleet.BisectSymptom(series, ruleID, catalog)` walks the oldest→newest series, finds the first snapshot where the rule fires, and (when there's a predecessor) flattens `diff.Compare(prev, firstBad).Sections` into co-occurring changes. Statuses: **found** / **clean** (never fires) / **already-firing** (fires in the oldest snapshot — nothing earlier to compare).
- `spectra bisect` loads the host's series from the store (`ListHosts` → `resolveBisectHost` by `--host` or the single stored host → reversed `ListSnapshots` → `GetSnapshotJSON`), then reports the first-tripped snapshot and the co-occurring changes. `--json` structured. Unknown rule id exits 2 (consistent with `fleet symptom`).

**Honesty, per the vetting note:** the output explicitly frames the co-occurring changes as **correlated, not the cause**, and notes that timing is **bounded by capture cadence** (snapshots are periodic, not continuous).

## Scope (v1)

Single-host bisection over the local store. Cross-host / golden bisection and MCP are follow-ups.

## Testing

- `fleet`: found (first-bad index + non-empty co-changes), clean, already-firing — over a synthetic series using the real `app-unsigned` rule.
- CLI: found render (asserts the correlation + cadence caveats are present), unknown-rule/no-args exits, load-error and empty-series paths, and `resolveBisectHost` (explicit/unknown/ambiguous/single/empty) — via an injected loader.
- `make vet complexity lint security docs-validate test` green locally (54 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #362
