### PR TITLE
runtime: spectra runtime <pid> — classify a live process's runtime and route to its diagnostics

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -69,6 +69,7 @@ func subcommandList() []subcommand {
 		{"install-daemon", "Install the user LaunchAgent for spectra serve", runInstallDaemonCmd},
 		{"schedule", "Schedule periodic snapshot capture via a launchd agent", runSchedule},
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
+		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},
 		{"crash", "Audit post-mortem readiness (can this machine produce a debuggable crash?)", runCrash},
 		{"web", "Diff an Electron app's app.asar payload between two versions", runWeb},

--- a/cmd/spectra/runtime.go
+++ b/cmd/spectra/runtime.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/runtimeattach"
+)
+
+// procLookup resolves a PID to the minimal identity runtimeattach classifies.
+type procLookup func(pid int) (runtimeattach.Process, bool)
+
+func runRuntime(args []string) int {
+	return runRuntimeWithIO(args, os.Stdout, os.Stderr, defaultProcLookup, runtimeattach.DefaultProbes())
+}
+
+func runRuntimeWithIO(args []string, stdout, stderr io.Writer, lookup procLookup, probes runtimeattach.Probes) int {
+	// Accept an optional leading "attach" verb: `spectra runtime attach <pid>`.
+	if len(args) > 0 && args[0] == "attach" {
+		args = args[1:]
+	}
+	fs := flag.NewFlagSet("spectra runtime", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "usage: spectra runtime [attach] [--json] <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil || pid <= 0 {
+		fmt.Fprintf(stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	proc, ok := lookup(pid)
+	if !ok {
+		fmt.Fprintf(stderr, "no running process with PID %d\n", pid)
+		return 1
+	}
+
+	result := runtimeattach.Classify(proc, probes)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return 0
+	}
+	printRuntimeResult(stdout, result)
+	return 0
+}
+
+func printRuntimeResult(w io.Writer, r runtimeattach.Result) {
+	fmt.Fprintf(w, "pid %d: %s\n", r.PID, r.Command)
+	if r.ExecutablePath != "" {
+		fmt.Fprintf(w, "  exe:      %s\n", r.ExecutablePath)
+	}
+	fmt.Fprintf(w, "  runtime:  %s (%s)\n", r.Runtime, r.Evidence)
+	fmt.Fprintln(w, "  you can ask it:")
+	for _, c := range r.Capabilities {
+		fmt.Fprintf(w, "    - %s\n        %s\n", c.Name, c.How)
+	}
+}
+
+func defaultProcLookup(pid int) (runtimeattach.Process, bool) {
+	procs := process.CollectAll(context.Background(), process.CollectOptions{})
+	for _, p := range procs {
+		if p.PID == pid {
+			return runtimeattach.Process{
+				PID:            p.PID,
+				Command:        p.Command,
+				ExecutablePath: p.ExecutablePath,
+				CommandLine:    p.FullCommandLine,
+			}, true
+		}
+	}
+	return runtimeattach.Process{}, false
+}

--- a/cmd/spectra/runtime_test.go
+++ b/cmd/spectra/runtime_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/runtimeattach"
+)
+
+func fixedLookup(p runtimeattach.Process, ok bool) procLookup {
+	return func(int) (runtimeattach.Process, bool) { return p, ok }
+}
+
+func TestRunRuntimeClassifiesJVM(t *testing.T) {
+	lookup := fixedLookup(runtimeattach.Process{PID: 321, Command: "java", ExecutablePath: "/usr/bin/java", CommandLine: "java -jar app.jar"}, true)
+	var out, errBuf bytes.Buffer
+	if code := runRuntimeWithIO([]string{"321"}, &out, &errBuf, lookup, runtimeattach.DefaultProbes()); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "runtime:  jvm") || !strings.Contains(s, "spectra jvm 321") {
+		t.Errorf("expected jvm classification routed to `spectra jvm`, got:\n%s", s)
+	}
+}
+
+func TestRunRuntimeAcceptsAttachVerb(t *testing.T) {
+	lookup := fixedLookup(runtimeattach.Process{PID: 9, Command: "node", ExecutablePath: "/usr/local/bin/node"}, true)
+	var out, errBuf bytes.Buffer
+	if code := runRuntimeWithIO([]string{"attach", "9"}, &out, &errBuf, lookup, runtimeattach.DefaultProbes()); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), "runtime:  node") {
+		t.Errorf("expected node classification, got:\n%s", out.String())
+	}
+}
+
+func TestRunRuntimeMissingProcess(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runRuntimeWithIO([]string{"404"}, &out, &errBuf, fixedLookup(runtimeattach.Process{}, false), runtimeattach.DefaultProbes()); code != 1 {
+		t.Fatalf("exit = %d, want 1 for missing process", code)
+	}
+}
+
+func TestRunRuntimeInvalidArgs(t *testing.T) {
+	lookup := fixedLookup(runtimeattach.Process{}, true)
+	cases := [][]string{{}, {"notapid"}, {"0"}, {"1", "2"}}
+	for _, args := range cases {
+		var out, errBuf bytes.Buffer
+		if code := runRuntimeWithIO(args, &out, &errBuf, lookup, runtimeattach.DefaultProbes()); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}
+
+func TestRunRuntimeJSON(t *testing.T) {
+	lookup := fixedLookup(runtimeattach.Process{PID: 5, Command: "server", ExecutablePath: "/opt/server"}, true)
+	var out, errBuf bytes.Buffer
+	if code := runRuntimeWithIO([]string{"--json", "5"}, &out, &errBuf, lookup, runtimeattach.DefaultProbes()); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"runtime"`) || !strings.Contains(out.String(), `"capabilities"`) {
+		t.Errorf("expected JSON with runtime + capabilities, got:\n%s", out.String())
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -327,6 +327,30 @@ spectra jvm jfr view gc-pauses /tmp/app.jfr
 spectra jvm jfr stop 4012 --name spectra
 ```
 
+## `spectra runtime`
+
+Identifies a live process's language runtime and lists the diagnostics available
+for it — one entry point when you have a PID but don't yet know whether it's a
+JVM, Node/Electron, Go, .NET, Python, or a native binary. It classifies from the
+executable path, the full command line, and two cheap pure-Go probes: the
+embedded Go build info (`debug/buildinfo`) fingerprints a Go binary, and a
+`dotnet-diagnostic-<pid>-*-socket` in the temp directory identifies .NET. It
+reports the evidence that decided the class and routes to the next step — an
+existing Spectra command where one exists (`spectra jvm <pid>`,
+`spectra web processes`) or the standard technique otherwise (SIGUSR1 + CDP for
+Node/Electron, a SIGQUIT goroutine dump or net/http/pprof for Go, the
+`dotnet-*` diagnostic tools for .NET, `py-spy` for Python) — always including
+the universal `spectra sample <pid>` fallback. It is read-only: it advises, and
+never signals, attaches to, or profiles the process itself.
+
+### Examples
+
+```bash
+spectra runtime 4012
+spectra runtime attach 4012
+spectra runtime --json 4012
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/runtimeattach/runtimeattach.go
+++ b/internal/runtimeattach/runtimeattach.go
@@ -124,7 +124,8 @@ func isJVM(base, hay string) bool {
 
 func isElectron(hay string) bool {
 	return strings.Contains(hay, "electron") ||
-		strings.Contains(hay, "--type=renderer") || strings.Contains(hay, "--type=gpu-process")
+		strings.Contains(hay, "--type=renderer") || strings.Contains(hay, "--type=gpu-process") ||
+		strings.Contains(hay, "--type=utility")
 }
 
 func isNode(base, hay string) bool {
@@ -174,8 +175,8 @@ func capabilities(r Runtime, pid int) []Capability {
 		}
 	default:
 		return []Capability{
-			sample,
 			{"attach a native debugger", fmt.Sprintf("lldb -p %d  (or spindump for a whole-system stack)", pid)},
+			sample,
 		}
 	}
 }

--- a/internal/runtimeattach/runtimeattach.go
+++ b/internal/runtimeattach/runtimeattach.go
@@ -1,0 +1,181 @@
+// Package runtimeattach identifies the language runtime of a live process and
+// routes to the diagnostics available for it. It only classifies and advises —
+// it never signals a process, attaches, or starts a profiler.
+package runtimeattach
+
+import (
+	"debug/buildinfo"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Runtime is a coarse language-runtime classification of a process.
+type Runtime string
+
+const (
+	RuntimeJVM      Runtime = "jvm"
+	RuntimeNode     Runtime = "node"
+	RuntimeElectron Runtime = "electron"
+	RuntimeGo       Runtime = "go"
+	RuntimeDotNet   Runtime = "dotnet"
+	RuntimePython   Runtime = "python"
+	RuntimeNative   Runtime = "native"
+	RuntimeUnknown  Runtime = "unknown"
+)
+
+// Process is the minimal identity runtimeattach classifies.
+type Process struct {
+	PID            int
+	Command        string // short comm / executable base name
+	ExecutablePath string
+	CommandLine    string // full argv joined
+}
+
+// Capability is one diagnostic action available for a runtime.
+type Capability struct {
+	Name string `json:"name"`
+	How  string `json:"how"`
+}
+
+// Result is the classification and routing for one process.
+type Result struct {
+	PID            int          `json:"pid"`
+	Command        string       `json:"command,omitempty"`
+	ExecutablePath string       `json:"executable_path,omitempty"`
+	Runtime        Runtime      `json:"runtime"`
+	Evidence       string       `json:"evidence,omitempty"`
+	Capabilities   []Capability `json:"capabilities"`
+}
+
+// Probes are the injectable checks that require touching the filesystem, so
+// classification stays a pure function in tests.
+type Probes struct {
+	// GoBinary reports whether the executable at path is a Go binary.
+	GoBinary func(path string) bool
+	// DotnetSocket reports whether a .NET diagnostic IPC socket exists for pid.
+	DotnetSocket func(pid int) bool
+}
+
+// DefaultProbes fingerprints Go binaries via the embedded build info and looks
+// for a .NET diagnostic socket in the temp directory.
+func DefaultProbes() Probes {
+	return Probes{
+		GoBinary: func(path string) bool {
+			if path == "" {
+				return false
+			}
+			_, err := buildinfo.ReadFile(path)
+			return err == nil
+		},
+		DotnetSocket: func(pid int) bool {
+			matches, _ := filepath.Glob(filepath.Join(os.TempDir(), fmt.Sprintf("dotnet-diagnostic-%d-*-socket", pid)))
+			return len(matches) > 0
+		},
+	}
+}
+
+// Classify determines a process's runtime and the diagnostics available for it.
+func Classify(p Process, probes Probes) Result {
+	runtime, evidence := detect(p, probes)
+	return Result{
+		PID:            p.PID,
+		Command:        p.Command,
+		ExecutablePath: p.ExecutablePath,
+		Runtime:        runtime,
+		Evidence:       evidence,
+		Capabilities:   capabilities(runtime, p.PID),
+	}
+}
+
+func detect(p Process, probes Probes) (Runtime, string) {
+	hay := strings.ToLower(p.ExecutablePath + " " + p.CommandLine + " " + p.Command)
+	base := strings.ToLower(filepath.Base(p.ExecutablePath))
+
+	switch {
+	case probes.DotnetSocket != nil && probes.DotnetSocket(p.PID):
+		return RuntimeDotNet, "a .NET diagnostic socket exists for this pid"
+	case isDotNet(base, hay):
+		return RuntimeDotNet, "executable is the .NET/Mono runtime"
+	case isJVM(base, hay):
+		return RuntimeJVM, "java executable or JVM launch flags"
+	case isElectron(hay):
+		return RuntimeElectron, "Electron/Chromium framework or child-process type flag"
+	case isNode(base, hay):
+		return RuntimeNode, "node executable or --inspect flag"
+	case isPython(base, hay):
+		return RuntimePython, "python executable"
+	case probes.GoBinary != nil && probes.GoBinary(p.ExecutablePath):
+		return RuntimeGo, "executable carries Go build info"
+	default:
+		return RuntimeNative, "no managed-runtime signal; treated as a native binary"
+	}
+}
+
+func isDotNet(base, hay string) bool {
+	return base == "dotnet" || strings.Contains(hay, "/dotnet ") || strings.Contains(hay, "mono-sgen")
+}
+
+func isJVM(base, hay string) bool {
+	return base == "java" || strings.Contains(hay, "javavirtualmachines") ||
+		strings.Contains(hay, "-xx") || strings.Contains(hay, "-jar ")
+}
+
+func isElectron(hay string) bool {
+	return strings.Contains(hay, "electron") ||
+		strings.Contains(hay, "--type=renderer") || strings.Contains(hay, "--type=gpu-process")
+}
+
+func isNode(base, hay string) bool {
+	return base == "node" || strings.Contains(hay, "/node ") || strings.Contains(hay, "--inspect")
+}
+
+func isPython(base, hay string) bool {
+	return strings.Contains(base, "python") || strings.Contains(hay, "python3")
+}
+
+// capabilities returns the diagnostics available for a runtime, most specific
+// first, always ending with the universal CPU sample.
+func capabilities(r Runtime, pid int) []Capability {
+	sample := Capability{"user-space CPU sample", fmt.Sprintf("spectra sample %d", pid)}
+	switch r {
+	case RuntimeJVM:
+		return []Capability{
+			{"thread dump, JFR, native memory", fmt.Sprintf("spectra jvm %d  (jcmd Thread.print, JFR.start, VM.native_memory)", pid)},
+			sample,
+		}
+	case RuntimeElectron:
+		return []Capability{
+			{"renderer/GPU process topology", "spectra web processes"},
+			{"open the V8 inspector", fmt.Sprintf("kill -USR1 %d, then connect a CDP client to 127.0.0.1:9229", pid)},
+			sample,
+		}
+	case RuntimeNode:
+		return []Capability{
+			{"open the V8 inspector", fmt.Sprintf("kill -USR1 %d, then connect a CDP client to 127.0.0.1:9229", pid)},
+			sample,
+		}
+	case RuntimeGo:
+		return []Capability{
+			{"full goroutine dump", fmt.Sprintf("kill -QUIT %d  (if SIGQUIT is not trapped)", pid)},
+			{"pprof, if net/http/pprof is imported", "curl http://127.0.0.1:<port>/debug/pprof/goroutine?debug=2"},
+			sample,
+		}
+	case RuntimeDotNet:
+		return []Capability{
+			{"traces, dumps, GC heap", fmt.Sprintf("dotnet-trace / dotnet-dump / dotnet-gcdump against pid %d via its diagnostic socket", pid)},
+			sample,
+		}
+	case RuntimePython:
+		return []Capability{
+			{"native stack sample", fmt.Sprintf("py-spy dump --pid %d", pid)},
+			sample,
+		}
+	default:
+		return []Capability{
+			sample,
+			{"attach a native debugger", fmt.Sprintf("lldb -p %d  (or spindump for a whole-system stack)", pid)},
+		}
+	}
+}

--- a/internal/runtimeattach/runtimeattach_test.go
+++ b/internal/runtimeattach/runtimeattach_test.go
@@ -1,0 +1,77 @@
+package runtimeattach
+
+import "testing"
+
+func noProbes() Probes {
+	return Probes{GoBinary: func(string) bool { return false }, DotnetSocket: func(int) bool { return false }}
+}
+
+func TestClassifyRuntimes(t *testing.T) {
+	goProbe := Probes{GoBinary: func(string) bool { return true }, DotnetSocket: func(int) bool { return false }}
+	dotnetProbe := Probes{GoBinary: func(string) bool { return false }, DotnetSocket: func(int) bool { return true }}
+
+	cases := []struct {
+		name  string
+		proc  Process
+		probe Probes
+		want  Runtime
+	}{
+		{"java exe + flags", Process{ExecutablePath: "/usr/bin/java", CommandLine: "java -Xmx2g -jar app.jar"}, noProbes(), RuntimeJVM},
+		{"jdk path", Process{ExecutablePath: "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java"}, noProbes(), RuntimeJVM},
+		{"electron renderer", Process{ExecutablePath: "/Applications/Foo.app/Contents/MacOS/Foo", CommandLine: "Foo --type=renderer"}, noProbes(), RuntimeElectron},
+		{"electron framework", Process{ExecutablePath: "/Applications/Foo.app/Contents/Frameworks/Electron Framework.framework/Electron"}, noProbes(), RuntimeElectron},
+		{"node exe", Process{ExecutablePath: "/usr/local/bin/node", CommandLine: "node server.js"}, noProbes(), RuntimeNode},
+		{"node inspect", Process{ExecutablePath: "/opt/x", CommandLine: "x --inspect=9229"}, noProbes(), RuntimeNode},
+		{"dotnet exe", Process{ExecutablePath: "/usr/local/share/dotnet/dotnet", CommandLine: "dotnet App.dll"}, noProbes(), RuntimeDotNet},
+		{"dotnet socket", Process{ExecutablePath: "/opt/app/App", PID: 42}, dotnetProbe, RuntimeDotNet},
+		{"python", Process{ExecutablePath: "/usr/bin/python3.11", CommandLine: "python3 run.py"}, noProbes(), RuntimePython},
+		{"go binary", Process{ExecutablePath: "/opt/svc/server"}, goProbe, RuntimeGo},
+		{"native", Process{ExecutablePath: "/bin/zsh", CommandLine: "-zsh"}, noProbes(), RuntimeNative},
+	}
+	for _, c := range cases {
+		got := Classify(c.proc, c.probe)
+		if got.Runtime != c.want {
+			t.Errorf("%s: runtime = %s, want %s (evidence %q)", c.name, got.Runtime, c.want, got.Evidence)
+		}
+		if got.Evidence == "" {
+			t.Errorf("%s: expected evidence", c.name)
+		}
+	}
+}
+
+func TestDotnetSocketWinsOverGoBinary(t *testing.T) {
+	// A dotnet host is itself a native binary; the socket must decide first.
+	probe := Probes{GoBinary: func(string) bool { return true }, DotnetSocket: func(int) bool { return true }}
+	if got := Classify(Process{PID: 7, ExecutablePath: "/x"}, probe); got.Runtime != RuntimeDotNet {
+		t.Errorf("runtime = %s, want dotnet", got.Runtime)
+	}
+}
+
+func TestCapabilitiesAlwaysIncludeSample(t *testing.T) {
+	for _, r := range []Runtime{RuntimeJVM, RuntimeNode, RuntimeElectron, RuntimeGo, RuntimeDotNet, RuntimePython, RuntimeNative} {
+		caps := capabilities(r, 1234)
+		if len(caps) == 0 {
+			t.Fatalf("%s: no capabilities", r)
+		}
+		found := false
+		for _, c := range caps {
+			if c.How == "spectra sample 1234" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s: capabilities missing the universal sample fallback", r)
+		}
+	}
+}
+
+func TestCapabilitiesRouteJVMAndElectron(t *testing.T) {
+	jvm := capabilities(RuntimeJVM, 5)
+	if jvm[0].How[:12] != "spectra jvm " {
+		t.Errorf("jvm should route to `spectra jvm`, got %q", jvm[0].How)
+	}
+	el := capabilities(RuntimeElectron, 5)
+	if el[0].How != "spectra web processes" {
+		t.Errorf("electron should route to web processes, got %q", el[0].How)
+	}
+}

--- a/internal/runtimeattach/runtimeattach_test.go
+++ b/internal/runtimeattach/runtimeattach_test.go
@@ -20,6 +20,7 @@ func TestClassifyRuntimes(t *testing.T) {
 		{"jdk path", Process{ExecutablePath: "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java"}, noProbes(), RuntimeJVM},
 		{"electron renderer", Process{ExecutablePath: "/Applications/Foo.app/Contents/MacOS/Foo", CommandLine: "Foo --type=renderer"}, noProbes(), RuntimeElectron},
 		{"electron framework", Process{ExecutablePath: "/Applications/Foo.app/Contents/Frameworks/Electron Framework.framework/Electron"}, noProbes(), RuntimeElectron},
+		{"electron utility child", Process{ExecutablePath: "/Applications/Foo.app/Contents/MacOS/Foo Helper", CommandLine: "Foo Helper --type=utility --utility-sub-type=network.mojom.NetworkService"}, noProbes(), RuntimeElectron},
 		{"node exe", Process{ExecutablePath: "/usr/local/bin/node", CommandLine: "node server.js"}, noProbes(), RuntimeNode},
 		{"node inspect", Process{ExecutablePath: "/opt/x", CommandLine: "x --inspect=9229"}, noProbes(), RuntimeNode},
 		{"dotnet exe", Process{ExecutablePath: "/usr/local/share/dotnet/dotnet", CommandLine: "dotnet App.dll"}, noProbes(), RuntimeDotNet},
@@ -61,6 +62,10 @@ func TestCapabilitiesAlwaysIncludeSample(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("%s: capabilities missing the universal sample fallback", r)
+		}
+		// The universal sample fallback is always listed last, per the contract.
+		if caps[len(caps)-1].How != "spectra sample 1234" {
+			t.Errorf("%s: sample fallback should be last, got %q", r, caps[len(caps)-1].How)
 		}
 	}
 }


### PR DESCRIPTION
## What

`spectra runtime <pid>` — one entry point that, given a live PID, says **what language runtime it is** and **what you can ask it**. Runtime intelligence was siloed in `spectra jvm`; with a bare PID you had to guess which tool applied.

## How

- **`internal/runtimeattach`** classifies a process as `jvm` / `node` / `electron` / `go` / `dotnet` / `python` / `native` from the executable path, the full command line, and two cheap **pure-Go** probes: `debug/buildinfo.ReadFile` fingerprints a Go binary, and a `dotnet-diagnostic-<pid>-*-socket` in the temp dir identifies .NET. It reports the deciding **evidence** and routes to concrete next steps — existing Spectra commands where they exist (`spectra jvm <pid>`, `spectra web processes`) and the standard technique otherwise (SIGUSR1 + CDP for Node/Electron; SIGQUIT / net-http-pprof for Go; `dotnet-trace/dump/gcdump` for .NET; `py-spy` for Python) — always including the universal `spectra sample <pid>` fallback.
- **`spectra runtime [attach] [--json] <pid>`** — read-only: it advises, and never signals, attaches to, or profiles the process itself. The probes and the PID lookup are injected.

## Testing

The classifier is unit-tested across all runtimes (java exe/flags, JDK path, Electron framework + `--type=renderer`, node exe/`--inspect`, dotnet exe + socket, python, Go-buildinfo, native), the dotnet-socket-wins ordering, and that every runtime's capability list includes the sample fallback and routes JVM/Electron to their Spectra commands. The CLI is tested for the `attach` verb, missing process (exit 1), invalid args (exit 2), and `--json`. `make vet complexity lint security docs-validate test` green (59 pkgs). Smoke-tested against live PIDs (zsh/launchd → native). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #397
