### PR TITLE
crash: spectra crash oom — attribute EXC_RESOURCE(MEMORY) & jetsam kills

### DIFF
--- a/cmd/spectra/crash.go
+++ b/cmd/spectra/crash.go
@@ -38,8 +38,10 @@ func runCrashWithIO(args []string, stdout, stderr io.Writer, inspect func(string
 		return runCrashSignatures(rest, stdout, stderr)
 	case "state":
 		return runCrashState(rest, stdout, stderr)
+	case "oom":
+		return runCrashOOM(rest, stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource, list, signatures, state)\n", sub)
+		fmt.Fprintf(stderr, "unknown crash subcommand %q (want: readiness, inspect, resource, list, signatures, state, oom)\n", sub)
 		return 2
 	}
 }

--- a/cmd/spectra/crash_oom.go
+++ b/cmd/spectra/crash_oom.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/crashreport"
+)
+
+// jetsamBugTypes are numeric .ips bug_type codes that mark a jetsam /
+// low-memory kill. Kept small and conservative.
+var jetsamBugTypes = map[string]bool{"298": true}
+
+type oomKill struct {
+	Time     string `json:"time"`
+	Process  string `json:"process"`
+	Reason   string `json:"reason"`
+	Limit    string `json:"limit,omitempty"`
+	Observed string `json:"observed,omitempty"`
+	File     string `json:"file"`
+	at       time.Time
+}
+
+// classifyMemoryKill reports whether a report is a memory/OOM termination and,
+// if so, the attributed kill. The reliable path is EXC_RESOURCE(MEMORY), which
+// the crash decoder already resolves; jetsam bug_types are a best-effort path.
+func classifyMemoryKill(r *crashreport.Report) (oomKill, bool) {
+	if r.Resource != nil && r.Resource.Flavor == "MEMORY" {
+		return oomKill{
+			Process:  r.Process,
+			Reason:   r.Resource.Explanation,
+			Limit:    r.Resource.Limit,
+			Observed: r.Resource.Observed,
+		}, true
+	}
+	if jetsamBugTypes[r.BugType] {
+		return oomKill{Process: r.Process, Reason: "jetsam / low-memory kill"}, true
+	}
+	return oomKill{}, false
+}
+
+func collectMemoryKills(swept []sweptReport) []oomKill {
+	var out []oomKill
+	for _, s := range swept {
+		kill, ok := classifyMemoryKill(s.Report)
+		if !ok {
+			continue
+		}
+		kill.Time = s.Report.Time
+		kill.File = s.File
+		if t, err := time.Parse(ipsTimeLayout, s.Report.Time); err == nil {
+			kill.at = t
+		}
+		out = append(out, kill)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].at.After(out[j].at) })
+	return out
+}
+
+func runCrashOOM(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("crash oom", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	limit := fs.Int("limit", 25, "maximum kills to show")
+	dir := fs.String("dir", defaultDiagnosticReportsDir(), "DiagnosticReports directory")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: spectra crash oom [--json] [--limit N] [--dir <path>]")
+		fmt.Fprintln(stderr, "List memory / OOM terminations (EXC_RESOURCE memory limits and jetsam kills).")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+	return runCrashOOMWithDeps(*asJSON, *limit, stdout, stderr, defaultCrashListDeps(*dir))
+}
+
+func runCrashOOMWithDeps(asJSON bool, limit int, stdout, stderr io.Writer, deps crashListDeps) int {
+	files, err := deps.list()
+	if err != nil {
+		fmt.Fprintf(stderr, "list reports: %v\n", err)
+		return 1
+	}
+	swept, _ := sweepCrashReports(files, deps.read)
+	kills := collectMemoryKills(swept)
+	if limit > 0 && len(kills) > limit {
+		kills = kills[:limit]
+	}
+	if asJSON {
+		return encodeJSON(stdout, stderr, kills)
+	}
+	renderOOM(stdout, kills, len(swept))
+	return 0
+}
+
+func renderOOM(w io.Writer, kills []oomKill, totalReports int) {
+	if len(kills) == 0 {
+		fmt.Fprintf(w, "No memory/OOM kills among %d report(s).\n", totalReports)
+		return
+	}
+	fmt.Fprintf(w, "Memory / OOM kills (%d of %d report(s)):\n", len(kills), totalReports)
+	for _, k := range kills {
+		when := k.Time
+		if !k.at.IsZero() {
+			when = k.at.Format("2006-01-02 15:04")
+		}
+		fmt.Fprintf(w, "  %-16s  %-24s %s%s\n", when, truncate(k.Process, 24), k.Reason, oomLimitNote(k))
+		if k.File != "" {
+			fmt.Fprintf(w, "        %s\n", k.File)
+		}
+	}
+}
+
+func oomLimitNote(k oomKill) string {
+	if k.Limit == "" && k.Observed == "" {
+		return ""
+	}
+	return fmt.Sprintf(" (limit %s, observed %s)", orDashKill(k.Limit), orDashKill(k.Observed))
+}
+
+func orDashKill(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/spectra/crash_oom_test.go
+++ b/cmd/spectra/crash_oom_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/crashreport"
+)
+
+func TestClassifyMemoryKill(t *testing.T) {
+	mem := &crashreport.Report{Process: "Hungry", Resource: &crashreport.ResourceKill{Flavor: "MEMORY", Explanation: "resident memory crossed a high-watermark limit", Limit: "1500MB", Observed: "1620MB"}}
+	if k, ok := classifyMemoryKill(mem); !ok || k.Process != "Hungry" || k.Limit != "1500MB" {
+		t.Errorf("MEMORY kill = %+v ok=%v, want included with limit", k, ok)
+	}
+	seg := &crashreport.Report{Process: "App", Exception: "EXC_BAD_ACCESS"}
+	if _, ok := classifyMemoryKill(seg); ok {
+		t.Error("a segfault must not be classified as an OOM kill")
+	}
+	cpu := &crashreport.Report{Process: "Busy", Resource: &crashreport.ResourceKill{Flavor: "CPU"}}
+	if _, ok := classifyMemoryKill(cpu); ok {
+		t.Error("a CPU EXC_RESOURCE must not be an OOM kill")
+	}
+	jet := &crashreport.Report{Process: "Jetted", BugType: "298"}
+	if k, ok := classifyMemoryKill(jet); !ok || !strings.Contains(k.Reason, "jetsam") {
+		t.Errorf("jetsam bug_type = %+v ok=%v, want jetsam kill", k, ok)
+	}
+}
+
+func TestCollectMemoryKillsSortsAndFilters(t *testing.T) {
+	swept := []sweptReport{
+		{File: "/r/a.ips", Report: &crashreport.Report{Process: "A", Time: "2026-08-01 10:00:00.00 -0500", Resource: &crashreport.ResourceKill{Flavor: "MEMORY", Explanation: "mem"}}},
+		{File: "/r/seg.ips", Report: &crashreport.Report{Process: "Seg", Time: "2026-08-02 10:00:00.00 -0500", Exception: "EXC_BAD_ACCESS"}},
+		{File: "/r/b.ips", Report: &crashreport.Report{Process: "B", Time: "2026-08-05 10:00:00.00 -0500", Resource: &crashreport.ResourceKill{Flavor: "MEMORY", Explanation: "mem"}}},
+	}
+	kills := collectMemoryKills(swept)
+	if len(kills) != 2 {
+		t.Fatalf("kills = %d, want 2 (segfault excluded): %+v", len(kills), kills)
+	}
+	if kills[0].Process != "B" {
+		t.Errorf("newest-first expected B, got %s", kills[0].Process)
+	}
+}
+
+func memResourceIPS(app, when string) string {
+	return `{"app_name":"` + app + `","timestamp":"` + when + `","bug_type":"309","name":"` + app + `"}
+{"procName":"` + app + `","pid":1,"exception":{"type":"EXC_RESOURCE","subtype":"MEMORY (Limit 1500 MB Observed 1620 MB)"},"termination":{"namespace":"RESOURCE","indicator":"MEMORY"},"faultingThread":0,"threads":[{"triggered":true,"frames":[]}],"usedImages":[]}`
+}
+
+func TestRunCrashOOMRenders(t *testing.T) {
+	deps := crashListDeps{
+		list: func() ([]string, error) { return []string{"mem.ips", "seg.ips"}, nil },
+		read: func(f string) ([]byte, error) {
+			if f == "mem.ips" {
+				return []byte(memResourceIPS("Hungry", "2026-08-05 10:00:00.00 -0500")), nil
+			}
+			return []byte(ipsReport("Fine", "2026-08-05 09:00:00.00 -0500", "EXC_BAD_ACCESS")), nil
+		},
+	}
+	var out, errBuf bytes.Buffer
+	if code := runCrashOOMWithDeps(false, 25, &out, &errBuf, deps); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "Hungry") || strings.Contains(s, "Fine") {
+		t.Errorf("expected only the memory kill (Hungry, not Fine); got:\n%s", s)
+	}
+	if !strings.Contains(s, "limit") {
+		t.Errorf("expected the limit note; got:\n%s", s)
+	}
+}
+
+func TestRunCrashOOMNone(t *testing.T) {
+	deps := crashListDeps{
+		list: func() ([]string, error) { return []string{"seg.ips"}, nil },
+		read: func(string) ([]byte, error) {
+			return []byte(ipsReport("Fine", "2026-08-05 09:00:00.00 -0500", "EXC_BAD_ACCESS")), nil
+		},
+	}
+	var out, errBuf bytes.Buffer
+	runCrashOOMWithDeps(false, 25, &out, &errBuf, deps)
+	if !strings.Contains(out.String(), "No memory/OOM kills") {
+		t.Errorf("out = %q", out.String())
+	}
+}
+
+func TestRunCrashOOMRejectsPositional(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runCrashOOM([]string{"extra"}, &out, &errBuf); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -461,6 +461,22 @@ spectra crash state ~/Library/Logs/DiagnosticReports/MyApp-2026.ips
 spectra crash state --window 30m --json report.ips
 ```
 
+## `spectra crash oom`
+
+Filters the crash inventory to **memory / OOM terminations** and attributes
+each. The reliable path is `EXC_RESOURCE(MEMORY)` — a high-watermark memory
+kill, already decoded — surfaced with the process, the limit/observed, and
+the plain-language reason; jetsam / low-memory bug_types are surfaced
+best-effort. Ordinary segfaults are excluded. `--json` structured;
+`--limit`/`--dir` as with `crash list`.
+
+### Examples
+
+```bash
+spectra crash oom
+spectra crash oom --json
+```
+
 ## `spectra crash inspect`
 
 Decodes a modern macOS `.ips` crash report (the JSON reports written to


### PR DESCRIPTION
## What

Adds **`spectra crash oom`** — filters the crash inventory to **memory / OOM terminations** and attributes each. Memory kills read like mystery terminations in the flat inventory; this pulls them out and names the process + reason.

## How

- Reuses the sweep from `crash list`, then keeps only memory kills via a pure `classifyMemoryKill`:
  - **`EXC_RESOURCE(MEMORY)`** — the reliable path, already decoded into `crashreport.Report.Resource` (from #333). Surfaces the process, the limit/observed, and the plain-language reason.
  - **jetsam bug_types** — best-effort, surfaced with process + time.
- Ordinary segfaults and non-memory `EXC_RESOURCE` (CPU/wakeups) are excluded. Sorted newest-first; `--json`; `--limit`/`--dir`.

## Scope / honesty

The reliable signal is `EXC_RESOURCE(MEMORY)`, which the crash decoder already resolves — that's the primary path. This machine has no jetsam report to sample, so jetsam-typed reports are surfaced by `bug_type` without deep-parsing a body I can't verify. **No new report parser** — this composes the existing `ResourceKill` decode with the sweep.

## Testing

- `classifyMemoryKill`: MEMORY EXC_RESOURCE included (with limit), segfault excluded, CPU EXC_RESOURCE excluded, jetsam bug_type included.
- `collectMemoryKills`: filters + newest-first.
- CLI: full parse→classify→render of an `EXC_RESOURCE(MEMORY)` `.ips` (limit note present, non-memory report excluded), none-found message, positional rejection — via injected sweep deps.
- `make vet complexity lint security docs-validate test` green locally (55 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #383
