### PR TITLE
storage: spectra storage db-check — embedded SQLite health (integrity, WAL bloat, fragmentation)

### DIFF
--- a/cmd/spectra/storage.go
+++ b/cmd/spectra/storage.go
@@ -4,13 +4,18 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
+	"github.com/kaeawc/spectra/internal/dbcheck"
 	"github.com/kaeawc/spectra/internal/storagestate"
 )
 
 func runStorage(args []string) int {
+	if len(args) > 0 && args[0] == "db-check" {
+		return runStorageDBCheck(args[1:], os.Stdout, os.Stderr)
+	}
 	fs := flag.NewFlagSet("spectra storage", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
@@ -34,6 +39,96 @@ func runStorage(args []string) int {
 
 	printStorageState(state, *includeSnapshots, *includeSpotlight)
 	return 0
+}
+
+func runStorageDBCheck(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("spectra storage db-check", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() == 0 {
+		fmt.Fprintln(stderr, "usage: spectra storage db-check [--json] <path>...  (a SQLite file, or a directory to scan)")
+		return 2
+	}
+
+	paths, err := resolveDBPaths(fs.Args())
+	if err != nil {
+		fmt.Fprintf(stderr, "db-check: %v\n", err)
+		return 1
+	}
+	if len(paths) == 0 {
+		fmt.Fprintln(stderr, "no SQLite databases found in the given paths")
+		return 1
+	}
+
+	report := dbcheck.Check(paths, dbcheck.DefaultDeps())
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+		return 0
+	}
+	printDBCheckReport(stdout, report)
+	return 0
+}
+
+// resolveDBPaths expands directory arguments into the SQLite files they contain
+// and keeps file arguments as-is.
+func resolveDBPaths(args []string) ([]string, error) {
+	var paths []string
+	for _, a := range args {
+		fi, err := os.Stat(a)
+		if err != nil {
+			return nil, err
+		}
+		if !fi.IsDir() {
+			paths = append(paths, a)
+			continue
+		}
+		found, err := dbcheck.Discover(a, readDBHeader)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, found...)
+	}
+	return paths, nil
+}
+
+func readDBHeader(path string) ([]byte, error) {
+	f, err := os.Open(path) // #nosec G304 -- inspecting user-supplied database paths
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	hdr := make([]byte, 16)
+	n, err := io.ReadFull(f, hdr)
+	if err != nil && n < 16 {
+		return nil, err
+	}
+	return hdr[:n], nil
+}
+
+func printDBCheckReport(stdout io.Writer, report dbcheck.Report) {
+	fmt.Fprintf(stdout, "=== SQLite db-check (%d scanned, %d with problems) ===\n", report.Scanned, report.Problems)
+	for _, db := range report.Databases {
+		if db.Error != "" {
+			fmt.Fprintf(stdout, "  %s\n    error: %s\n", db.Path, db.Error)
+			continue
+		}
+		status := "ok"
+		if !db.IntegrityOK {
+			status = fmt.Sprintf("INTEGRITY (%d)", len(db.IntegrityErrors))
+		}
+		fmt.Fprintf(stdout, "  %s\n", db.Path)
+		fmt.Fprintf(stdout, "    size=%s journal=%s integrity=%s frag=%.1f%% free=%d/%d pages wal=%s\n",
+			humanSize(db.SizeBytes), stateOrDash(db.JournalMode), status,
+			db.FragmentationPct, db.FreelistCount, db.PageCount, humanSize(db.WALBytes))
+		for _, e := range db.IntegrityErrors {
+			fmt.Fprintf(stdout, "      - %s\n", truncate(e, 100))
+		}
+	}
 }
 
 func printStorageState(s storagestate.State, includeSnapshots, includeSpotlight bool) {

--- a/cmd/spectra/storage.go
+++ b/cmd/spectra/storage.go
@@ -53,11 +53,7 @@ func runStorageDBCheck(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	paths, err := resolveDBPaths(fs.Args())
-	if err != nil {
-		fmt.Fprintf(stderr, "db-check: %v\n", err)
-		return 1
-	}
+	paths := resolveDBPaths(fs.Args())
 	if len(paths) == 0 {
 		fmt.Fprintln(stderr, "no SQLite databases found in the given paths")
 		return 1
@@ -75,25 +71,25 @@ func runStorageDBCheck(args []string, stdout, stderr io.Writer) int {
 }
 
 // resolveDBPaths expands directory arguments into the SQLite files they contain
-// and keeps file arguments as-is.
-func resolveDBPaths(args []string) ([]string, error) {
+// and keeps file arguments as-is. A path that cannot be stat'd or a directory
+// that cannot be scanned is preserved so db-check reports its error rather than
+// silently skipping it or aborting the whole run.
+func resolveDBPaths(args []string) []string {
 	var paths []string
 	for _, a := range args {
 		fi, err := os.Stat(a)
-		if err != nil {
-			return nil, err
-		}
-		if !fi.IsDir() {
+		if err != nil || !fi.IsDir() {
 			paths = append(paths, a)
 			continue
 		}
 		found, err := dbcheck.Discover(a, readDBHeader)
 		if err != nil {
-			return nil, err
+			paths = append(paths, a)
+			continue
 		}
 		paths = append(paths, found...)
 	}
-	return paths, nil
+	return paths
 }
 
 func readDBHeader(path string) ([]byte, error) {

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -410,6 +410,28 @@ spectra network firewall
 spectra network firewall --json
 ```
 
+## `spectra storage db-check`
+
+Inspects the health of embedded SQLite databases — the state stores macOS apps
+scatter through `~/Library/Application Support` and `~/Library/Containers`.
+Each argument is a database file or a directory (directories are walked for
+files with the SQLite header). Every database is opened **read-only** — the
+file under inspection is never written — and reported with its size, page
+geometry, journal mode, free-page fragmentation, the size of any
+un-checkpointed `-wal` sidecar, and the result of `PRAGMA quick_check`. A
+database is counted as a problem when it fails integrity, carries WAL bloat
+over 32 MiB, or has a freelist above 25% of its pages; one that cannot be
+opened (missing, locked by a live writer, or not a database) is reported with
+its error instead of failing the whole run.
+
+### Examples
+
+```bash
+spectra storage db-check ~/Library/Messages/chat.db
+spectra storage db-check --json "~/Library/Application Support/MyApp"
+spectra storage db-check app1.db app2.db
+```
+
 ## `spectra crash readiness`
 
 Audits whether the machine can produce a debuggable crash *before* one

--- a/internal/dbcheck/dbcheck.go
+++ b/internal/dbcheck/dbcheck.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	_ "modernc.org/sqlite" // register the pure-Go "sqlite" driver
 )
@@ -72,7 +73,7 @@ type Deps struct {
 func DefaultDeps() Deps {
 	return Deps{
 		Open: func(path string) (*sql.DB, error) {
-			return sql.Open("sqlite", "file:"+path+"?mode=ro&_pragma=busy_timeout(2000)")
+			return sql.Open("sqlite", "file:"+escapeSQLiteURIPath(path)+"?mode=ro&_pragma=busy_timeout(2000)")
 		},
 		Stat: func(path string) (int64, error) {
 			fi, err := os.Stat(path)
@@ -99,8 +100,16 @@ func Check(paths []string, deps Deps) Report {
 	return rep
 }
 
+// isBloated matches the documented contract: WAL over the threshold, or a
+// freelist above the fragmentation threshold (strict, so exact boundaries pass).
 func isBloated(db DB) bool {
-	return db.WALBytes >= walBloatThreshold || db.FragmentationPct >= fragmentationProblemPct
+	return db.WALBytes > walBloatThreshold || db.FragmentationPct > fragmentationProblemPct
+}
+
+// escapeSQLiteURIPath percent-encodes the URI-reserved characters that would
+// otherwise let a path change the database target or drop the mode=ro query.
+func escapeSQLiteURIPath(path string) string {
+	return strings.NewReplacer("%", "%25", "?", "%3F", "#", "%23").Replace(path)
 }
 
 func inspect(path string, deps Deps) DB {
@@ -114,13 +123,19 @@ func inspect(path string, deps Deps) DB {
 
 	conn, err := deps.Open(path)
 	if err != nil {
-		out.Error = fmt.Sprintf("open: %v", err)
+		out.Error = fmt.Errorf("open %s: %w", path, err).Error()
 		return out
 	}
 	defer conn.Close()
 
+	// database/sql.Open defers the connection, so force a header read here: a
+	// missing, locked, or non-database file surfaces as an inspection error
+	// rather than a fabricated integrity failure.
+	if err := conn.QueryRow("PRAGMA page_count").Scan(&out.PageCount); err != nil {
+		out.Error = fmt.Errorf("read %s: %w", path, err).Error()
+		return out
+	}
 	out.PageSize = intPragma(conn, "page_size")
-	out.PageCount = int64Pragma(conn, "page_count")
 	out.FreelistCount = int64Pragma(conn, "freelist_count")
 	if out.PageCount > 0 {
 		out.FragmentationPct = fragmentationPct(out.FreelistCount, out.PageCount)
@@ -195,9 +210,10 @@ func int64Pragma(conn *sql.DB, name string) int64 {
 func Discover(root string, readHeader func(path string) ([]byte, error)) ([]string, error) {
 	var found []string
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
-		// Tolerate unreadable entries and only collect regular files whose
-		// header identifies them as SQLite; always return nil to keep scanning.
-		if walkErr == nil && !d.IsDir() {
+		// Tolerate unreadable entries and only inspect regular files (never a
+		// FIFO/device, whose open could block) whose header identifies them as
+		// SQLite; always return nil to keep scanning.
+		if walkErr == nil && d.Type().IsRegular() {
 			if hdr, readErr := readHeader(path); readErr == nil && IsSQLite(hdr) {
 				found = append(found, path)
 			}

--- a/internal/dbcheck/dbcheck.go
+++ b/internal/dbcheck/dbcheck.go
@@ -1,0 +1,209 @@
+// Package dbcheck inspects the health of embedded SQLite databases: physical
+// integrity, un-checkpointed WAL bloat, and free-page fragmentation. It opens
+// databases read-only and never writes to the file under inspection.
+package dbcheck
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	_ "modernc.org/sqlite" // register the pure-Go "sqlite" driver
+)
+
+// sqliteMagic is the 16-byte header prefix of every SQLite 3 database file.
+const sqliteMagic = "SQLite format 3\x00"
+
+// maxIntegrityErrors bounds how many quick_check rows are retained per database.
+const maxIntegrityErrors = 10
+
+// Report is the result of checking a set of databases.
+type Report struct {
+	Databases []DB `json:"databases"`
+	Scanned   int  `json:"scanned"`
+	Problems  int  `json:"problems"`
+}
+
+// DB is the health of a single SQLite database.
+type DB struct {
+	Path             string   `json:"path"`
+	SizeBytes        int64    `json:"size_bytes"`
+	PageSize         int      `json:"page_size,omitempty"`
+	PageCount        int64    `json:"page_count,omitempty"`
+	FreelistCount    int64    `json:"freelist_count,omitempty"`
+	FragmentationPct float64  `json:"fragmentation_pct,omitempty"`
+	JournalMode      string   `json:"journal_mode,omitempty"`
+	WALBytes         int64    `json:"wal_bytes,omitempty"`
+	IntegrityOK      bool     `json:"integrity_ok"`
+	IntegrityErrors  []string `json:"integrity_errors,omitempty"`
+	Error            string   `json:"error,omitempty"`
+}
+
+// walBloatThreshold marks a WAL sidecar that has grown large enough to warrant
+// a checkpoint (32 MiB).
+const walBloatThreshold = 32 << 20
+
+// fragmentationProblemPct marks a database whose freelist is a large share of
+// its pages.
+const fragmentationProblemPct = 25.0
+
+// IsSQLite reports whether b begins with the SQLite 3 file header.
+func IsSQLite(b []byte) bool {
+	return len(b) >= len(sqliteMagic) && string(b[:len(sqliteMagic)]) == sqliteMagic
+}
+
+// Opener opens a database file for read-only inspection.
+type Opener func(path string) (*sql.DB, error)
+
+// StatSizer returns the size in bytes of a file, or an error if it is absent.
+type StatSizer func(path string) (int64, error)
+
+// Deps injects the file and database access dbcheck needs, so the analysis can
+// be exercised against temporary databases in tests.
+type Deps struct {
+	Open Opener
+	Stat StatSizer
+}
+
+// DefaultDeps opens databases read-only via the vendored sqlite driver and
+// stats files from the real filesystem.
+func DefaultDeps() Deps {
+	return Deps{
+		Open: func(path string) (*sql.DB, error) {
+			return sql.Open("sqlite", "file:"+path+"?mode=ro&_pragma=busy_timeout(2000)")
+		},
+		Stat: func(path string) (int64, error) {
+			fi, err := os.Stat(path)
+			if err != nil {
+				return 0, err
+			}
+			return fi.Size(), nil
+		},
+	}
+}
+
+// Check inspects each database path and returns their combined health. A path
+// that cannot be opened is recorded with its error rather than aborting.
+func Check(paths []string, deps Deps) Report {
+	rep := Report{}
+	for _, p := range paths {
+		db := inspect(p, deps)
+		if db.Error != "" || !db.IntegrityOK || isBloated(db) {
+			rep.Problems++
+		}
+		rep.Databases = append(rep.Databases, db)
+	}
+	rep.Scanned = len(rep.Databases)
+	return rep
+}
+
+func isBloated(db DB) bool {
+	return db.WALBytes >= walBloatThreshold || db.FragmentationPct >= fragmentationProblemPct
+}
+
+func inspect(path string, deps Deps) DB {
+	out := DB{Path: path}
+	if size, err := deps.Stat(path); err == nil {
+		out.SizeBytes = size
+	}
+	if size, err := deps.Stat(path + "-wal"); err == nil {
+		out.WALBytes = size
+	}
+
+	conn, err := deps.Open(path)
+	if err != nil {
+		out.Error = fmt.Sprintf("open: %v", err)
+		return out
+	}
+	defer conn.Close()
+
+	out.PageSize = intPragma(conn, "page_size")
+	out.PageCount = int64Pragma(conn, "page_count")
+	out.FreelistCount = int64Pragma(conn, "freelist_count")
+	if out.PageCount > 0 {
+		out.FragmentationPct = fragmentationPct(out.FreelistCount, out.PageCount)
+	}
+	out.JournalMode = stringPragma(conn, "journal_mode")
+	out.IntegrityOK, out.IntegrityErrors = quickCheck(conn)
+	return out
+}
+
+// fragmentationPct is the freelist share of the total page count, rounded to
+// one decimal place.
+func fragmentationPct(freelist, pageCount int64) float64 {
+	if pageCount <= 0 {
+		return 0
+	}
+	pct := float64(freelist) / float64(pageCount) * 100
+	return float64(int64(pct*10+0.5)) / 10
+}
+
+func quickCheck(conn *sql.DB) (bool, []string) {
+	rows, err := conn.Query("PRAGMA quick_check")
+	if err != nil {
+		return false, []string{fmt.Sprintf("quick_check: %v", err)}
+	}
+	defer rows.Close()
+	var msgs []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return false, []string{fmt.Sprintf("scan: %v", err)}
+		}
+		if s == "ok" {
+			continue
+		}
+		if len(msgs) < maxIntegrityErrors {
+			msgs = append(msgs, s)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, []string{fmt.Sprintf("quick_check: %v", err)}
+	}
+	sort.Strings(msgs)
+	return len(msgs) == 0, msgs
+}
+
+func stringPragma(conn *sql.DB, name string) string {
+	var v string
+	if err := conn.QueryRow("PRAGMA " + name).Scan(&v); err != nil {
+		return ""
+	}
+	return v
+}
+
+func intPragma(conn *sql.DB, name string) int {
+	var v int
+	if err := conn.QueryRow("PRAGMA " + name).Scan(&v); err != nil {
+		return 0
+	}
+	return v
+}
+
+func int64Pragma(conn *sql.DB, name string) int64 {
+	var v int64
+	if err := conn.QueryRow("PRAGMA " + name).Scan(&v); err != nil {
+		return 0
+	}
+	return v
+}
+
+// Discover walks root and returns the paths of files whose header identifies
+// them as SQLite databases. readHeader reads up to n leading bytes of a file.
+func Discover(root string, readHeader func(path string) ([]byte, error)) ([]string, error) {
+	var found []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		// Tolerate unreadable entries and only collect regular files whose
+		// header identifies them as SQLite; always return nil to keep scanning.
+		if walkErr == nil && !d.IsDir() {
+			if hdr, readErr := readHeader(path); readErr == nil && IsSQLite(hdr) {
+				found = append(found, path)
+			}
+		}
+		return nil
+	})
+	sort.Strings(found)
+	return found, err
+}

--- a/internal/dbcheck/dbcheck_test.go
+++ b/internal/dbcheck/dbcheck_test.go
@@ -130,6 +130,44 @@ func TestCheckFlagsWALBloat(t *testing.T) {
 	}
 }
 
+func TestExactBoundariesAreNotProblems(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "boundary.db")
+	makeDB(t, path, nil)
+	deps := DefaultDeps()
+	real := deps.Stat
+	deps.Stat = func(p string) (int64, error) {
+		if p == path+"-wal" {
+			return walBloatThreshold, nil // exactly at the threshold, not over
+		}
+		return real(p)
+	}
+	rep := Check([]string{path}, deps)
+	if rep.Problems != 0 {
+		t.Errorf("WAL exactly at threshold must not be a problem, got %d", rep.Problems)
+	}
+	if isBloated(DB{FragmentationPct: fragmentationProblemPct}) {
+		t.Error("fragmentation exactly at threshold must not be a problem")
+	}
+}
+
+func TestCheckNonDatabaseFileIsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notes.txt")
+	if err := os.WriteFile(path, []byte("this is not a database, just some text bytes"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	rep := Check([]string{path}, DefaultDeps())
+	db := rep.Databases[0]
+	if db.Error == "" {
+		t.Errorf("a non-database file must be reported as an error, not integrity: %+v", db)
+	}
+	if len(db.IntegrityErrors) != 0 {
+		t.Errorf("inspection failure must not be recorded as integrity errors: %v", db.IntegrityErrors)
+	}
+	if rep.Problems != 1 {
+		t.Errorf("problems = %d, want 1", rep.Problems)
+	}
+}
+
 func TestDiscover(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "app.db")

--- a/internal/dbcheck/dbcheck_test.go
+++ b/internal/dbcheck/dbcheck_test.go
@@ -1,0 +1,158 @@
+package dbcheck
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func makeDB(t *testing.T, path string, setup func(*sql.DB)) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec("CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if setup != nil {
+		setup(db)
+	}
+}
+
+func TestIsSQLite(t *testing.T) {
+	if !IsSQLite([]byte(sqliteMagic + "rest")) {
+		t.Error("valid header not recognized")
+	}
+	if IsSQLite([]byte("not a database")) {
+		t.Error("non-sqlite header matched")
+	}
+	if IsSQLite([]byte("short")) {
+		t.Error("too-short header matched")
+	}
+}
+
+func TestFragmentationPct(t *testing.T) {
+	cases := []struct {
+		free, pages int64
+		want        float64
+	}{
+		{0, 100, 0},
+		{25, 100, 25},
+		{1, 3, 33.3},
+		{5, 0, 0},
+	}
+	for _, c := range cases {
+		if got := fragmentationPct(c.free, c.pages); got != c.want {
+			t.Errorf("fragmentationPct(%d,%d)=%v want %v", c.free, c.pages, got, c.want)
+		}
+	}
+}
+
+func TestCheckHealthyDB(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "good.db")
+	makeDB(t, path, func(db *sql.DB) {
+		if _, err := db.Exec("INSERT INTO t(v) VALUES (zeroblob(64))"); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	})
+
+	rep := Check([]string{path}, DefaultDeps())
+	if rep.Scanned != 1 || rep.Problems != 0 {
+		t.Fatalf("scanned=%d problems=%d, want 1/0", rep.Scanned, rep.Problems)
+	}
+	db := rep.Databases[0]
+	if !db.IntegrityOK {
+		t.Errorf("healthy DB should pass integrity: %v", db.IntegrityErrors)
+	}
+	if db.PageSize == 0 || db.PageCount == 0 {
+		t.Errorf("expected page geometry, got size=%d count=%d", db.PageSize, db.PageCount)
+	}
+	if db.SizeBytes == 0 {
+		t.Error("expected non-zero file size")
+	}
+}
+
+func TestCheckReportsFreePages(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "frag.db")
+	makeDB(t, path, func(db *sql.DB) {
+		for i := 0; i < 2000; i++ {
+			if _, err := db.Exec("INSERT INTO t(v) VALUES (zeroblob(256))"); err != nil {
+				t.Fatalf("insert: %v", err)
+			}
+		}
+		if _, err := db.Exec("DELETE FROM t"); err != nil {
+			t.Fatalf("delete: %v", err)
+		}
+	})
+
+	rep := Check([]string{path}, DefaultDeps())
+	db := rep.Databases[0]
+	if db.FreelistCount == 0 || db.FragmentationPct == 0 {
+		t.Errorf("expected free pages after bulk delete, got free=%d frag=%.1f", db.FreelistCount, db.FragmentationPct)
+	}
+	if !db.IntegrityOK {
+		t.Errorf("fragmented DB is still structurally valid: %v", db.IntegrityErrors)
+	}
+}
+
+func TestCheckOpenErrorIsRecorded(t *testing.T) {
+	deps := Deps{
+		Open: func(string) (*sql.DB, error) { return nil, errors.New("boom") },
+		Stat: func(string) (int64, error) { return 0, errors.New("nope") },
+	}
+	rep := Check([]string{"/whatever.db"}, deps)
+	if rep.Problems != 1 || rep.Databases[0].Error == "" {
+		t.Fatalf("expected recorded open error as a problem, got %+v", rep.Databases[0])
+	}
+}
+
+func TestCheckFlagsWALBloat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wal.db")
+	makeDB(t, path, nil)
+	deps := DefaultDeps()
+	real := deps.Stat
+	deps.Stat = func(p string) (int64, error) {
+		if p == path+"-wal" {
+			return walBloatThreshold + 1, nil
+		}
+		return real(p)
+	}
+	rep := Check([]string{path}, deps)
+	if rep.Problems != 1 {
+		t.Fatalf("expected WAL bloat to count as a problem, got %d", rep.Problems)
+	}
+	if rep.Databases[0].WALBytes <= walBloatThreshold {
+		t.Errorf("WALBytes not captured: %d", rep.Databases[0].WALBytes)
+	}
+}
+
+func TestDiscover(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "app.db")
+	makeDB(t, dbPath, nil)
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write txt: %v", err)
+	}
+
+	readHeader := func(p string) ([]byte, error) {
+		b, err := os.ReadFile(p) // #nosec G304 -- test reads temp files
+		if err != nil {
+			return nil, err
+		}
+		if len(b) > 16 {
+			b = b[:16]
+		}
+		return b, nil
+	}
+	found, err := Discover(dir, readHeader)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(found) != 1 || found[0] != dbPath {
+		t.Errorf("discover = %v, want [%s]", found, dbPath)
+	}
+}


### PR DESCRIPTION
## What

`spectra storage db-check` — a read-only health check for the embedded SQLite databases macOS apps scatter through `~/Library`. When one is corrupt, bloated by an un-checkpointed WAL, or heavily fragmented, the app slows or loses data with no easy way to see it. Spectra already vendors the pure-Go `modernc.org/sqlite` driver, so it can inspect these without cgo or root.

## How

- **`internal/dbcheck`** opens each database **read-only** (`file:…?mode=ro`, never writes the file) and reports: size, page size/count, freelist count + fragmentation %, journal mode, `-wal` sidecar size, and `PRAGMA quick_check` integrity (bounded to the first 10 errors). A DB counts as a problem when integrity fails, WAL bloat exceeds 32 MiB, or the freelist exceeds 25% of pages. An unopenable/locked/non-database file is recorded with its error rather than failing the run. fs + db-open are injected (`Deps`) for testing.
- **`spectra storage db-check [--json] <path>...`** — each path is a database file or a directory (walked for files with the SQLite header, matched on the 16-byte magic).

## Testing

`internal/dbcheck` is tested against real temporary databases created through the driver: a healthy DB (integrity ok, page geometry present), a bulk-delete DB (free pages / fragmentation observed), header recognition, pure `fragmentationPct`, directory discovery (SQLite file found, text file skipped), an injected open-error (recorded as a problem), and an injected 32 MiB `-wal` (flagged as bloat). `make vet complexity lint security docs-validate test` green (56 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #391
