### PR TITLE
fleet: fleet.Reconcile + spectra reconcile — dry-run teammate-environment reconciliation plan

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -61,6 +61,7 @@ func subcommandList() []subcommand {
 		{"hosts", "List hosts known from stored snapshots", runHosts},
 		{"fleet", "Cross-host rollups: which hosts trip a rule, and version-drift matrices", runFleet},
 		{"bisect", "Find the snapshot where a rule started firing, and what changed alongside it", runBisect},
+		{"reconcile", "Print an advisory plan to make one host's toolchain match another's", runReconcile},
 		{"status", "Check whether the local daemon is running", runStatus},
 		{"metrics", "Show stored process metrics (requires spectra serve)", runMetrics},
 		{"anomalies", "Flag processes deviating from their rolling RSS baseline", runAnomalies},

--- a/cmd/spectra/reconcile.go
+++ b/cmd/spectra/reconcile.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kaeawc/spectra/internal/fleet"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+type toolchainPair struct {
+	FromTC   toolchain.Toolchains
+	ToTC     toolchain.Toolchains
+	FromName string
+	ToName   string
+}
+
+type reconcileLoader func(from, target string) (toolchainPair, error)
+
+func runReconcile(args []string) int {
+	return runReconcileWithIO(args, os.Stdout, os.Stderr, defaultReconcileLoader)
+}
+
+func runReconcileWithIO(args []string, stdout, stderr io.Writer, load reconcileLoader) int {
+	fs := flag.NewFlagSet("reconcile", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	from := fs.String("from", "", "source host to change (defaults to this machine)")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra reconcile [--json] [--from <host>] <target-host>")
+		fmt.Fprintln(stderr, "Print an advisory plan to make one host's toolchain match another's. Nothing is executed.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	pair, err := load(*from, fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	steps := fleet.Reconcile(pair.FromTC, pair.ToTC)
+	if *asJSON {
+		return encodeJSON(stdout, stderr, struct {
+			From  string                `json:"from"`
+			To    string                `json:"to"`
+			Steps []fleet.ReconcileStep `json:"steps"`
+		}{pair.FromName, pair.ToName, steps})
+	}
+	renderReconcile(stdout, pair.FromName, pair.ToName, steps)
+	return 0
+}
+
+func defaultReconcileLoader(from, target string) (toolchainPair, error) {
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		return toolchainPair{}, fmt.Errorf("resolve store path: %w", err)
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return toolchainPair{}, fmt.Errorf("open store %s: %w", dbPath, err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	rows, err := db.ListHosts(ctx)
+	if err != nil {
+		return toolchainPair{}, fmt.Errorf("list hosts: %w", err)
+	}
+	if from == "" {
+		if h, herr := os.Hostname(); herr == nil {
+			from = h
+		}
+	}
+	fromHR, err := resolveBisectHost(rows, from)
+	if err != nil {
+		return toolchainPair{}, fmt.Errorf("source host: %w", err)
+	}
+	toHR, err := resolveBisectHost(rows, target)
+	if err != nil {
+		return toolchainPair{}, fmt.Errorf("target host: %w", err)
+	}
+	fromTC, err := loadHostToolchains(ctx, db, fromHR)
+	if err != nil {
+		return toolchainPair{}, err
+	}
+	toTC, err := loadHostToolchains(ctx, db, toHR)
+	if err != nil {
+		return toolchainPair{}, err
+	}
+	return toolchainPair{FromTC: fromTC, ToTC: toTC, FromName: fromHR.Hostname, ToName: toHR.Hostname}, nil
+}
+
+func loadHostToolchains(ctx context.Context, db *store.DB, hr store.HostRow) (toolchain.Toolchains, error) {
+	snaps, err := db.ListSnapshots(ctx, hr.MachineUUID)
+	if err != nil {
+		return toolchain.Toolchains{}, fmt.Errorf("list snapshots for %s: %w", hr.Hostname, err)
+	}
+	if len(snaps) == 0 {
+		return toolchain.Toolchains{}, fmt.Errorf("no snapshots stored for %s", hr.Hostname)
+	}
+	data, err := db.GetSnapshotJSON(ctx, snaps[0].ID)
+	if err != nil {
+		return toolchain.Toolchains{}, fmt.Errorf("load snapshot for %s: %w", hr.Hostname, err)
+	}
+	var s snapshot.Snapshot
+	if err := json.Unmarshal(data, &s); err != nil {
+		return toolchain.Toolchains{}, fmt.Errorf("parse snapshot for %s: %w", hr.Hostname, err)
+	}
+	return s.Toolchains, nil
+}
+
+func renderReconcile(w io.Writer, fromName, toName string, steps []fleet.ReconcileStep) {
+	if len(steps) == 0 {
+		fmt.Fprintf(w, "%s's toolchain already matches %s.\n", fromName, toName)
+		return
+	}
+	fmt.Fprintf(w, "DRY RUN — advisory plan to make %s match %s.\n", fromName, toName)
+	fmt.Fprintln(w, "Nothing here runs automatically; these are descriptions, not commands — verify each before acting.")
+	for i, s := range steps {
+		fmt.Fprintf(w, "%d) [%s/%s] %s\n", i+1, s.Category, s.Action, s.Detail)
+	}
+}

--- a/cmd/spectra/reconcile_test.go
+++ b/cmd/spectra/reconcile_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+func driftPair() toolchainPair {
+	return toolchainPair{
+		FromName: "my-mac",
+		ToName:   "ci-mac-1",
+		FromTC:   toolchain.Toolchains{JDKs: []toolchain.JDKInstall{{VersionMajor: 17, ReleaseString: "17.0.10"}}},
+		ToTC: toolchain.Toolchains{JDKs: []toolchain.JDKInstall{
+			{VersionMajor: 17, ReleaseString: "17.0.10"},
+			{VersionMajor: 21, ReleaseString: "21.0.6", Vendor: "Temurin", Source: "brew"},
+		}},
+	}
+}
+
+func TestRunReconcileRenders(t *testing.T) {
+	load := func(from, target string) (toolchainPair, error) { return driftPair(), nil }
+	var out, errBuf bytes.Buffer
+	if code := runReconcileWithIO([]string{"ci-mac-1"}, &out, &errBuf, load); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "DRY RUN") || !strings.Contains(s, "make my-mac match ci-mac-1") {
+		t.Errorf("missing DRY RUN header; got:\n%s", s)
+	}
+	if !strings.Contains(s, "JDK 21") {
+		t.Errorf("expected the JDK 21 install step; got:\n%s", s)
+	}
+	// steps must be descriptions, not runnable commands
+	if strings.Contains(s, "brew install temurin@21") {
+		t.Errorf("plan should not emit a runnable command; got:\n%s", s)
+	}
+}
+
+func TestRunReconcileIdentical(t *testing.T) {
+	same := toolchain.Toolchains{JDKs: []toolchain.JDKInstall{{VersionMajor: 21, ReleaseString: "21.0.6"}}}
+	load := func(from, target string) (toolchainPair, error) {
+		return toolchainPair{FromName: "a", ToName: "b", FromTC: same, ToTC: same}, nil
+	}
+	var out, errBuf bytes.Buffer
+	runReconcileWithIO([]string{"b"}, &out, &errBuf, load)
+	if !strings.Contains(out.String(), "already matches") {
+		t.Errorf("expected already-matches message; got:\n%s", out.String())
+	}
+}
+
+func TestRunReconcileNoArgs(t *testing.T) {
+	load := func(from, target string) (toolchainPair, error) { return driftPair(), nil }
+	var out, errBuf bytes.Buffer
+	if code := runReconcileWithIO(nil, &out, &errBuf, load); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}
+
+func TestRunReconcileLoadError(t *testing.T) {
+	load := func(from, target string) (toolchainPair, error) {
+		return toolchainPair{}, errors.New("no stored host named \"ci-mac-1\"")
+	}
+	var out, errBuf bytes.Buffer
+	if code := runReconcileWithIO([]string{"ci-mac-1"}, &out, &errBuf, load); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestRunReconcileJSON(t *testing.T) {
+	load := func(from, target string) (toolchainPair, error) { return driftPair(), nil }
+	var out, errBuf bytes.Buffer
+	runReconcileWithIO([]string{"--json", "ci-mac-1"}, &out, &errBuf, load)
+	if !strings.Contains(out.String(), `"category": "jdk"`) {
+		t.Errorf("json missing steps; got:\n%s", out.String())
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -52,6 +52,7 @@ The short `-v` is unaffected: it still means "show detection signals" for
 | `hosts` | List hosts known from stored snapshots |
 | `fleet` | Cross-host symptom rollups and version-drift matrices |
 | `bisect` | Find the snapshot where a rule started firing, and what changed alongside it |
+| `reconcile` | Print an advisory plan to make one host's toolchain match another's |
 | `status` | Check whether the local daemon is running |
 | `metrics` | Show stored process metrics from daemon sampling |
 | `sample` | Collect a user-space CPU sample of a process |
@@ -797,6 +798,27 @@ the cause**. `--host` selects the host (defaults to the only stored one);
 ```bash
 spectra bisect app-no-hardened-runtime
 spectra bisect app-no-hardened-runtime --host work-mac --json
+```
+
+## `spectra reconcile`
+
+Turns toolchain drift from a read-only diff into an actionable checklist:
+an **advisory, print-only** plan to make one host's toolchain match
+another's, over the snapshots in the local store. It compares JDKs (by
+major, naming the target's vendor/release), Homebrew formulae (install /
+upgrade to the target version), the language runtimes, and `JAVA_HOME` /
+active-JVM-manager differences.
+
+Every line is a **description, not a runnable command** — install steps
+name the target's vendor/cask/release rather than assert an exact command
+that may not exist on your tap. Nothing is executed. `--from` selects the
+source host (defaults to this machine); `--json` emits the structured plan.
+
+### Examples
+
+```bash
+spectra reconcile ci-mac-1
+spectra reconcile ci-mac-1 --from my-laptop --json
 ```
 
 ## `spectra fleet`

--- a/internal/fleet/reconcile.go
+++ b/internal/fleet/reconcile.go
@@ -1,0 +1,159 @@
+package fleet
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+// ReconcileStep is one advisory step in a reconciliation plan. Every step is
+// descriptive text, never a runnable command — the plan is print-only.
+type ReconcileStep struct {
+	Category string `json:"category"` // jdk, brew, node, python, go, ruby, env
+	Action   string `json:"action"`   // install, upgrade, note
+	Detail   string `json:"detail"`
+}
+
+// Reconcile produces an ordered, advisory set of steps to make the `from`
+// toolchain match `to`. It names target vendors/releases rather than asserting
+// exact install commands, because the output is print-only and users may paste
+// it into a shell — nothing here is meant to be executed as-is.
+func Reconcile(from, to toolchain.Toolchains) []ReconcileStep {
+	var steps []ReconcileStep
+	steps = append(steps, reconcileJDKs(from, to)...)
+	steps = append(steps, reconcileBrew(from, to)...)
+	steps = append(steps, reconcileRuntime("node", from.Node, to.Node)...)
+	steps = append(steps, reconcileRuntime("python", from.Python, to.Python)...)
+	steps = append(steps, reconcileRuntime("go", from.Go, to.Go)...)
+	steps = append(steps, reconcileRuntime("ruby", from.Ruby, to.Ruby)...)
+	steps = append(steps, reconcileEnv(from, to)...)
+	return steps
+}
+
+func reconcileJDKs(from, to toolchain.Toolchains) []ReconcileStep {
+	fromMajors := jdkMajorSet(from.JDKs)
+	toByMajor := jdkByMajor(to.JDKs)
+	var steps []ReconcileStep
+	for _, m := range sortedInts(toByMajor) {
+		if !fromMajors[m] {
+			j := toByMajor[m]
+			steps = append(steps, ReconcileStep{"jdk", "install",
+				fmt.Sprintf("install a JDK %d to match target (target has %s, vendor %s, via %s)",
+					m, jdkRelease(j), orNA(j.Vendor), orNA(j.Source))})
+		}
+	}
+	toMajors := jdkMajorSet(to.JDKs)
+	for _, m := range sortedInts(jdkByMajor(from.JDKs)) {
+		if !toMajors[m] {
+			steps = append(steps, ReconcileStep{"jdk", "note",
+				fmt.Sprintf("you have JDK %d that the target does not", m)})
+		}
+	}
+	return steps
+}
+
+func reconcileBrew(from, to toolchain.Toolchains) []ReconcileStep {
+	fromF := brewByName(from.Brew.Formulae)
+	tf := append([]toolchain.BrewFormula(nil), to.Brew.Formulae...)
+	sort.Slice(tf, func(i, j int) bool { return tf[i].Name < tf[j].Name })
+	var steps []ReconcileStep
+	for _, f := range tf {
+		cur, ok := fromF[f.Name]
+		switch {
+		case !ok:
+			steps = append(steps, ReconcileStep{"brew", "install",
+				fmt.Sprintf("install Homebrew formula %s (target %s)", f.Name, orNA(f.Version))})
+		case f.Version != "" && cur.Version != f.Version:
+			steps = append(steps, ReconcileStep{"brew", "upgrade",
+				fmt.Sprintf("align Homebrew formula %s: target %s, you have %s", f.Name, f.Version, orNA(cur.Version))})
+		}
+	}
+	return steps
+}
+
+func reconcileRuntime(lang string, from, to []toolchain.RuntimeInstall) []ReconcileStep {
+	tv := activeRuntimeVersion(to)
+	fv := activeRuntimeVersion(from)
+	if tv == "" || tv == fv {
+		return nil
+	}
+	return []ReconcileStep{{lang, "note",
+		fmt.Sprintf("target uses %s %s; you have %s", lang, tv, orNA(fv))}}
+}
+
+func reconcileEnv(from, to toolchain.Toolchains) []ReconcileStep {
+	var steps []ReconcileStep
+	if to.Env.JavaHome != "" && from.Env.JavaHome != to.Env.JavaHome {
+		steps = append(steps, ReconcileStep{"env", "note",
+			fmt.Sprintf("target JAVA_HOME points at %s; yours is %s", to.Env.JavaHome, orNA(from.Env.JavaHome))})
+	}
+	if to.ActiveJVMManager != "" && from.ActiveJVMManager != to.ActiveJVMManager {
+		steps = append(steps, ReconcileStep{"env", "note",
+			fmt.Sprintf("target's active JVM manager is %s; yours is %s", to.ActiveJVMManager, orNA(from.ActiveJVMManager))})
+	}
+	return steps
+}
+
+// --- helpers ---
+
+func jdkMajorSet(jdks []toolchain.JDKInstall) map[int]bool {
+	m := map[int]bool{}
+	for _, j := range jdks {
+		m[j.VersionMajor] = true
+	}
+	return m
+}
+
+func jdkByMajor(jdks []toolchain.JDKInstall) map[int]toolchain.JDKInstall {
+	m := map[int]toolchain.JDKInstall{}
+	for _, j := range jdks {
+		if _, ok := m[j.VersionMajor]; !ok {
+			m[j.VersionMajor] = j
+		}
+	}
+	return m
+}
+
+func sortedInts(m map[int]toolchain.JDKInstall) []int {
+	out := make([]int, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func brewByName(fs []toolchain.BrewFormula) map[string]toolchain.BrewFormula {
+	m := map[string]toolchain.BrewFormula{}
+	for _, f := range fs {
+		m[f.Name] = f
+	}
+	return m
+}
+
+func activeRuntimeVersion(rs []toolchain.RuntimeInstall) string {
+	for _, r := range rs {
+		if r.Active {
+			return r.Version
+		}
+	}
+	if len(rs) > 0 {
+		return rs[0].Version
+	}
+	return ""
+}
+
+func jdkRelease(j toolchain.JDKInstall) string {
+	if j.ReleaseString != "" {
+		return j.ReleaseString
+	}
+	return fmt.Sprintf("%d.%d.%d", j.VersionMajor, j.VersionMinor, j.VersionPatch)
+}
+
+func orNA(s string) string {
+	if s == "" {
+		return "n/a"
+	}
+	return s
+}

--- a/internal/fleet/reconcile_test.go
+++ b/internal/fleet/reconcile_test.go
@@ -1,0 +1,79 @@
+package fleet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+func TestReconcileInstallsMissingJDK(t *testing.T) {
+	from := toolchain.Toolchains{JDKs: []toolchain.JDKInstall{{VersionMajor: 17, ReleaseString: "17.0.10", Vendor: "Zulu"}}}
+	to := toolchain.Toolchains{JDKs: []toolchain.JDKInstall{
+		{VersionMajor: 17, ReleaseString: "17.0.10", Vendor: "Zulu"},
+		{VersionMajor: 21, ReleaseString: "21.0.6", Vendor: "Temurin", Source: "brew"},
+	}}
+	steps := Reconcile(from, to)
+	if len(steps) != 1 {
+		t.Fatalf("steps = %d, want 1: %+v", len(steps), steps)
+	}
+	s := steps[0]
+	if s.Category != "jdk" || s.Action != "install" || !strings.Contains(s.Detail, "JDK 21") || !strings.Contains(s.Detail, "Temurin") {
+		t.Errorf("step = %+v, want install JDK 21 (Temurin)", s)
+	}
+}
+
+func TestReconcileBrewInstallAndUpgrade(t *testing.T) {
+	from := toolchain.Toolchains{Brew: toolchain.BrewInventory{Formulae: []toolchain.BrewFormula{{Name: "foo", Version: "1.0"}}}}
+	to := toolchain.Toolchains{Brew: toolchain.BrewInventory{Formulae: []toolchain.BrewFormula{
+		{Name: "foo", Version: "2.0"},
+		{Name: "bar", Version: "3.1"},
+	}}}
+	steps := Reconcile(from, to)
+	var install, upgrade bool
+	for _, s := range steps {
+		if s.Category == "brew" && s.Action == "install" && strings.Contains(s.Detail, "bar") {
+			install = true
+		}
+		if s.Category == "brew" && s.Action == "upgrade" && strings.Contains(s.Detail, "foo") && strings.Contains(s.Detail, "2.0") {
+			upgrade = true
+		}
+	}
+	if !install || !upgrade {
+		t.Errorf("expected a brew install(bar) and upgrade(foo->2.0); got %+v", steps)
+	}
+}
+
+func TestReconcileRuntimeAndEnv(t *testing.T) {
+	from := toolchain.Toolchains{
+		Node: []toolchain.RuntimeInstall{{Version: "18.19.0", Active: true}},
+		Env:  toolchain.EnvSnapshot{JavaHome: "/old/jdk17"},
+	}
+	to := toolchain.Toolchains{
+		Node: []toolchain.RuntimeInstall{{Version: "20.11.0", Active: true}},
+		Env:  toolchain.EnvSnapshot{JavaHome: "/new/jdk21"},
+	}
+	steps := Reconcile(from, to)
+	var node, java bool
+	for _, s := range steps {
+		if s.Category == "node" && strings.Contains(s.Detail, "20.11.0") {
+			node = true
+		}
+		if s.Category == "env" && strings.Contains(s.Detail, "JAVA_HOME") && strings.Contains(s.Detail, "/new/jdk21") {
+			java = true
+		}
+	}
+	if !node || !java {
+		t.Errorf("expected node-version and JAVA_HOME notes; got %+v", steps)
+	}
+}
+
+func TestReconcileIdenticalIsEmpty(t *testing.T) {
+	tc := toolchain.Toolchains{
+		JDKs: []toolchain.JDKInstall{{VersionMajor: 21, ReleaseString: "21.0.6"}},
+		Brew: toolchain.BrewInventory{Formulae: []toolchain.BrewFormula{{Name: "foo", Version: "1.0"}}},
+	}
+	if steps := Reconcile(tc, tc); len(steps) != 0 {
+		t.Errorf("identical toolchains should yield no steps, got %+v", steps)
+	}
+}


### PR DESCRIPTION
## What

Adds **`fleet.Reconcile`** + **`spectra reconcile <target-host> [--from <host>]`** — turns toolchain drift from a read-only diff into an actionable checklist: an advisory plan to make one host's toolchain match another's. "Works on my machine" becomes a fix plan.

## How

- `fleet.Reconcile(from, to toolchain.Toolchains)` is a pure reducer that emits ordered steps: install for JDK majors / Homebrew formulae the target has and the source lacks, upgrade for version differences, and notes for extra JDKs, differing runtime versions (Node/Python/Go/Ruby), and `JAVA_HOME` / active-JVM-manager drift. Identical toolchains yield an empty plan.
- `spectra reconcile <target>` loads the target and source (`--from`, default = this machine) latest snapshots from the store and prints the plan. `--json` structured.

**Safety — the whole point (per the vetting note):** the plan is strictly **print-only**. Every line is a **description, not a runnable command** — install steps name the target's vendor/cask/release rather than assert an exact command that may not exist on the user's tap. Nothing is executed, and a test asserts the output is not a pasteable `brew install …` line. `path-shadows-active-runtime` already exists as a rule and is referenced, not duplicated.

## Scope (v1)

Toolchain reconciliation (JDK / brew / runtimes / JAVA_HOME) over two stored hosts. Live fan-out pull and MCP are follow-ups.

## Testing

- `fleet`: installs a missing JDK (naming the target's vendor), brew install + upgrade, runtime + `JAVA_HOME` notes, and identical-is-empty.
- CLI: DRY-RUN render (asserts it is *not* a runnable command), already-matches, no-args, load-error, and `--json` — via an injected loader.
- `make vet complexity lint security docs-validate test` green locally (55 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #366
