### PR TITLE
crash: spectra crash list — sweep DiagnosticReports into a crash inventory

### DIFF
--- a/cmd/spectra/crash.go
+++ b/cmd/spectra/crash.go
@@ -32,8 +32,10 @@ func runCrashWithIO(args []string, stdout, stderr io.Writer, inspect func(string
 		return runCrashInspect(rest, stdout, stderr, os.ReadFile)
 	case "resource":
 		return runCrashResource(rest, stdout, stderr, os.ReadFile)
+	case "list":
+		return runCrashList(rest, stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource)\n", sub)
+		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource, list)\n", sub)
 		return 2
 	}
 }

--- a/cmd/spectra/crash_list.go
+++ b/cmd/spectra/crash_list.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/crashreport"
+)
+
+// ipsTimeLayout is the timestamp format in an .ips header, e.g.
+// "2026-08-05 23:17:34.00 -0500".
+const ipsTimeLayout = "2006-01-02 15:04:05.00 -0700"
+
+// sweptReport pairs a parsed crash report with its source file. It is the
+// reusable unit the crash-inventory, signature, and jetsam commands share.
+type sweptReport struct {
+	File   string
+	Report *crashreport.Report
+}
+
+// sweepCrashReports parses each file, skipping legacy/unreadable/unparseable
+// ones (returned as the skipped count) so one bad report never breaks a sweep.
+func sweepCrashReports(files []string, read func(string) ([]byte, error)) ([]sweptReport, int) {
+	var out []sweptReport
+	skipped := 0
+	for _, f := range files {
+		data, err := read(f)
+		if err != nil {
+			skipped++
+			continue
+		}
+		rep, err := crashreport.Parse(data)
+		if err != nil {
+			skipped++
+			continue
+		}
+		out = append(out, sweptReport{File: f, Report: rep})
+	}
+	return out, skipped
+}
+
+type crashSummary struct {
+	Time      string    `json:"time"`
+	Process   string    `json:"process"`
+	Kind      string    `json:"kind"`
+	Exception string    `json:"exception,omitempty"`
+	Incident  string    `json:"incident_id,omitempty"`
+	File      string    `json:"file"`
+	at        time.Time // parsed, for sorting only
+}
+
+func summarize(s sweptReport) crashSummary {
+	r := s.Report
+	cs := crashSummary{
+		Time: r.Time, Process: r.Process, Kind: r.Kind,
+		Exception: r.Exception, Incident: r.IncidentID, File: s.File,
+	}
+	if t, err := time.Parse(ipsTimeLayout, r.Time); err == nil {
+		cs.at = t
+	}
+	return cs
+}
+
+type crashListDeps struct {
+	list func() ([]string, error)
+	read func(string) ([]byte, error)
+}
+
+func defaultCrashListDeps(dir string) crashListDeps {
+	return crashListDeps{
+		list: func() ([]string, error) { return findIPSFiles(dir) },
+		read: os.ReadFile,
+	}
+}
+
+// findIPSFiles walks dir (including Retired/ and dotfile reports) collecting
+// .ips files. It tolerates unreadable entries and a missing directory,
+// yielding whatever it could enumerate rather than an error.
+func findIPSFiles(dir string) ([]string, error) {
+	var out []string
+	// The callback always returns nil so the walk continues past any
+	// unreadable subtree; entries are only collected when walkErr is nil.
+	_ = filepath.WalkDir(dir, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr == nil && !d.IsDir() && filepath.Ext(p) == ".ips" {
+			out = append(out, p)
+		}
+		return nil
+	})
+	return out, nil
+}
+
+func defaultDiagnosticReportsDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, "Library", "Logs", "DiagnosticReports")
+}
+
+func runCrashList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("crash list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	limit := fs.Int("limit", 25, "maximum reports to show")
+	dir := fs.String("dir", defaultDiagnosticReportsDir(), "DiagnosticReports directory")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra crash list [--json] [--limit N] [--dir <path>]")
+		fmt.Fprintln(stderr, "List the .ips crash reports macOS has collected, newest first.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	return runCrashListWithDeps(*asJSON, *limit, stdout, stderr, defaultCrashListDeps(*dir))
+}
+
+func runCrashListWithDeps(asJSON bool, limit int, stdout, stderr io.Writer, deps crashListDeps) int {
+	files, err := deps.list()
+	if err != nil {
+		fmt.Fprintf(stderr, "list reports: %v\n", err)
+		return 1
+	}
+	swept, skipped := sweepCrashReports(files, deps.read)
+	summaries := make([]crashSummary, 0, len(swept))
+	for _, s := range swept {
+		summaries = append(summaries, summarize(s))
+	}
+	sort.Slice(summaries, func(i, j int) bool { return summaries[i].at.After(summaries[j].at) })
+	if limit > 0 && len(summaries) > limit {
+		summaries = summaries[:limit]
+	}
+	if asJSON {
+		return encodeJSON(stdout, stderr, summaries)
+	}
+	renderCrashList(stdout, summaries, len(swept), skipped)
+	return 0
+}
+
+func renderCrashList(w io.Writer, summaries []crashSummary, total, skipped int) {
+	if total == 0 {
+		fmt.Fprintf(w, "No crash reports found (%d skipped).\n", skipped)
+		return
+	}
+	fmt.Fprintf(w, "Crash reports (%d shown of %d", len(summaries), total)
+	if skipped > 0 {
+		fmt.Fprintf(w, ", %d skipped", skipped)
+	}
+	fmt.Fprintln(w, "):")
+	for _, s := range summaries {
+		when := s.Time
+		if !s.at.IsZero() {
+			when = s.at.Format("2006-01-02 15:04")
+		}
+		fmt.Fprintf(w, "  %-16s  %-28s %-8s %s\n", when, truncate(s.Process, 28), s.Kind, s.Exception)
+	}
+}

--- a/cmd/spectra/crash_list.go
+++ b/cmd/spectra/crash_list.go
@@ -116,6 +116,10 @@ func runCrashList(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
 	return runCrashListWithDeps(*asJSON, *limit, stdout, stderr, defaultCrashListDeps(*dir))
 }
 
@@ -157,5 +161,24 @@ func renderCrashList(w io.Writer, summaries []crashSummary, total, skipped int) 
 			when = s.at.Format("2006-01-02 15:04")
 		}
 		fmt.Fprintf(w, "  %-16s  %-28s %-8s %s\n", when, truncate(s.Process, 28), s.Kind, s.Exception)
+		if detail := crashListDetail(s); detail != "" {
+			fmt.Fprintf(w, "      %s\n", detail)
+		}
 	}
+}
+
+// crashListDetail is the second line under an entry: the incident id and the
+// source file (which the user can pass to `spectra crash inspect`).
+func crashListDetail(s crashSummary) string {
+	detail := ""
+	if s.Incident != "" {
+		detail = "incident " + s.Incident
+	}
+	if s.File != "" {
+		if detail != "" {
+			detail += " · "
+		}
+		detail += s.File
+	}
+	return detail
 }

--- a/cmd/spectra/crash_list_test.go
+++ b/cmd/spectra/crash_list_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func ipsReport(app, when, exc string) string {
+	return `{"app_name":"` + app + `","timestamp":"` + when + `","bug_type":"309","name":"` + app + `"}
+{"procName":"` + app + `","pid":1,"exception":{"type":"` + exc + `","signal":"SIGSEGV"},"termination":{"indicator":"x"},"faultingThread":0,"threads":[{"triggered":true,"frames":[]}],"usedImages":[]}`
+}
+
+func TestSweepSkipsUnparseable(t *testing.T) {
+	read := func(f string) ([]byte, error) {
+		switch f {
+		case "good.ips":
+			return []byte(ipsReport("Good", "2026-08-05 10:00:00.00 -0500", "EXC_BAD_ACCESS")), nil
+		case "legacy.crash":
+			return []byte("Process: Old [1]\n"), nil // legacy plain-text
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+	swept, skipped := sweepCrashReports([]string{"good.ips", "legacy.crash", "missing.ips"}, read)
+	if len(swept) != 1 || swept[0].Report.Process != "Good" {
+		t.Errorf("swept = %+v, want 1 (Good)", swept)
+	}
+	if skipped != 2 {
+		t.Errorf("skipped = %d, want 2 (legacy + missing)", skipped)
+	}
+}
+
+func TestRunCrashListNewestFirst(t *testing.T) {
+	deps := crashListDeps{
+		list: func() ([]string, error) { return []string{"old.ips", "new.ips"}, nil },
+		read: func(f string) ([]byte, error) {
+			if f == "new.ips" {
+				return []byte(ipsReport("NewApp", "2026-08-05 10:00:00.00 -0500", "EXC_BREAKPOINT")), nil
+			}
+			return []byte(ipsReport("OldApp", "2026-01-09 21:20:32.00 -0600", "EXC_BAD_ACCESS")), nil
+		},
+	}
+	var out, errBuf bytes.Buffer
+	if code := runCrashListWithDeps(false, 25, &out, &errBuf, deps); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	ni, oi := strings.Index(s, "NewApp"), strings.Index(s, "OldApp")
+	if ni < 0 || oi < 0 || ni > oi {
+		t.Errorf("expected NewApp before OldApp; got:\n%s", s)
+	}
+}
+
+func TestRunCrashListJSON(t *testing.T) {
+	deps := crashListDeps{
+		list: func() ([]string, error) { return []string{"a.ips"}, nil },
+		read: func(string) ([]byte, error) {
+			return []byte(ipsReport("Solo", "2026-08-05 10:00:00.00 -0500", "EXC_CRASH")), nil
+		},
+	}
+	var out, errBuf bytes.Buffer
+	runCrashListWithDeps(true, 25, &out, &errBuf, deps)
+	if !strings.Contains(out.String(), `"process": "Solo"`) {
+		t.Errorf("json = %q", out.String())
+	}
+}
+
+func TestRunCrashListEmpty(t *testing.T) {
+	deps := crashListDeps{
+		list: func() ([]string, error) { return nil, nil },
+		read: func(string) ([]byte, error) { return nil, nil },
+	}
+	var out, errBuf bytes.Buffer
+	if code := runCrashListWithDeps(false, 25, &out, &errBuf, deps); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), "No crash reports found") {
+		t.Errorf("out = %q", out.String())
+	}
+}
+
+func TestFindIPSFilesWalksRetiredAndDotfiles(t *testing.T) {
+	dir := t.TempDir()
+	retired := filepath.Join(dir, "Retired")
+	if err := os.Mkdir(retired, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(p string) {
+		if err := os.WriteFile(p, []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(dir, "App-2026.ips"))
+	write(filepath.Join(dir, ".hidden-2026.ips")) // dotfile report
+	write(filepath.Join(retired, "Old-2026.ips"))
+	write(filepath.Join(dir, "power.diag")) // must be ignored
+
+	got, err := findIPSFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("found %d .ips, want 3: %v", len(got), got)
+	}
+	for _, g := range got {
+		if filepath.Ext(g) != ".ips" {
+			t.Errorf("non-.ips in results: %s", g)
+		}
+	}
+}
+
+func TestFindIPSFilesMissingDir(t *testing.T) {
+	got, err := findIPSFiles(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil || got != nil {
+		t.Errorf("missing dir = %v, %v; want nil, nil", got, err)
+	}
+}

--- a/cmd/spectra/crash_list_test.go
+++ b/cmd/spectra/crash_list_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ipsReport(app, when, exc string) string {
-	return `{"app_name":"` + app + `","timestamp":"` + when + `","bug_type":"309","name":"` + app + `"}
+	return `{"app_name":"` + app + `","timestamp":"` + when + `","bug_type":"309","incident_id":"INC-` + app + `","name":"` + app + `"}
 {"procName":"` + app + `","pid":1,"exception":{"type":"` + exc + `","signal":"SIGSEGV"},"termination":{"indicator":"x"},"faultingThread":0,"threads":[{"triggered":true,"frames":[]}],"usedImages":[]}`
 }
 
@@ -51,6 +51,31 @@ func TestRunCrashListNewestFirst(t *testing.T) {
 	ni, oi := strings.Index(s, "NewApp"), strings.Index(s, "OldApp")
 	if ni < 0 || oi < 0 || ni > oi {
 		t.Errorf("expected NewApp before OldApp; got:\n%s", s)
+	}
+}
+
+func TestRunCrashListShowsFileAndIncident(t *testing.T) {
+	deps := crashListDeps{
+		list: func() ([]string, error) { return []string{"/reports/MyApp-2026.ips"}, nil },
+		read: func(string) ([]byte, error) {
+			return []byte(ipsReport("MyApp", "2026-08-05 10:00:00.00 -0500", "EXC_CRASH")), nil
+		},
+	}
+	var out, errBuf bytes.Buffer
+	runCrashListWithDeps(false, 25, &out, &errBuf, deps)
+	s := out.String()
+	if !strings.Contains(s, "/reports/MyApp-2026.ips") {
+		t.Errorf("text output should show the source file for follow-up; got:\n%s", s)
+	}
+	if !strings.Contains(s, "incident INC-MyApp") {
+		t.Errorf("text output should show the incident id; got:\n%s", s)
+	}
+}
+
+func TestRunCrashListRejectsPositional(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runCrashList([]string{"extra"}, &out, &errBuf); code != 2 {
+		t.Fatalf("exit = %d, want 2 for a stray positional arg", code)
 	}
 }
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -412,6 +412,23 @@ spectra crash readiness --json
 spectra crash readiness /Applications/MyApp.app
 ```
 
+## `spectra crash list`
+
+Sweeps the DiagnosticReports directory macOS writes crash reports into and
+prints a newest-first inventory — the answer to "what has been crashing on
+this Mac lately?" without opening Console. It recursively walks
+`~/Library/Logs/DiagnosticReports/` (including `Retired/` and dotfile
+reports), parses each `.ips` via the crash decoder, and skips legacy /
+unparseable files rather than failing. `--limit` caps the rows, `--dir`
+overrides the directory, and `--json` emits the structured inventory.
+
+### Examples
+
+```bash
+spectra crash list
+spectra crash list --limit 50 --json
+```
+
 ## `spectra crash inspect`
 
 Decodes a modern macOS `.ips` crash report (the JSON reports written to


### PR DESCRIPTION
## What

Adds **`spectra crash list`** — a newest-first inventory of the `.ips` crash reports macOS has already collected in `~/Library/Logs/DiagnosticReports/`. Answers "what has been crashing on this Mac lately?" without opening Console. This is the **foundation of the crash cluster**: the follow-on signature-aggregation and jetsam-attribution commands reuse its sweep.

## How

- Recursively walks the reports directory including `Retired/` and dotfile reports (`.adb-*.ips`), collecting `*.ips`. Tolerates unreadable entries and a missing directory (yields what it could enumerate).
- Parses each via `crashreport.Parse`; **legacy plain-text and unparseable files are skipped and counted**, never fatal.
- Prints time / process / kind / decoded exception, newest-first, `--limit`-capped (default 25). `--dir` overrides the directory; `--json` emits the structured inventory.
- `sweepCrashReports` returns parsed reports paired with their source file — the reusable unit the next two crash items build on. Enumeration + reads are injected.

## Testing

- `sweepCrashReports` skips legacy + missing files (counts them); newest-first ordering; `--json`; empty-dir message; `findIPSFiles` walks `Retired/` + dotfiles and ignores `.diag`; missing-dir yields nil.
- Verified against the real DiagnosticReports directory during development (2 reports found + parsed).
- `make vet complexity lint security docs-validate test` green locally (55 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #377
