### PR TITLE
xattr: spectra xattr-inspect — quarantine, provenance, where-froms & AppleDouble across a file or dir

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -70,6 +70,7 @@ func subcommandList() []subcommand {
 		{"schedule", "Schedule periodic snapshot capture via a launchd agent", runSchedule},
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
+		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},
 		{"crash", "Audit post-mortem readiness (can this machine produce a debuggable crash?)", runCrash},
 		{"web", "Diff an Electron app's app.asar payload between two versions", runWeb},

--- a/cmd/spectra/xattr.go
+++ b/cmd/spectra/xattr.go
@@ -92,9 +92,15 @@ func defaultXattrDeps() xattrinspect.Deps {
 				return []string{root}, nil
 			}
 			var files []string
-			_ = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
-				if walkErr != nil || !d.Type().IsRegular() {
-					return nil //nolint:nilerr // tolerate unreadable entries; keep scanning
+			walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, entryErr error) error {
+				if entryErr != nil {
+					if path == root {
+						return entryErr // a root traversal failure is fatal for this argument
+					}
+					return nil //nolint:nilerr // tolerate descendant errors; keep scanning
+				}
+				if !d.Type().IsRegular() {
+					return nil
 				}
 				files = append(files, path)
 				if len(files) >= xattrWalkFileLimit {
@@ -102,6 +108,9 @@ func defaultXattrDeps() xattrinspect.Deps {
 				}
 				return nil
 			})
+			if walkErr != nil {
+				return nil, fmt.Errorf("walk %s: %w", root, walkErr)
+			}
 			return files, nil
 		},
 		Exists: func(path string) bool {

--- a/cmd/spectra/xattr.go
+++ b/cmd/spectra/xattr.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kaeawc/spectra/internal/xattrinspect"
+)
+
+// xattrWalkFileLimit bounds how many files a directory argument expands to.
+const xattrWalkFileLimit = 20000
+
+func runXattrInspect(args []string) int {
+	return runXattrInspectWithIO(args, os.Stdout, os.Stderr, defaultXattrDeps())
+}
+
+func runXattrInspectWithIO(args []string, stdout, stderr io.Writer, deps xattrinspect.Deps) int {
+	fs := flag.NewFlagSet("spectra xattr-inspect", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() == 0 {
+		fmt.Fprintln(stderr, "usage: spectra xattr-inspect [--json] <path>...")
+		return 2
+	}
+
+	report := xattrinspect.Inspect(fs.Args(), deps)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+		return 0
+	}
+	printXattrReport(stdout, report)
+	return 0
+}
+
+func printXattrReport(w io.Writer, report xattrinspect.Report) {
+	fmt.Fprintf(w, "=== xattr-inspect (%d scanned) ===\n", report.Scanned)
+	fmt.Fprintf(w, "quarantined %d | provenance %d | where-froms %d | AppleDouble %d\n",
+		report.Quarantined, report.Provenanced, report.WithWhereFroms, report.WithAppleDouble)
+	for _, fr := range report.Files {
+		if fr.Error != "" {
+			fmt.Fprintf(w, "  %s\n    error: %s\n", fr.Path, fr.Error)
+			continue
+		}
+		if len(fr.Attrs) == 0 && !fr.AppleDouble {
+			continue // nothing notable; keep the output focused
+		}
+		fmt.Fprintf(w, "  %s\n", fr.Path)
+		for _, a := range xattrinspect.SortedAttrs(fr) {
+			fmt.Fprintf(w, "    [%s] %s\n", a.Class, a.Name)
+		}
+		if fr.Quarantine != nil {
+			fmt.Fprintf(w, "    quarantine: agent=%s time=%s flags=%s\n",
+				orDashXattr(fr.Quarantine.Agent), orDashXattr(fr.Quarantine.Timestamp), orDashXattr(fr.Quarantine.Flags))
+		}
+		for _, u := range fr.WhereFroms {
+			fmt.Fprintf(w, "    from: %s\n", truncate(u, 96))
+		}
+		if fr.AppleDouble {
+			fmt.Fprintln(w, "    has an AppleDouble ._ sidecar")
+		}
+	}
+}
+
+func orDashXattr(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func defaultXattrDeps() xattrinspect.Deps {
+	return xattrinspect.Deps{
+		Run: func(args ...string) ([]byte, error) {
+			return exec.Command("xattr", args...).Output()
+		},
+		Files: func(root string) ([]string, error) {
+			fi, err := os.Stat(root)
+			if err != nil {
+				return nil, err
+			}
+			if !fi.IsDir() {
+				return []string{root}, nil
+			}
+			var files []string
+			_ = filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+				if walkErr != nil || !d.Type().IsRegular() {
+					return nil //nolint:nilerr // tolerate unreadable entries; keep scanning
+				}
+				files = append(files, path)
+				if len(files) >= xattrWalkFileLimit {
+					return filepath.SkipAll
+				}
+				return nil
+			})
+			return files, nil
+		},
+		Exists: func(path string) bool {
+			_, err := os.Lstat(path)
+			return err == nil
+		},
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -351,6 +351,26 @@ spectra runtime attach 4012
 spectra runtime --json 4012
 ```
 
+## `spectra xattr-inspect`
+
+Surfaces the macOS extended attributes that record a file's origin and security
+state — normally invisible without `xattr`/`mdls`. Each argument is a file or a
+directory (directories are walked, bounded). For each file it lists the notable
+extended attributes present, each classified (quarantine / provenance /
+where-froms / security / other), parses the `com.apple.quarantine` record into
+the downloading agent, timestamp, and flags, extracts the `where-froms` source
+URLs from the attribute value, and flags whether an AppleDouble `._` sidecar
+exists. The summary counts files with quarantine, provenance, where-froms, and
+AppleDouble sidecars. It is read-only and never modifies an attribute.
+
+### Examples
+
+```bash
+spectra xattr-inspect ~/Downloads/installer.dmg
+spectra xattr-inspect --json /Applications/Some.app
+spectra xattr-inspect ~/Downloads
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/xattrinspect/xattrinspect.go
+++ b/internal/xattrinspect/xattrinspect.go
@@ -88,20 +88,22 @@ func Inspect(paths []string, deps Deps) Report {
 	return rep
 }
 
+// tally counts a file by the attributes it carries, not by whether their
+// values parsed: a present-but-unparseable com.apple.quarantine, or a
+// where-froms with no HTTP URL, still counts toward the summary.
 func tally(rep *Report, fr FileReport) {
-	if fr.Quarantine != nil {
-		rep.Quarantined++
+	for _, a := range fr.Attrs {
+		switch a.Class {
+		case "quarantine":
+			rep.Quarantined++
+		case "provenance":
+			rep.Provenanced++
+		case "where-froms":
+			rep.WithWhereFroms++
+		}
 	}
 	if fr.AppleDouble {
 		rep.WithAppleDouble++
-	}
-	if len(fr.WhereFroms) > 0 {
-		rep.WithWhereFroms++
-	}
-	for _, a := range fr.Attrs {
-		if a.Class == "provenance" {
-			rep.Provenanced++
-		}
 	}
 }
 

--- a/internal/xattrinspect/xattrinspect.go
+++ b/internal/xattrinspect/xattrinspect.go
@@ -1,0 +1,204 @@
+// Package xattrinspect surfaces the macOS extended attributes that record a
+// file's origin and security state — Gatekeeper quarantine, provenance,
+// where-froms source URLs — plus AppleDouble sidecar files. It reads only;
+// it never modifies attributes.
+package xattrinspect
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	attrQuarantine = "com.apple.quarantine"
+	attrProvenance = "com.apple.provenance"
+	attrWhereFroms = "com.apple.metadata:kMDItemWhereFroms"
+)
+
+// urlPattern matches an http(s) URL up to the first control byte; where-froms
+// values are binary plists whose URL strings are plain ASCII substrings.
+var urlPattern = regexp.MustCompile(`https?://[^\x00-\x1f\x7f]+`)
+
+// Deps injects the external access xattrinspect needs so parsing can be tested
+// without touching the filesystem.
+type Deps struct {
+	// Run executes the `xattr` tool with args and returns its stdout.
+	Run func(args ...string) ([]byte, error)
+	// Files returns the regular-file paths to inspect for a root argument: the
+	// root itself if it is a file, or its files (bounded) if it is a directory.
+	Files func(root string) ([]string, error)
+	// Exists reports whether a path exists (used to find AppleDouble sidecars).
+	Exists func(path string) bool
+}
+
+// Attr is one extended attribute present on a file.
+type Attr struct {
+	Name  string `json:"name"`
+	Class string `json:"class"`
+}
+
+// Quarantine is the parsed com.apple.quarantine record.
+type Quarantine struct {
+	Agent     string `json:"agent,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+	Flags     string `json:"flags,omitempty"`
+}
+
+// FileReport is the extended-attribute picture of one file.
+type FileReport struct {
+	Path        string      `json:"path"`
+	Attrs       []Attr      `json:"attrs,omitempty"`
+	Quarantine  *Quarantine `json:"quarantine,omitempty"`
+	WhereFroms  []string    `json:"where_froms,omitempty"`
+	AppleDouble bool        `json:"apple_double,omitempty"`
+	Error       string      `json:"error,omitempty"`
+}
+
+// Report is the combined result plus summary counts.
+type Report struct {
+	Files           []FileReport `json:"files"`
+	Scanned         int          `json:"scanned"`
+	Quarantined     int          `json:"quarantined"`
+	Provenanced     int          `json:"provenanced"`
+	WithWhereFroms  int          `json:"with_where_froms"`
+	WithAppleDouble int          `json:"with_apple_double"`
+}
+
+// Inspect expands each path to its files and reports their extended attributes.
+func Inspect(paths []string, deps Deps) Report {
+	var rep Report
+	for _, p := range paths {
+		files, err := deps.Files(p)
+		if err != nil {
+			rep.Files = append(rep.Files, FileReport{Path: p, Error: fmt.Errorf("scan %s: %w", p, err).Error()})
+			continue
+		}
+		for _, f := range files {
+			fr := inspectFile(f, deps)
+			tally(&rep, fr)
+			rep.Files = append(rep.Files, fr)
+		}
+	}
+	rep.Scanned = len(rep.Files)
+	return rep
+}
+
+func tally(rep *Report, fr FileReport) {
+	if fr.Quarantine != nil {
+		rep.Quarantined++
+	}
+	if fr.AppleDouble {
+		rep.WithAppleDouble++
+	}
+	if len(fr.WhereFroms) > 0 {
+		rep.WithWhereFroms++
+	}
+	for _, a := range fr.Attrs {
+		if a.Class == "provenance" {
+			rep.Provenanced++
+		}
+	}
+}
+
+func inspectFile(path string, deps Deps) FileReport {
+	fr := FileReport{Path: path}
+	out, err := deps.Run(path)
+	if err != nil {
+		fr.Error = fmt.Errorf("xattr %s: %w", path, err).Error()
+		return fr
+	}
+	names := splitNames(out)
+	present := map[string]bool{}
+	for _, n := range names {
+		present[n] = true
+		fr.Attrs = append(fr.Attrs, Attr{Name: n, Class: classifyAttr(n)})
+	}
+
+	if present[attrQuarantine] {
+		if raw, err := deps.Run("-p", attrQuarantine, path); err == nil {
+			if q, ok := parseQuarantine(string(raw)); ok {
+				fr.Quarantine = &q
+			}
+		}
+	}
+	if present[attrWhereFroms] {
+		if raw, err := deps.Run("-p", attrWhereFroms, path); err == nil {
+			fr.WhereFroms = extractURLs(raw)
+		}
+	}
+	if deps.Exists != nil {
+		fr.AppleDouble = deps.Exists(appleDoubleSibling(path))
+	}
+	return fr
+}
+
+func splitNames(out []byte) []string {
+	var names []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if n := strings.TrimSpace(line); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+// classifyAttr labels an attribute name by the concern it reveals.
+func classifyAttr(name string) string {
+	switch {
+	case name == attrQuarantine:
+		return "quarantine"
+	case name == attrProvenance:
+		return "provenance"
+	case name == attrWhereFroms:
+		return "where-froms"
+	case name == "com.apple.macl" || name == "com.apple.rootless" ||
+		strings.HasPrefix(name, "com.apple.cs.") || strings.HasPrefix(name, "com.apple.security"):
+		return "security"
+	default:
+		return "other"
+	}
+}
+
+// parseQuarantine parses "flags;hex-timestamp;agent;uuid" into a record.
+func parseQuarantine(raw string) (Quarantine, bool) {
+	fields := strings.Split(strings.TrimSpace(raw), ";")
+	if len(fields) < 3 {
+		return Quarantine{}, false
+	}
+	q := Quarantine{Flags: fields[0], Agent: fields[2]}
+	if ts, err := strconv.ParseInt(fields[1], 16, 64); err == nil && ts > 0 {
+		q.Timestamp = time.Unix(ts, 0).UTC().Format(time.RFC3339)
+	}
+	return q, true
+}
+
+// extractURLs pulls the source URLs out of a where-froms attribute value.
+func extractURLs(raw []byte) []string {
+	seen := map[string]bool{}
+	var urls []string
+	for _, m := range urlPattern.FindAll(raw, -1) {
+		u := strings.TrimRight(string(m), " ")
+		if !seen[u] {
+			seen[u] = true
+			urls = append(urls, u)
+		}
+	}
+	return urls
+}
+
+// appleDoubleSibling returns the AppleDouble ._ sidecar path for a file.
+func appleDoubleSibling(path string) string {
+	return filepath.Join(filepath.Dir(path), "._"+filepath.Base(path))
+}
+
+// SortedAttrs returns a file's attribute names sorted, for stable rendering.
+func SortedAttrs(fr FileReport) []Attr {
+	out := append([]Attr(nil), fr.Attrs...)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/internal/xattrinspect/xattrinspect_test.go
+++ b/internal/xattrinspect/xattrinspect_test.go
@@ -1,0 +1,134 @@
+package xattrinspect
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseQuarantine(t *testing.T) {
+	q, ok := parseQuarantine("0083;66d1a400;Safari;A1B2C3D4-0000\n")
+	if !ok {
+		t.Fatal("expected a valid quarantine record")
+	}
+	if q.Agent != "Safari" || q.Flags != "0083" {
+		t.Errorf("agent/flags = %q/%q", q.Agent, q.Flags)
+	}
+	if !strings.HasPrefix(q.Timestamp, "2024-") {
+		t.Errorf("timestamp not decoded: %q", q.Timestamp)
+	}
+	if _, ok := parseQuarantine("garbage"); ok {
+		t.Error("a value with too few fields must not parse")
+	}
+}
+
+func TestExtractURLs(t *testing.T) {
+	// A where-froms binary plist has ASCII URL substrings between control bytes.
+	raw := []byte("bplist00\x00\x00https://example.com/app.dmg\x00\x08https://example.com/\x00\x00https://example.com/app.dmg")
+	urls := extractURLs(raw)
+	if len(urls) != 2 {
+		t.Fatalf("urls = %v, want 2 deduped", urls)
+	}
+	if urls[0] != "https://example.com/app.dmg" {
+		t.Errorf("first url = %q", urls[0])
+	}
+}
+
+func TestClassifyAttr(t *testing.T) {
+	cases := map[string]string{
+		attrQuarantine:                 "quarantine",
+		attrProvenance:                 "provenance",
+		attrWhereFroms:                 "where-froms",
+		"com.apple.macl":               "security",
+		"com.apple.cs.CodeDirectory":   "security",
+		"com.apple.security.something": "security",
+		"com.apple.FinderInfo":         "other",
+		"com.apple.lastuseddate#PS":    "other",
+	}
+	for name, want := range cases {
+		if got := classifyAttr(name); got != want {
+			t.Errorf("classifyAttr(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestAppleDoubleSibling(t *testing.T) {
+	if got := appleDoubleSibling("/a/b/file.dmg"); got != "/a/b/._file.dmg" {
+		t.Errorf("sibling = %q", got)
+	}
+}
+
+// fakeXattr serves canned `xattr` output keyed by the joined args.
+type fakeXattr struct {
+	names      string            // output of `xattr <path>`
+	values     map[string]string // "<attr>" -> `xattr -p <attr> <path>` output
+	existsPath map[string]bool
+}
+
+func (f fakeXattr) deps() Deps {
+	return Deps{
+		Run: func(args ...string) ([]byte, error) {
+			if len(args) == 1 { // list names
+				return []byte(f.names), nil
+			}
+			if len(args) == 3 && args[0] == "-p" { // -p <attr> <path>
+				if v, ok := f.values[args[1]]; ok {
+					return []byte(v), nil
+				}
+				return nil, errors.New("no such attr")
+			}
+			return nil, errors.New("unexpected args")
+		},
+		Files:  func(root string) ([]string, error) { return []string{root}, nil },
+		Exists: func(path string) bool { return f.existsPath[path] },
+	}
+}
+
+func TestInspectFileFull(t *testing.T) {
+	f := fakeXattr{
+		names: "com.apple.quarantine\ncom.apple.metadata:kMDItemWhereFroms\ncom.apple.provenance\n",
+		values: map[string]string{
+			attrQuarantine: "0083;66d1a400;Firefox;X",
+			attrWhereFroms: "bplist00\x00https://dl.example.com/tool.pkg\x00",
+		},
+		existsPath: map[string]bool{"/dir/._tool.pkg": true},
+	}
+	rep := Inspect([]string{"/dir/tool.pkg"}, f.deps())
+	if rep.Scanned != 1 {
+		t.Fatalf("scanned = %d", rep.Scanned)
+	}
+	fr := rep.Files[0]
+	if fr.Quarantine == nil || fr.Quarantine.Agent != "Firefox" {
+		t.Errorf("quarantine not parsed: %+v", fr.Quarantine)
+	}
+	if len(fr.WhereFroms) != 1 || fr.WhereFroms[0] != "https://dl.example.com/tool.pkg" {
+		t.Errorf("where-froms = %v", fr.WhereFroms)
+	}
+	if !fr.AppleDouble {
+		t.Error("expected AppleDouble sidecar detection")
+	}
+	if rep.Quarantined != 1 || rep.WithWhereFroms != 1 || rep.Provenanced != 1 || rep.WithAppleDouble != 1 {
+		t.Errorf("summary counts wrong: %+v", rep)
+	}
+}
+
+func TestInspectFileError(t *testing.T) {
+	deps := Deps{
+		Run:   func(args ...string) ([]byte, error) { return nil, errors.New("no xattr") },
+		Files: func(root string) ([]string, error) { return []string{root}, nil },
+	}
+	rep := Inspect([]string{"/missing"}, deps)
+	if rep.Files[0].Error == "" {
+		t.Error("expected an error recorded for a failing xattr call")
+	}
+}
+
+func TestInspectFilesExpansionError(t *testing.T) {
+	deps := Deps{
+		Files: func(root string) ([]string, error) { return nil, errors.New("stat failed") },
+	}
+	rep := Inspect([]string{"/nope"}, deps)
+	if rep.Files[0].Error == "" {
+		t.Error("expected a scan error when the path cannot be expanded")
+	}
+}

--- a/internal/xattrinspect/xattrinspect_test.go
+++ b/internal/xattrinspect/xattrinspect_test.go
@@ -112,6 +112,29 @@ func TestInspectFileFull(t *testing.T) {
 	}
 }
 
+func TestInspectCountsPresentButUnparseableAttrs(t *testing.T) {
+	// quarantine present with an unparseable value, and where-froms present with
+	// no HTTP URL: both must still count toward the summary.
+	f := fakeXattr{
+		names: "com.apple.quarantine\ncom.apple.metadata:kMDItemWhereFroms\n",
+		values: map[string]string{
+			attrQuarantine: "garbage",
+			attrWhereFroms: "bplist00\x00file:///local/only\x00",
+		},
+	}
+	rep := Inspect([]string{"/dir/file"}, f.deps())
+	fr := rep.Files[0]
+	if fr.Quarantine != nil {
+		t.Errorf("garbage quarantine should not parse into detail, got %+v", fr.Quarantine)
+	}
+	if len(fr.WhereFroms) != 0 {
+		t.Errorf("no http url should be extracted, got %v", fr.WhereFroms)
+	}
+	if rep.Quarantined != 1 || rep.WithWhereFroms != 1 {
+		t.Errorf("present attributes must count in the summary: %+v", rep)
+	}
+}
+
 func TestInspectFileError(t *testing.T) {
 	deps := Deps{
 		Run:   func(args ...string) ([]byte, error) { return nil, errors.New("no xattr") },


### PR DESCRIPTION
## What

`spectra xattr-inspect [--json] <path>...` — surfaces the macOS extended attributes that record where a file came from and its security state, normally invisible without `xattr`/`mdls`.

## How

For each file (a directory argument is walked, bounded), it:
- lists the notable extended attributes present, each **classified** — quarantine / provenance / where-froms / security / other;
- parses **`com.apple.quarantine`** into the downloading agent, timestamp (decoded from the hex epoch), and flags;
- extracts the **where-froms** source URLs straight out of the attribute value (the binary plist's URL substrings), deduped;
- flags whether the file has an **AppleDouble `._` sidecar**.

Summary counts files with quarantine / provenance / where-froms / AppleDouble. Read-only — it never modifies an attribute. It shells out to `xattr` through an **injected runner** (consistent with how the codebase calls codesign/pmset/mdutil) and expands directories with a bounded `filepath.WalkDir`; **no new module dependency, no root**.

## Testing

Parsing is a pure, unit-tested layer: quarantine record parsing (valid + too-few-fields), where-froms URL extraction + dedup, attribute classification (all classes), and AppleDouble sibling naming. `Inspect` is tested with a fake `xattr` runner: a full file (quarantine + where-froms + provenance + AppleDouble with correct summary counts), a failing `xattr` call (error recorded), and a path-expansion error. Smoke-tested end-to-end against a real stamped quarantine file (agent/timestamp decoded, `._` sidecar detected). `make vet complexity lint security docs-validate test` green (60 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #401
