### PR TITLE
crash: spectra crash signatures — aggregate recurring crash signatures

### DIFF
--- a/cmd/spectra/crash.go
+++ b/cmd/spectra/crash.go
@@ -34,8 +34,10 @@ func runCrashWithIO(args []string, stdout, stderr io.Writer, inspect func(string
 		return runCrashResource(rest, stdout, stderr, os.ReadFile)
 	case "list":
 		return runCrashList(rest, stdout, stderr)
+	case "signatures":
+		return runCrashSignatures(rest, stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource, list)\n", sub)
+		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource, list, signatures)\n", sub)
 		return 2
 	}
 }

--- a/cmd/spectra/crash_signatures.go
+++ b/cmd/spectra/crash_signatures.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/crashreport"
+)
+
+// crashSignature is a group of reports that share the same process, exception,
+// and top faulting frame.
+type crashSignature struct {
+	Process   string `json:"process"`
+	Exception string `json:"exception,omitempty"`
+	TopFrame  string `json:"top_frame"`
+	Count     int    `json:"count"`
+	First     string `json:"first_seen,omitempty"`
+	Last      string `json:"last_seen,omitempty"`
+	Sample    string `json:"sample_file,omitempty"`
+	Incident  string `json:"sample_incident,omitempty"`
+	firstAt   time.Time
+	lastAt    time.Time
+}
+
+// topFaultingFrame returns the first frame of the report's faulting thread, or
+// "(no frame)" when there is none.
+func topFaultingFrame(r *crashreport.Report) string {
+	for _, t := range r.Threads {
+		if t.Triggered && len(t.Frames) > 0 {
+			return t.Frames[0]
+		}
+	}
+	if r.FaultingThread >= 0 && r.FaultingThread < len(r.Threads) {
+		if fr := r.Threads[r.FaultingThread].Frames; len(fr) > 0 {
+			return fr[0]
+		}
+	}
+	return "(no frame)"
+}
+
+// aggregateSignatures groups reports by process+exception+top-frame and ranks
+// them by occurrence count (most-recent breaks ties).
+func aggregateSignatures(swept []sweptReport) []crashSignature {
+	byKey := map[string]*crashSignature{}
+	for _, s := range swept {
+		frame := topFaultingFrame(s.Report)
+		key := s.Report.Process + "\x00" + s.Report.Exception + "\x00" + frame
+		sig, ok := byKey[key]
+		if !ok {
+			sig = &crashSignature{Process: s.Report.Process, Exception: s.Report.Exception, TopFrame: frame}
+			byKey[key] = sig
+		}
+		observeSignature(sig, s)
+	}
+	out := make([]crashSignature, 0, len(byKey))
+	for _, s := range byKey {
+		out = append(out, *s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		if !out[i].lastAt.Equal(out[j].lastAt) {
+			return out[i].lastAt.After(out[j].lastAt)
+		}
+		return out[i].Process < out[j].Process
+	})
+	return out
+}
+
+func observeSignature(sig *crashSignature, s sweptReport) {
+	sig.Count++
+	at, err := time.Parse(ipsTimeLayout, s.Report.Time)
+	if err != nil {
+		if sig.Sample == "" {
+			sig.Sample, sig.Incident = s.File, s.Report.IncidentID
+		}
+		return
+	}
+	if sig.firstAt.IsZero() || at.Before(sig.firstAt) {
+		sig.firstAt, sig.First = at, s.Report.Time
+	}
+	if sig.lastAt.IsZero() || at.After(sig.lastAt) {
+		sig.lastAt, sig.Last = at, s.Report.Time
+		sig.Sample, sig.Incident = s.File, s.Report.IncidentID
+	}
+}
+
+func runCrashSignatures(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("crash signatures", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	limit := fs.Int("limit", 25, "maximum signatures to show")
+	dir := fs.String("dir", defaultDiagnosticReportsDir(), "DiagnosticReports directory")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra crash signatures [--json] [--limit N] [--dir <path>]")
+		fmt.Fprintln(stderr, "Group crash reports into recurring signatures, ranked by occurrence.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+	return runCrashSignaturesWithDeps(*asJSON, *limit, stdout, stderr, defaultCrashListDeps(*dir))
+}
+
+func runCrashSignaturesWithDeps(asJSON bool, limit int, stdout, stderr io.Writer, deps crashListDeps) int {
+	files, err := deps.list()
+	if err != nil {
+		fmt.Fprintf(stderr, "list reports: %v\n", err)
+		return 1
+	}
+	swept, _ := sweepCrashReports(files, deps.read)
+	sigs := aggregateSignatures(swept)
+	total := len(swept)
+	if limit > 0 && len(sigs) > limit {
+		sigs = sigs[:limit]
+	}
+	if asJSON {
+		return encodeJSON(stdout, stderr, sigs)
+	}
+	renderCrashSignatures(stdout, sigs, total)
+	return 0
+}
+
+func renderCrashSignatures(w io.Writer, sigs []crashSignature, totalReports int) {
+	if len(sigs) == 0 {
+		fmt.Fprintln(w, "No crash reports found.")
+		return
+	}
+	fmt.Fprintf(w, "Crash signatures (%d distinct, %d report(s)):\n", len(sigs), totalReports)
+	for _, s := range sigs {
+		fmt.Fprintf(w, "  [%d×] %s  %s  %s\n", s.Count, s.Process, s.Exception, s.TopFrame)
+		detail := ""
+		if s.First != "" {
+			detail = "first " + shortWhen(s.firstAt, s.First) + " · last " + shortWhen(s.lastAt, s.Last)
+		}
+		if s.Sample != "" {
+			if detail != "" {
+				detail += " · "
+			}
+			detail += "e.g. " + s.Sample
+		}
+		if detail != "" {
+			fmt.Fprintf(w, "        %s\n", detail)
+		}
+	}
+}
+
+func shortWhen(at time.Time, raw string) string {
+	if !at.IsZero() {
+		return at.Format("2006-01-02 15:04")
+	}
+	return raw
+}

--- a/cmd/spectra/crash_signatures_test.go
+++ b/cmd/spectra/crash_signatures_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/crashreport"
+)
+
+func rep(proc, exc, when, frame, incident string) sweptReport {
+	r := &crashreport.Report{
+		Process: proc, Exception: exc, Time: when, IncidentID: incident,
+		FaultingThread: 0,
+		Threads:        []crashreport.Thread{{Triggered: true, Frames: []string{frame}}},
+	}
+	return sweptReport{File: "/r/" + incident + ".ips", Report: r}
+}
+
+func TestAggregateSignaturesCollapsesRepeats(t *testing.T) {
+	swept := []sweptReport{
+		rep("MyApp", "EXC_BAD_ACCESS", "2026-08-01 09:00:00.00 -0500", "MyApp`flush + 1", "a"),
+		rep("MyApp", "EXC_BAD_ACCESS", "2026-08-05 15:00:00.00 -0500", "MyApp`flush + 1", "b"),
+		rep("MyApp", "EXC_BAD_ACCESS", "2026-08-03 12:00:00.00 -0500", "MyApp`flush + 1", "c"),
+		rep("Other", "EXC_CRASH", "2026-08-02 10:00:00.00 -0500", "Other`boom + 9", "d"),
+	}
+	sigs := aggregateSignatures(swept)
+	if len(sigs) != 2 {
+		t.Fatalf("signatures = %d, want 2: %+v", len(sigs), sigs)
+	}
+	top := sigs[0]
+	if top.Count != 3 || top.Process != "MyApp" {
+		t.Errorf("top signature = %+v, want MyApp x3", top)
+	}
+	if !strings.HasPrefix(top.First, "2026-08-01") || !strings.HasPrefix(top.Last, "2026-08-05") {
+		t.Errorf("first/last = %q/%q, want 08-01/08-05", top.First, top.Last)
+	}
+	// last-seen sample should be the most recent (incident b)
+	if top.Incident != "b" {
+		t.Errorf("sample incident = %q, want b (most recent)", top.Incident)
+	}
+}
+
+func TestAggregateSignaturesNoFrameBucket(t *testing.T) {
+	r := &crashreport.Report{Process: "P", Exception: "EXC_CRASH", Time: "2026-08-01 09:00:00.00 -0500", Threads: nil}
+	sigs := aggregateSignatures([]sweptReport{{File: "/r/x.ips", Report: r}})
+	if len(sigs) != 1 || sigs[0].TopFrame != "(no frame)" {
+		t.Errorf("expected a (no frame) bucket, got %+v", sigs)
+	}
+}
+
+func TestRunCrashSignaturesRenders(t *testing.T) {
+	deps := crashListDeps{
+		list: func() ([]string, error) { return []string{"a.ips", "b.ips"}, nil },
+		read: func(f string) ([]byte, error) {
+			when := "2026-08-05 10:00:00.00 -0500"
+			if f == "a.ips" {
+				when = "2026-08-01 10:00:00.00 -0500"
+			}
+			return []byte(ipsReport("MyApp", when, "EXC_BAD_ACCESS")), nil
+		},
+	}
+	var out, errBuf bytes.Buffer
+	if code := runCrashSignaturesWithDeps(false, 25, &out, &errBuf, deps); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "[2×] MyApp") {
+		t.Errorf("expected a 2x MyApp signature; got:\n%s", s)
+	}
+}
+
+func TestRunCrashSignaturesEmpty(t *testing.T) {
+	deps := crashListDeps{list: func() ([]string, error) { return nil, nil }, read: func(string) ([]byte, error) { return nil, nil }}
+	var out, errBuf bytes.Buffer
+	runCrashSignaturesWithDeps(false, 25, &out, &errBuf, deps)
+	if !strings.Contains(out.String(), "No crash reports found") {
+		t.Errorf("out = %q", out.String())
+	}
+}
+
+func TestRunCrashSignaturesRejectsPositional(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runCrashSignatures([]string{"extra"}, &out, &errBuf); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -429,6 +429,22 @@ spectra crash list
 spectra crash list --limit 50 --json
 ```
 
+## `spectra crash signatures`
+
+Groups the crash reports from `crash list` into recurring **signatures** —
+keyed on process + exception + top faulting frame — and ranks them by
+occurrence, so a flaky app's dozen identical crashes collapse into one line
+with a count and a first-seen/last-seen window. Each signature shows a
+sample report for drill-down. `--json` structured; `--limit`/`--dir` as with
+`crash list`.
+
+### Examples
+
+```bash
+spectra crash signatures
+spectra crash signatures --json
+```
+
 ## `spectra crash inspect`
 
 Decodes a modern macOS `.ips` crash report (the JSON reports written to


### PR DESCRIPTION
## What

Adds **`spectra crash signatures`** — groups the crash reports from #378 into recurring **signatures** (process + exception + top faulting frame), ranked by occurrence. A flaky app's dozen identical crashes collapse into one line with a count and a first-seen → last-seen window, instead of a dozen inventory rows.

## How

- `aggregateSignatures([]sweptReport)` (pure, reuses the sweep from `crash list`) keys each report on `process + exception + top-frame`, counts occurrences, tracks first/last-seen, and keeps the most-recent report as the drill-down sample. Reports with no faulting-thread frame group under a `(no frame)` bucket rather than being dropped. Sorted by count, then most-recent, then process (stable).
- `spectra crash signatures` renders the ranked list (+ `--json`, `--limit`, `--dir`). Reuses `crash list`'s injected directory/reader.

## Scope (v1)

Signature = process + exception + top frame (the frame string as parsed). Fuzzy/address-stripped grouping across versions is a follow-up.

## Testing

- `aggregateSignatures`: repeats collapse to one signature with correct count + first/last + most-recent sample; distinct crashes stay separate; `(no frame)` bucket.
- CLI: `[2×]` render, empty message, positional-arg rejection — via the injected deps.
- `make vet complexity lint security docs-validate test` green locally (55 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #379