### PR TITLE
perf: store review follow-ups (empty-batch guards, wrapped prepare errors, benchmark fixture reuse)

### DIFF
--- a/internal/detect/detect_bench_test.go
+++ b/internal/detect/detect_bench_test.go
@@ -6,15 +6,14 @@ import (
 	"testing"
 )
 
-// benchBundle builds a synthetic .app with a multi-key Info.plist (identity,
-// version, and several NS*UsageDescription privacy strings) plus a nested
-// Frameworks/Resources tree, so the benchmark exercises the plist-parse cache
-// and the bundle walks the way a real inspection does.
+// benchBundle builds on makeBundle, then overwrites Info.plist with a multi-key
+// variant (identity, version, and several NS*UsageDescription privacy strings)
+// and adds a nested Frameworks/Resources tree, so the benchmark exercises the
+// plist-parse cache and the bundle walks the way a real inspection does.
 func benchBundle(b *testing.B) string {
 	b.Helper()
-	app := filepath.Join(b.TempDir(), "BenchApp.app")
+	app := makeBundle(b, "BenchApp")
 	for _, sub := range []string{
-		"Contents/MacOS",
 		"Contents/Resources/app/lib",
 		"Contents/Frameworks/Some.framework/Resources",
 	} {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -149,12 +149,12 @@ func (c fakeNodeCommands) OtoolL(path string) []string {
 
 // makeBundle creates a synthetic .app skeleton at t.TempDir()/Name.app
 // and returns its path. Subsequent helpers add markers.
-func makeBundle(t *testing.T, name string) string {
-	t.Helper()
-	app := filepath.Join(t.TempDir(), name+".app")
+func makeBundle(tb testing.TB, name string) string {
+	tb.Helper()
+	app := filepath.Join(tb.TempDir(), name+".app")
 	for _, sub := range []string{"Contents/MacOS", "Contents/Resources", "Contents/Frameworks"} {
 		if err := os.MkdirAll(filepath.Join(app, sub), 0o755); err != nil {
-			t.Fatal(err)
+			tb.Fatal(err)
 		}
 	}
 	// Minimal Info.plist (XML) pointing CFBundleExecutable at "main".
@@ -164,10 +164,10 @@ func makeBundle(t *testing.T, name string) string {
 <key>CFBundleExecutable</key><string>main</string>
 </dict></plist>`
 	if err := os.WriteFile(filepath.Join(app, "Contents", "Info.plist"), []byte(plist), 0o644); err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(app, "Contents", "MacOS", "main"), []byte("\x7fELF placeholder"), 0o755); err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 	return app
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -358,7 +358,7 @@ func (s *DB) SaveSnapshot(ctx context.Context, snap SnapshotInput) error {
 			     packaging, confidence, app_version, architectures, result_json)
 			VALUES (?,?,?,?,?,?,?,?,?,?,?)`)
 		if err != nil {
-			return err
+			return fmt.Errorf("store: prepare snapshot_apps: %w", err)
 		}
 		defer stmt.Close() //nolint:errcheck
 		for _, app := range snap.Apps {
@@ -622,6 +622,9 @@ type ProcessSnapshotRow struct {
 // SaveSnapshotProcesses inserts process rows for snapID. Uses INSERT OR IGNORE
 // to be idempotent (safe to call multiple times for the same snapshot).
 func (s *DB) SaveSnapshotProcesses(ctx context.Context, snapID string, procs []ProcessSnapshotRow) error {
+	if len(procs) == 0 {
+		return nil
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -632,7 +635,7 @@ func (s *DB) SaveSnapshotProcesses(ctx context.Context, snapID string, procs []P
 		  (snapshot_id, pid, ppid, command, rss_kib, cpu_pct, app_path)
 		VALUES (?,?,?,?,?,?,?)`)
 	if err != nil {
-		return err
+		return fmt.Errorf("store: prepare snapshot_processes: %w", err)
 	}
 	defer stmt.Close() //nolint:errcheck
 	for _, p := range procs {
@@ -691,7 +694,7 @@ func (s *DB) SaveLoginItems(ctx context.Context, snapID string, items []LoginIte
 		  (snapshot_id, bundle_id, plist_path, label, scope, daemon, run_at_load, keep_alive)
 		VALUES (?,?,?,?,?,?,?,?)`)
 	if err != nil {
-		return err
+		return fmt.Errorf("store: prepare login_items: %w", err)
 	}
 	defer stmt.Close() //nolint:errcheck
 	for _, it := range items {
@@ -751,7 +754,7 @@ func (s *DB) SaveGrantedPerms(ctx context.Context, snapID string, perms []Grante
 		INSERT OR IGNORE INTO granted_perms (snapshot_id, bundle_id, service)
 		VALUES (?,?,?)`)
 	if err != nil {
-		return err
+		return fmt.Errorf("store: prepare granted_perms: %w", err)
 	}
 	defer stmt.Close() //nolint:errcheck
 	for _, p := range perms {
@@ -795,6 +798,9 @@ func boolInt(b bool) int {
 // buffer. Rows are upserted because each flush may include a more complete
 // aggregate for a minute that was already partially written.
 func (s *DB) SaveProcessMetrics(ctx context.Context, aggs []ProcessMetricRow) error {
+	if len(aggs) == 0 {
+		return nil
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -811,7 +817,7 @@ func (s *DB) SaveProcessMetrics(ctx context.Context, aggs []ProcessMetricRow) er
 		    max_cpu_pct=excluded.max_cpu_pct,
 		    sample_count=excluded.sample_count`)
 	if err != nil {
-		return err
+		return fmt.Errorf("store: prepare process_metrics: %w", err)
 	}
 	defer stmt.Close() //nolint:errcheck
 	for _, a := range aggs {
@@ -1002,7 +1008,7 @@ func (s *DB) SaveJVMSamples(ctx context.Context, samples []snapshot.JVMSample) e
 		    fgct=excluded.fgct,
 		    heap_mb=excluded.heap_mb`)
 	if err != nil {
-		return err
+		return fmt.Errorf("store: prepare jvm_samples: %w", err)
 	}
 	defer stmt.Close() //nolint:errcheck
 	for _, sm := range samples {


### PR DESCRIPTION
Follow-up to #371. These were the three CodeRabbit review points addressed on that PR's branch, but #371 was squash-merged at its first commit before the fix commit registered (a GitHub PR-head sync lag), so they didn't land. Re-applying them here as a small, self-contained PR.

### Changes
- **store: empty-batch guards.** `SaveSnapshotProcesses` and `SaveProcessMetrics` now return early when given no rows, matching the other bulk writers — no `BeginTx`/`PrepareContext` cost for empty batches.
- **store: wrap prepare errors.** The new `PrepareContext` calls wrap their errors with `fmt.Errorf("store: prepare <table>: %w", err)` (preserves `errors.Is`/`As`), consistent with the existing `begin tx` wrapping.
- **test: reuse `makeBundle`.** `benchBundle` builds on `makeBundle` (generalized to `testing.TB`) instead of duplicating the `.app` skeleton, per repo test conventions.

No behavior change to inspection output. `go build`, `go vet`, `gofmt`, and `internal/detect` + `internal/store` tests are green.