### PR TITLE
web: spectra web leveldb-health — Chromium/Electron LevelDB store structural health

### DIFF
--- a/cmd/spectra/web.go
+++ b/cmd/spectra/web.go
@@ -60,11 +60,14 @@ func runWebLevelDBHealth(args []string, stdout, stderr io.Writer, deps leveldbch
 
 	var paths []string
 	for _, arg := range fs.Args() {
-		paths = append(paths, leveldbcheck.Discover(arg, deps)...)
-	}
-	if len(paths) == 0 {
-		fmt.Fprintln(stderr, "no LevelDB stores found in the given paths")
-		return 1
+		// Discover nested stores under a parent; when the argument itself yields
+		// no store (e.g. a store directory whose CURRENT is missing), inspect it
+		// directly so the corruption is reported rather than silently skipped.
+		if found := leveldbcheck.Discover(arg, deps); len(found) > 0 {
+			paths = append(paths, found...)
+		} else {
+			paths = append(paths, arg)
+		}
 	}
 
 	report := leveldbcheck.Check(paths, deps)

--- a/cmd/spectra/web.go
+++ b/cmd/spectra/web.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kaeawc/spectra/internal/asar"
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/electronfuse"
+	"github.com/kaeawc/spectra/internal/leveldbcheck"
 )
 
 func runWeb(args []string) int {
@@ -37,10 +38,71 @@ func runWebWithIO(args []string, stdout, stderr io.Writer, inspect detectFunc) i
 		return runWebProcesses(rest, stdout, stderr, defaultProcessCollector)
 	case "symbolicate":
 		return runWebSymbolicate(rest, stdout, stderr, os.ReadFile)
+	case "leveldb-health":
+		return runWebLevelDBHealth(rest, stdout, stderr, leveldbcheck.DefaultDeps())
 	default:
-		fmt.Fprintf(stderr, "unknown web subcommand %q (want: asar-diff, fuses, processes, symbolicate)\n", sub)
+		fmt.Fprintf(stderr, "unknown web subcommand %q (want: asar-diff, fuses, processes, symbolicate, leveldb-health)\n", sub)
 		return 2
 	}
+}
+
+func runWebLevelDBHealth(args []string, stdout, stderr io.Writer, deps leveldbcheck.Deps) int {
+	fs := flag.NewFlagSet("spectra web leveldb-health", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() == 0 {
+		fmt.Fprintln(stderr, "usage: spectra web leveldb-health [--json] <path>...  (a LevelDB store dir, or a parent to scan)")
+		return 2
+	}
+
+	var paths []string
+	for _, arg := range fs.Args() {
+		paths = append(paths, leveldbcheck.Discover(arg, deps)...)
+	}
+	if len(paths) == 0 {
+		fmt.Fprintln(stderr, "no LevelDB stores found in the given paths")
+		return 1
+	}
+
+	report := leveldbcheck.Check(paths, deps)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+		return 0
+	}
+	renderLevelDBHealth(stdout, report)
+	return 0
+}
+
+func renderLevelDBHealth(w io.Writer, report leveldbcheck.Report) {
+	fmt.Fprintf(w, "=== LevelDB health (%d scanned, %d with problems) ===\n", report.Scanned, report.Problems)
+	for _, s := range report.Stores {
+		if s.Error != "" {
+			fmt.Fprintf(w, "  %s\n    error: %s\n", s.Path, s.Error)
+			continue
+		}
+		fmt.Fprintf(w, "  %s\n", s.Path)
+		fmt.Fprintf(w, "    tables=%d (%s) logs=%d (%s) manifest=%s total=%s\n",
+			s.TableFiles, humanSize(s.TableBytes), s.LogFiles, humanSize(s.LogBytes),
+			manifestLabel(s), humanSize(s.TotalBytes))
+		for _, p := range s.Problems {
+			fmt.Fprintf(w, "      - %s\n", p)
+		}
+	}
+}
+
+func manifestLabel(s leveldbcheck.Store) string {
+	if s.ManifestOK {
+		return s.ManifestFile + " (ok)"
+	}
+	if s.ManifestFile != "" {
+		return s.ManifestFile + " (MISSING)"
+	}
+	return "none"
 }
 
 type webFusesOutput struct {

--- a/cmd/spectra/web_leveldb_test.go
+++ b/cmd/spectra/web_leveldb_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/leveldbcheck"
+)
+
+// fakeLevelFS serves a directory layout to leveldbcheck.Deps.
+func fakeLevelFS(dirs map[string][]leveldbcheck.Entry, files map[string]string) leveldbcheck.Deps {
+	return leveldbcheck.Deps{
+		ReadDir: func(dir string) ([]leveldbcheck.Entry, error) {
+			e, ok := dirs[dir]
+			if !ok {
+				return nil, errors.New("no such directory")
+			}
+			return e, nil
+		},
+		ReadFile: func(path string) ([]byte, error) {
+			b, ok := files[path]
+			if !ok {
+				return nil, errors.New("no such file")
+			}
+			return []byte(b), nil
+		},
+	}
+}
+
+// A store directory whose CURRENT is missing must still be inspected and its
+// corruption reported, rather than "no LevelDB stores found".
+func TestWebLevelDBHealthExplicitMissingCurrent(t *testing.T) {
+	deps := fakeLevelFS(
+		map[string][]leveldbcheck.Entry{
+			"/store": {{Name: "000003.ldb", Size: 10}},
+		},
+		nil,
+	)
+	var out, errBuf bytes.Buffer
+	code := runWebLevelDBHealth([]string{"/store"}, &out, &errBuf, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "no CURRENT file") {
+		t.Errorf("expected the missing-CURRENT store to be flagged, got:\n%s", out.String())
+	}
+}
+
+func TestWebLevelDBHealthDiscoversParent(t *testing.T) {
+	deps := fakeLevelFS(
+		map[string][]leveldbcheck.Entry{
+			"/root":         {{Name: "leveldb", IsDir: true}},
+			"/root/leveldb": {{Name: "CURRENT", Size: 16}, {Name: "MANIFEST-1", Size: 10}},
+		},
+		map[string]string{"/root/leveldb/CURRENT": "MANIFEST-1"},
+	)
+	var out, errBuf bytes.Buffer
+	if code := runWebLevelDBHealth([]string{"/root"}, &out, &errBuf, deps); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), "/root/leveldb") {
+		t.Errorf("expected the nested store to be discovered, got:\n%s", out.String())
+	}
+}
+
+func TestWebLevelDBHealthRequiresArg(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runWebLevelDBHealth(nil, &out, &errBuf, leveldbcheck.DefaultDeps()); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -639,8 +639,8 @@ use.
 ### Examples
 
 ```bash
-spectra web leveldb-health "~/Library/Application Support/MyApp/Local Storage/leveldb"
-spectra web leveldb-health --json "~/Library/Application Support/MyApp/IndexedDB"
+spectra web leveldb-health "$HOME/Library/Application Support/MyApp/Local Storage/leveldb"
+spectra web leveldb-health --json "$HOME/Library/Application Support/MyApp/IndexedDB"
 ```
 
 ## `spectra anomalies`

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -620,6 +620,29 @@ spectra web symbolicate app.js.map 1:284620
 spectra web symbolicate --json app.js.map 1:284620 1:9931
 ```
 
+## `spectra web leveldb-health`
+
+Reports the structural health of the LevelDB stores Chromium/Electron apps use
+for IndexedDB, Local Storage, and Session Storage. Each argument is a LevelDB
+store directory or a parent directory to scan (a directory containing a
+`CURRENT` file is a store). Inspection is **file-level only** — it counts the
+sorted table files (`.ldb`/`.sst`) and write-ahead logs (`.log`), reads the
+small `CURRENT` file to check the manifest it names actually exists, and sums
+the store size — so it never decodes tables, never opens the store for writing,
+and does not contend with a running browser. A store is flagged when `CURRENT`
+is missing/unreadable or points at an absent manifest, when the table-file
+count crosses the compaction-backlog threshold, or when the write-ahead log is
+bloated (an unclean shutdown or heavy pending writes). The persistent `LOCK`
+file is ignored — its presence is normal and does not indicate the store is in
+use.
+
+### Examples
+
+```bash
+spectra web leveldb-health "~/Library/Application Support/MyApp/Local Storage/leveldb"
+spectra web leveldb-health --json "~/Library/Application Support/MyApp/IndexedDB"
+```
+
 ## `spectra anomalies`
 
 Flags processes whose latest RSS sits well above their own recent baseline,

--- a/internal/leveldbcheck/leveldbcheck.go
+++ b/internal/leveldbcheck/leveldbcheck.go
@@ -102,6 +102,7 @@ func Inspect(dir string, deps Deps) Store {
 
 	names := make(map[string]bool, len(entries))
 	hasCurrent := false
+	var largestLog int64
 	for _, e := range entries {
 		if e.IsDir {
 			continue
@@ -117,6 +118,9 @@ func Inspect(dir string, deps Deps) Store {
 		case strings.HasSuffix(e.Name, ".log"):
 			s.LogFiles++
 			s.LogBytes += e.Size
+			if e.Size > largestLog {
+				largestLog = e.Size
+			}
 		}
 	}
 
@@ -124,8 +128,10 @@ func Inspect(dir string, deps Deps) Store {
 	if s.TableFiles > compactionBacklogTables {
 		s.Problems = append(s.Problems, fmt.Sprintf("compaction backlog: %d table files", s.TableFiles))
 	}
-	if s.LogBytes > logBloatThreshold {
-		s.Problems = append(s.Problems, fmt.Sprintf("write-ahead log bloat: %d bytes across %d log(s)", s.LogBytes, s.LogFiles))
+	// Flag on the largest single log, not the aggregate: several normal logs can
+	// sum past the threshold without any one being oversized.
+	if largestLog > logBloatThreshold {
+		s.Problems = append(s.Problems, fmt.Sprintf("write-ahead log bloat: a log file is %d bytes (%d total across %d log(s))", largestLog, s.LogBytes, s.LogFiles))
 	}
 	return s
 }
@@ -145,6 +151,10 @@ func (s *Store) resolveManifest(dir string, hasCurrent bool, names map[string]bo
 	s.ManifestFile = name
 	if name == "" {
 		s.Problems = append(s.Problems, "empty CURRENT file")
+		return
+	}
+	if !strings.HasPrefix(name, "MANIFEST-") {
+		s.Problems = append(s.Problems, "CURRENT does not name a manifest: "+name)
 		return
 	}
 	if names[name] {

--- a/internal/leveldbcheck/leveldbcheck.go
+++ b/internal/leveldbcheck/leveldbcheck.go
@@ -1,0 +1,182 @@
+// Package leveldbcheck inspects the structural health of LevelDB stores as used
+// by Chromium/Electron for IndexedDB, Local Storage, and Session Storage. It
+// reads only the on-disk file layout — never decoding tables or opening the
+// store for writing — so it is safe to run against a store a browser is using.
+package leveldbcheck
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// compactionBacklogTables flags a store carrying an unusual number of sorted
+// table files, which points at a compaction backlog.
+const compactionBacklogTables = 500
+
+// logBloatThreshold flags an oversized write-ahead log (100 MiB), which points
+// at an unclean shutdown or a large volume of un-compacted writes.
+const logBloatThreshold = 100 << 20
+
+// Entry is one directory entry with the fields leveldbcheck needs.
+type Entry struct {
+	Name  string
+	Size  int64
+	IsDir bool
+}
+
+// Deps injects filesystem access so inspection can run against synthetic store
+// layouts in tests.
+type Deps struct {
+	ReadDir  func(string) ([]Entry, error)
+	ReadFile func(string) ([]byte, error)
+}
+
+// DefaultDeps reads from the real filesystem.
+func DefaultDeps() Deps {
+	return Deps{
+		ReadDir: func(dir string) ([]Entry, error) {
+			des, err := os.ReadDir(dir)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]Entry, 0, len(des))
+			for _, de := range des {
+				e := Entry{Name: de.Name(), IsDir: de.IsDir()}
+				if info, err := de.Info(); err == nil {
+					e.Size = info.Size()
+				}
+				out = append(out, e)
+			}
+			return out, nil
+		},
+		ReadFile: os.ReadFile,
+	}
+}
+
+// Store is the structural health of one LevelDB store.
+type Store struct {
+	Path         string   `json:"path"`
+	TableFiles   int      `json:"table_files"`
+	TableBytes   int64    `json:"table_bytes"`
+	LogFiles     int      `json:"log_files"`
+	LogBytes     int64    `json:"log_bytes"`
+	ManifestFile string   `json:"manifest_file,omitempty"`
+	ManifestOK   bool     `json:"manifest_ok"`
+	TotalBytes   int64    `json:"total_bytes"`
+	Problems     []string `json:"problems,omitempty"`
+	Error        string   `json:"error,omitempty"`
+}
+
+// Report is the combined result of inspecting a set of stores.
+type Report struct {
+	Stores   []Store `json:"stores"`
+	Scanned  int     `json:"scanned"`
+	Problems int     `json:"problems"`
+}
+
+// Check inspects the store at each path and returns their combined health.
+func Check(paths []string, deps Deps) Report {
+	rep := Report{}
+	for _, p := range paths {
+		s := Inspect(p, deps)
+		if s.Error != "" || len(s.Problems) > 0 {
+			rep.Problems++
+		}
+		rep.Stores = append(rep.Stores, s)
+	}
+	rep.Scanned = len(rep.Stores)
+	return rep
+}
+
+// Inspect reports the structural health of a single LevelDB store directory.
+func Inspect(dir string, deps Deps) Store {
+	s := Store{Path: dir}
+	entries, err := deps.ReadDir(dir)
+	if err != nil {
+		s.Error = fmt.Errorf("read %s: %w", dir, err).Error()
+		return s
+	}
+
+	names := make(map[string]bool, len(entries))
+	hasCurrent := false
+	for _, e := range entries {
+		if e.IsDir {
+			continue
+		}
+		names[e.Name] = true
+		s.TotalBytes += e.Size
+		switch {
+		case e.Name == "CURRENT":
+			hasCurrent = true
+		case strings.HasSuffix(e.Name, ".ldb"), strings.HasSuffix(e.Name, ".sst"):
+			s.TableFiles++
+			s.TableBytes += e.Size
+		case strings.HasSuffix(e.Name, ".log"):
+			s.LogFiles++
+			s.LogBytes += e.Size
+		}
+	}
+
+	s.resolveManifest(dir, hasCurrent, names, deps)
+	if s.TableFiles > compactionBacklogTables {
+		s.Problems = append(s.Problems, fmt.Sprintf("compaction backlog: %d table files", s.TableFiles))
+	}
+	if s.LogBytes > logBloatThreshold {
+		s.Problems = append(s.Problems, fmt.Sprintf("write-ahead log bloat: %d bytes across %d log(s)", s.LogBytes, s.LogFiles))
+	}
+	return s
+}
+
+// resolveManifest records whether CURRENT names an existing manifest file.
+func (s *Store) resolveManifest(dir string, hasCurrent bool, names map[string]bool, deps Deps) {
+	if !hasCurrent {
+		s.Problems = append(s.Problems, "no CURRENT file (not an initialized LevelDB store)")
+		return
+	}
+	raw, err := deps.ReadFile(filepath.Join(dir, "CURRENT"))
+	if err != nil {
+		s.Problems = append(s.Problems, "unreadable CURRENT file")
+		return
+	}
+	name := strings.TrimSpace(string(raw))
+	s.ManifestFile = name
+	if name == "" {
+		s.Problems = append(s.Problems, "empty CURRENT file")
+		return
+	}
+	if names[name] {
+		s.ManifestOK = true
+		return
+	}
+	s.Problems = append(s.Problems, "CURRENT points to missing manifest "+name)
+}
+
+// Discover walks root and returns the directories that are LevelDB stores (a
+// directory containing a CURRENT file). Symlinked directories are not followed.
+func Discover(root string, deps Deps) []string {
+	var stores []string
+	var walk func(string)
+	walk = func(dir string) {
+		entries, err := deps.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if !e.IsDir && e.Name == "CURRENT" {
+				stores = append(stores, dir)
+				break
+			}
+		}
+		for _, e := range entries {
+			if e.IsDir {
+				walk(filepath.Join(dir, e.Name))
+			}
+		}
+	}
+	walk(root)
+	sort.Strings(stores)
+	return stores
+}

--- a/internal/leveldbcheck/leveldbcheck_test.go
+++ b/internal/leveldbcheck/leveldbcheck_test.go
@@ -117,6 +117,38 @@ func TestInspectLogBloat(t *testing.T) {
 	}
 }
 
+func TestInspectAggregateLogsNotBloat(t *testing.T) {
+	half := int64(logBloatThreshold/2 + 1) // two of these exceed the threshold together
+	fs := fakeFS{
+		dirs: map[string][]Entry{"/store": {
+			file("CURRENT", 16), file("MANIFEST-1", 10),
+			file("000009.log", half), file("000010.log", half),
+		}},
+		files: map[string]string{"/store/CURRENT": "MANIFEST-1"},
+	}
+	s := Inspect("/store", fs.deps())
+	if hasProblem(s, "write-ahead log bloat") {
+		t.Errorf("two normal logs summing over the threshold must not be flagged: %v", s.Problems)
+	}
+	if s.LogBytes != 2*half {
+		t.Errorf("aggregate log bytes still reported: got %d", s.LogBytes)
+	}
+}
+
+func TestInspectCurrentNotAManifest(t *testing.T) {
+	fs := fakeFS{
+		dirs:  map[string][]Entry{"/store": {file("CURRENT", 16), file("000003.ldb", 10)}},
+		files: map[string]string{"/store/CURRENT": "000003.ldb"},
+	}
+	s := Inspect("/store", fs.deps())
+	if s.ManifestOK {
+		t.Error("a CURRENT naming a .ldb file must not count as a valid manifest")
+	}
+	if !hasProblem(s, "does not name a manifest") {
+		t.Errorf("expected not-a-manifest problem, got %v", s.Problems)
+	}
+}
+
 func TestInspectUnreadableDir(t *testing.T) {
 	s := Inspect("/missing", fakeFS{dirs: map[string][]Entry{}}.deps())
 	if s.Error == "" {

--- a/internal/leveldbcheck/leveldbcheck_test.go
+++ b/internal/leveldbcheck/leveldbcheck_test.go
@@ -1,0 +1,162 @@
+package leveldbcheck
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// fakeFS builds Deps from an in-memory layout: dir -> entries, and file -> body.
+type fakeFS struct {
+	dirs  map[string][]Entry
+	files map[string]string
+}
+
+func (f fakeFS) deps() Deps {
+	return Deps{
+		ReadDir: func(dir string) ([]Entry, error) {
+			e, ok := f.dirs[dir]
+			if !ok {
+				return nil, errors.New("no such directory")
+			}
+			return e, nil
+		},
+		ReadFile: func(path string) ([]byte, error) {
+			b, ok := f.files[path]
+			if !ok {
+				return nil, errors.New("no such file")
+			}
+			return []byte(b), nil
+		},
+	}
+}
+
+func file(name string, size int64) Entry { return Entry{Name: name, Size: size} }
+
+func TestInspectHealthyStore(t *testing.T) {
+	fs := fakeFS{
+		dirs: map[string][]Entry{
+			"/store": {
+				file("CURRENT", 16),
+				file("MANIFEST-000001", 200),
+				file("000003.ldb", 4096),
+				file("000004.ldb", 8192),
+				file("000005.log", 1024),
+				{Name: "LOCK", Size: 0},
+			},
+		},
+		files: map[string]string{"/store/CURRENT": "MANIFEST-000001\n"},
+	}
+	s := Inspect("/store", fs.deps())
+	if len(s.Problems) != 0 {
+		t.Fatalf("healthy store should have no problems, got %v", s.Problems)
+	}
+	if !s.ManifestOK || s.ManifestFile != "MANIFEST-000001" {
+		t.Errorf("manifest = %q ok=%v", s.ManifestFile, s.ManifestOK)
+	}
+	if s.TableFiles != 2 || s.TableBytes != 12288 {
+		t.Errorf("tables = %d/%d, want 2/12288", s.TableFiles, s.TableBytes)
+	}
+	if s.LogFiles != 1 || s.LogBytes != 1024 {
+		t.Errorf("logs = %d/%d, want 1/1024", s.LogFiles, s.LogBytes)
+	}
+	if s.TotalBytes != 16+200+4096+8192+1024 {
+		t.Errorf("total = %d", s.TotalBytes)
+	}
+}
+
+func TestInspectMissingManifest(t *testing.T) {
+	fs := fakeFS{
+		dirs:  map[string][]Entry{"/store": {file("CURRENT", 16), file("000003.ldb", 10)}},
+		files: map[string]string{"/store/CURRENT": "MANIFEST-999999\n"},
+	}
+	s := Inspect("/store", fs.deps())
+	if s.ManifestOK {
+		t.Error("manifest should be reported missing")
+	}
+	if !hasProblem(s, "missing manifest MANIFEST-999999") {
+		t.Errorf("expected missing-manifest problem, got %v", s.Problems)
+	}
+}
+
+func TestInspectNoCurrent(t *testing.T) {
+	fs := fakeFS{dirs: map[string][]Entry{"/store": {file("random.txt", 5)}}}
+	s := Inspect("/store", fs.deps())
+	if !hasProblem(s, "no CURRENT file") {
+		t.Errorf("expected no-CURRENT problem, got %v", s.Problems)
+	}
+}
+
+func TestInspectCompactionBacklog(t *testing.T) {
+	entries := []Entry{file("CURRENT", 16), file("MANIFEST-1", 10)}
+	for i := 0; i < compactionBacklogTables+1; i++ {
+		entries = append(entries, file("t"+strconv.Itoa(i)+".ldb", 100))
+	}
+	fs := fakeFS{
+		dirs:  map[string][]Entry{"/store": entries},
+		files: map[string]string{"/store/CURRENT": "MANIFEST-1"},
+	}
+	s := Inspect("/store", fs.deps())
+	if !hasProblem(s, "compaction backlog") {
+		t.Errorf("expected compaction-backlog problem, got %v", s.Problems)
+	}
+}
+
+func TestInspectLogBloat(t *testing.T) {
+	fs := fakeFS{
+		dirs: map[string][]Entry{"/store": {
+			file("CURRENT", 16), file("MANIFEST-1", 10),
+			file("000009.log", logBloatThreshold+1),
+		}},
+		files: map[string]string{"/store/CURRENT": "MANIFEST-1"},
+	}
+	s := Inspect("/store", fs.deps())
+	if !hasProblem(s, "write-ahead log bloat") {
+		t.Errorf("expected log-bloat problem, got %v", s.Problems)
+	}
+}
+
+func TestInspectUnreadableDir(t *testing.T) {
+	s := Inspect("/missing", fakeFS{dirs: map[string][]Entry{}}.deps())
+	if s.Error == "" {
+		t.Error("expected an error for an unreadable directory")
+	}
+}
+
+func TestCheckCountsProblems(t *testing.T) {
+	fs := fakeFS{
+		dirs: map[string][]Entry{
+			"/good": {file("CURRENT", 16), file("MANIFEST-1", 10)},
+			"/bad":  {file("CURRENT", 16)},
+		},
+		files: map[string]string{"/good/CURRENT": "MANIFEST-1", "/bad/CURRENT": "MANIFEST-missing"},
+	}
+	rep := Check([]string{"/good", "/bad"}, fs.deps())
+	if rep.Scanned != 2 || rep.Problems != 1 {
+		t.Fatalf("scanned=%d problems=%d, want 2/1", rep.Scanned, rep.Problems)
+	}
+}
+
+func TestDiscover(t *testing.T) {
+	fs := fakeFS{
+		dirs: map[string][]Entry{
+			"/root":                               {{Name: "IndexedDB", IsDir: true}, {Name: "notes.txt"}},
+			"/root/IndexedDB":                     {{Name: "a.indexeddb.leveldb", IsDir: true}},
+			"/root/IndexedDB/a.indexeddb.leveldb": {file("CURRENT", 16), file("MANIFEST-1", 10)},
+		},
+	}
+	stores := Discover("/root", fs.deps())
+	if len(stores) != 1 || stores[0] != "/root/IndexedDB/a.indexeddb.leveldb" {
+		t.Errorf("discover = %v, want the one leveldb dir", stores)
+	}
+}
+
+func hasProblem(s Store, substr string) bool {
+	for _, p := range s.Problems {
+		if strings.Contains(p, substr) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

`spectra web leveldb-health` — structural health for the LevelDB stores Chromium/Electron apps use for IndexedDB, Local Storage, and Session Storage. A `CURRENT` pointing at a missing manifest (corruption), a compaction backlog of hundreds of tiny `.ldb` tables, or a bloated write-ahead `.log` from an unclean shutdown makes an app slow to open or lose state — with nothing surfacing it.

## How

- **`internal/leveldbcheck`** inspects each store **at the file level only**: counts sorted table files (`.ldb`/`.sst`) and write-ahead logs (`.log`) with their bytes, reads the small `CURRENT` file and checks the manifest it names exists on disk, and sums store size. Flags: missing / unreadable / empty `CURRENT`, `CURRENT` → absent manifest, table count over the compaction-backlog threshold (500), and `.log` bloat (>100 MiB). It never decodes tables, never opens the store for writing, and does **not** contend with a running browser. The persistent `LOCK` file is deliberately ignored — its existence is normal and is not evidence the store is in use.
- **`spectra web leveldb-health [--json] <path>...`** — each path is a store directory or a parent directory scanned for stores (any directory containing `CURRENT`).

## Testing

fs access is injected (`Deps`), so inspection is unit-tested against synthetic layouts: a healthy store (table/log/manifest/size accounting), a `CURRENT`→missing-manifest store, a store with no `CURRENT`, a compaction backlog, `.log` bloat, an unreadable directory (error path), multi-store problem counting, and directory discovery (finds the `.indexeddb.leveldb` dir, skips others). `make vet complexity lint security docs-validate test` green (57 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #393
