### PR TITLE
perf: run lsof once in netdiag.Diagnose

### DIFF
--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -158,9 +158,12 @@ func Diagnose(ctx context.Context, opts Options) (Report, error) {
 		tlsProbe = realTLSProber{dialer: &net.Dialer{Timeout: opts.Timeout}}
 	}
 
-	state := netstate.Collect(run)
-	procs := procRun(ctx, process.CollectOptions{CmdRunner: run})
+	// Collect the socket list once and reuse it for both the State's
+	// established-connection count and the report's connection list, instead
+	// of running `lsof -i -P -n` twice.
 	conns := netstate.CollectConnections(run)
+	state := netstate.CollectWithConnections(run, conns)
+	procs := procRun(ctx, process.CollectOptions{CmdRunner: run})
 	report := Report{
 		AppPath: opts.AppPath,
 		PID:     opts.PID,

--- a/internal/netdiag/netdiag_test.go
+++ b/internal/netdiag/netdiag_test.go
@@ -44,6 +44,32 @@ func TestDiagnoseAppNetworkBehavior(t *testing.T) {
 	}
 }
 
+func TestDiagnoseCollectsConnectionsOnce(t *testing.T) {
+	base := appBehaviorRunner(t)
+	var connLsofCalls int
+	run := func(name string, args ...string) ([]byte, error) {
+		if fakeCommand(name, args...) == "lsof -i -P -n" {
+			connLsofCalls++
+		}
+		return base(name, args...)
+	}
+	procRun := func(context.Context, process.CollectOptions) []process.Info {
+		return []process.Info{{PID: 412, Command: "Slack", ExecutablePath: "/Applications/Slack.app/Contents/MacOS/Slack", AppPath: "/Applications/Slack.app"}}
+	}
+	if _, err := Diagnose(context.Background(), Options{
+		AppPath:    "/Applications/Slack.app",
+		NetRunner:  run,
+		ProcRunner: procRun,
+		Dialer:     fakeDialer{},
+		TLSProbe:   fakeTLS{},
+	}); err != nil {
+		t.Fatalf("Diagnose: %v", err)
+	}
+	if connLsofCalls != 1 {
+		t.Fatalf("`lsof -i -P -n` invoked %d times, want 1 (collect once, share between State count and connection list)", connLsofCalls)
+	}
+}
+
 func appBehaviorRunner(t *testing.T) func(string, ...string) ([]byte, error) {
 	t.Helper()
 	fixtures := map[string][]byte{

--- a/internal/netstate/netstate.go
+++ b/internal/netstate/netstate.go
@@ -76,6 +76,15 @@ func DefaultRunner(name string, args ...string) ([]byte, error) {
 // Collect gathers network state. Any sub-command failure is silently
 // absorbed; partial results are still valid.
 func Collect(run CmdRunner) State {
+	return CollectWithConnections(run, collectConnectionRows(run))
+}
+
+// CollectWithConnections is Collect for callers that have already gathered the
+// active socket list (via CollectConnections). It reuses those rows for the
+// established-connection count instead of running `lsof -i -P -n` a second time.
+// netdiag.Diagnose needs both the full connection list and the State, so it
+// collects once and passes the rows here.
+func CollectWithConnections(run CmdRunner, conns []Connection) State {
 	var s State
 	if out, err := run("route", "-n", "get", "default"); err == nil {
 		s.DefaultRouteIface, s.DefaultRouteGW = parseRoute(string(out))
@@ -94,7 +103,7 @@ func Collect(run CmdRunner) State {
 		s.VPNInterfaces = parseVPNInterfaces(string(out))
 		s.VPNActive = len(s.VPNInterfaces) > 0
 	}
-	s.EstablishedConnectionsCount = countEstablishedConnections(collectConnectionRows(run))
+	s.EstablishedConnectionsCount = countEstablishedConnections(conns)
 	s.ProcessThroughput = CollectThroughput(run)
 	return s
 }


### PR DESCRIPTION
Closes #328.

`netdiag.Diagnose` ran the expensive `lsof -i -P -n` **twice**:
- `netstate.Collect(run)` gathered the socket rows internally for `EstablishedConnectionsCount`
- `netstate.CollectConnections(run)` gathered them again for the report's connection list

This adds `netstate.CollectWithConnections(run, conns)` so `Diagnose` collects the rows once (via `CollectConnections`) and reuses them for both the State count and the connection list. `Collect(run)` is unchanged, so standalone callers (snapshot, mcp, serve, `spectra network`) keep their single self-contained collection.

### Verification
- New test `TestDiagnoseCollectsConnectionsOnce` asserts `lsof -i -P -n` is invoked exactly once per `Diagnose` (was 2).
- No output change; `internal/netstate`, `internal/netdiag`, `internal/mcp`, `internal/serve`, `internal/snapshot`, `cmd/...` tests all green. `go vet`, `gofmt` clean.