### PR TITLE
rules: app-debuggable-posture — flag apps shipped with the get-task-allow entitlement

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -202,6 +202,7 @@ Implemented rules:
 - `library-storage-footprint`
 - `app-no-hardened-runtime`
 - `app-unsigned`
+- `app-debuggable-posture`
 - `electron-chromium-eol`
 - `login-item-dangling`
 - `brew-deprecated-formula`

--- a/internal/rules/app_posture_test.go
+++ b/internal/rules/app_posture_test.go
@@ -1,0 +1,64 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/detect"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func TestAppDebuggablePostureFires(t *testing.T) {
+	s := snapshot.Snapshot{Apps: []detect.Result{
+		{Path: "/Applications/Debuggable.app", TeamID: "TEAM1", Entitlements: []string{"app-sandbox", "get-task-allow"}},
+	}}
+	findings := ruleAppDebuggablePosture().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	f := findings[0]
+	if f.RuleID != "app-debuggable-posture" || f.Severity != SeverityHigh {
+		t.Errorf("rule/severity = %s/%s", f.RuleID, f.Severity)
+	}
+	if f.Subject != "Debuggable" {
+		t.Errorf("subject = %q, want Debuggable", f.Subject)
+	}
+	if !strings.Contains(f.Message, "get-task-allow") || f.Fix == "" {
+		t.Errorf("message/fix incomplete: %q / %q", f.Message, f.Fix)
+	}
+}
+
+func TestAppDebuggablePostureSilentWithoutEntitlement(t *testing.T) {
+	s := snapshot.Snapshot{Apps: []detect.Result{
+		{Path: "/Applications/Clean.app", TeamID: "TEAM1", Entitlements: []string{"app-sandbox", "network.client"}},
+		{Path: "/Applications/NoEnts.app", TeamID: "TEAM2"},
+	}}
+	if findings := ruleAppDebuggablePosture().MatchFn(s); len(findings) != 0 {
+		t.Errorf("expected no findings, got %v", findings)
+	}
+}
+
+func TestAppDebuggablePostureInCatalog(t *testing.T) {
+	found := false
+	for _, r := range V1Catalog() {
+		if r.ID == "app-debuggable-posture" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("app-debuggable-posture is not registered in V1Catalog")
+	}
+}
+
+func TestHasEntitlement(t *testing.T) {
+	ents := []string{"app-sandbox", "get-task-allow"}
+	if !hasEntitlement(ents, "get-task-allow") {
+		t.Error("expected get-task-allow to be found")
+	}
+	if hasEntitlement(ents, "network.client") {
+		t.Error("did not expect network.client")
+	}
+	if hasEntitlement(nil, "get-task-allow") {
+		t.Error("nil entitlements should not match")
+	}
+}

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -32,6 +32,7 @@ func V1Catalog() []Rule {
 		ruleStorageFootprint(),
 		ruleAppNoHardenedRuntime(),
 		ruleAppUnsigned(),
+		ruleAppDebuggablePosture(),
 		ruleElectronChromiumEOL(),
 		ruleLoginItemDangling(),
 		ruleBrewDeprecatedFormula(),
@@ -342,6 +343,45 @@ func ruleAppUnsigned() Rule {
 			return findings
 		},
 	}
+}
+
+// ruleAppDebuggablePosture fires for apps signed with the get-task-allow
+// entitlement. It is a Debug-only entitlement Xcode adds for development
+// signing; shipped in a Release build it defeats the hardened runtime — any
+// process running as the same user can attach a debugger, read the app's
+// memory, or inject code via task_for_pid.
+func ruleAppDebuggablePosture() Rule {
+	return Rule{
+		ID:       "app-debuggable-posture",
+		Severity: SeverityHigh,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, app := range s.Apps {
+				if !hasEntitlement(app.Entitlements, "get-task-allow") {
+					continue
+				}
+				findings = append(findings, Finding{
+					RuleID:   "app-debuggable-posture",
+					Severity: SeverityHigh,
+					Subject:  appDisplayName(app.Path),
+					Message:  fmt.Sprintf("%s is signed with the get-task-allow entitlement — any process running as this user can attach a debugger, read its memory, or inject code, defeating the hardened runtime. This is a Debug-only entitlement that must not ship.", appDisplayName(app.Path)),
+					Fix:      "Remove com.apple.security.get-task-allow from Release builds; Xcode adds it automatically only for development signing.",
+				})
+			}
+			return findings
+		},
+	}
+}
+
+// hasEntitlement reports whether the notable-entitlement list contains key
+// (stored with the com.apple.security. prefix trimmed).
+func hasEntitlement(entitlements []string, key string) bool {
+	for _, e := range entitlements {
+		if e == key {
+			return true
+		}
+	}
+	return false
 }
 
 // ruleLoginItemDangling fires when a login-item plist exists on disk but the


### PR DESCRIPTION
## What

A new high-severity recommendations rule, **`app-debuggable-posture`**, that flags any installed app shipped with the `com.apple.security.get-task-allow` entitlement.

## Why

`get-task-allow` is a Debug-only entitlement Xcode adds automatically for development signing. Shipped in a Release build it **defeats the hardened runtime**: any process running as the same user can `task_for_pid` the app to attach a debugger, read its memory (secrets, tokens), or inject code. Spectra already parses this entitlement into `detect.Result.Entitlements` — nothing was surfacing it.

## How

- `ruleAppDebuggablePosture()` (severity high) fires per app whose `Entitlements` contains `get-task-allow`; message explains the risk, fix advises removing it from Release builds. Registered in `V1Catalog()` so it flows through `spectra rules`, `spectra issues`, and `spectra fleet symptom`/`issues`. Reuses the already-parsed entitlement list — no new exec/process work, no root.
- Documented in the rule list in `docs/design/recommendations-engine.md`.

## Scope

Covers the static, snapshot-visible signing posture. Live per-process `P_TRACED` (a process *currently* being traced) is a deeper platform-`proc` addition and is intentionally left as a follow-on.

## Testing

Rule tests: fires once for an app with the entitlement (correct id/severity/subject/message/fix), silent for apps without it (including one with no entitlements), present in `V1Catalog`, plus `hasEntitlement` unit coverage. `make vet complexity lint security docs-validate test` green (59 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #399
