### PR TITLE
diag: internal/anomaly + spectra anomalies — EWMA rolling-baseline anomaly detection

### DIFF
--- a/cmd/spectra/anomalies.go
+++ b/cmd/spectra/anomalies.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/kaeawc/spectra/internal/anomaly"
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+type metricsLoader func() ([]store.ProcessMetricRow, error)
+type nameResolver func() map[int]string
+
+func runAnomalies(args []string) int {
+	return runAnomaliesWithIO(args, os.Stdout, os.Stderr, defaultMetricsLoader, defaultNameResolver)
+}
+
+func runAnomaliesWithIO(args []string, stdout, stderr io.Writer, loadMetrics metricsLoader, resolveNames nameResolver) int {
+	fs := flag.NewFlagSet("anomalies", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	z := fs.Float64("z", 3.0, "z-score threshold")
+	minSamples := fs.Int("min-samples", 5, "baseline points required before flagging")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	rows, err := loadMetrics()
+	if err != nil {
+		fmt.Fprintf(stderr, "load metrics: %v\n", err)
+		return 1
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(stderr, "no process metrics stored — run `spectra serve` to sample processes over time")
+		return 1
+	}
+	findings := anomaly.Detect(buildRSSSeries(rows), *minSamples, *z)
+	names := resolveNames()
+	if *asJSON {
+		return encodeJSON(stdout, stderr, findings)
+	}
+	renderAnomalies(stdout, findings, names)
+	return 0
+}
+
+func buildRSSSeries(rows []store.ProcessMetricRow) []anomaly.Series {
+	byPID := map[int][]anomaly.Point{}
+	for _, r := range rows {
+		byPID[r.PID] = append(byPID[r.PID], anomaly.Point{Value: float64(r.AvgRSSKiB), At: r.MinuteAt})
+	}
+	series := make([]anomaly.Series, 0, len(byPID))
+	for pid, pts := range byPID {
+		series = append(series, anomaly.Series{Key: strconv.Itoa(pid), Points: pts})
+	}
+	return series
+}
+
+func defaultMetricsLoader() ([]store.ProcessMetricRow, error) {
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		return nil, fmt.Errorf("resolve store path: %w", err)
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open store %s: %w", dbPath, err)
+	}
+	defer db.Close()
+	return db.GetAllProcessMetrics(context.Background(), 20000)
+}
+
+func defaultNameResolver() map[int]string {
+	names := map[int]string{}
+	for _, p := range process.CollectAll(context.Background(), process.CollectOptions{}) {
+		names[p.PID] = p.Command
+	}
+	return names
+}
+
+func renderAnomalies(w io.Writer, findings []anomaly.Finding, names map[int]string) {
+	if len(findings) == 0 {
+		fmt.Fprintln(w, "No process RSS anomalies vs their rolling baselines.")
+		return
+	}
+	fmt.Fprintf(w, "Process RSS anomalies vs rolling baseline (%d):\n", len(findings))
+	for _, f := range findings {
+		fmt.Fprintf(w, "  %s RSS %s is %+.1fσ vs baseline (~%s, %d samples)\n",
+			anomalyLabel(f.Key, names), mibFromKiB(f.Latest), f.Z, mibFromKiB(f.Mean), f.Samples)
+	}
+}
+
+func anomalyLabel(key string, names map[int]string) string {
+	pid, err := strconv.Atoi(key)
+	if err != nil {
+		return key
+	}
+	if name := names[pid]; name != "" {
+		return fmt.Sprintf("pid %d (%s)", pid, name)
+	}
+	return fmt.Sprintf("pid %d (exited)", pid)
+}
+
+func mibFromKiB(kib float64) string {
+	mb := kib / 1024
+	if mb >= 1024 {
+		return fmt.Sprintf("%.1f GB", mb/1024)
+	}
+	return fmt.Sprintf("%.0f MB", mb)
+}

--- a/cmd/spectra/anomalies.go
+++ b/cmd/spectra/anomalies.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 
@@ -27,6 +28,14 @@ func runAnomaliesWithIO(args []string, stdout, stderr io.Writer, loadMetrics met
 	z := fs.Float64("z", 3.0, "z-score threshold")
 	minSamples := fs.Int("min-samples", 5, "baseline points required before flagging")
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *z <= 0 || math.IsNaN(*z) {
+		fmt.Fprintln(stderr, "-z must be a positive number")
+		return 2
+	}
+	if *minSamples < 2 {
+		fmt.Fprintln(stderr, "--min-samples must be >= 2 (a baseline needs at least two points for variance)")
 		return 2
 	}
 	rows, err := loadMetrics()
@@ -69,7 +78,11 @@ func defaultMetricsLoader() ([]store.ProcessMetricRow, error) {
 		return nil, fmt.Errorf("open store %s: %w", dbPath, err)
 	}
 	defer db.Close()
-	return db.GetAllProcessMetrics(context.Background(), 20000)
+	rows, err := db.GetAllProcessMetrics(context.Background(), 20000)
+	if err != nil {
+		return nil, fmt.Errorf("query process metrics: %w", err)
+	}
+	return rows, nil
 }
 
 func defaultNameResolver() map[int]string {

--- a/cmd/spectra/anomalies_test.go
+++ b/cmd/spectra/anomalies_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+func metricRows() []store.ProcessMetricRow {
+	base := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	var rows []store.ProcessMetricRow
+	// pid 8123: noisy ~600MB baseline then a spike to ~2.1GB (in KiB)
+	vals := []int64{600_000, 610_000, 595_000, 605_000, 600_000, 615_000, 590_000, 2_100_000}
+	for i, v := range vals {
+		rows = append(rows, store.ProcessMetricRow{PID: 8123, MinuteAt: base.Add(time.Duration(i) * time.Minute), AvgRSSKiB: v})
+	}
+	return rows
+}
+
+func TestRunAnomaliesFlagsSpike(t *testing.T) {
+	load := func() ([]store.ProcessMetricRow, error) { return metricRows(), nil }
+	names := func() map[int]string { return map[int]string{8123: "com.corp.helper"} }
+	var out, errBuf bytes.Buffer
+	if code := runAnomaliesWithIO(nil, &out, &errBuf, load, names); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "pid 8123 (com.corp.helper)") || !strings.Contains(s, "σ") {
+		t.Errorf("output = %q", s)
+	}
+	if !strings.Contains(s, "GB") {
+		t.Errorf("expected a GB-scale spike in output; got %q", s)
+	}
+}
+
+func TestRunAnomaliesExitedLabel(t *testing.T) {
+	load := func() ([]store.ProcessMetricRow, error) { return metricRows(), nil }
+	names := func() map[int]string { return map[int]string{} } // pid no longer running
+	var out, errBuf bytes.Buffer
+	runAnomaliesWithIO(nil, &out, &errBuf, load, names)
+	if !strings.Contains(out.String(), "pid 8123 (exited)") {
+		t.Errorf("expected exited label; got %q", out.String())
+	}
+}
+
+func TestRunAnomaliesNoneClean(t *testing.T) {
+	base := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	flat := []store.ProcessMetricRow{}
+	for i, v := range []int64{600_000, 610_000, 595_000, 605_000, 600_000, 615_000, 590_000, 600_000} {
+		flat = append(flat, store.ProcessMetricRow{PID: 1, MinuteAt: base.Add(time.Duration(i) * time.Minute), AvgRSSKiB: v})
+	}
+	load := func() ([]store.ProcessMetricRow, error) { return flat, nil }
+	names := func() map[int]string { return nil }
+	var out, errBuf bytes.Buffer
+	runAnomaliesWithIO(nil, &out, &errBuf, load, names)
+	if !strings.Contains(out.String(), "No process RSS anomalies") {
+		t.Errorf("expected clean message; got %q", out.String())
+	}
+}
+
+func TestRunAnomaliesEmpty(t *testing.T) {
+	load := func() ([]store.ProcessMetricRow, error) { return nil, nil }
+	names := func() map[int]string { return nil }
+	var out, errBuf bytes.Buffer
+	if code := runAnomaliesWithIO(nil, &out, &errBuf, load, names); code != 1 {
+		t.Fatalf("exit = %d, want 1 for empty metrics", code)
+	}
+}
+
+func TestRunAnomaliesLoadError(t *testing.T) {
+	load := func() ([]store.ProcessMetricRow, error) { return nil, errors.New("db locked") }
+	names := func() map[int]string { return nil }
+	var out, errBuf bytes.Buffer
+	if code := runAnomaliesWithIO(nil, &out, &errBuf, load, names); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}

--- a/cmd/spectra/anomalies_test.go
+++ b/cmd/spectra/anomalies_test.go
@@ -71,6 +71,17 @@ func TestRunAnomaliesEmpty(t *testing.T) {
 	}
 }
 
+func TestRunAnomaliesRejectsBadParams(t *testing.T) {
+	load := func() ([]store.ProcessMetricRow, error) { return metricRows(), nil }
+	names := func() map[int]string { return nil }
+	for _, args := range [][]string{{"-z", "0"}, {"-z", "-2"}, {"--min-samples", "1"}} {
+		var out, errBuf bytes.Buffer
+		if code := runAnomaliesWithIO(args, &out, &errBuf, load, names); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}
+
 func TestRunAnomaliesLoadError(t *testing.T) {
 	load := func() ([]store.ProcessMetricRow, error) { return nil, errors.New("db locked") }
 	names := func() map[int]string { return nil }

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -63,6 +63,7 @@ func subcommandList() []subcommand {
 		{"bisect", "Find the snapshot where a rule started firing, and what changed alongside it", runBisect},
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
+		{"anomalies", "Flag processes deviating from their rolling RSS baseline", runAnomalies},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},
 		{"install-daemon", "Install the user LaunchAgent for spectra serve", runInstallDaemonCmd},
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -514,6 +514,26 @@ spectra web symbolicate app.js.map 1:284620
 spectra web symbolicate --json app.js.map 1:284620 1:9931
 ```
 
+## `spectra anomalies`
+
+Flags processes whose latest RSS deviates from their own rolling baseline,
+using an EWMA mean+variance / z-score detector over the metrics the daemon
+samples. It catches a slow leak days before a static ceiling would — "pid
+8123 (com.corp.helper) RSS 2.1 GB is +4.3σ vs baseline (~600 MB)".
+
+Series are keyed on **PID** (the metrics ring is PID-keyed); the current
+process name is attached best-effort and exited PIDs are labeled as such.
+A series needs a few baseline points before it can flag (no cold-start
+false positives). `-z` and `--min-samples` tune sensitivity; `--json`
+emits the structured findings.
+
+### Examples
+
+```bash
+spectra anomalies
+spectra anomalies -z 4 --min-samples 10 --json
+```
+
 ## `spectra whatswrong`
 
 A single whole-system triage: samples memory pressure and swap

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -516,10 +516,12 @@ spectra web symbolicate --json app.js.map 1:284620 1:9931
 
 ## `spectra anomalies`
 
-Flags processes whose latest RSS deviates from their own rolling baseline,
+Flags processes whose latest RSS sits well above their own recent baseline,
 using an EWMA mean+variance / z-score detector over the metrics the daemon
-samples. It catches a slow leak days before a static ceiling would — "pid
-8123 (com.corp.helper) RSS 2.1 GB is +4.3σ vs baseline (~600 MB)".
+samples — a sudden jump or step change, e.g. "pid 8123 (com.corp.helper)
+RSS 2.1 GB is +4.3σ vs baseline (~600 MB)". (It compares the latest point to
+the baseline, so a gradual creep the baseline follows won't trip it — that's
+a job for a dedicated trend detector.)
 
 Series are keyed on **PID** (the metrics ring is PID-keyed); the current
 process name is attached best-effort and exited PIDs are labeled as such.

--- a/internal/anomaly/anomaly.go
+++ b/internal/anomaly/anomaly.go
@@ -1,8 +1,10 @@
 // Package anomaly is a small, dependency-free rolling-baseline detector. It
 // builds an exponentially-weighted (EWMA) mean and variance for each series and
-// flags the latest point when it deviates from that baseline by more than a
-// z-score threshold. It generalizes the rising-trend logic that today only the
-// jvm-gc-pressure rule has, so slow leaks are caught before a static ceiling.
+// flags the *latest* point when it sits more than a z-score threshold away from
+// that baseline — i.e. a sudden jump or step change relative to the recent
+// history. It does not track a gradual trend: a slow creep that the EWMA
+// baseline follows will not be flagged; that is what a dedicated trend detector
+// would add.
 package anomaly
 
 import (
@@ -30,7 +32,7 @@ type Finding struct {
 	Mean    float64 `json:"baseline_mean"`
 	StdDev  float64 `json:"baseline_stddev"`
 	Z       float64 `json:"z"`
-	Samples int     `json:"samples"`
+	Samples int     `json:"samples"` // baseline sample count (excludes the latest point)
 }
 
 // defaultAlpha is the EWMA smoothing factor: higher weights recent points more.
@@ -75,5 +77,5 @@ func detectOne(s Series, minSamples int, zThreshold float64) (Finding, bool) {
 	if math.Abs(z) < zThreshold {
 		return Finding{}, false
 	}
-	return Finding{Key: s.Key, Latest: latest, Mean: mean, StdDev: std, Z: z, Samples: len(pts)}, true
+	return Finding{Key: s.Key, Latest: latest, Mean: mean, StdDev: std, Z: z, Samples: len(pts) - 1}, true
 }

--- a/internal/anomaly/anomaly.go
+++ b/internal/anomaly/anomaly.go
@@ -1,0 +1,79 @@
+// Package anomaly is a small, dependency-free rolling-baseline detector. It
+// builds an exponentially-weighted (EWMA) mean and variance for each series and
+// flags the latest point when it deviates from that baseline by more than a
+// z-score threshold. It generalizes the rising-trend logic that today only the
+// jvm-gc-pressure rule has, so slow leaks are caught before a static ceiling.
+package anomaly
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+// Point is one observation in a series.
+type Point struct {
+	Value float64
+	At    time.Time
+}
+
+// Series is a named sequence of observations (any order; sorted internally).
+type Series struct {
+	Key    string
+	Points []Point
+}
+
+// Finding describes a series whose latest value is anomalous vs its baseline.
+type Finding struct {
+	Key     string  `json:"key"`
+	Latest  float64 `json:"latest"`
+	Mean    float64 `json:"baseline_mean"`
+	StdDev  float64 `json:"baseline_stddev"`
+	Z       float64 `json:"z"`
+	Samples int     `json:"samples"`
+}
+
+// defaultAlpha is the EWMA smoothing factor: higher weights recent points more.
+const defaultAlpha = 0.3
+
+// Detect flags each series whose latest point deviates from its EWMA baseline by
+// more than zThreshold standard deviations. A series needs at least minSamples
+// baseline points (cold-start guard) and non-zero baseline variance. Results are
+// sorted by descending absolute z-score.
+func Detect(series []Series, minSamples int, zThreshold float64) []Finding {
+	var out []Finding
+	for _, s := range series {
+		if f, ok := detectOne(s, minSamples, zThreshold); ok {
+			out = append(out, f)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return math.Abs(out[i].Z) > math.Abs(out[j].Z) })
+	return out
+}
+
+func detectOne(s Series, minSamples int, zThreshold float64) (Finding, bool) {
+	pts := append([]Point(nil), s.Points...)
+	sort.Slice(pts, func(i, j int) bool { return pts[i].At.Before(pts[j].At) })
+	if len(pts) < minSamples+1 {
+		return Finding{}, false // cold start: not enough baseline yet
+	}
+	// EWMA mean + variance over every point except the latest (the baseline).
+	mean := pts[0].Value
+	variance := 0.0
+	for i := 1; i < len(pts)-1; i++ {
+		x := pts[i].Value
+		diff := x - mean
+		mean += defaultAlpha * diff
+		variance = (1 - defaultAlpha) * (variance + defaultAlpha*diff*diff)
+	}
+	std := math.Sqrt(variance)
+	if std <= 0 {
+		return Finding{}, false // flat baseline: no meaningful z-score
+	}
+	latest := pts[len(pts)-1].Value
+	z := (latest - mean) / std
+	if math.Abs(z) < zThreshold {
+		return Finding{}, false
+	}
+	return Finding{Key: s.Key, Latest: latest, Mean: mean, StdDev: std, Z: z, Samples: len(pts)}, true
+}

--- a/internal/anomaly/anomaly_test.go
+++ b/internal/anomaly/anomaly_test.go
@@ -1,0 +1,64 @@
+package anomaly
+
+import (
+	"testing"
+	"time"
+)
+
+func series(key string, values ...float64) Series {
+	base := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	pts := make([]Point, len(values))
+	for i, v := range values {
+		pts[i] = Point{Value: v, At: base.Add(time.Duration(i) * time.Minute)}
+	}
+	return Series{Key: key, Points: pts}
+}
+
+func TestDetectSpike(t *testing.T) {
+	// noisy ~100 baseline, then a large spike
+	s := series("leaky", 98, 102, 99, 101, 100, 103, 97, 1000)
+	f := Detect([]Series{s}, 5, 3.0)
+	if len(f) != 1 {
+		t.Fatalf("findings = %d, want 1: %+v", len(f), f)
+	}
+	if f[0].Key != "leaky" || f[0].Z < 3 {
+		t.Errorf("finding = %+v, want leaky with z>=3", f[0])
+	}
+	if f[0].Latest != 1000 {
+		t.Errorf("latest = %v, want 1000", f[0].Latest)
+	}
+}
+
+func TestDetectNormalIgnored(t *testing.T) {
+	s := series("steady", 98, 102, 99, 101, 100, 103, 97, 100)
+	if f := Detect([]Series{s}, 5, 3.0); len(f) != 0 {
+		t.Errorf("normal series should not flag, got %+v", f)
+	}
+}
+
+func TestDetectColdStart(t *testing.T) {
+	s := series("young", 100, 5000) // only 2 points, minSamples 5
+	if f := Detect([]Series{s}, 5, 3.0); len(f) != 0 {
+		t.Errorf("cold-start series should not flag, got %+v", f)
+	}
+}
+
+func TestDetectFlatBaseline(t *testing.T) {
+	// zero-variance baseline can't produce a z-score even with a jump
+	s := series("flat", 100, 100, 100, 100, 100, 100, 900)
+	if f := Detect([]Series{s}, 5, 3.0); len(f) != 0 {
+		t.Errorf("flat baseline should not flag, got %+v", f)
+	}
+}
+
+func TestDetectSortedByZ(t *testing.T) {
+	big := series("big", 98, 102, 99, 101, 100, 103, 97, 5000)
+	small := series("small", 98, 102, 99, 101, 100, 103, 97, 400)
+	f := Detect([]Series{small, big}, 5, 3.0)
+	if len(f) != 2 {
+		t.Fatalf("findings = %d, want 2", len(f))
+	}
+	if f[0].Key != "big" {
+		t.Errorf("expected the larger-z 'big' first, got %q", f[0].Key)
+	}
+}


### PR DESCRIPTION
## What

Adds **`internal/anomaly`** (a stdlib EWMA / z-score detector) + **`spectra anomalies`** — a per-process rolling baseline. The only trend-aware rule today is `jvm-gc-pressure`; everything else is a static threshold. This catches a slow leak — "RSS is 3× its normal" — days before a hard ceiling.

## How

- `anomaly.Detect(series, minSamples, z)` builds an **EWMA mean + variance** baseline over each series (every point except the latest), then flags the latest when its z-score exceeds the threshold. Guards: needs `minSamples` baseline points (no cold-start false positives) and skips zero-variance (flat) baselines. Results sorted by |z|.
- `spectra anomalies` loads per-process RSS history from the metrics ring (`store.GetAllProcessMetrics`), builds a series per process, runs the detector, and reports outliers with σ and baseline.

**Honest scoping (from the vetting note):**
- The metrics ring is **PID-keyed** (no name column), so series key on PID and the live process name is attached best-effort (exited PIDs labeled as such). Name-keyed baselines would need a metrics-schema change — out of scope.
- Plain EWMA does **not** model diurnal seasonality, so there's no "normal for this time of day" claim.

## Scope (v1)

Detector + `spectra anomalies` over the local ring. A `process-anomaly` rule (into issues/watch/fleet) is a natural follow-up on the same detector.

## Testing

- `anomaly`: spike flagged (z≥3), normal series ignored, cold-start (too few points) ignored, flat/zero-variance baseline ignored, sorted-by-z.
- CLI: spike render (name + σ + GB), exited-PID label, clean message, empty-metrics and load-error exits — via injected metrics loader and name map.
- `make vet complexity lint security docs-validate test` green locally (55 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #364
