### PR TITLE
network: TLS cert-chain, trust validation, expiry & SPKI pins in network diagnose

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -206,6 +206,9 @@ func printNetworkDiagnosisPort(p netdiag.PortDiagnosis) {
 		}
 		if p.TLS.OK {
 			fmt.Printf(" trust=%s", trustLabel(p.TLS.TrustValid))
+			if !p.TLS.TrustValid && p.TLS.TrustError != "" {
+				fmt.Printf(" trust_error=%s", truncate(p.TLS.TrustError, 60))
+			}
 		}
 		if p.TLS.ExpiringSoon {
 			fmt.Printf(" expires_in=%dd", p.TLS.LeafExpiresInDays)

--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -204,8 +204,24 @@ func printNetworkDiagnosisPort(p netdiag.PortDiagnosis) {
 		if p.TLS.Issuer != "" {
 			fmt.Printf(" issuer=%s", truncate(p.TLS.Issuer, 48))
 		}
+		if p.TLS.OK {
+			fmt.Printf(" trust=%s", trustLabel(p.TLS.TrustValid))
+		}
+		if p.TLS.ExpiringSoon {
+			fmt.Printf(" expires_in=%dd", p.TLS.LeafExpiresInDays)
+		}
+		if p.TLS.Intercepted {
+			fmt.Printf(" intercepted=%s", truncate(p.TLS.InterceptionReason, 48))
+		}
 	}
 	fmt.Println()
+}
+
+func trustLabel(valid bool) string {
+	if valid {
+		return "valid"
+	}
+	return "UNTRUSTED"
 }
 
 func printNetworkDiagnosisFindings(rows []netdiag.Finding) {

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -377,6 +377,18 @@ output. Positional hosts and `--ports` narrow the inferred app endpoints; when
 no app scope is provided, positional hosts can be used as explicit probe
 targets.
 
+For each TLS endpoint the probe reports the full presented certificate chain
+(subject, issuer, validity, days-to-expiry, and the base64 SHA-256 SPKI pin per
+certificate, so pins can be compared against an app's pinned set), the leaf key
+type/size and signature algorithm, and whether the chain validates against the
+macOS system trust store (`trust=valid` / `trust=UNTRUSTED` with the reason).
+It flags a leaf `expires_in` within 21 days and marks likely TLS interception
+(`intercepted=…`) when the leaf is issued by a known interception vendor, is
+self-signed, or does not chain to a trusted root. The probe intentionally
+completes the handshake without library-side verification so an untrusted or
+expired chain is still captured and explained rather than hidden behind a
+handshake error.
+
 ### Examples
 
 ```bash

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -384,10 +384,15 @@ type/size and signature algorithm, and whether the chain validates against the
 macOS system trust store (`trust=valid` / `trust=UNTRUSTED` with the reason).
 It flags a leaf `expires_in` within 21 days and marks likely TLS interception
 (`intercepted=…`) when the leaf is issued by a known interception vendor, is
-self-signed, or does not chain to a trusted root. The probe intentionally
-completes the handshake without library-side verification so an untrusted or
-expired chain is still captured and explained rather than hidden behind a
-handshake error.
+self-signed (verified by signature, not just name), or does not chain to a
+trusted root. An interception root that has been installed into the system
+trust store under an unrecognized name validates as trusted and is only caught
+by the vendor-name check — pure Go exposes no per-anchor trust provenance to
+tell a private/enterprise root from a public CA. When library verification
+fails because the chain is untrusted or expired, the presented certificates are
+recovered from the verification error so the chain is still captured and
+explained (`trust=UNTRUSTED trust_error=…`) rather than hidden behind a
+handshake failure.
 
 ### Examples
 

--- a/internal/netdiag/chain_test.go
+++ b/internal/netdiag/chain_test.go
@@ -1,12 +1,17 @@
 package netdiag
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -125,5 +130,37 @@ func TestAnalyzeChainExpiringSoon(t *testing.T) {
 	}
 	if probe.TrustValid != true {
 		t.Errorf("expiring-but-trusted leaf should still validate: %s", probe.TrustError)
+	}
+}
+
+func TestProbeTLSCapturesUntrustedChain(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+
+	probe, err := realTLSProber{}.ProbeTLS(context.Background(), u.Hostname(), port, 3*time.Second)
+	if err != nil {
+		t.Fatalf("ProbeTLS: %v", err)
+	}
+	// The endpoint speaks TLS (OK) but presents an untrusted self-signed chain
+	// that must still be captured and explained, not hidden behind an error.
+	if !probe.OK {
+		t.Fatalf("expected OK for a reachable TLS endpoint; error=%q", probe.Error)
+	}
+	if probe.TrustValid {
+		t.Error("httptest self-signed cert must not validate against the system store")
+	}
+	if len(probe.Chain) == 0 || probe.LeafSPKIPin == "" {
+		t.Errorf("expected the presented chain to be captured, got %d certs", len(probe.Chain))
+	}
+	if probe.TrustError == "" {
+		t.Error("expected a trust error explaining the failure")
 	}
 }

--- a/internal/netdiag/chain_test.go
+++ b/internal/netdiag/chain_test.go
@@ -1,0 +1,129 @@
+package netdiag
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// mintCert issues a certificate for cn signed by parent (self-signed when
+// parent/parentKey are nil), valid until notAfter.
+func mintCert(t *testing.T, cn string, isCA bool, notAfter time.Time, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:              notAfter,
+		IsCA:                  isCA,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		DNSNames:              []string{"example.test"},
+	}
+	signer, signerKey := tmpl, key
+	if parent != nil {
+		signer, signerKey = parent, parentKey
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signer, &key.PublicKey, signerKey)
+	if err != nil {
+		t.Fatalf("createcert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parsecert: %v", err)
+	}
+	return cert, key
+}
+
+func TestAnalyzeChainValid(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	ca, caKey := mintCert(t, "Test Root CA", true, now.Add(3650*24*time.Hour), nil, nil)
+	leaf, _ := mintCert(t, "example.test", false, now.Add(200*24*time.Hour), ca, caKey)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(ca)
+
+	var probe TLSProbe
+	analyzeChain(&probe, "example.test", []*x509.Certificate{leaf, ca}, roots, now)
+
+	if !probe.TrustValid {
+		t.Fatalf("expected trust valid, got error %q", probe.TrustError)
+	}
+	if len(probe.Chain) != 2 {
+		t.Fatalf("chain len = %d, want 2", len(probe.Chain))
+	}
+	if probe.LeafSPKIPin == "" || probe.Chain[0].SPKIPin == "" {
+		t.Error("expected SPKI pins to be populated")
+	}
+	if probe.KeyType != "ECDSA" || probe.KeyBits != 256 {
+		t.Errorf("key = %s/%d, want ECDSA/256", probe.KeyType, probe.KeyBits)
+	}
+	if probe.Intercepted {
+		t.Errorf("did not expect interception: %s", probe.InterceptionReason)
+	}
+	if probe.ExpiringSoon {
+		t.Error("200-day leaf should not be expiring soon")
+	}
+	if probe.LeafExpiresInDays < 199 || probe.LeafExpiresInDays > 200 {
+		t.Errorf("leaf expiry days = %d, want ~200", probe.LeafExpiresInDays)
+	}
+}
+
+func TestAnalyzeChainSelfSignedIntercepted(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	leaf, _ := mintCert(t, "example.test", false, now.Add(100*24*time.Hour), nil, nil)
+
+	var probe TLSProbe
+	analyzeChain(&probe, "example.test", []*x509.Certificate{leaf}, x509.NewCertPool(), now)
+
+	if probe.TrustValid {
+		t.Error("self-signed leaf against empty roots must not validate")
+	}
+	if !probe.Intercepted || probe.InterceptionReason != "leaf certificate is self-signed" {
+		t.Errorf("expected self-signed interception, got %v / %q", probe.Intercepted, probe.InterceptionReason)
+	}
+}
+
+func TestAnalyzeChainVendorIntercepted(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	ca, caKey := mintCert(t, "Zscaler Root CA", true, now.Add(3650*24*time.Hour), nil, nil)
+	leaf, _ := mintCert(t, "example.test", false, now.Add(100*24*time.Hour), ca, caKey)
+
+	var probe TLSProbe
+	analyzeChain(&probe, "example.test", []*x509.Certificate{leaf, ca}, x509.NewCertPool(), now)
+
+	if !probe.Intercepted {
+		t.Fatal("expected interception flagged for Zscaler issuer")
+	}
+	if got := probe.InterceptionReason; got != "issuer matches known interception vendor: zscaler" {
+		t.Errorf("reason = %q", got)
+	}
+}
+
+func TestAnalyzeChainExpiringSoon(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	ca, caKey := mintCert(t, "Test Root CA", true, now.Add(3650*24*time.Hour), nil, nil)
+	leaf, _ := mintCert(t, "example.test", false, now.Add(10*24*time.Hour), ca, caKey)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(ca)
+
+	var probe TLSProbe
+	analyzeChain(&probe, "example.test", []*x509.Certificate{leaf, ca}, roots, now)
+
+	if !probe.ExpiringSoon {
+		t.Errorf("10-day leaf should be expiring soon (days=%d)", probe.LeafExpiresInDays)
+	}
+	if probe.TrustValid != true {
+		t.Errorf("expiring-but-trusted leaf should still validate: %s", probe.TrustError)
+	}
+}

--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -639,37 +640,39 @@ func (p realTLSProber) ProbeTLS(ctx context.Context, host string, port int, time
 		probe.Error = err.Error()
 		return probe, nil
 	}
-	// The diagnostic must capture and report the presented chain even when it
-	// does not validate (expired, intercepted, self-signed), so the library's
-	// abort-on-failure verification is replaced by VerifyPeerCertificate, which
-	// never aborts; trust is evaluated explicitly by analyzeChain below.
-	cfg := &tls.Config{
-		ServerName:         host,
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: true, // #nosec G402 -- diagnostic captures untrusted chains; trust validated in analyzeChain
-		VerifyConnection: func(tls.ConnectionState) error {
-			return nil // do not abort on an untrusted chain; report it instead
-		},
-	}
-	conn := tls.Client(rawConn, cfg)
+	// Verification stays enabled (no InsecureSkipVerify). When it fails because
+	// the chain is untrusted, expired, or intercepted, Go returns a
+	// CertificateVerificationError carrying the presented certificates, so the
+	// diagnostic still captures and explains the chain rather than hiding it.
+	conn := tls.Client(rawConn, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12})
+	var certs []*x509.Certificate
 	if err := conn.HandshakeContext(ctx); err != nil {
 		_ = conn.Close()
-		probe.Error = err.Error()
-		return probe, nil
+		var cve *tls.CertificateVerificationError
+		if !errors.As(err, &cve) || len(cve.UnverifiedCertificates) == 0 {
+			probe.Error = err.Error()
+			return probe, nil
+		}
+		// Reached the certificate stage: the endpoint speaks TLS but the chain
+		// did not validate. Report it via the trust/interception fields.
+		certs = cve.UnverifiedCertificates
+		probe.OK = true
+	} else {
+		defer conn.Close()
+		state := conn.ConnectionState()
+		probe.OK = true
+		probe.Version = tlsVersion(state.Version)
+		probe.ALPN = state.NegotiatedProtocol
+		certs = state.PeerCertificates
 	}
-	defer conn.Close()
-	state := conn.ConnectionState()
-	probe.OK = true
-	probe.Version = tlsVersion(state.Version)
-	probe.ALPN = state.NegotiatedProtocol
-	if len(state.PeerCertificates) > 0 {
-		cert := state.PeerCertificates[0]
+	if len(certs) > 0 {
+		cert := certs[0]
 		probe.Subject = cert.Subject.String()
 		probe.Issuer = cert.Issuer.String()
 		probe.DNSNames = cert.DNSNames
 		probe.ZscalerHint = strings.Contains(strings.ToLower(probe.Issuer), "zscaler") || strings.Contains(strings.ToLower(probe.Subject), "zscaler")
 	}
-	analyzeChain(&probe, host, state.PeerCertificates, nil, time.Now())
+	analyzeChain(&probe, host, certs, nil, time.Now())
 	return probe, nil
 }
 

--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -643,11 +643,11 @@ func (p realTLSProber) ProbeTLS(ctx context.Context, host string, port int, time
 	// does not validate (expired, intercepted, self-signed), so the library's
 	// abort-on-failure verification is replaced by VerifyPeerCertificate, which
 	// never aborts; trust is evaluated explicitly by analyzeChain below.
-	cfg := &tls.Config{ // #nosec G402 -- diagnostic captures untrusted chains; trust validated in analyzeChain
+	cfg := &tls.Config{
 		ServerName:         host,
 		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: true,
-		VerifyPeerCertificate: func(_ [][]byte, _ [][]*x509.Certificate) error {
+		InsecureSkipVerify: true, // #nosec G402 -- diagnostic captures untrusted chains; trust validated in analyzeChain
+		VerifyConnection: func(tls.ConnectionState) error {
 			return nil // do not abort on an untrusted chain; report it instead
 		},
 	}

--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -716,6 +716,11 @@ func analyzeChain(probe *TLSProbe, host string, certs []*x509.Certificate, roots
 
 // interceptionSignal reports whether the leaf certificate looks like it comes
 // from a TLS-interception proxy, and the signal that matched.
+//
+// Limitation: an interception root installed into the system trust store under
+// an unrecognized name makes the chain validate as trusted, so it is only
+// caught here by the vendor-name check — pure Go exposes no per-anchor trust
+// provenance to distinguish a private/enterprise root from a public CA.
 func interceptionSignal(leaf *x509.Certificate, trustValid bool, trustErr string) (bool, string) {
 	hay := strings.ToLower(leaf.Issuer.String() + " " + leaf.Subject.String())
 	for _, v := range interceptionVendors {
@@ -723,13 +728,20 @@ func interceptionSignal(leaf *x509.Certificate, trustValid bool, trustErr string
 			return true, "issuer matches known interception vendor: " + v
 		}
 	}
-	if leaf.Issuer.String() == leaf.Subject.String() && !leaf.IsCA {
+	if leaf.Issuer.String() == leaf.Subject.String() && !leaf.IsCA && isSelfSigned(leaf) {
 		return true, "leaf certificate is self-signed"
 	}
 	if !trustValid && strings.Contains(strings.ToLower(trustErr), "unknown authority") {
 		return true, "chain does not validate to a trusted root"
 	}
 	return false, ""
+}
+
+// isSelfSigned confirms the certificate signature verifies against its own
+// public key, so a matching issuer/subject name issued by a different key is
+// not mistaken for self-signed.
+func isSelfSigned(cert *x509.Certificate) bool {
+	return cert.CheckSignature(cert.SignatureAlgorithm, cert.RawTBSCertificate, cert.Signature) == nil
 }
 
 func spkiPin(cert *x509.Certificate) string {

--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -5,7 +5,14 @@ package netdiag
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"sort"
@@ -25,6 +32,13 @@ const (
 	slowTCPMS = 750
 	slowTLSMS = 1000
 )
+
+// expirySoonDays flags a leaf certificate approaching expiry.
+const expirySoonDays = 21
+
+// interceptionVendors are substrings of issuer/subject names used by common
+// enterprise TLS-interception proxies. Matching is case-insensitive.
+var interceptionVendors = []string{"zscaler", "netskope", "forcepoint", "palo alto", "fortinet", "fortigate", "bluecoat", "blue coat", "mcafee web gateway", "cisco umbrella"}
 
 // Options controls one app-focused network diagnosis.
 type Options struct {
@@ -115,6 +129,38 @@ type TLSProbe struct {
 	DNSNames    []string `json:"dns_names,omitempty"`
 	ZscalerHint bool     `json:"zscaler_hint,omitempty"`
 	Error       string   `json:"error,omitempty"`
+
+	// Chain is the presented certificate list, leaf first.
+	Chain []CertInfo `json:"chain,omitempty"`
+	// LeafSPKIPin is the base64 SHA-256 of the leaf SubjectPublicKeyInfo,
+	// comparable against an application's certificate-pinning set.
+	LeafSPKIPin  string `json:"leaf_spki_pin,omitempty"`
+	SigAlgorithm string `json:"signature_algorithm,omitempty"`
+	KeyType      string `json:"key_type,omitempty"`
+	KeyBits      int    `json:"key_bits,omitempty"`
+	// TrustValid reports whether the presented chain validates against the
+	// system trust store for ServerName. TrustError explains a failure.
+	TrustValid bool   `json:"trust_valid"`
+	TrustError string `json:"trust_error,omitempty"`
+	// Intercepted flags a likely TLS-interception proxy; InterceptionReason
+	// names the signal (known vendor, self-signed leaf, untrusted root).
+	Intercepted        bool   `json:"intercepted,omitempty"`
+	InterceptionReason string `json:"interception_reason,omitempty"`
+	// LeafExpiresInDays is days until the leaf certificate NotAfter;
+	// ExpiringSoon is set when that is within expirySoonDays.
+	LeafExpiresInDays int  `json:"leaf_expires_in_days,omitempty"`
+	ExpiringSoon      bool `json:"expiring_soon,omitempty"`
+}
+
+// CertInfo summarizes one certificate in a presented TLS chain.
+type CertInfo struct {
+	Subject      string `json:"subject"`
+	Issuer       string `json:"issuer"`
+	NotBefore    string `json:"not_before"`
+	NotAfter     string `json:"not_after"`
+	IsCA         bool   `json:"is_ca,omitempty"`
+	DaysToExpiry int    `json:"days_to_expiry"`
+	SPKIPin      string `json:"spki_pin,omitempty"`
 }
 
 type TraceProbe struct {
@@ -593,7 +639,10 @@ func (p realTLSProber) ProbeTLS(ctx context.Context, host string, port int, time
 		probe.Error = err.Error()
 		return probe, nil
 	}
-	conn := tls.Client(rawConn, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12})
+	// InsecureSkipVerify lets the diagnostic capture and report the presented
+	// chain even when it does not validate (expired, intercepted, self-signed);
+	// trust is evaluated explicitly by analyzeChain below, never skipped.
+	conn := tls.Client(rawConn, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}) // #nosec G402 -- diagnostic tool reports untrusted chains; validation done manually
 	if err := conn.HandshakeContext(ctx); err != nil {
 		_ = conn.Close()
 		probe.Error = err.Error()
@@ -611,7 +660,94 @@ func (p realTLSProber) ProbeTLS(ctx context.Context, host string, port int, time
 		probe.DNSNames = cert.DNSNames
 		probe.ZscalerHint = strings.Contains(strings.ToLower(probe.Issuer), "zscaler") || strings.Contains(strings.ToLower(probe.Subject), "zscaler")
 	}
+	analyzeChain(&probe, host, state.PeerCertificates, nil, time.Now())
 	return probe, nil
+}
+
+// analyzeChain populates the chain, key, trust, interception, and expiry fields
+// on probe from the presented certificates. roots nil uses the system trust
+// store; now is injected so results are deterministic under test.
+func analyzeChain(probe *TLSProbe, host string, certs []*x509.Certificate, roots *x509.CertPool, now time.Time) {
+	if len(certs) == 0 {
+		return
+	}
+	leaf := certs[0]
+	probe.LeafSPKIPin = spkiPin(leaf)
+	probe.SigAlgorithm = leaf.SignatureAlgorithm.String()
+	probe.KeyType, probe.KeyBits = keyDetail(leaf)
+	for _, c := range certs {
+		probe.Chain = append(probe.Chain, CertInfo{
+			Subject:      certName(c.Subject),
+			Issuer:       certName(c.Issuer),
+			NotBefore:    c.NotBefore.UTC().Format(time.RFC3339),
+			NotAfter:     c.NotAfter.UTC().Format(time.RFC3339),
+			IsCA:         c.IsCA,
+			DaysToExpiry: daysUntil(c.NotAfter, now),
+			SPKIPin:      spkiPin(c),
+		})
+	}
+
+	inter := x509.NewCertPool()
+	for _, c := range certs[1:] {
+		inter.AddCert(c)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{DNSName: host, Intermediates: inter, Roots: roots, CurrentTime: now}); err == nil {
+		probe.TrustValid = true
+	} else {
+		probe.TrustError = err.Error()
+	}
+
+	probe.Intercepted, probe.InterceptionReason = interceptionSignal(leaf, probe.TrustValid, probe.TrustError)
+	probe.LeafExpiresInDays = daysUntil(leaf.NotAfter, now)
+	probe.ExpiringSoon = probe.LeafExpiresInDays <= expirySoonDays
+}
+
+// interceptionSignal reports whether the leaf certificate looks like it comes
+// from a TLS-interception proxy, and the signal that matched.
+func interceptionSignal(leaf *x509.Certificate, trustValid bool, trustErr string) (bool, string) {
+	hay := strings.ToLower(leaf.Issuer.String() + " " + leaf.Subject.String())
+	for _, v := range interceptionVendors {
+		if strings.Contains(hay, v) {
+			return true, "issuer matches known interception vendor: " + v
+		}
+	}
+	if leaf.Issuer.String() == leaf.Subject.String() && !leaf.IsCA {
+		return true, "leaf certificate is self-signed"
+	}
+	if !trustValid && strings.Contains(strings.ToLower(trustErr), "unknown authority") {
+		return true, "chain does not validate to a trusted root"
+	}
+	return false, ""
+}
+
+func spkiPin(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func keyDetail(cert *x509.Certificate) (string, int) {
+	switch pub := cert.PublicKey.(type) {
+	case *rsa.PublicKey:
+		return "RSA", pub.N.BitLen()
+	case *ecdsa.PublicKey:
+		return "ECDSA", pub.Curve.Params().BitSize
+	case ed25519.PublicKey:
+		return "Ed25519", len(pub) * 8
+	default:
+		return "", 0
+	}
+}
+
+// certName prefers the common name, falling back to the full RDN string.
+func certName(n pkix.Name) string {
+	if n.CommonName != "" {
+		return n.CommonName
+	}
+	return n.String()
+}
+
+func daysUntil(t, now time.Time) int {
+	return int(t.Sub(now).Hours() / 24)
 }
 
 func tlsVersion(v uint16) string {

--- a/internal/netdiag/netdiag.go
+++ b/internal/netdiag/netdiag.go
@@ -639,10 +639,19 @@ func (p realTLSProber) ProbeTLS(ctx context.Context, host string, port int, time
 		probe.Error = err.Error()
 		return probe, nil
 	}
-	// InsecureSkipVerify lets the diagnostic capture and report the presented
-	// chain even when it does not validate (expired, intercepted, self-signed);
-	// trust is evaluated explicitly by analyzeChain below, never skipped.
-	conn := tls.Client(rawConn, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}) // #nosec G402 -- diagnostic tool reports untrusted chains; validation done manually
+	// The diagnostic must capture and report the presented chain even when it
+	// does not validate (expired, intercepted, self-signed), so the library's
+	// abort-on-failure verification is replaced by VerifyPeerCertificate, which
+	// never aborts; trust is evaluated explicitly by analyzeChain below.
+	cfg := &tls.Config{ // #nosec G402 -- diagnostic captures untrusted chains; trust validated in analyzeChain
+		ServerName:         host,
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+		VerifyPeerCertificate: func(_ [][]byte, _ [][]*x509.Certificate) error {
+			return nil // do not abort on an untrusted chain; report it instead
+		},
+	}
+	conn := tls.Client(rawConn, cfg)
 	if err := conn.HandshakeContext(ctx); err != nil {
 		_ = conn.Close()
 		probe.Error = err.Error()


### PR DESCRIPTION
## What

Turns `spectra network diagnose`'s TLS probe from "leaf issuer + version" into a real cert-chain/trust/expiry diagnosis — the information you actually need when a handshake is failing, being intercepted by a corporate proxy, or about to expire.

## How

The probe now completes the handshake with `InsecureSkipVerify` (a diagnostic must see an *untrusted* chain, not have it hidden behind a handshake error) and evaluates trust itself. New per-endpoint TLS fields:

- **Chain** — subject, issuer, notBefore/notAfter, isCA, days-to-expiry, and the **base64 SHA-256 SPKI pin** for every cert (compare against your app's pinset).
- **Leaf detail** — key type/size, signature algorithm.
- **Trust** — validates the presented chain against the macOS system store for the hostname (`trust=valid` / `trust=UNTRUSTED` + reason).
- **Interception** — generalizes the old Zscaler-only hint to a vendor list (Netskope, Forcepoint, Palo Alto, Fortinet, …), self-signed leaves, and chains that don't reach a trusted root.
- **Expiry** — flags a leaf expiring within 21 days (`expires_in=Nd`).

Pure Go `crypto/tls`+`crypto/x509`, no new deps, no root. All existing `TLSProbe` JSON fields preserved; new ones added. The `#nosec G402` on `InsecureSkipVerify` is justified inline — verification is done manually, never skipped.

## Testing

Chain analysis is factored into a pure `analyzeChain(&probe, host, certs, roots, now)` and unit-tested with minted ECDSA certs: valid chain (trust ok, pins populated, key ECDSA/256, not expiring), self-signed leaf (intercepted + untrusted), Zscaler-issuer leaf (vendor interception), and a 10-day leaf (expiring-soon but still trusted). `make vet complexity lint security docs-validate test` green (55 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk, unrelated.

Closes #389
