### PR TITLE
fleet: spectra fleet issues — deduplicate findings across hosts into fleet issues

### DIFF
--- a/cmd/spectra/fleet.go
+++ b/cmd/spectra/fleet.go
@@ -22,7 +22,7 @@ func runFleet(args []string) int {
 
 func runFleetWithIO(args []string, stdout, stderr io.Writer, load fleetLoader) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
-		fmt.Fprintln(stderr, "usage: spectra fleet <symptom <rule-id> | drift (--jdk | --app <bundleID>)> [--json]")
+		fmt.Fprintln(stderr, "usage: spectra fleet <symptom <rule-id> | drift (--jdk | --app <bundleID>) | issues> [--json]")
 		return 2
 	}
 	switch args[0] {
@@ -30,10 +30,46 @@ func runFleetWithIO(args []string, stdout, stderr io.Writer, load fleetLoader) i
 		return runFleetSymptom(args[1:], stdout, stderr, load)
 	case "drift":
 		return runFleetDrift(args[1:], stdout, stderr, load)
+	case "issues":
+		return runFleetIssues(args[1:], stdout, stderr, load)
 	default:
-		fmt.Fprintf(stderr, "unknown fleet subcommand %q (want: symptom, drift)\n", args[0])
+		fmt.Fprintf(stderr, "unknown fleet subcommand %q (want: symptom, drift, issues)\n", args[0])
 		return 2
 	}
+}
+
+func runFleetIssues(args []string, stdout, stderr io.Writer, load fleetLoader) int {
+	fs := flag.NewFlagSet("fleet issues", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "output JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: spectra fleet issues [--json]")
+		return 2
+	}
+	hosts, code := loadFleet(load, stderr)
+	if code != 0 {
+		return code
+	}
+	findings := fleet.RollupFindings(hosts, rules.V1Catalog())
+	if *asJSON {
+		return encodeJSON(stdout, stderr, findings)
+	}
+	if len(findings) == 0 {
+		fmt.Fprintf(stdout, "No findings across %d host(s).\n", len(hosts))
+		return 0
+	}
+	fmt.Fprintf(stdout, "Fleet findings across %d host(s):\n", len(hosts))
+	for _, f := range findings {
+		subject := ""
+		if f.Subject != "" {
+			subject = " (" + f.Subject + ")"
+		}
+		fmt.Fprintf(stdout, "  [%s] %s%s — %d host(s): %s\n", f.Severity, f.RuleID, subject, len(f.Hosts), joinOrDash(f.Hosts))
+	}
+	return 0
 }
 
 // defaultFleetLoader loads each host's latest snapshot from the local store.

--- a/cmd/spectra/fleet.go
+++ b/cmd/spectra/fleet.go
@@ -22,7 +22,7 @@ func runFleet(args []string) int {
 
 func runFleetWithIO(args []string, stdout, stderr io.Writer, load fleetLoader) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
-		fmt.Fprintln(stderr, "usage: spectra fleet <symptom <rule-id> | drift (--jdk | --app <bundleID>) | issues> [--json]")
+		fmt.Fprintln(stderr, "usage:\n  spectra fleet symptom [--json] <rule-id>\n  spectra fleet drift (--jdk | --app <bundleID>) [--json]\n  spectra fleet issues [--json]")
 		return 2
 	}
 	switch args[0] {

--- a/cmd/spectra/fleet_issues_test.go
+++ b/cmd/spectra/fleet_issues_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/fleet"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func sharedUnsignedFleet() []fleet.HostSnapshot {
+	unsigned := []detect.Result{{Path: "/Applications/Shared.app", TeamID: ""}}
+	return []fleet.HostSnapshot{
+		{Hostname: "laptop", Snap: snapshot.Snapshot{Apps: unsigned}},
+		{Hostname: "ci-mac", Snap: snapshot.Snapshot{Apps: unsigned}},
+	}
+}
+
+func TestRunFleetIssuesRollsUp(t *testing.T) {
+	load := func() ([]fleet.HostSnapshot, error) { return sharedUnsignedFleet(), nil }
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"issues"}, &out, &errBuf, load); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "app-unsigned") || !strings.Contains(s, "2 host(s): ci-mac, laptop") {
+		t.Errorf("expected one app-unsigned finding across both hosts; got:\n%s", s)
+	}
+}
+
+func TestRunFleetIssuesEmptyStore(t *testing.T) {
+	load := func() ([]fleet.HostSnapshot, error) { return nil, nil }
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"issues"}, &out, &errBuf, load); code != 1 {
+		t.Fatalf("exit = %d, want 1 for empty store", code)
+	}
+}
+
+func TestRunFleetIssuesRejectsPositional(t *testing.T) {
+	load := func() ([]fleet.HostSnapshot, error) { return sharedUnsignedFleet(), nil }
+	var out, errBuf bytes.Buffer
+	if code := runFleetWithIO([]string{"issues", "extra"}, &out, &errBuf, load); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -915,6 +915,9 @@ answers — the grouped result that fan-out enabled but never produced.
 
 - `spectra fleet symptom <rule-id>` groups hosts by whether that rule fires
   against their latest snapshot ("which Macs trip `app-no-hardened-runtime`?").
+- `spectra fleet issues` rolls every rule finding up across hosts,
+  deduplicated by (rule, subject), into one entry with the member host list
+  ranked most-widespread first ("5 hosts trip app-no-hardened-runtime").
 - `spectra fleet drift --jdk` / `--app <bundleID>` prints a per-host version
   matrix ("why does it repro on CI only?" — `laptop=21.0.6, ci-mac=17.0.10`).
 
@@ -927,6 +930,7 @@ than a false "missing". `--json` emits the structured result.
 spectra fleet symptom app-no-hardened-runtime
 spectra fleet drift --jdk
 spectra fleet drift --app com.tinyapp.jvm --json
+spectra fleet issues
 ```
 
 ## `spectra fan`

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -916,8 +916,8 @@ answers — the grouped result that fan-out enabled but never produced.
 - `spectra fleet symptom <rule-id>` groups hosts by whether that rule fires
   against their latest snapshot ("which Macs trip `app-no-hardened-runtime`?").
 - `spectra fleet issues` rolls every rule finding up across hosts,
-  deduplicated by (rule, subject), into one entry with the member host list
-  ranked most-widespread first ("5 hosts trip app-no-hardened-runtime").
+  deduplicated by (rule, subject), into one entry with the member host list.
+  Findings rank most-widespread first ("5 hosts trip app-no-hardened-runtime").
 - `spectra fleet drift --jdk` / `--app <bundleID>` prints a per-host version
   matrix ("why does it repro on CI only?" — `laptop=21.0.6, ci-mac=17.0.10`).
 

--- a/internal/fleet/rollup_findings.go
+++ b/internal/fleet/rollup_findings.go
@@ -1,0 +1,75 @@
+package fleet
+
+import (
+	"sort"
+
+	"github.com/kaeawc/spectra/internal/rules"
+)
+
+// FleetFinding is one rule finding deduplicated across the hosts that trip it.
+type FleetFinding struct {
+	RuleID   string   `json:"rule_id"`
+	Subject  string   `json:"subject,omitempty"`
+	Severity string   `json:"severity"`
+	Message  string   `json:"message,omitempty"`
+	Hosts    []string `json:"hosts"`
+}
+
+// RollupFindings evaluates catalog against every host's snapshot and groups the
+// resulting findings by (rule id, subject), collecting the distinct hosts that
+// trip each. Results are ranked most-widespread first, then by severity, then
+// rule id. Hosts with no usable snapshot are skipped.
+func RollupFindings(hosts []HostSnapshot, catalog []rules.Rule) []FleetFinding {
+	labels := displayLabels(hosts)
+	byKey := map[string]*FleetFinding{}
+	seen := map[string]map[string]bool{}
+	var order []string
+	for i, h := range hosts {
+		if h.Empty {
+			continue
+		}
+		for _, f := range rules.Evaluate(h.Snap, catalog) {
+			key := f.RuleID + "\x00" + f.Subject
+			ff, ok := byKey[key]
+			if !ok {
+				ff = &FleetFinding{RuleID: f.RuleID, Subject: f.Subject, Severity: string(f.Severity), Message: f.Message}
+				byKey[key] = ff
+				seen[key] = map[string]bool{}
+				order = append(order, key)
+			}
+			if !seen[key][labels[i]] {
+				seen[key][labels[i]] = true
+				ff.Hosts = append(ff.Hosts, labels[i])
+			}
+		}
+	}
+	out := make([]FleetFinding, 0, len(byKey))
+	for _, k := range order {
+		f := byKey[k]
+		sort.Strings(f.Hosts)
+		out = append(out, *f)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if len(out[i].Hosts) != len(out[j].Hosts) {
+			return len(out[i].Hosts) > len(out[j].Hosts)
+		}
+		if si, sj := findingSevRank(out[i].Severity), findingSevRank(out[j].Severity); si != sj {
+			return si < sj
+		}
+		return out[i].RuleID < out[j].RuleID
+	})
+	return out
+}
+
+func findingSevRank(s string) int {
+	switch s {
+	case "high":
+		return 0
+	case "medium":
+		return 1
+	case "low":
+		return 2
+	default:
+		return 3
+	}
+}

--- a/internal/fleet/rollup_findings_test.go
+++ b/internal/fleet/rollup_findings_test.go
@@ -1,0 +1,69 @@
+package fleet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/rules"
+)
+
+func TestRollupFindingsDedupesAcrossHosts(t *testing.T) {
+	// laptop and ci-mac both have the same unsigned app -> one rolled-up finding
+	// with both hosts; other-mac has a different unsigned app -> separate finding.
+	hosts := []HostSnapshot{
+		host("laptop", []detect.Result{{Path: "/Applications/Shared.app", TeamID: ""}}, nil),
+		host("ci-mac", []detect.Result{{Path: "/Applications/Shared.app", TeamID: ""}}, nil),
+		host("other-mac", []detect.Result{{Path: "/Applications/Solo.app", TeamID: ""}}, nil),
+	}
+	findings := RollupFindings(hosts, rules.V1Catalog())
+
+	var shared, solo *FleetFinding
+	for i := range findings {
+		if findings[i].RuleID != "app-unsigned" {
+			continue
+		}
+		switch findings[i].Subject {
+		case "Shared":
+			shared = &findings[i]
+		case "Solo":
+			solo = &findings[i]
+		}
+	}
+	if shared == nil || solo == nil {
+		t.Fatalf("expected Shared and Solo app-unsigned findings; got %+v", findings)
+	}
+	if strings.Join(shared.Hosts, ",") != "ci-mac,laptop" {
+		t.Errorf("Shared hosts = %v, want [ci-mac laptop]", shared.Hosts)
+	}
+	if len(solo.Hosts) != 1 || solo.Hosts[0] != "other-mac" {
+		t.Errorf("Solo hosts = %v, want [other-mac]", solo.Hosts)
+	}
+	// the more widespread finding must sort ahead of the single-host one
+	if indexOfRule(findings, "app-unsigned", "Shared") > indexOfRule(findings, "app-unsigned", "Solo") {
+		t.Error("the 2-host finding should rank ahead of the 1-host finding")
+	}
+}
+
+func TestRollupFindingsSkipsEmptyHosts(t *testing.T) {
+	hosts := []HostSnapshot{
+		host("laptop", []detect.Result{{Path: "/Applications/X.app", TeamID: ""}}, nil),
+		{Hostname: "offline", Empty: true},
+	}
+	for _, f := range RollupFindings(hosts, rules.V1Catalog()) {
+		for _, h := range f.Hosts {
+			if h == "offline" {
+				t.Error("an empty host must not appear in any finding")
+			}
+		}
+	}
+}
+
+func indexOfRule(fs []FleetFinding, rule, subject string) int {
+	for i, f := range fs {
+		if f.RuleID == rule && f.Subject == subject {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## What

Adds **`spectra fleet issues`** + **`fleet.RollupFindings`** — the fleet-wide deduplication that `fleet symptom`/`drift` set up but didn't finish. The same rule finding across N hosts was N unrelated per-host issues; this rolls it up into one entry with a member list ("5 hosts trip `app-no-hardened-runtime` on Slack.app").

## How

- `fleet.RollupFindings(hosts, catalog)` runs `rules.Evaluate` per host and groups the resulting findings by `(RuleID, Subject)` into a `FleetFinding{RuleID, Subject, Severity, Message, Hosts []string}` — the distinct hosts that trip it (reusing `fleet`'s duplicate-hostname disambiguation; empty hosts skipped). Ranked by host count (most widespread first), then severity, then rule id.
- `spectra fleet issues` prints the ranked rollup (+ `--json`), reusing the existing fleet store loader.

## Scope (v1)

Read-side rollup over the local store's per-host latest snapshots (as with `fleet symptom`/`drift`). Persisting fleet issues into the issues store with lifecycle is a follow-up.

## Testing

- `RollupFindings`: two hosts sharing an unsigned app collapse to one finding with both hosts; a distinct unsigned app stays separate; the 2-host finding ranks ahead of the 1-host one; empty hosts never appear.
- CLI: rollup render (`2 host(s): ci-mac, laptop`), empty-store, positional rejection — via an injected loader.
- `make vet complexity lint security docs-validate test` green locally (55 pkgs). `make licenses` fails on the pre-existing local `go-licenses`/Go 1.26 quirk, unrelated.

Closes #387
