### PR TITLE
perf: fan out endpoint probes in netdiag.Diagnose

### DIFF
--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kaeawc/spectra/internal/netstate"
@@ -179,25 +180,10 @@ func Diagnose(ctx context.Context, opts Options) (Report, error) {
 	diagnosticNoEndpoints := len(report.Connections) > 0 &&
 		len(targets) == 0 &&
 		(len(opts.Targets) > 0 || len(opts.Ports) > 0)
-	for _, target := range targets {
-		diag := EndpointDiagnosis{
-			Host:       target.host,
-			DNS:        probeDNS(run, target.host),
-			Traceroute: probeTrace(run, target.host),
-		}
-		for _, port := range target.ports {
-			pd := PortDiagnosis{Port: port, TCP: probeTCP(ctx, dialer, target.host, port)}
-			if port == 443 || port == 8443 {
-				tp, err := tlsProbe.ProbeTLS(ctx, target.host, port, opts.Timeout)
-				if err != nil {
-					tp = TLSProbe{Error: err.Error()}
-				}
-				pd.TLS = &tp
-			}
-			diag.Ports = append(diag.Ports, pd)
-		}
-		report.Endpoints = append(report.Endpoints, diag)
-	}
+	// Each target's probes (DNS, a up-to-12s traceroute, per-port TCP/TLS
+	// dials) are independent and network-I/O-bound, so run them concurrently.
+	// Results are written by index to keep output ordering deterministic.
+	report.Endpoints = diagnoseEndpoints(ctx, run, dialer, tlsProbe, targets, opts.Timeout)
 	report.Findings = findings(report)
 	if diagnosticNoEndpoints {
 		report.Findings = append(report.Findings, Finding{
@@ -404,6 +390,61 @@ func splitHostPortLoose(addr string) (string, int) {
 		return strings.Trim(addr, "[]"), 0
 	}
 	return strings.Trim(addr[:idx], "[]"), port
+}
+
+// maxEndpointConcurrency bounds how many endpoints are probed at once. Probes
+// are network-I/O-bound (and traceroute can block for ~12s), so a small fixed
+// fan-out keeps a many-endpoint diagnosis from serializing into minutes without
+// spawning an unbounded number of traceroutes.
+const maxEndpointConcurrency = 8
+
+// diagnoseEndpoints probes every target concurrently (bounded) and returns the
+// diagnoses in the same order as targets.
+func diagnoseEndpoints(ctx context.Context, run netstate.CmdRunner, dialer Dialer, tlsProbe TLSProber, targets []target, timeout time.Duration) []EndpointDiagnosis {
+	if len(targets) == 0 {
+		return nil
+	}
+	out := make([]EndpointDiagnosis, len(targets))
+	limit := maxEndpointConcurrency
+	if len(targets) < limit {
+		limit = len(targets)
+	}
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	for i := range targets {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			out[i] = diagnoseEndpoint(ctx, run, dialer, tlsProbe, targets[i], timeout)
+		}(i)
+	}
+	wg.Wait()
+	return out
+}
+
+// diagnoseEndpoint runs the DNS, traceroute, and per-port TCP/TLS probes for a
+// single target. It has no shared mutable state, so callers may run it
+// concurrently across targets.
+func diagnoseEndpoint(ctx context.Context, run netstate.CmdRunner, dialer Dialer, tlsProbe TLSProber, t target, timeout time.Duration) EndpointDiagnosis {
+	diag := EndpointDiagnosis{
+		Host:       t.host,
+		DNS:        probeDNS(run, t.host),
+		Traceroute: probeTrace(run, t.host),
+	}
+	for _, port := range t.ports {
+		pd := PortDiagnosis{Port: port, TCP: probeTCP(ctx, dialer, t.host, port)}
+		if port == 443 || port == 8443 {
+			tp, err := tlsProbe.ProbeTLS(ctx, t.host, port, timeout)
+			if err != nil {
+				tp = TLSProbe{Error: err.Error()}
+			}
+			pd.TLS = &tp
+		}
+		diag.Ports = append(diag.Ports, pd)
+	}
+	return diag
 }
 
 func probeDNS(run netstate.CmdRunner, host string) DNSProbe {

--- a/internal/netdiag/netdiag_test.go
+++ b/internal/netdiag/netdiag_test.go
@@ -70,6 +70,51 @@ func TestDiagnoseCollectsConnectionsOnce(t *testing.T) {
 	}
 }
 
+func TestDiagnoseProbesEndpointsInOrder(t *testing.T) {
+	// Explicit multi-target diagnosis exercises the concurrent endpoint fan-out;
+	// the result must stay in endpointTargets order regardless of probe timing.
+	// Runners here return errors (never t.Fatalf) since they run off-goroutine.
+	run := func(name string, args ...string) ([]byte, error) {
+		cmd := fakeCommand(name, args...)
+		switch {
+		case cmd == "route -n get default", cmd == "scutil --dns", cmd == "scutil --proxy",
+			cmd == "ifconfig", strings.HasPrefix(cmd, "lsof "), strings.HasPrefix(cmd, "nettop "):
+			return []byte(""), nil
+		case strings.HasPrefix(cmd, "dig "):
+			return []byte(digNOERRORFixture), nil
+		case strings.HasPrefix(cmd, "traceroute "):
+			return []byte("1 192.0.2.1 1.0 ms\n"), nil
+		default:
+			return nil, errors.New("unexpected command: " + cmd)
+		}
+	}
+	opts := Options{
+		Targets:    []string{"c.example", "a.example", "b.example", "d.example"},
+		Ports:      []int{443},
+		NetRunner:  run,
+		ProcRunner: func(context.Context, process.CollectOptions) []process.Info { return nil },
+		Dialer:     fakeDialer{},
+		TLSProbe:   fakeTLS{},
+	}
+	report, err := Diagnose(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Diagnose: %v", err)
+	}
+	want := endpointTargets(opts.Targets, nil, opts.Ports)
+	if len(want) < 2 {
+		t.Fatalf("test needs multiple targets to exercise fan-out, got %d", len(want))
+	}
+	if len(report.Endpoints) != len(want) {
+		t.Fatalf("endpoints = %d, want %d", len(report.Endpoints), len(want))
+	}
+	for i := range want {
+		if report.Endpoints[i].Host != want[i].host {
+			t.Fatalf("endpoint[%d].Host = %q, want %q (fan-out must preserve target order)",
+				i, report.Endpoints[i].Host, want[i].host)
+		}
+	}
+}
+
 func appBehaviorRunner(t *testing.T) func(string, ...string) ([]byte, error) {
 	t.Helper()
 	fixtures := map[string][]byte{


### PR DESCRIPTION
Closes #326.

`Diagnose` probed endpoints **serially** — each target ran DNS (`dig`), a `traceroute -n -m 12 -w 1` (up to ~12s), then per-port TCP/TLS dials before the next target began, so a multi-endpoint diagnosis serialized into tens of seconds.

This extracts the per-target work into `diagnoseEndpoint` and runs targets **concurrently** via `diagnoseEndpoints` with a bounded pool (`maxEndpointConcurrency = 8`). Results are written into a pre-sized slice by index, so output ordering is unchanged. The probes have no shared mutable state.

### Verification
- New test `TestDiagnoseProbesEndpointsInOrder` (4 targets) asserts endpoints return in `endpointTargets` order; the whole package passes under `-race`.
- No output change; `internal/netdiag` and `cmd/spectra` tests green, `go vet`/`gofmt` clean.