### PR TITLE
storage: spectra storage cache-triage — classify cache subdirs safe/regenerable/risky with reclaimable bytes

### DIFF
--- a/cmd/spectra/storage.go
+++ b/cmd/spectra/storage.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/kaeawc/spectra/internal/cachetriage"
 	"github.com/kaeawc/spectra/internal/dbcheck"
 	"github.com/kaeawc/spectra/internal/storagestate"
 )
@@ -15,6 +17,9 @@ import (
 func runStorage(args []string) int {
 	if len(args) > 0 && args[0] == "db-check" {
 		return runStorageDBCheck(args[1:], os.Stdout, os.Stderr)
+	}
+	if len(args) > 0 && args[0] == "cache-triage" {
+		return runStorageCacheTriage(args[1:], os.Stdout, os.Stderr)
 	}
 	fs := flag.NewFlagSet("spectra storage", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -68,6 +73,55 @@ func runStorageDBCheck(args []string, stdout, stderr io.Writer) int {
 	}
 	printDBCheckReport(stdout, report)
 	return 0
+}
+
+func runStorageCacheTriage(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("spectra storage cache-triage", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() > 1 {
+		fmt.Fprintln(stderr, "usage: spectra storage cache-triage [--json] [<root>]")
+		return 2
+	}
+
+	root := fs.Arg(0)
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(stderr, "cache-triage: resolve home: %v\n", err)
+			return 1
+		}
+		root = filepath.Join(home, "Library", "Caches")
+	}
+
+	report, err := cachetriage.Triage(root, cachetriage.DefaultDeps())
+	if err != nil {
+		fmt.Fprintf(stderr, "cache-triage: %v\n", err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+		return 0
+	}
+	printCacheTriage(stdout, report)
+	return 0
+}
+
+func printCacheTriage(w io.Writer, report cachetriage.Report) {
+	fmt.Fprintf(w, "=== Cache triage: %s ===\n", report.Root)
+	fmt.Fprintf(w, "total %s | reclaimable %s (safe+regenerable) | risky %s held back\n",
+		humanSize(report.TotalBytes), humanSize(report.ReclaimableBytes), humanSize(report.RiskyBytes))
+	for _, e := range report.Entries {
+		fmt.Fprintf(w, "  %-10s %10s  %s\n", e.Class, humanSize(e.SizeBytes), truncate(e.Name, 44))
+		if e.Class == cachetriage.ClassRisky && e.Reason != "" {
+			fmt.Fprintf(w, "               %s\n", truncate(e.Reason, 64))
+		}
+	}
 }
 
 // resolveDBPaths expands directory arguments into the SQLite files they contain

--- a/cmd/spectra/storage.go
+++ b/cmd/spectra/storage.go
@@ -19,7 +19,7 @@ func runStorage(args []string) int {
 		return runStorageDBCheck(args[1:], os.Stdout, os.Stderr)
 	}
 	if len(args) > 0 && args[0] == "cache-triage" {
-		return runStorageCacheTriage(args[1:], os.Stdout, os.Stderr)
+		return runStorageCacheTriage(args[1:], os.Stdout, os.Stderr, os.UserHomeDir)
 	}
 	fs := flag.NewFlagSet("spectra storage", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -75,7 +75,7 @@ func runStorageDBCheck(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func runStorageCacheTriage(args []string, stdout, stderr io.Writer) int {
+func runStorageCacheTriage(args []string, stdout, stderr io.Writer, homeDir func() (string, error)) int {
 	fs := flag.NewFlagSet("spectra storage cache-triage", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
@@ -89,7 +89,7 @@ func runStorageCacheTriage(args []string, stdout, stderr io.Writer) int {
 
 	root := fs.Arg(0)
 	if root == "" {
-		home, err := os.UserHomeDir()
+		home, err := homeDir()
 		if err != nil {
 			fmt.Fprintf(stderr, "cache-triage: resolve home: %v\n", err)
 			return 1
@@ -117,9 +117,9 @@ func printCacheTriage(w io.Writer, report cachetriage.Report) {
 	fmt.Fprintf(w, "total %s | reclaimable %s (safe+regenerable) | risky %s held back\n",
 		humanSize(report.TotalBytes), humanSize(report.ReclaimableBytes), humanSize(report.RiskyBytes))
 	for _, e := range report.Entries {
-		fmt.Fprintf(w, "  %-10s %10s  %s\n", e.Class, humanSize(e.SizeBytes), truncate(e.Name, 44))
-		if e.Class == cachetriage.ClassRisky && e.Reason != "" {
-			fmt.Fprintf(w, "               %s\n", truncate(e.Reason, 64))
+		fmt.Fprintf(w, "  %-11s %10s  %s\n", e.Class, humanSize(e.SizeBytes), truncate(e.Name, 44))
+		if e.Reason != "" {
+			fmt.Fprintf(w, "                %s\n", truncate(e.Reason, 72))
 		}
 	}
 }

--- a/cmd/spectra/storage_cachetriage_test.go
+++ b/cmd/spectra/storage_cachetriage_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunStorageCacheTriageUsesInjectedHome(t *testing.T) {
+	home := t.TempDir()
+	caches := filepath.Join(home, "Library", "Caches", "go-build")
+	if err := os.MkdirAll(caches, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(caches, "a.o"), []byte("obj"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var out, errBuf bytes.Buffer
+	code := runStorageCacheTriage(nil, &out, &errBuf, func() (string, error) { return home, nil })
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "go-build") || !strings.Contains(s, "safe") {
+		t.Errorf("expected the injected cache root to be triaged, got:\n%s", s)
+	}
+}
+
+func TestRunStorageCacheTriageHomeError(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runStorageCacheTriage(nil, &out, &errBuf, func() (string, error) {
+		return "", errors.New("no home")
+	})
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 on home-resolution failure", code)
+	}
+}
+
+func TestRunStorageCacheTriageTooManyArgs(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runStorageCacheTriage([]string{"a", "b"}, &out, &errBuf, os.UserHomeDir)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -428,8 +428,35 @@ its error instead of failing the whole run.
 
 ```bash
 spectra storage db-check ~/Library/Messages/chat.db
-spectra storage db-check --json "~/Library/Application Support/MyApp"
+spectra storage db-check --json "$HOME/Library/Application Support/MyApp"
 spectra storage db-check app1.db app2.db
+```
+
+## `spectra storage cache-triage`
+
+Classifies each subdirectory of a cache root (default `~/Library/Caches`) so you
+can reclaim space without deleting real data. `~/Library/Caches` is usually the
+largest safe win, but some apps stash cookies, tokens, or SQLite state there, so
+"delete all caches" is risky. Each subdirectory is sized and classed as:
+
+- **safe** — a pure build/tooling cache that fully reconstructs from source or
+  network (Go build cache, npm/yarn/pnpm, pip, CocoaPods, Homebrew, node-gyp,
+  Playwright, …);
+- **regenerable** — an ordinary app runtime cache (the default), safe to delete
+  and rebuilt on demand;
+- **risky** — a subtree containing markers of real data (cookies, credentials or
+  tokens, `.sqlite`/`.db`, LevelDB) that should be reviewed before deletion.
+
+Risky data outweighs a safe-looking name, so the classification is conservative.
+The command is read-only — it never deletes anything — and reports total cache
+bytes, reclaimable bytes (safe + regenerable), and the risky bytes held back.
+
+### Examples
+
+```bash
+spectra storage cache-triage
+spectra storage cache-triage --json
+spectra storage cache-triage "$HOME/Library/Containers/com.example.App/Data/Library/Caches"
 ```
 
 ## `spectra crash readiness`

--- a/internal/cachetriage/cachetriage.go
+++ b/internal/cachetriage/cachetriage.go
@@ -1,0 +1,168 @@
+// Package cachetriage classifies the subdirectories of a cache root (typically
+// ~/Library/Caches) as safe, regenerable, or risky to delete, and reports how
+// much space could be reclaimed. It only reads the filesystem — it never
+// deletes anything.
+package cachetriage
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Class is the reclamation classification of a cache subdirectory.
+type Class string
+
+const (
+	// ClassSafe is a pure build/tooling cache that fully reconstructs from
+	// source or network with no user-visible loss.
+	ClassSafe Class = "safe"
+	// ClassRegenerable is an ordinary app runtime cache: safe to delete, the
+	// app rebuilds it. This is the default when nothing else matches.
+	ClassRegenerable Class = "regenerable"
+	// ClassRisky holds markers of real, non-regenerable data mislabeled as
+	// cache; the user should review it before deleting.
+	ClassRisky Class = "risky"
+)
+
+// scanFileLimit bounds the per-subdirectory walk so a pathological tree cannot
+// stall triage; sizing stops contributing markers past it but keeps summing.
+const scanFileLimit = 50000
+
+// safeMarkers are name fragments of build/tooling caches that are always safe
+// to clear. Matched case-insensitively against the subdirectory name.
+var safeMarkers = []string{
+	"go-build", "gomod", "npm", "_cacache", "yarn", "pnpm", "pip", "cocoapods",
+	"homebrew", "node-gyp", "ms-playwright", "puppeteer", "electron", "esbuild",
+	"typescript", "carthage", "deno", "gradle", "cargo",
+}
+
+// riskyNameFragments identify a file or directory name that suggests real data
+// rather than a cache. Matched case-insensitively.
+var riskyNameFragments = []string{
+	"cookie", "credential", "token", "account", "session", "keychain",
+	".sqlite", ".db", ".realm", "leveldb", "indexeddb",
+}
+
+// Entry is one cache subdirectory's triage result.
+type Entry struct {
+	Path      string `json:"path"`
+	Name      string `json:"name"`
+	SizeBytes int64  `json:"size_bytes"`
+	Class     Class  `json:"class"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// Report is the triage of every subdirectory of a cache root.
+type Report struct {
+	Root             string  `json:"root"`
+	Entries          []Entry `json:"entries"`
+	TotalBytes       int64   `json:"total_bytes"`
+	ReclaimableBytes int64   `json:"reclaimable_bytes"`
+	RiskyBytes       int64   `json:"risky_bytes"`
+}
+
+// Deps injects filesystem access so triage can be tested without real caches.
+type Deps struct {
+	// Subdirs returns the immediate child directory names of root.
+	Subdirs func(root string) ([]string, error)
+	// Scan invokes fn for each file under dir (bounded) with its base name and
+	// size, so triage can sum size and detect risky markers.
+	Scan func(dir string, fn func(name string, size int64)) error
+}
+
+// DefaultDeps reads from the real filesystem.
+func DefaultDeps() Deps {
+	return Deps{
+		Subdirs: func(root string) ([]string, error) {
+			des, err := os.ReadDir(root)
+			if err != nil {
+				return nil, err
+			}
+			var out []string
+			for _, de := range des {
+				if de.IsDir() {
+					out = append(out, de.Name())
+				}
+			}
+			return out, nil
+		},
+		Scan: func(dir string, fn func(name string, size int64)) error {
+			count := 0
+			return filepath.WalkDir(dir, func(_ string, d os.DirEntry, walkErr error) error {
+				if walkErr != nil || d.IsDir() {
+					return nil //nolint:nilerr // tolerate unreadable entries; keep scanning
+				}
+				count++
+				if count > scanFileLimit {
+					return filepath.SkipAll
+				}
+				if info, err := d.Info(); err == nil {
+					fn(d.Name(), info.Size())
+				}
+				return nil
+			})
+		},
+	}
+}
+
+// Triage classifies every subdirectory of root and totals the reclaimable and
+// risky bytes.
+func Triage(root string, deps Deps) (Report, error) {
+	subs, err := deps.Subdirs(root)
+	if err != nil {
+		return Report{Root: root}, err
+	}
+	rep := Report{Root: root}
+	for _, name := range subs {
+		dir := filepath.Join(root, name)
+		var size int64
+		var markers []string
+		_ = deps.Scan(dir, func(fileName string, sz int64) {
+			size += sz
+			if m := riskyMarker(fileName); m != "" && len(markers) < 5 {
+				markers = append(markers, m)
+			}
+		})
+		class, reason := classify(name, markers)
+		rep.Entries = append(rep.Entries, Entry{Path: dir, Name: name, SizeBytes: size, Class: class, Reason: reason})
+		rep.TotalBytes += size
+		switch class {
+		case ClassRisky:
+			rep.RiskyBytes += size
+		default:
+			rep.ReclaimableBytes += size
+		}
+	}
+	sort.SliceStable(rep.Entries, func(i, j int) bool {
+		return rep.Entries[i].SizeBytes > rep.Entries[j].SizeBytes
+	})
+	return rep, nil
+}
+
+// classify decides a subdirectory's class from its name and any risky markers
+// found in its subtree. Risky data wins over a safe-looking name.
+func classify(name string, markers []string) (Class, string) {
+	if len(markers) > 0 {
+		return ClassRisky, "contains possible non-cache data: " + strings.Join(markers, ", ")
+	}
+	lname := strings.ToLower(name)
+	for _, m := range safeMarkers {
+		if strings.Contains(lname, m) {
+			return ClassSafe, "build/tooling cache (" + m + ")"
+		}
+	}
+	return ClassRegenerable, "app runtime cache"
+}
+
+// riskyMarker returns the risky fragment a file name matches, or "".
+func riskyMarker(name string) string {
+	lname := strings.ToLower(name)
+	for _, frag := range riskyNameFragments {
+		if strings.Contains(lname, frag) {
+			return frag
+		}
+	}
+	return ""
+}

--- a/internal/cachetriage/cachetriage.go
+++ b/internal/cachetriage/cachetriage.go
@@ -5,6 +5,7 @@
 package cachetriage
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -42,17 +43,30 @@ var safeMarkers = []string{
 // rather than a cache. Matched case-insensitively.
 var riskyNameFragments = []string{
 	"cookie", "credential", "token", "account", "session", "keychain",
-	".sqlite", ".db", ".realm", "leveldb", "indexeddb",
+	".sqlite", ".db", ".ldb", ".realm", "leveldb", "indexeddb",
 }
 
 // Entry is one cache subdirectory's triage result.
 type Entry struct {
-	Path      string `json:"path"`
-	Name      string `json:"name"`
-	SizeBytes int64  `json:"size_bytes"`
-	Class     Class  `json:"class"`
-	Reason    string `json:"reason,omitempty"`
+	Path       string `json:"path"`
+	Name       string `json:"name"`
+	SizeBytes  int64  `json:"size_bytes"`
+	Class      Class  `json:"class"`
+	Reason     string `json:"reason,omitempty"`
+	Incomplete bool   `json:"incomplete,omitempty"`
 }
+
+// ScanResult reports whether a subdirectory scan saw everything. An incomplete
+// or truncated scan cannot prove a directory holds no real data, so triage must
+// not classify it as reclaimable.
+type ScanResult struct {
+	// Truncated is set when the per-directory file limit was reached.
+	Truncated bool
+	// Incomplete is set when one or more entries could not be read.
+	Incomplete bool
+}
+
+func (r ScanResult) partial() bool { return r.Truncated || r.Incomplete }
 
 // Report is the triage of every subdirectory of a cache root.
 type Report struct {
@@ -68,8 +82,10 @@ type Deps struct {
 	// Subdirs returns the immediate child directory names of root.
 	Subdirs func(root string) ([]string, error)
 	// Scan invokes fn for each file under dir (bounded) with its base name and
-	// size, so triage can sum size and detect risky markers.
-	Scan func(dir string, fn func(name string, size int64)) error
+	// size, so triage can sum size and detect risky markers. It returns whether
+	// the scan was complete; a non-nil error means the subtree could not be
+	// walked at all.
+	Scan func(dir string, fn func(name string, size int64)) (ScanResult, error)
 }
 
 // DefaultDeps reads from the real filesystem.
@@ -88,21 +104,36 @@ func DefaultDeps() Deps {
 			}
 			return out, nil
 		},
-		Scan: func(dir string, fn func(name string, size int64)) error {
+		Scan: func(dir string, fn func(name string, size int64)) (ScanResult, error) {
+			var res ScanResult
 			count := 0
-			return filepath.WalkDir(dir, func(_ string, d os.DirEntry, walkErr error) error {
-				if walkErr != nil || d.IsDir() {
-					return nil //nolint:nilerr // tolerate unreadable entries; keep scanning
+			err := filepath.WalkDir(dir, func(_ string, d os.DirEntry, walkErr error) error {
+				if walkErr != nil {
+					// Record that the scan missed something and keep going, rather
+					// than aborting; an incomplete scan is held back downstream.
+					res.Incomplete = true
+					return nil //nolint:nilerr // incompleteness recorded in res; keep scanning
+				}
+				if d.IsDir() {
+					return nil
 				}
 				count++
 				if count > scanFileLimit {
+					res.Truncated = true
 					return filepath.SkipAll
 				}
-				if info, err := d.Info(); err == nil {
-					fn(d.Name(), info.Size())
+				info, err := d.Info()
+				if err != nil {
+					res.Incomplete = true
+					return nil //nolint:nilerr // incompleteness recorded in res; keep scanning
 				}
+				fn(d.Name(), info.Size())
 				return nil
 			})
+			if err != nil {
+				return res, fmt.Errorf("scan %s: %w", dir, err)
+			}
+			return res, nil
 		},
 	}
 }
@@ -119,19 +150,22 @@ func Triage(root string, deps Deps) (Report, error) {
 		dir := filepath.Join(root, name)
 		var size int64
 		var markers []string
-		_ = deps.Scan(dir, func(fileName string, sz int64) {
+		res, scanErr := deps.Scan(dir, func(fileName string, sz int64) {
 			size += sz
 			if m := riskyMarker(fileName); m != "" && len(markers) < 5 {
 				markers = append(markers, m)
 			}
 		})
-		class, reason := classify(name, markers)
-		rep.Entries = append(rep.Entries, Entry{Path: dir, Name: name, SizeBytes: size, Class: class, Reason: reason})
+		incomplete := res.partial() || scanErr != nil
+		class, reason := classify(name, markers, incomplete)
+		rep.Entries = append(rep.Entries, Entry{Path: dir, Name: name, SizeBytes: size, Class: class, Reason: reason, Incomplete: incomplete})
 		rep.TotalBytes += size
-		switch class {
-		case ClassRisky:
+		// Only a fully scanned, non-risky directory counts as reclaimable; an
+		// incomplete scan (unreadable entries, truncation, or an error) is held
+		// back so the user never deletes a directory that was not fully inspected.
+		if class == ClassRisky {
 			rep.RiskyBytes += size
-		default:
+		} else {
 			rep.ReclaimableBytes += size
 		}
 	}
@@ -141,11 +175,15 @@ func Triage(root string, deps Deps) (Report, error) {
 	return rep, nil
 }
 
-// classify decides a subdirectory's class from its name and any risky markers
-// found in its subtree. Risky data wins over a safe-looking name.
-func classify(name string, markers []string) (Class, string) {
+// classify decides a subdirectory's class from its name, any risky markers found
+// in its subtree, and whether the scan was complete. Risky data — and an
+// incomplete scan that cannot rule it out — win over a safe-looking name.
+func classify(name string, markers []string, incomplete bool) (Class, string) {
 	if len(markers) > 0 {
 		return ClassRisky, "contains possible non-cache data: " + strings.Join(markers, ", ")
+	}
+	if incomplete {
+		return ClassRisky, "scan incomplete (unreadable or truncated) — held back from reclaimable"
 	}
 	lname := strings.ToLower(name)
 	for _, m := range safeMarkers {

--- a/internal/cachetriage/cachetriage_test.go
+++ b/internal/cachetriage/cachetriage_test.go
@@ -8,20 +8,22 @@ import (
 
 func TestClassify(t *testing.T) {
 	cases := []struct {
-		name    string
-		markers []string
-		want    Class
+		name       string
+		markers    []string
+		incomplete bool
+		want       Class
 	}{
-		{"go-build", nil, ClassSafe},
-		{"com.corp.SomeApp", nil, ClassRegenerable},
-		{"com.corp.SomeApp", []string{"cookie"}, ClassRisky},
-		{"go-build", []string{".sqlite"}, ClassRisky}, // risky wins over a safe name
-		{"Homebrew", nil, ClassSafe},
+		{"go-build", nil, false, ClassSafe},
+		{"com.corp.SomeApp", nil, false, ClassRegenerable},
+		{"com.corp.SomeApp", []string{"cookie"}, false, ClassRisky},
+		{"go-build", []string{".sqlite"}, false, ClassRisky}, // risky wins over a safe name
+		{"Homebrew", nil, false, ClassSafe},
+		{"go-build", nil, true, ClassRisky}, // an incomplete scan is held back
 	}
 	for _, c := range cases {
-		got, reason := classify(c.name, c.markers)
+		got, reason := classify(c.name, c.markers, c.incomplete)
 		if got != c.want {
-			t.Errorf("classify(%q, %v) = %s, want %s", c.name, c.markers, got, c.want)
+			t.Errorf("classify(%q, %v, incomplete=%v) = %s, want %s", c.name, c.markers, c.incomplete, got, c.want)
 		}
 		if got != ClassRegenerable && reason == "" {
 			t.Errorf("classify(%q) gave class %s with no reason", c.name, got)
@@ -35,7 +37,7 @@ func TestRiskyMarker(t *testing.T) {
 		"state.sqlite": ".sqlite",
 		"creds.token":  "token",
 		"photo.jpg":    "",
-		"index.ldb":    "", // a bare .ldb is a leveldb table, not itself a marker name here
+		"000003.ldb":   ".ldb", // a LevelDB table means the subtree holds real data
 	}
 	for name, want := range cases {
 		if got := riskyMarker(name); got != want {
@@ -54,12 +56,12 @@ func TestTriageClassifiesAndTotals(t *testing.T) {
 		Subdirs: func(root string) ([]string, error) {
 			return []string{"go-build", "com.corp.big", "com.corp.private"}, nil
 		},
-		Scan: func(dir string, fn func(string, int64)) error {
+		Scan: func(dir string, fn func(string, int64)) (ScanResult, error) {
 			files := layout[filepath.Base(dir)]
 			for name, sz := range files {
 				fn(name, sz)
 			}
-			return nil
+			return ScanResult{}, nil
 		},
 	}
 
@@ -101,5 +103,43 @@ func TestTriageSubdirsError(t *testing.T) {
 	}
 	if _, err := Triage("/nope", deps); err == nil {
 		t.Error("expected error when the root cannot be listed")
+	}
+}
+
+func TestTriageIncompleteScanHeldBack(t *testing.T) {
+	deps := Deps{
+		Subdirs: func(string) ([]string, error) { return []string{"go-build"}, nil },
+		// A build cache that would normally be "safe", but its scan is truncated.
+		Scan: func(dir string, fn func(string, int64)) (ScanResult, error) {
+			fn("a.o", 1000)
+			return ScanResult{Truncated: true}, nil
+		},
+	}
+	rep, err := Triage("/caches", deps)
+	if err != nil {
+		t.Fatalf("Triage: %v", err)
+	}
+	e := rep.Entries[0]
+	if e.Class != ClassRisky || !e.Incomplete {
+		t.Errorf("a truncated scan must be risky/incomplete, got class=%s incomplete=%v", e.Class, e.Incomplete)
+	}
+	if rep.ReclaimableBytes != 0 || rep.RiskyBytes != 1000 {
+		t.Errorf("truncated bytes must be held back: reclaimable=%d risky=%d", rep.ReclaimableBytes, rep.RiskyBytes)
+	}
+}
+
+func TestTriageScanErrorHeldBack(t *testing.T) {
+	deps := Deps{
+		Subdirs: func(string) ([]string, error) { return []string{"com.corp.app"}, nil },
+		Scan: func(dir string, fn func(string, int64)) (ScanResult, error) {
+			return ScanResult{}, errors.New("permission denied")
+		},
+	}
+	rep, err := Triage("/caches", deps)
+	if err != nil {
+		t.Fatalf("Triage: %v", err)
+	}
+	if rep.Entries[0].Class != ClassRisky || rep.ReclaimableBytes != 0 {
+		t.Errorf("a scan error must hold the entry back, got %+v", rep.Entries[0])
 	}
 }

--- a/internal/cachetriage/cachetriage_test.go
+++ b/internal/cachetriage/cachetriage_test.go
@@ -1,0 +1,105 @@
+package cachetriage
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		name    string
+		markers []string
+		want    Class
+	}{
+		{"go-build", nil, ClassSafe},
+		{"com.corp.SomeApp", nil, ClassRegenerable},
+		{"com.corp.SomeApp", []string{"cookie"}, ClassRisky},
+		{"go-build", []string{".sqlite"}, ClassRisky}, // risky wins over a safe name
+		{"Homebrew", nil, ClassSafe},
+	}
+	for _, c := range cases {
+		got, reason := classify(c.name, c.markers)
+		if got != c.want {
+			t.Errorf("classify(%q, %v) = %s, want %s", c.name, c.markers, got, c.want)
+		}
+		if got != ClassRegenerable && reason == "" {
+			t.Errorf("classify(%q) gave class %s with no reason", c.name, got)
+		}
+	}
+}
+
+func TestRiskyMarker(t *testing.T) {
+	cases := map[string]string{
+		"Cookies":      "cookie",
+		"state.sqlite": ".sqlite",
+		"creds.token":  "token",
+		"photo.jpg":    "",
+		"index.ldb":    "", // a bare .ldb is a leveldb table, not itself a marker name here
+	}
+	for name, want := range cases {
+		if got := riskyMarker(name); got != want {
+			t.Errorf("riskyMarker(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestTriageClassifiesAndTotals(t *testing.T) {
+	layout := map[string]map[string]int64{
+		"go-build":         {"a.o": 1000, "b.o": 2000},          // safe
+		"com.corp.big":     {"blob1": 5000, "blob2": 5000},      // regenerable
+		"com.corp.private": {"Cookies": 10, "data.sqlite": 900}, // risky
+	}
+	deps := Deps{
+		Subdirs: func(root string) ([]string, error) {
+			return []string{"go-build", "com.corp.big", "com.corp.private"}, nil
+		},
+		Scan: func(dir string, fn func(string, int64)) error {
+			files := layout[filepath.Base(dir)]
+			for name, sz := range files {
+				fn(name, sz)
+			}
+			return nil
+		},
+	}
+
+	rep, err := Triage("/caches", deps)
+	if err != nil {
+		t.Fatalf("Triage: %v", err)
+	}
+	byName := map[string]Entry{}
+	for _, e := range rep.Entries {
+		byName[e.Name] = e
+	}
+	if byName["go-build"].Class != ClassSafe {
+		t.Errorf("go-build class = %s", byName["go-build"].Class)
+	}
+	if byName["com.corp.big"].Class != ClassRegenerable {
+		t.Errorf("com.corp.big class = %s", byName["com.corp.big"].Class)
+	}
+	if byName["com.corp.private"].Class != ClassRisky {
+		t.Errorf("com.corp.private class = %s", byName["com.corp.private"].Class)
+	}
+	if rep.TotalBytes != 3000+10000+910 {
+		t.Errorf("total = %d", rep.TotalBytes)
+	}
+	if rep.ReclaimableBytes != 3000+10000 {
+		t.Errorf("reclaimable = %d, want %d", rep.ReclaimableBytes, 13000)
+	}
+	if rep.RiskyBytes != 910 {
+		t.Errorf("risky = %d, want 910", rep.RiskyBytes)
+	}
+	// entries sorted by size descending
+	if rep.Entries[0].Name != "com.corp.big" {
+		t.Errorf("largest entry = %s, want com.corp.big", rep.Entries[0].Name)
+	}
+}
+
+func TestTriageSubdirsError(t *testing.T) {
+	deps := Deps{
+		Subdirs: func(string) ([]string, error) { return nil, errors.New("cannot read cache root") },
+	}
+	if _, err := Triage("/nope", deps); err == nil {
+		t.Error("expected error when the root cannot be listed")
+	}
+}


### PR DESCRIPTION
## What

`spectra storage cache-triage` — classifies each subdirectory of a cache root (default `~/Library/Caches`) so you can reclaim space **without** nuking real data. `~/Library/Caches` is usually the biggest safe win, but some apps stash cookies, tokens, or SQLite state there, so "delete all caches" is dangerous. Today Spectra only reports the aggregate size.

## How

- **`internal/cachetriage`** sizes each immediate subdirectory and classes it:
  - **safe** — pure build/tooling caches (Go build, npm/yarn/pnpm, pip, CocoaPods, Homebrew, node-gyp, Playwright, …);
  - **regenerable** — ordinary app runtime cache (default);
  - **risky** — subtree contains markers of real data (cookie / credential / token / `.sqlite` / `.db` / leveldb / indexeddb).
  Risky data **outweighs** a safe-looking name, so it errs toward holding back. Classification is a pure `classify(name, markers)`; the per-subdir walk is injected and bounded (`scanFileLimit`) so a pathological tree can't stall it.
- **`spectra storage cache-triage [--json] [<root>]`** — read-only, never deletes; reports total, reclaimable (safe+regenerable), and risky bytes held back, entries sorted largest-first.

## Testing

`classify` and `riskyMarker` are unit-tested exhaustively (safe name, default, markers-win-over-name, marker detection). `Triage` runs against an injected three-subdir layout asserting per-entry class, the byte totals (total / reclaimable / risky), and size-descending order; plus the subdirs-error path. `make vet complexity lint security docs-validate test` green (58 pkgs). Verified on a real `~/Library/Caches` (55 GB → 11.6 GB reclaimable, 43.7 GB risky held back). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #395
