### PR TITLE
schedule: spectra schedule — periodic snapshot capture via a launchd agent

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -67,6 +67,7 @@ func subcommandList() []subcommand {
 		{"anomalies", "Flag processes deviating from their rolling RSS baseline", runAnomalies},
 		{"install-helper", "Install the privileged helper daemon (requires sudo)", runInstallHelperCmd},
 		{"install-daemon", "Install the user LaunchAgent for spectra serve", runInstallDaemonCmd},
+		{"schedule", "Schedule periodic snapshot capture via a launchd agent", runSchedule},
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},
 		{"crash", "Audit post-mortem readiness (can this machine produce a debuggable crash?)", runCrash},

--- a/cmd/spectra/schedule.go
+++ b/cmd/spectra/schedule.go
@@ -2,15 +2,30 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
 const scheduleAgentLabel = "dev.spectra.snapshot"
+
+// validateScheduleInterval rejects intervals that can't be represented exactly
+// as the whole-second StartInterval a LaunchAgent takes, so the plist and the
+// reported value never disagree.
+func validateScheduleInterval(interval time.Duration) error {
+	if interval < time.Minute {
+		return errors.New("--interval must be at least 1m")
+	}
+	if interval%time.Second != 0 {
+		return errors.New("--interval must be a whole number of seconds")
+	}
+	return nil
+}
 
 func runSchedule(args []string) int {
 	return runScheduleWithIO(args, os.Stdout, os.Stderr, defaultDaemonAgentDeps())
@@ -44,8 +59,8 @@ func runScheduleInstall(args []string, stdout, stderr io.Writer, deps daemonAgen
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *interval < time.Minute {
-		fmt.Fprintln(stderr, "--interval must be at least 1m")
+	if err := validateScheduleInterval(*interval); err != nil {
+		fmt.Fprintln(stderr, err)
 		return 2
 	}
 	plistPath, err := installScheduleAgent(int(interval.Seconds()), *noLoad, deps)
@@ -67,9 +82,13 @@ func runScheduleUninstall(_ []string, stdout, stderr io.Writer, deps daemonAgent
 	return 0
 }
 
-func runScheduleStatus(_ []string, stdout, _ io.Writer, deps daemonAgentDeps) int {
-	out, err := scheduleAgentStatus(deps)
+func runScheduleStatus(_ []string, stdout, stderr io.Writer, deps daemonAgentDeps) int {
+	out, loaded, err := scheduleAgentStatus(deps)
 	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	if !loaded {
 		fmt.Fprintln(stdout, "spectra snapshot LaunchAgent is not loaded")
 		return 0
 	}
@@ -82,6 +101,10 @@ func runSchedulePrintPlist(args []string, stdout, stderr io.Writer, deps daemonA
 	fs.SetOutput(stderr)
 	interval := fs.Duration("interval", time.Hour, "how often to capture a snapshot")
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if err := validateScheduleInterval(*interval); err != nil {
+		fmt.Fprintln(stderr, err)
 		return 2
 	}
 	exe, err := deps.executable()
@@ -153,12 +176,23 @@ func uninstallScheduleAgent(deps daemonAgentDeps) (string, error) {
 	return paths.plistPath, nil
 }
 
-func scheduleAgentStatus(deps daemonAgentDeps) ([]byte, error) {
+// scheduleAgentStatus returns the launchctl print output and whether the agent
+// is loaded. A "service not found" result means simply not-loaded (loaded=false,
+// err=nil); any other launchctl failure is a real error.
+func scheduleAgentStatus(deps daemonAgentDeps) ([]byte, bool, error) {
 	out, err := deps.output("print", "gui/"+deps.uid()+"/"+scheduleAgentLabel)
 	if err != nil {
-		return nil, fmt.Errorf("launchctl print: %w", err)
+		if isServiceNotFound(out, err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("launchctl print: %w", err)
 	}
-	return out, nil
+	return out, true, nil
+}
+
+func isServiceNotFound(out []byte, err error) bool {
+	blob := strings.ToLower(string(out) + " " + err.Error())
+	return strings.Contains(blob, "could not find") || strings.Contains(blob, "no such process")
 }
 
 func snapshotLaunchAgentPlist(executable string, intervalSec int, stdoutPath, stderrPath string) string {

--- a/cmd/spectra/schedule.go
+++ b/cmd/spectra/schedule.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const scheduleAgentLabel = "dev.spectra.snapshot"
+
+func runSchedule(args []string) int {
+	return runScheduleWithIO(args, os.Stdout, os.Stderr, defaultDaemonAgentDeps())
+}
+
+func runScheduleWithIO(args []string, stdout, stderr io.Writer, deps daemonAgentDeps) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: spectra schedule <install [--interval 1h] [--no-load] | uninstall | status | print-plist>")
+		return 2
+	}
+	switch args[0] {
+	case "install":
+		return runScheduleInstall(args[1:], stdout, stderr, deps)
+	case "uninstall":
+		return runScheduleUninstall(args[1:], stdout, stderr, deps)
+	case "status":
+		return runScheduleStatus(args[1:], stdout, stderr, deps)
+	case "print-plist":
+		return runSchedulePrintPlist(args[1:], stdout, stderr, deps)
+	default:
+		fmt.Fprintf(stderr, "unknown schedule subcommand %q (want: install, uninstall, status, print-plist)\n", args[0])
+		return 2
+	}
+}
+
+func runScheduleInstall(args []string, stdout, stderr io.Writer, deps daemonAgentDeps) int {
+	fs := flag.NewFlagSet("schedule install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	interval := fs.Duration("interval", time.Hour, "how often to capture a snapshot")
+	noLoad := fs.Bool("no-load", false, "write the plist but do not bootstrap with launchd")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *interval < time.Minute {
+		fmt.Fprintln(stderr, "--interval must be at least 1m")
+		return 2
+	}
+	plistPath, err := installScheduleAgent(int(interval.Seconds()), *noLoad, deps)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "spectra snapshot LaunchAgent installed at %s (every %s)\n", plistPath, *interval)
+	return 0
+}
+
+func runScheduleUninstall(_ []string, stdout, stderr io.Writer, deps daemonAgentDeps) int {
+	plistPath, err := uninstallScheduleAgent(deps)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "spectra snapshot LaunchAgent removed from %s\n", plistPath)
+	return 0
+}
+
+func runScheduleStatus(_ []string, stdout, _ io.Writer, deps daemonAgentDeps) int {
+	out, err := scheduleAgentStatus(deps)
+	if err != nil {
+		fmt.Fprintln(stdout, "spectra snapshot LaunchAgent is not loaded")
+		return 0
+	}
+	fmt.Fprint(stdout, string(out))
+	return 0
+}
+
+func runSchedulePrintPlist(args []string, stdout, stderr io.Writer, deps daemonAgentDeps) int {
+	fs := flag.NewFlagSet("schedule print-plist", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	interval := fs.Duration("interval", time.Hour, "how often to capture a snapshot")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	exe, err := deps.executable()
+	if err != nil {
+		fmt.Fprintf(stderr, "resolve executable: %v\n", err)
+		return 1
+	}
+	home, err := deps.homeDir()
+	if err != nil {
+		fmt.Fprintf(stderr, "resolve home directory: %v\n", err)
+		return 1
+	}
+	paths := scheduleAgentPaths(home)
+	fmt.Fprint(stdout, snapshotLaunchAgentPlist(exe, int(interval.Seconds()), paths.stdoutPath, paths.stderrPath))
+	return 0
+}
+
+func scheduleAgentPaths(home string) daemonAgentPathSet {
+	return daemonAgentPathSet{
+		launchAgentsDir: filepath.Join(home, "Library", "LaunchAgents"),
+		logDir:          filepath.Join(home, "Library", "Logs", "Spectra"),
+		plistPath:       filepath.Join(home, "Library", "LaunchAgents", scheduleAgentLabel+".plist"),
+		stdoutPath:      filepath.Join(home, "Library", "Logs", "Spectra", "snapshot.launchd.out.log"),
+		stderrPath:      filepath.Join(home, "Library", "Logs", "Spectra", "snapshot.launchd.err.log"),
+	}
+}
+
+func installScheduleAgent(intervalSec int, noLoad bool, deps daemonAgentDeps) (string, error) {
+	exe, err := deps.executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve executable: %w", err)
+	}
+	home, err := deps.homeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	paths := scheduleAgentPaths(home)
+	if err := deps.mkdirAll(paths.launchAgentsDir, 0o700); err != nil {
+		return "", fmt.Errorf("create LaunchAgents directory: %w", err)
+	}
+	if err := deps.mkdirAll(paths.logDir, 0o700); err != nil {
+		return "", fmt.Errorf("create snapshot log directory: %w", err)
+	}
+	plist := snapshotLaunchAgentPlist(exe, intervalSec, paths.stdoutPath, paths.stderrPath)
+	if err := deps.writeFile(paths.plistPath, []byte(plist), 0o644); err != nil {
+		return "", fmt.Errorf("write LaunchAgent plist: %w", err)
+	}
+	if noLoad {
+		return paths.plistPath, nil
+	}
+	domain := "gui/" + deps.uid()
+	_ = deps.run("bootout", domain, paths.plistPath)
+	if err := deps.run("bootstrap", domain, paths.plistPath); err != nil {
+		return "", fmt.Errorf("launchctl bootstrap: %w", err)
+	}
+	return paths.plistPath, nil
+}
+
+func uninstallScheduleAgent(deps daemonAgentDeps) (string, error) {
+	home, err := deps.homeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	paths := scheduleAgentPaths(home)
+	_ = deps.run("bootout", "gui/"+deps.uid(), paths.plistPath)
+	if err := deps.remove(paths.plistPath); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("remove LaunchAgent plist: %w", err)
+	}
+	return paths.plistPath, nil
+}
+
+func scheduleAgentStatus(deps daemonAgentDeps) ([]byte, error) {
+	out, err := deps.output("print", "gui/"+deps.uid()+"/"+scheduleAgentLabel)
+	if err != nil {
+		return nil, fmt.Errorf("launchctl print: %w", err)
+	}
+	return out, nil
+}
+
+func snapshotLaunchAgentPlist(executable string, intervalSec int, stdoutPath, stderrPath string) string {
+	var b bytes.Buffer
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	b.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	b.WriteString(`<plist version="1.0">` + "\n")
+	b.WriteString("<dict>\n")
+	writePlistKeyString(&b, "Label", scheduleAgentLabel)
+	b.WriteString("    <key>ProgramArguments</key>\n")
+	b.WriteString("    <array>\n")
+	writePlistString(&b, executable)
+	writePlistString(&b, "snapshot")
+	b.WriteString("    </array>\n")
+	b.WriteString("    <key>StartInterval</key>\n")
+	fmt.Fprintf(&b, "    <integer>%d</integer>\n", intervalSec)
+	b.WriteString("    <key>RunAtLoad</key>\n")
+	b.WriteString("    <true/>\n")
+	writePlistKeyString(&b, "StandardOutPath", stdoutPath)
+	writePlistKeyString(&b, "StandardErrorPath", stderrPath)
+	b.WriteString("</dict>\n")
+	b.WriteString("</plist>\n")
+	return b.String()
+}

--- a/cmd/spectra/schedule_test.go
+++ b/cmd/spectra/schedule_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+type fakeAgent struct {
+	written map[string][]byte
+	removed []string
+	runs    [][]string
+	printOK bool
+}
+
+func newFakeAgent() *fakeAgent { return &fakeAgent{written: map[string][]byte{}} }
+
+func (f *fakeAgent) deps() daemonAgentDeps {
+	return daemonAgentDeps{
+		executable: func() (string, error) { return "/usr/local/bin/spectra", nil },
+		homeDir:    func() (string, error) { return "/home/tester", nil },
+		uid:        func() string { return "501" },
+		mkdirAll:   func(string, os.FileMode) error { return nil },
+		writeFile:  func(p string, b []byte, _ os.FileMode) error { f.written[p] = b; return nil },
+		remove:     func(p string) error { f.removed = append(f.removed, p); return nil },
+		run:        func(a ...string) error { f.runs = append(f.runs, a); return nil },
+		output: func(a ...string) ([]byte, error) {
+			if f.printOK {
+				return []byte("dev.spectra.snapshot => loaded"), nil
+			}
+			return nil, errors.New("not loaded")
+		},
+	}
+}
+
+func TestScheduleInstallWritesPlistAndLoads(t *testing.T) {
+	f := newFakeAgent()
+	var out, errBuf bytes.Buffer
+	if code := runScheduleWithIO([]string{"install", "--interval", "30m"}, &out, &errBuf, f.deps()); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	plist := f.written["/home/tester/Library/LaunchAgents/dev.spectra.snapshot.plist"]
+	if plist == nil {
+		t.Fatalf("plist not written; wrote %v", f.written)
+	}
+	s := string(plist)
+	if !strings.Contains(s, "<integer>1800</integer>") {
+		t.Errorf("StartInterval should be 1800s; got:\n%s", s)
+	}
+	if !strings.Contains(s, "<string>snapshot</string>") {
+		t.Errorf("ProgramArguments should run snapshot; got:\n%s", s)
+	}
+	// launchctl bootstrap should have run
+	var bootstrapped bool
+	for _, r := range f.runs {
+		if len(r) > 0 && r[0] == "bootstrap" {
+			bootstrapped = true
+		}
+	}
+	if !bootstrapped {
+		t.Errorf("expected a launchctl bootstrap; runs=%v", f.runs)
+	}
+}
+
+func TestScheduleInstallNoLoad(t *testing.T) {
+	f := newFakeAgent()
+	var out, errBuf bytes.Buffer
+	if code := runScheduleWithIO([]string{"install", "--interval", "1h", "--no-load"}, &out, &errBuf, f.deps()); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if len(f.runs) != 0 {
+		t.Errorf("--no-load must not call launchctl; runs=%v", f.runs)
+	}
+	if len(f.written) != 1 {
+		t.Errorf("expected exactly the plist written; got %v", f.written)
+	}
+}
+
+func TestScheduleInstallRejectsShortInterval(t *testing.T) {
+	f := newFakeAgent()
+	var out, errBuf bytes.Buffer
+	if code := runScheduleWithIO([]string{"install", "--interval", "10s"}, &out, &errBuf, f.deps()); code != 2 {
+		t.Fatalf("exit = %d, want 2 for a sub-minute interval", code)
+	}
+}
+
+func TestScheduleUninstall(t *testing.T) {
+	f := newFakeAgent()
+	var out, errBuf bytes.Buffer
+	if code := runScheduleWithIO([]string{"uninstall"}, &out, &errBuf, f.deps()); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if len(f.removed) != 1 || !strings.HasSuffix(f.removed[0], "dev.spectra.snapshot.plist") {
+		t.Errorf("expected the plist removed; removed=%v", f.removed)
+	}
+}
+
+func TestSchedulePrintPlistWritesNothing(t *testing.T) {
+	f := newFakeAgent()
+	var out, errBuf bytes.Buffer
+	if code := runScheduleWithIO([]string{"print-plist", "--interval", "15m"}, &out, &errBuf, f.deps()); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if len(f.written) != 0 || len(f.runs) != 0 {
+		t.Errorf("print-plist must not write or load; written=%v runs=%v", f.written, f.runs)
+	}
+	if !strings.Contains(out.String(), "<integer>900</integer>") {
+		t.Errorf("printed plist should carry StartInterval 900; got:\n%s", out.String())
+	}
+}
+
+func TestScheduleStatusNotLoaded(t *testing.T) {
+	f := newFakeAgent()
+	var out, errBuf bytes.Buffer
+	runScheduleWithIO([]string{"status"}, &out, &errBuf, f.deps())
+	if !strings.Contains(out.String(), "not loaded") {
+		t.Errorf("out = %q", out.String())
+	}
+}
+
+func TestScheduleUnknownSub(t *testing.T) {
+	f := newFakeAgent()
+	var out, errBuf bytes.Buffer
+	if code := runScheduleWithIO([]string{"bogus"}, &out, &errBuf, f.deps()); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/cmd/spectra/schedule_test.go
+++ b/cmd/spectra/schedule_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 type fakeAgent struct {
-	written map[string][]byte
-	removed []string
-	runs    [][]string
-	printOK bool
+	written  map[string][]byte
+	removed  []string
+	runs     [][]string
+	printOK  bool
+	printErr bool // simulate a real launchctl failure (not "service not found")
 }
 
 func newFakeAgent() *fakeAgent { return &fakeAgent{written: map[string][]byte{}} }
@@ -27,10 +28,14 @@ func (f *fakeAgent) deps() daemonAgentDeps {
 		remove:     func(p string) error { f.removed = append(f.removed, p); return nil },
 		run:        func(a ...string) error { f.runs = append(f.runs, a); return nil },
 		output: func(a ...string) ([]byte, error) {
-			if f.printOK {
+			switch {
+			case f.printOK:
 				return []byte("dev.spectra.snapshot => loaded"), nil
+			case f.printErr:
+				return []byte("Operation not permitted"), errors.New("exit status 5")
+			default:
+				return []byte(`Could not find service "dev.spectra.snapshot"`), errors.New("exit status 113")
 			}
-			return nil, errors.New("not loaded")
 		},
 	}
 }
@@ -117,6 +122,29 @@ func TestScheduleStatusNotLoaded(t *testing.T) {
 	runScheduleWithIO([]string{"status"}, &out, &errBuf, f.deps())
 	if !strings.Contains(out.String(), "not loaded") {
 		t.Errorf("out = %q", out.String())
+	}
+}
+
+func TestScheduleInstallRejectsFractionalSeconds(t *testing.T) {
+	f := newFakeAgent()
+	var out, errBuf bytes.Buffer
+	if code := runScheduleWithIO([]string{"install", "--interval", "1m500ms"}, &out, &errBuf, f.deps()); code != 2 {
+		t.Fatalf("exit = %d, want 2 for a fractional-second interval", code)
+	}
+	if len(f.written) != 0 {
+		t.Errorf("nothing should be written for an invalid interval; got %v", f.written)
+	}
+}
+
+func TestScheduleStatusRealErrorFails(t *testing.T) {
+	f := newFakeAgent()
+	f.printErr = true
+	var out, errBuf bytes.Buffer
+	if code := runScheduleWithIO([]string{"status"}, &out, &errBuf, f.deps()); code != 1 {
+		t.Fatalf("exit = %d, want 1 for a real launchctl error", code)
+	}
+	if errBuf.Len() == 0 {
+		t.Error("a real launchctl error should be surfaced on stderr")
 	}
 }
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -59,6 +59,7 @@ The short `-v` is unaffected: it still means "show detection signals" for
 | `cache` | Manage the local blob cache |
 | `install-helper` | Install the privileged helper daemon |
 | `install-daemon` | Install the user LaunchAgent for `spectra serve` |
+| `schedule` | Schedule periodic snapshot capture via a launchd agent |
 | `version` | Print Spectra version and exit |
 | `help` | Show top-level help |
 
@@ -616,6 +617,26 @@ the structured signals alongside the ranking so it's auditable.
 ```bash
 spectra whatswrong
 spectra whatswrong --json
+```
+
+## `spectra schedule`
+
+Installs a per-user LaunchAgent that runs `spectra snapshot` on an interval,
+so `spectra bisect` and `spectra anomalies` have a dense capture history to
+work over (both are only as good as how often snapshots and metrics were
+taken). Mirrors `install-daemon`: `install --interval <dur>` writes
+`~/Library/LaunchAgents/dev.spectra.snapshot.plist` (with `StartInterval`)
+and bootstraps it with launchd; `uninstall` removes it; `status` reports
+whether it's loaded; `print-plist` prints the plist without writing.
+`--no-load` writes the plist without loading it.
+
+### Examples
+
+```bash
+spectra schedule install --interval 30m
+spectra schedule status
+spectra schedule uninstall
+spectra schedule print-plist --interval 1h
 ```
 
 ## `spectra playbook`


### PR DESCRIPTION
## What

Adds **`spectra schedule`** — a per-user LaunchAgent that runs `spectra snapshot` on an interval. `bisect` resolution and `anomalies` baselines are only as good as how often captures happen, but snapshots were on-demand only. This gives them a dense history.

## How

Mirrors the existing `install-daemon` LaunchAgent pattern, reusing its injectable agent deps + plist helpers:
- `schedule install --interval <dur>` writes `~/Library/LaunchAgents/dev.spectra.snapshot.plist` (`ProgramArguments` = the spectra binary + `snapshot`, `StartInterval` = the interval in seconds, `RunAtLoad`) and bootstraps it with `launchctl`. `--no-load` writes only.
- `uninstall` unloads + removes; `status` reports whether it's loaded; `print-plist` prints the plist without writing.
- Sub-minute intervals are rejected.

## Scope (v1)

Interval-based snapshot capture (LaunchAgent `StartInterval`). Calendar scheduling and metrics-sampling cadence control are follow-ups. Underpins the capture density that `bisect` (#362) and `anomalies` (#364) rely on.

## Testing

- `install` writes a plist with `StartInterval` 1800 (from `30m`) + `ProgramArguments` running `snapshot`, and bootstraps via the fake launchctl; `--no-load` writes without loading; sub-minute interval rejected; `uninstall` removes the plist; `print-plist` writes nothing; `status` reports not-loaded; unknown subcommand.
- All via a fake `daemonAgentDeps` (in-memory filesystem + captured launchctl calls) — no real side effects.
- `make vet complexity lint security docs-validate test` green locally (55 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #385
