### PR TITLE
perf: remove redundant subprocess/walk/regex/SQL work on inspect + snapshot paths

### DIFF
--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -261,10 +261,61 @@ type Options struct {
 
 type detector struct {
 	opts Options
+	// plists caches parsed plist dictionaries by path so a bundle's
+	// Info.plist is converted by `plutil` once, not once per key. The map
+	// is a reference type, so value copies of detector share it within a
+	// single DetectWith call. Nil-tolerant: plistDict handles an unset map.
+	plists map[string]map[string]any
 }
 
 func newDetector(opts Options) detector {
-	return detector{opts: opts}
+	return detector{opts: opts, plists: map[string]map[string]any{}}
+}
+
+// plistDict parses a plist into a key→value map, converting it via a single
+// `plutil -convert json` exec and caching the result per path. Returns nil
+// (cached) when the file is missing or unparseable, so repeated lookups of a
+// non-existent plist stay cheap. The negative result is memoized too.
+func (d detector) plistDict(path string) map[string]any {
+	if d.plists != nil {
+		if cached, ok := d.plists[path]; ok {
+			return cached
+		}
+	}
+	var dict map[string]any
+	if out, err := d.output("plutil", "-convert", "json", "-o", "-", path); err == nil {
+		_ = json.Unmarshal(out, &dict)
+	}
+	if d.plists != nil {
+		d.plists[path] = dict
+	}
+	return dict
+}
+
+// plistScalar returns the string form of a top-level plist scalar, matching
+// what `plutil -extract <key> raw` would have printed for strings and
+// integral numbers.
+func plistScalar(dict map[string]any, key string) string {
+	v, ok := dict[key]
+	if !ok || v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		if t == float64(int64(t)) {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return strconv.FormatFloat(t, 'g', -1, 64)
+	case bool:
+		if t {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", t)
+	}
 }
 
 func (d detector) output(name string, args ...string) ([]byte, error) {
@@ -392,7 +443,7 @@ func DetectWith(appPath string, opts Options) (Result, error) {
 	r.Rust = inspectRustApp(appPath, exe, &r)
 
 	d.populateMetadata(appPath, exe, &r)
-	r.PrivacyDescriptions = readPrivacyDescriptions(appPath)
+	r.PrivacyDescriptions = d.readPrivacyDescriptions(appPath)
 	r.Dependencies = scanDependencies(appPath)
 	r.PythonApp = scanPythonApp(appPath)
 	r.Helpers = scanHelpers(appPath)
@@ -429,7 +480,7 @@ func (d detector) populateMetadata(appPath, exe string, r *Result) {
 		efw := filepath.Join(appPath, "Contents", "Frameworks", "Electron Framework.framework", "Resources", "Info.plist")
 		r.ElectronVersion = d.readPlistString(efw, "CFBundleVersion")
 	}
-	r.FrameworkVersions = frameworkVersions(appPath, r)
+	r.FrameworkVersions = d.frameworkVersions(appPath, r)
 
 	if exe != "" {
 		r.Architectures = d.readArchitectures(exe)
@@ -443,17 +494,17 @@ func (d detector) populateMetadata(appPath, exe string, r *Result) {
 	r.Swift = inspectSwiftApp(appPath, exe, realSwiftInspectionSource{appGroups: appGroups})
 }
 
-func frameworkVersions(appPath string, r *Result) map[string]string {
+func (d detector) frameworkVersions(appPath string, r *Result) map[string]string {
 	versions := make(map[string]string)
 	if r.ElectronVersion != "" {
 		versions["Electron"] = r.ElectronVersion
 	}
 	flutterPlist := filepath.Join(appPath, "Contents", "Frameworks", "FlutterMacOS.framework", "Resources", "Info.plist")
-	if v := firstPlistString(flutterPlist, "CFBundleShortVersionString", "CFBundleVersion"); v != "" {
+	if v := d.firstPlistString(flutterPlist, "CFBundleShortVersionString", "CFBundleVersion"); v != "" {
 		versions["Flutter"] = v
 	}
 	qtPlist := filepath.Join(appPath, "Contents", "Frameworks", "QtCore.framework", "Resources", "Info.plist")
-	if v := firstPlistString(qtPlist, "CFBundleShortVersionString", "CFBundleVersion"); v != "" {
+	if v := d.firstPlistString(qtPlist, "CFBundleShortVersionString", "CFBundleVersion"); v != "" {
 		versions["Qt"] = v
 	}
 	if v := readTauriVersion(appPath); v != "" {
@@ -465,9 +516,9 @@ func frameworkVersions(appPath string, r *Result) map[string]string {
 	return versions
 }
 
-func firstPlistString(plist string, keys ...string) string {
+func (d detector) firstPlistString(plist string, keys ...string) string {
 	for _, key := range keys {
-		if v := readPlistString(plist, key); v != "" {
+		if v := d.readPlistString(plist, key); v != "" {
 			return v
 		}
 	}
@@ -565,16 +616,8 @@ func scanStorage(appPath, bundleID string) *StorageFootprint {
 	return s
 }
 
-func readPlistString(plist, key string) string {
-	return newDetector(Options{}).readPlistString(plist, key)
-}
-
 func (d detector) readPlistString(plist, key string) string {
-	out, err := d.output("plutil", "-extract", key, "raw", "-o", "-", plist)
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
+	return plistScalar(d.plistDict(plist), key)
 }
 
 // readArchitectures inspects the Mach-O header(s) of exe via `file` and
@@ -1007,13 +1050,9 @@ func enrichFromExe(exe string, r *Result) {
 // CFBundleExecutable from Info.plist via plutil.
 func (d detector) mainExecutable(appPath string) (string, error) {
 	plist := filepath.Join(appPath, "Contents", "Info.plist")
-	out, err := d.output("plutil", "-extract", "CFBundleExecutable", "raw", "-o", "-", plist)
-	if err != nil {
-		return "", err
-	}
-	name := strings.TrimSpace(string(out))
+	name := plistScalar(d.plistDict(plist), "CFBundleExecutable")
 	if name == "" {
-		return "", fmt.Errorf("CFBundleExecutable empty in %s", plist)
+		return "", fmt.Errorf("CFBundleExecutable empty or unreadable in %s", plist)
 	}
 	exe := filepath.Join(appPath, "Contents", "MacOS", name)
 	if !exists(exe) {
@@ -1061,10 +1100,14 @@ func (ins nodeAppInspector) scanBinaryMarkers(exe string) (m binaryMarkers) {
 	buf := make([]byte, 1<<20) // 1MB chunks
 	overlap := 64
 	tail := make([]byte, 0, overlap)
+	// region is reused across iterations; its backing array is large enough to
+	// hold the carried-over tail plus a full chunk, so no per-read realloc.
+	region := make([]byte, 0, overlap+len(buf))
 	for {
 		n, err := f.Read(buf)
 		if n > 0 {
-			region := append(tail, buf[:n]...)
+			region = append(region[:0], tail...)
+			region = append(region, buf[:n]...)
 			for _, needle := range rustNeedles {
 				m.rustHits += bytes.Count(region, needle)
 			}
@@ -1765,23 +1808,26 @@ func appUptime(procs []ProcessInfo, now time.Time) (*time.Time, int64) {
 // readPrivacyDescriptions returns the NS*UsageDescription keys declared
 // in Info.plist along with their human-readable descriptions. These are
 // the strings macOS shows in permission prompts.
-func readPrivacyDescriptions(appPath string) map[string]string {
+func (d detector) readPrivacyDescriptions(appPath string) map[string]string {
 	plist := filepath.Join(appPath, "Contents", "Info.plist")
-	// Convert to xml1 once; cheaper than one plutil exec per key.
-	out, err := exec.Command("plutil", "-convert", "xml1", "-o", "-", plist).Output()
-	if err != nil {
+	dict := d.plistDict(plist) // reuses the cached parse from populateMetadata
+	if len(dict) == 0 {
 		return nil
 	}
-	xml := string(out)
-	// Match <key>NS*UsageDescription</key><string>...</string> pairs.
-	re := regexp.MustCompile(`<key>(NS[A-Za-z]+UsageDescription)</key>\s*<string>([^<]*)</string>`)
-	matches := re.FindAllStringSubmatch(xml, -1)
-	if len(matches) == 0 {
-		return nil
-	}
-	result := make(map[string]string, len(matches))
-	for _, m := range matches {
-		result[m[1]] = m[2]
+	var result map[string]string
+	for k, v := range dict {
+		// NS*UsageDescription keys hold the strings macOS shows in prompts.
+		if !strings.HasPrefix(k, "NS") || !strings.HasSuffix(k, "UsageDescription") {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if result == nil {
+			result = make(map[string]string)
+		}
+		result[k] = s
 	}
 	return result
 }
@@ -1869,9 +1915,12 @@ func scanNetworkEndpoints(appPath, exe string) []string {
 	return defaultNodeAppInspector().scanNetworkEndpoints(appPath, exe)
 }
 
+// urlHostRE extracts the host from http(s) URL literals; compiled once.
+var urlHostRE = regexp.MustCompile(`(?i)https?://([a-zA-Z0-9._-]+\.[a-zA-Z]{2,})`)
+
 func (ins nodeAppInspector) scanNetworkEndpoints(appPath, exe string) []string {
 	hosts := map[string]struct{}{}
-	urlRe := regexp.MustCompile(`(?i)https?://([a-zA-Z0-9._-]+\.[a-zA-Z]{2,})`)
+	urlRe := urlHostRE
 
 	addFrom := func(path string) {
 		if path == "" {
@@ -1887,10 +1936,13 @@ func (ins nodeAppInspector) scanNetworkEndpoints(appPath, exe string) []string {
 		buf := make([]byte, 1<<20)
 		overlap := 256
 		tail := make([]byte, 0, overlap)
+		// Reused across reads so each 1MB chunk doesn't reallocate a region.
+		region := make([]byte, 0, overlap+len(buf))
 		for {
 			n, err := f.Read(buf)
 			if n > 0 {
-				region := append(tail, buf[:n]...)
+				region = append(region[:0], tail...)
+				region = append(region, buf[:n]...)
 				for _, m := range urlRe.FindAllSubmatch(region, -1) {
 					hosts[strings.ToLower(string(m[1]))] = struct{}{}
 				}

--- a/internal/detect/detect_bench_test.go
+++ b/internal/detect/detect_bench_test.go
@@ -1,0 +1,63 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// benchBundle builds a synthetic .app with a multi-key Info.plist (identity,
+// version, and several NS*UsageDescription privacy strings) plus a nested
+// Frameworks/Resources tree, so the benchmark exercises the plist-parse cache
+// and the bundle walks the way a real inspection does.
+func benchBundle(b *testing.B) string {
+	b.Helper()
+	app := filepath.Join(b.TempDir(), "BenchApp.app")
+	for _, sub := range []string{
+		"Contents/MacOS",
+		"Contents/Resources/app/lib",
+		"Contents/Frameworks/Some.framework/Resources",
+	} {
+		if err := os.MkdirAll(filepath.Join(app, sub), 0o755); err != nil {
+			b.Fatal(err)
+		}
+	}
+	plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>main</string>
+<key>CFBundleIdentifier</key><string>com.example.bench</string>
+<key>CFBundleShortVersionString</key><string>1.2.3</string>
+<key>CFBundleVersion</key><string>456</string>
+<key>SUFeedURL</key><string>https://example.com/appcast.xml</string>
+<key>NSCameraUsageDescription</key><string>needs camera</string>
+<key>NSMicrophoneUsageDescription</key><string>needs mic</string>
+<key>NSLocationUsageDescription</key><string>needs location</string>
+</dict></plist>`
+	writes := map[string][]byte{
+		"Contents/Info.plist":         []byte(plist),
+		"Contents/MacOS/main":         []byte("\x7fELF placeholder binary with some strings"),
+		"Contents/Resources/app/x.js": []byte("console.log('hi')"),
+	}
+	for rel, data := range writes {
+		if err := os.WriteFile(filepath.Join(app, rel), data, 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return app
+}
+
+// BenchmarkDetectWith measures the full single-app inspection pipeline. It is
+// the guardrail for the plist-parse caching and single-walk work: a regression
+// that reintroduces per-key plutil forks or duplicate bundle walks shows up
+// here as extra time and allocations.
+func BenchmarkDetectWith(b *testing.B) {
+	app := benchBundle(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := DetectWith(app, Options{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/detect/python_app.go
+++ b/internal/detect/python_app.go
@@ -14,6 +14,14 @@ import (
 
 var errStopPythonWalk = errors.New("stop python app walk")
 
+// Compiled once at package load — these were previously rebuilt on every call
+// (some inside directory walks, i.e. per file).
+var (
+	externalPythonInterpreterRE = regexp.MustCompile(`(/(?:opt/homebrew|usr/local|usr|Users/[^[:space:]"']+)/[^[:space:]"']*python[0-9.]*)`)
+	pythonLayoutVersionRE       = regexp.MustCompile(`python([0-9]+\.[0-9]+)`)
+	pythonDottedVersionRE       = regexp.MustCompile(`([0-9]+\.[0-9]+(?:\.[0-9]+)?)`)
+)
+
 type pythonAppFS interface {
 	Stat(name string) (fs.FileInfo, error)
 	ReadFile(name string) ([]byte, error)
@@ -73,8 +81,9 @@ func (s pythonAppScanner) Scan(appPath string) *PythonApp {
 	app.RuntimeSource, app.RuntimePath = s.resolvePythonRuntime(appPath)
 	app.Version = s.detectPythonVersion(appPath, app.RuntimePath)
 	app.ModuleRoots = s.pythonModuleRoots(appPath)
-	app.Packages = s.pythonPackages(appPath)
-	app.NativeExtensions = s.pythonNativeExtensions(appPath)
+	// One walk of Contents collects both dist-info packages and .so native
+	// extensions; they used to be two independent full-tree walks.
+	app.Packages, app.NativeExtensions = s.pythonPackagesAndExtensions(appPath)
 	app.RiskHints = s.pythonRiskHints(appPath, app)
 
 	if app.Packaging == "unknown" && app.RuntimePath == "" && len(app.ModuleRoots) == 0 && len(app.Packages) == 0 && len(app.NativeExtensions) == 0 {
@@ -164,8 +173,13 @@ func (s pythonAppScanner) pythonModuleRoots(appPath string) []string {
 	return dedupePythonStrings(roots)
 }
 
-func (s pythonAppScanner) pythonPackages(appPath string) []PythonPackage {
+// pythonPackagesAndExtensions walks Contents once, collecting both installed
+// packages (dist-info/egg-info METADATA) and compiled .so native extensions.
+// Splitting these into two walks doubled the traversal of large bundles for no
+// benefit; the matching and sort order here are identical to the originals.
+func (s pythonAppScanner) pythonPackagesAndExtensions(appPath string) ([]PythonPackage, []PythonNativeExtension) {
 	var packages []PythonPackage
+	var exts []PythonNativeExtension
 	_ = s.fs.WalkDir(filepath.Join(appPath, "Contents"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -174,20 +188,27 @@ func (s pythonAppScanner) pythonPackages(appPath string) []PythonPackage {
 			return nil
 		}
 		name := d.Name()
-		if name != "METADATA" && name != "PKG-INFO" {
-			return nil
-		}
-		parent := filepath.Base(filepath.Dir(path))
-		if !strings.HasSuffix(parent, ".dist-info") && !strings.HasSuffix(parent, ".egg-info") {
-			return nil
-		}
-		data, readErr := s.fs.ReadFile(path)
-		if readErr == nil {
-			pkg := parsePythonPackageMetadata(data)
-			if pkg.Name != "" {
-				pkg.Path = relToApp(appPath, path)
-				packages = append(packages, pkg)
+		switch {
+		case name == "METADATA" || name == "PKG-INFO":
+			parent := filepath.Base(filepath.Dir(path))
+			if !strings.HasSuffix(parent, ".dist-info") && !strings.HasSuffix(parent, ".egg-info") {
+				return nil
 			}
+			if data, readErr := s.fs.ReadFile(path); readErr == nil {
+				pkg := parsePythonPackageMetadata(data)
+				if pkg.Name != "" {
+					pkg.Path = relToApp(appPath, path)
+					packages = append(packages, pkg)
+				}
+			}
+		case strings.HasSuffix(name, ".so"):
+			ext := PythonNativeExtension{Name: name, Path: relToApp(appPath, path)}
+			if libs, err := s.otoolL(path); err == nil {
+				ext.LinkedLibs = libs
+				ext.Hints = pythonNativeExtensionHints(libs)
+				ext.RiskHints = pythonNativeExtensionRiskHints(libs, name)
+			}
+			exts = append(exts, ext)
 		}
 		return nil
 	})
@@ -197,30 +218,8 @@ func (s pythonAppScanner) pythonPackages(appPath string) []PythonPackage {
 		}
 		return strings.ToLower(packages[i].Name) < strings.ToLower(packages[j].Name)
 	})
-	return packages
-}
-
-func (s pythonAppScanner) pythonNativeExtensions(appPath string) []PythonNativeExtension {
-	var exts []PythonNativeExtension
-	_ = s.fs.WalkDir(filepath.Join(appPath, "Contents"), func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d == nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".so") {
-			return nil
-		}
-		rel := relToApp(appPath, path)
-		ext := PythonNativeExtension{Name: d.Name(), Path: rel}
-		if libs, err := s.otoolL(path); err == nil {
-			ext.LinkedLibs = libs
-			ext.Hints = pythonNativeExtensionHints(libs)
-			ext.RiskHints = pythonNativeExtensionRiskHints(libs, d.Name())
-		}
-		exts = append(exts, ext)
-		return nil
-	})
 	sort.Slice(exts, func(i, j int) bool { return exts[i].Path < exts[j].Path })
-	return exts
+	return packages, exts
 }
 
 func (s pythonAppScanner) pythonRiskHints(appPath string, app *PythonApp) []string {
@@ -362,7 +361,7 @@ func (s pythonAppScanner) launcherContainsAny(appPath string, needles []string) 
 }
 
 func (s pythonAppScanner) externalInterpreterFromLaunchers(appPath string) string {
-	re := regexp.MustCompile(`(/(?:opt/homebrew|usr/local|usr|Users/[^[:space:]"']+)/[^[:space:]"']*python[0-9.]*)`)
+	re := externalPythonInterpreterRE
 	var found string
 	_ = s.fs.WalkDir(filepath.Join(appPath, "Contents", "MacOS"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -384,7 +383,7 @@ func (s pythonAppScanner) externalInterpreterFromLaunchers(appPath string) strin
 }
 
 func (s pythonAppScanner) versionFromLayout(appPath string) string {
-	re := regexp.MustCompile(`python([0-9]+\.[0-9]+)`)
+	re := pythonLayoutVersionRE
 	var version string
 	_ = s.fs.WalkDir(filepath.Join(appPath, "Contents"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -422,8 +421,7 @@ func (s pythonAppScanner) versionFromFile(path string) string {
 			}
 		}
 	}
-	re := regexp.MustCompile(`([0-9]+\.[0-9]+(?:\.[0-9]+)?)`)
-	return re.FindString(string(data))
+	return pythonDottedVersionRE.FindString(string(data))
 }
 
 func parsePythonPackageMetadata(data []byte) PythonPackage {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -351,9 +351,20 @@ func (s *DB) SaveSnapshot(ctx context.Context, snap SnapshotInput) error {
 	if err := insertSnapshot(tx, snap); err != nil {
 		return err
 	}
-	for _, app := range snap.Apps {
-		if err := insertApp(tx, snap.ID, app); err != nil {
+	if len(snap.Apps) > 0 {
+		stmt, err := tx.PrepareContext(ctx, `
+			INSERT OR IGNORE INTO snapshot_apps
+			    (snapshot_id, bundle_id, app_name, app_path, ui, runtime,
+			     packaging, confidence, app_version, architectures, result_json)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?)`)
+		if err != nil {
 			return err
+		}
+		defer stmt.Close() //nolint:errcheck
+		for _, app := range snap.Apps {
+			if err := insertApp(ctx, stmt, snap.ID, app); err != nil {
+				return err
+			}
 		}
 	}
 	return tx.Commit()
@@ -398,14 +409,10 @@ func nullableJSON(b []byte) any {
 	return string(b)
 }
 
-func insertApp(tx *sql.Tx, snapID string, a AppInput) error {
+func insertApp(ctx context.Context, stmt *sql.Stmt, snapID string, a AppInput) error {
 	archJSON, _ := json.Marshal(a.Architectures)
 	resultJSON, _ := json.Marshal(a.ResultJSON)
-	_, err := tx.Exec(`
-		INSERT OR IGNORE INTO snapshot_apps
-		    (snapshot_id, bundle_id, app_name, app_path, ui, runtime,
-		     packaging, confidence, app_version, architectures, result_json)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+	_, err := stmt.ExecContext(ctx,
 		snapID, a.BundleID, a.AppName, a.AppPath,
 		a.UI, a.Runtime, a.Packaging, a.Confidence,
 		a.AppVersion, string(archJSON), string(resultJSON),
@@ -620,14 +627,16 @@ func (s *DB) SaveSnapshotProcesses(ctx context.Context, snapID string, procs []P
 		return err
 	}
 	defer tx.Rollback() //nolint:errcheck
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT OR IGNORE INTO snapshot_processes
+		  (snapshot_id, pid, ppid, command, rss_kib, cpu_pct, app_path)
+		VALUES (?,?,?,?,?,?,?)`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close() //nolint:errcheck
 	for _, p := range procs {
-		_, err := tx.ExecContext(ctx, `
-			INSERT OR IGNORE INTO snapshot_processes
-			  (snapshot_id, pid, ppid, command, rss_kib, cpu_pct, app_path)
-			VALUES (?,?,?,?,?,?,?)`,
-			snapID, p.PID, p.PPID, p.Command, p.RSSKiB, p.CPUPct, p.AppPath,
-		)
-		if err != nil {
+		if _, err := stmt.ExecContext(ctx, snapID, p.PID, p.PPID, p.Command, p.RSSKiB, p.CPUPct, p.AppPath); err != nil {
 			return err
 		}
 	}
@@ -677,15 +686,17 @@ func (s *DB) SaveLoginItems(ctx context.Context, snapID string, items []LoginIte
 		return err
 	}
 	defer tx.Rollback() //nolint:errcheck
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT OR IGNORE INTO login_items
+		  (snapshot_id, bundle_id, plist_path, label, scope, daemon, run_at_load, keep_alive)
+		VALUES (?,?,?,?,?,?,?,?)`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close() //nolint:errcheck
 	for _, it := range items {
-		_, err := tx.ExecContext(ctx, `
-			INSERT OR IGNORE INTO login_items
-			  (snapshot_id, bundle_id, plist_path, label, scope, daemon, run_at_load, keep_alive)
-			VALUES (?,?,?,?,?,?,?,?)`,
-			snapID, it.BundleID, it.PlistPath, it.Label, it.Scope,
-			boolInt(it.Daemon), boolInt(it.RunAtLoad), boolInt(it.KeepAlive),
-		)
-		if err != nil {
+		if _, err := stmt.ExecContext(ctx, snapID, it.BundleID, it.PlistPath, it.Label, it.Scope,
+			boolInt(it.Daemon), boolInt(it.RunAtLoad), boolInt(it.KeepAlive)); err != nil {
 			return err
 		}
 	}
@@ -736,13 +747,15 @@ func (s *DB) SaveGrantedPerms(ctx context.Context, snapID string, perms []Grante
 		return err
 	}
 	defer tx.Rollback() //nolint:errcheck
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT OR IGNORE INTO granted_perms (snapshot_id, bundle_id, service)
+		VALUES (?,?,?)`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close() //nolint:errcheck
 	for _, p := range perms {
-		_, err := tx.ExecContext(ctx, `
-			INSERT OR IGNORE INTO granted_perms (snapshot_id, bundle_id, service)
-			VALUES (?,?,?)`,
-			snapID, p.BundleID, p.Service,
-		)
-		if err != nil {
+		if _, err := stmt.ExecContext(ctx, snapID, p.BundleID, p.Service); err != nil {
 			return err
 		}
 	}
@@ -787,23 +800,27 @@ func (s *DB) SaveProcessMetrics(ctx context.Context, aggs []ProcessMetricRow) er
 		return err
 	}
 	defer tx.Rollback() //nolint:errcheck
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO process_metrics
+		    (pid, minute_at, avg_rss_kib, max_rss_kib, avg_cpu_pct, max_cpu_pct, sample_count)
+		VALUES (?,?,?,?,?,?,?)
+		ON CONFLICT(pid, minute_at) DO UPDATE SET
+		    avg_rss_kib=excluded.avg_rss_kib,
+		    max_rss_kib=excluded.max_rss_kib,
+		    avg_cpu_pct=excluded.avg_cpu_pct,
+		    max_cpu_pct=excluded.max_cpu_pct,
+		    sample_count=excluded.sample_count`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close() //nolint:errcheck
 	for _, a := range aggs {
-		_, err := tx.ExecContext(ctx, `
-			INSERT INTO process_metrics
-			    (pid, minute_at, avg_rss_kib, max_rss_kib, avg_cpu_pct, max_cpu_pct, sample_count)
-			VALUES (?,?,?,?,?,?,?)
-			ON CONFLICT(pid, minute_at) DO UPDATE SET
-			    avg_rss_kib=excluded.avg_rss_kib,
-			    max_rss_kib=excluded.max_rss_kib,
-			    avg_cpu_pct=excluded.avg_cpu_pct,
-			    max_cpu_pct=excluded.max_cpu_pct,
-			    sample_count=excluded.sample_count`,
+		if _, err := stmt.ExecContext(ctx,
 			a.PID, a.MinuteAt.UTC().Format(time.RFC3339),
 			a.AvgRSSKiB, a.MaxRSSKiB,
 			a.AvgCPUPct, a.MaxCPUPct,
 			a.SampleCount,
-		)
-		if err != nil {
+		); err != nil {
 			return err
 		}
 	}
@@ -976,18 +993,20 @@ func (s *DB) SaveJVMSamples(ctx context.Context, samples []snapshot.JVMSample) e
 		return err
 	}
 	defer tx.Rollback() //nolint:errcheck
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO jvm_samples (pid, at_nano, old_gen_pct, fgc, fgct, heap_mb)
+		VALUES (?,?,?,?,?,?)
+		ON CONFLICT(pid, at_nano) DO UPDATE SET
+		    old_gen_pct=excluded.old_gen_pct,
+		    fgc=excluded.fgc,
+		    fgct=excluded.fgct,
+		    heap_mb=excluded.heap_mb`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close() //nolint:errcheck
 	for _, sm := range samples {
-		_, err := tx.ExecContext(ctx, `
-			INSERT INTO jvm_samples (pid, at_nano, old_gen_pct, fgc, fgct, heap_mb)
-			VALUES (?,?,?,?,?,?)
-			ON CONFLICT(pid, at_nano) DO UPDATE SET
-			    old_gen_pct=excluded.old_gen_pct,
-			    fgc=excluded.fgc,
-			    fgct=excluded.fgct,
-			    heap_mb=excluded.heap_mb`,
-			sm.PID, sm.At.UTC().UnixNano(), sm.OldGenPct, sm.FGC, sm.FGCT, sm.HeapMB,
-		)
-		if err != nil {
+		if _, err := stmt.ExecContext(ctx, sm.PID, sm.At.UTC().UnixNano(), sm.OldGenPct, sm.FGC, sm.FGCT, sm.HeapMB); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Closes #370.

Behavior-preserving performance pass — the low-risk batch. Output is **byte-identical** to `main` for Electron, native AppKit/Swift, Go/Rust, and Python apps (verified with `inspect --network --json` across 6 real apps). More aggressive, execution-reordering work is tracked in #325–#328.

### Changes
- **detect: parse each plist once.** Cache one `plutil -convert json` per plist path and read every key from the parsed map — replaces 6–8 `plutil -extract` forks per app. `readPrivacyDescriptions` reads the cached dict instead of a separate `plutil -convert xml1` + regex.
- **detect: one Python-tree walk.** Merge `pythonPackages` + `pythonNativeExtensions` into a single `Contents/` walk (same matching + sort order).
- **detect: hoist per-call regexps** to package-level vars.
- **detect: reuse the chunk-scan buffer** so large binaries don't reallocate a ~1 MB region per read.
- **store: prepared statements** for the six bulk-insert loops (prepare once per batch, not per row).
- **test: add `BenchmarkDetectWith`** as a regression guardrail.

### Measured
`BenchmarkDetectWith` (synthetic bundle, `-count=3`) vs `main`: ~205 ms/op → ~176 ms/op (**~14% faster**), 8040 → 7090 allocs/op (**~12% fewer**). Dominant win is eliminating per-key `plutil` forks; buffer reuse only pays off on real large executables.

### Verification
`go build ./...`, `go vet`, `gofmt -l` clean; `internal/detect`, `internal/store`, `internal/snapshot`, `cmd/...` tests green.