### PR TITLE
crash: spectra crash state — reconstruct machine state at crash time from the nearest snapshot

### DIFF
--- a/cmd/spectra/crash.go
+++ b/cmd/spectra/crash.go
@@ -36,8 +36,10 @@ func runCrashWithIO(args []string, stdout, stderr io.Writer, inspect func(string
 		return runCrashList(rest, stdout, stderr)
 	case "signatures":
 		return runCrashSignatures(rest, stdout, stderr)
+	case "state":
+		return runCrashState(rest, stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource, list, signatures)\n", sub)
+		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource, list, signatures, state)\n", sub)
 		return 2
 	}
 }

--- a/cmd/spectra/crash_state.go
+++ b/cmd/spectra/crash_state.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/crashreport"
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+)
+
+type crashStateDeps struct {
+	readFile      func(string) ([]byte, error)
+	loadSnapshots func(host string) (hostname string, rows []store.SnapshotRow, err error)
+	loadSnapshot  func(id string) (*snapshot.Snapshot, error)
+}
+
+// nearestSnapshot returns the snapshot closest in time to crashAt within
+// window, and the signed delta (snapshot time minus crash time). ok is false
+// when no snapshot falls inside the window.
+func nearestSnapshot(crashAt time.Time, rows []store.SnapshotRow, window time.Duration) (store.SnapshotRow, time.Duration, bool) {
+	var best store.SnapshotRow
+	var bestAbs time.Duration
+	found := false
+	for _, r := range rows {
+		delta := r.TakenAt.Sub(crashAt)
+		abs := delta
+		if abs < 0 {
+			abs = -abs
+		}
+		if abs > window {
+			continue
+		}
+		if !found || abs < bestAbs {
+			best, bestAbs, found = r, abs, true
+		}
+	}
+	if !found {
+		return store.SnapshotRow{}, 0, false
+	}
+	return best, best.TakenAt.Sub(crashAt), true
+}
+
+func runCrashState(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("crash state", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	host := fs.String("host", "", "host whose snapshots to search (defaults to the only stored host)")
+	window := fs.Duration("window", time.Hour, "max time between the crash and a usable snapshot")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra crash state [--json] [--host <h>] [--window 1h] <report.ips>")
+		fmt.Fprintln(stderr, "Show what the machine was doing around a crash, from the nearest stored snapshot.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	return runCrashStateWithDeps(fs.Arg(0), *host, *window, *asJSON, stdout, stderr, defaultCrashStateDeps())
+}
+
+type crashStateOutput struct {
+	Process   string   `json:"process"`
+	Exception string   `json:"exception,omitempty"`
+	CrashTime string   `json:"crash_time"`
+	Snapshot  string   `json:"snapshot_id"`
+	DeltaSec  float64  `json:"delta_seconds"`
+	Thermal   string   `json:"thermal_pressure,omitempty"`
+	Throttled bool     `json:"thermal_throttled"`
+	TopByRSS  []string `json:"top_by_rss,omitempty"`
+}
+
+func runCrashStateWithDeps(path, host string, window time.Duration, asJSON bool, stdout, stderr io.Writer, deps crashStateDeps) int {
+	data, err := deps.readFile(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "read %s: %v\n", path, err)
+		return 1
+	}
+	report, err := crashreport.Parse(data)
+	if err != nil {
+		fmt.Fprintf(stderr, "parse %s: %v\n", path, err)
+		return 1
+	}
+	crashAt, err := time.Parse(ipsTimeLayout, report.Time)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s has no parseable timestamp (%q)\n", path, report.Time)
+		return 1
+	}
+	hostname, rows, err := deps.loadSnapshots(host)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	row, delta, ok := nearestSnapshot(crashAt, rows, window)
+	if !ok {
+		fmt.Fprintf(stderr, "no snapshot within %s of the crash on %s (%d snapshot(s) stored)\n", window, hostname, len(rows))
+		return 1
+	}
+	snap, err := deps.loadSnapshot(row.ID)
+	if err != nil {
+		fmt.Fprintf(stderr, "load snapshot %s: %v\n", row.ID, err)
+		return 1
+	}
+	if asJSON {
+		return encodeJSON(stdout, stderr, buildCrashStateOutput(report, row, delta, snap))
+	}
+	renderCrashState(stdout, report, crashAt, hostname, row, delta, snap)
+	return 0
+}
+
+func buildCrashStateOutput(r *crashreport.Report, row store.SnapshotRow, delta time.Duration, snap *snapshot.Snapshot) crashStateOutput {
+	out := crashStateOutput{
+		Process: r.Process, Exception: r.Exception, CrashTime: r.Time,
+		Snapshot: row.ID, DeltaSec: delta.Seconds(),
+		Thermal: snap.Power.ThermalPressure, Throttled: snap.Power.ThermalThrottled,
+	}
+	for _, p := range topNByRSS(snap.Processes, 5) {
+		out.TopByRSS = append(out.TopByRSS, fmt.Sprintf("%s %dMB", p.Command, p.RSSKiB/1024))
+	}
+	return out
+}
+
+func topNByRSS(procs []process.Info, n int) []process.Info {
+	sorted := append([]process.Info(nil), procs...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].RSSKiB > sorted[j].RSSKiB })
+	if len(sorted) > n {
+		sorted = sorted[:n]
+	}
+	return sorted
+}
+
+func renderCrashState(w io.Writer, r *crashreport.Report, crashAt time.Time, hostname string, row store.SnapshotRow, delta time.Duration, snap *snapshot.Snapshot) {
+	fmt.Fprintf(w, "%s crashed at %s", r.Process, crashAt.Format("2006-01-02 15:04:05"))
+	if r.Exception != "" {
+		fmt.Fprintf(w, " (%s)", r.Exception)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Nearest snapshot on %s: %s at %s (%s)\n",
+		hostname, row.ID, row.TakenAt.Format("2006-01-02 15:04:05"), relativeDelta(delta))
+	fmt.Fprintln(w, "Machine context at that snapshot (correlational, bounded by capture cadence):")
+	if snap.Power.ThermalPressure != "" || snap.Power.ThermalThrottled {
+		fmt.Fprintf(w, "  thermal: %s%s\n", naOr(snap.Power.ThermalPressure), throttleNote(snap.Power.ThermalThrottled))
+	}
+	top := topNByRSS(snap.Processes, 5)
+	if len(top) > 0 {
+		fmt.Fprintln(w, "  top processes by RSS:")
+		for _, p := range top {
+			fmt.Fprintf(w, "    %-28s %dMB\n", truncate(p.Command, 28), p.RSSKiB/1024)
+		}
+	}
+}
+
+func naOr(s string) string {
+	if s == "" {
+		return "n/a"
+	}
+	return s
+}
+
+func throttleNote(throttled bool) string {
+	if throttled {
+		return " (throttled)"
+	}
+	return ""
+}
+
+func relativeDelta(delta time.Duration) string {
+	if delta == 0 {
+		return "at crash time"
+	}
+	mag := delta
+	rel := "after the crash"
+	if delta < 0 {
+		mag = -delta
+		rel = "before the crash"
+	}
+	return fmt.Sprintf("%s %s", mag.Round(time.Second), rel)
+}
+
+func defaultCrashStateDeps() crashStateDeps {
+	return crashStateDeps{
+		readFile:      os.ReadFile,
+		loadSnapshots: storeSnapshotRows,
+		loadSnapshot:  storeFullSnapshot,
+	}
+}
+
+func storeSnapshotRows(host string) (string, []store.SnapshotRow, error) {
+	db, cleanup, err := openStoreDB()
+	if err != nil {
+		return "", nil, err
+	}
+	defer cleanup()
+	ctx := context.Background()
+	hostRows, err := db.ListHosts(ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("list hosts: %w", err)
+	}
+	hr, err := resolveBisectHost(hostRows, host)
+	if err != nil {
+		return "", nil, err
+	}
+	rows, err := db.ListSnapshots(ctx, hr.MachineUUID)
+	if err != nil {
+		return hr.Hostname, nil, fmt.Errorf("list snapshots: %w", err)
+	}
+	return hr.Hostname, rows, nil
+}
+
+func storeFullSnapshot(id string) (*snapshot.Snapshot, error) {
+	db, cleanup, err := openStoreDB()
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	data, err := db.GetSnapshotJSON(context.Background(), id)
+	if err != nil {
+		return nil, err
+	}
+	var snap snapshot.Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, err
+	}
+	return &snap, nil
+}
+
+func openStoreDB() (*store.DB, func(), error) {
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve store path: %w", err)
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open store %s: %w", dbPath, err)
+	}
+	return db, func() { _ = db.Close() }, nil
+}

--- a/cmd/spectra/crash_state_test.go
+++ b/cmd/spectra/crash_state_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/snapshot"
+	"github.com/kaeawc/spectra/internal/store"
+	"github.com/kaeawc/spectra/internal/sysinfo"
+)
+
+func at(s string) time.Time {
+	t, _ := time.Parse("2006-01-02 15:04:05", s)
+	return t
+}
+
+func TestNearestSnapshot(t *testing.T) {
+	crash := at("2026-08-05 15:04:00")
+	rows := []store.SnapshotRow{
+		{ID: "s1", TakenAt: at("2026-08-05 14:00:00")}, // 64m before
+		{ID: "s2", TakenAt: at("2026-08-05 14:58:00")}, // 6m before  <- nearest
+		{ID: "s3", TakenAt: at("2026-08-05 16:30:00")}, // 86m after
+	}
+	row, delta, ok := nearestSnapshot(crash, rows, time.Hour)
+	if !ok || row.ID != "s2" {
+		t.Fatalf("nearest = %q ok=%v, want s2", row.ID, ok)
+	}
+	if delta != -6*time.Minute {
+		t.Errorf("delta = %v, want -6m", delta)
+	}
+}
+
+func TestNearestSnapshotOutOfWindow(t *testing.T) {
+	crash := at("2026-08-05 15:04:00")
+	rows := []store.SnapshotRow{{ID: "s1", TakenAt: at("2026-08-05 10:00:00")}}
+	if _, _, ok := nearestSnapshot(crash, rows, time.Hour); ok {
+		t.Error("expected no snapshot within a 1h window")
+	}
+}
+
+func ipsWithTime(when string) string {
+	return `{"app_name":"MyApp","timestamp":"` + when + `","bug_type":"309","name":"MyApp"}
+{"procName":"MyApp","pid":1,"exception":{"type":"EXC_BAD_ACCESS","signal":"SIGSEGV"},"termination":{"indicator":"x"},"faultingThread":0,"threads":[{"triggered":true,"frames":[]}],"usedImages":[]}`
+}
+
+func TestRunCrashStateRenders(t *testing.T) {
+	deps := crashStateDeps{
+		readFile: func(string) ([]byte, error) {
+			return []byte(ipsWithTime("2026-08-05 15:04:00.00 -0500")), nil
+		},
+		loadSnapshots: func(host string) (string, []store.SnapshotRow, error) {
+			// crash is 15:04:00 -0500 = 20:04:00 UTC; this snapshot (UTC) is 6m before.
+			return "my-mac", []store.SnapshotRow{{ID: "snap-1", TakenAt: at("2026-08-05 19:58:00")}}, nil
+		},
+		loadSnapshot: func(id string) (*snapshot.Snapshot, error) {
+			return &snapshot.Snapshot{
+				Power:     sysinfo.PowerState{ThermalPressure: "serious"},
+				Processes: []process.Info{{Command: "MyApp", RSSKiB: 1258291}, {Command: "idle", RSSKiB: 1024}},
+			}, nil
+		},
+	}
+	var out, errBuf bytes.Buffer
+	if code := runCrashStateWithDeps("r.ips", "", time.Hour, false, &out, &errBuf, deps); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	for _, want := range []string{"MyApp crashed", "snap-1", "before the crash", "thermal: serious", "correlational"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+func TestRunCrashStateNoSnapshotInWindow(t *testing.T) {
+	deps := crashStateDeps{
+		readFile: func(string) ([]byte, error) { return []byte(ipsWithTime("2026-08-05 15:04:00.00 -0500")), nil },
+		loadSnapshots: func(string) (string, []store.SnapshotRow, error) {
+			return "m", []store.SnapshotRow{{ID: "s", TakenAt: at("2020-01-01 00:00:00")}}, nil
+		},
+		loadSnapshot: func(string) (*snapshot.Snapshot, error) { return &snapshot.Snapshot{}, nil },
+	}
+	var out, errBuf bytes.Buffer
+	if code := runCrashStateWithDeps("r.ips", "", time.Hour, false, &out, &errBuf, deps); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "no snapshot within") {
+		t.Errorf("stderr = %q", errBuf.String())
+	}
+}
+
+func TestRunCrashStateBadTimestamp(t *testing.T) {
+	deps := crashStateDeps{
+		readFile:      func(string) ([]byte, error) { return []byte(ipsWithTime("not-a-time")), nil },
+		loadSnapshots: func(string) (string, []store.SnapshotRow, error) { return "m", nil, nil },
+		loadSnapshot:  func(string) (*snapshot.Snapshot, error) { return &snapshot.Snapshot{}, nil },
+	}
+	var out, errBuf bytes.Buffer
+	if code := runCrashStateWithDeps("r.ips", "", time.Hour, false, &out, &errBuf, deps); code != 1 {
+		t.Fatalf("exit = %d, want 1 for unparseable timestamp", code)
+	}
+}
+
+func TestRunCrashStateNoArgs(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runCrashState(nil, &out, &errBuf); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -445,6 +445,22 @@ spectra crash signatures
 spectra crash signatures --json
 ```
 
+## `spectra crash state`
+
+Reconstructs what the machine was doing around a crash. Given a `.ips`
+report, it finds the **nearest stored snapshot by time** (within `--window`,
+default 1h) and shows the machine context at that moment — top processes by
+RSS and thermal state — reported as **correlational, not cause**, and
+bounded by snapshot cadence. `--host` selects the host; `--json` structured.
+A precursor to a unified incident timeline.
+
+### Examples
+
+```bash
+spectra crash state ~/Library/Logs/DiagnosticReports/MyApp-2026.ips
+spectra crash state --window 30m --json report.ips
+```
+
 ## `spectra crash inspect`
 
 Decodes a modern macOS `.ips` crash report (the JSON reports written to


### PR DESCRIPTION
## What

Adds **`spectra crash state <report.ips>`** — reconstructs what the machine was doing around a crash. `crash inspect` says *why* a process died; this adds *what the machine was doing then*: it finds the nearest stored snapshot by time and shows the context. A precursor to a unified incident timeline.

## How

- Parses the `.ips` (`crashreport`), reads its timestamp, and `nearestSnapshot(crashTime, rows, window)` (pure) picks the snapshot with the smallest absolute time delta within `--window` (default 1h), reporting the signed delta ("6m before the crash").
- Loads that snapshot and shows the machine context — top processes by RSS and thermal state — explicitly framed as **correlational, not cause**, and **bounded by snapshot cadence**. `--host` selects the host (defaults to the single stored one); `--json` structured. "No snapshot in window" is handled.
- The report reader and the two snapshot loaders are injected, so the whole command is tested without a live store.

## Scope (v1)

Single nearest snapshot within a window; top-RSS + thermal context. Interpolation between bracketing snapshots and network/power lanes are follow-ups.

## Testing

- `nearestSnapshot`: picks the closest within window (before/after), signed delta, and rejects out-of-window.
- CLI: full render (crash line, nearest snapshot, delta, thermal, correlational caveat), no-snapshot-in-window, unparseable-timestamp, no-args — via injected deps.
- `make vet complexity lint security docs-validate test` green locally (55 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #381
