### PR TITLE
network: spectra network captive — replicate Apple's captive-portal probe, detect portals & transparent proxies

### DIFF
--- a/cmd/spectra/network.go
+++ b/cmd/spectra/network.go
@@ -52,6 +52,9 @@ func runNetwork(args []string) int {
 	if len(args) > 0 && args[0] == "diagnose" {
 		return runNetworkDiagnose(args[1:])
 	}
+	if len(args) > 0 && args[0] == "captive" {
+		return runNetworkCaptive(args[1:])
+	}
 
 	fs := flag.NewFlagSet("spectra network", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)

--- a/cmd/spectra/network_captive.go
+++ b/cmd/spectra/network_captive.go
@@ -102,7 +102,10 @@ func defaultCaptiveFetcher(ctx context.Context, url string) (captiveportal.Respo
 		return captiveportal.Response{}, err
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, captiveBodyCap))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, captiveBodyCap))
+	if err != nil {
+		return captiveportal.Response{}, fmt.Errorf("read probe body: %w", err)
+	}
 	return captiveportal.Response{
 		StatusCode: resp.StatusCode,
 		Location:   resp.Header.Get("Location"),

--- a/cmd/spectra/network_captive.go
+++ b/cmd/spectra/network_captive.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/captiveportal"
+)
+
+const (
+	captiveTimeout = 5 * time.Second
+	captiveBodyCap = 64 * 1024
+)
+
+func runNetworkCaptive(args []string) int {
+	return runNetworkCaptiveWithIO(args, os.Stdout, os.Stderr, defaultCaptiveFetcher)
+}
+
+func runNetworkCaptiveWithIO(args []string, stdout, stderr io.Writer, fetch captiveportal.Fetcher) int {
+	fs := flag.NewFlagSet("spectra network captive", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: spectra network captive [--json]")
+		return 2
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), captiveTimeout)
+	defer cancel()
+	result := captiveportal.Probe(ctx, fetch)
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return jsonExit(result)
+	}
+	printCaptiveResult(stdout, result)
+	return captiveExitCode(result)
+}
+
+func printCaptiveResult(w io.Writer, r captiveportal.Result) {
+	verdict := "CLEAR"
+	if r.Portal {
+		verdict = "CAPTIVE PORTAL"
+	} else if r.Proxied {
+		verdict = "PROXIED"
+	}
+	fmt.Fprintf(w, "captive-portal probe: %s\n", verdict)
+	fmt.Fprintf(w, "  url:     %s\n", r.URL)
+	if r.Error != "" {
+		fmt.Fprintf(w, "  error:   %s\n", r.Error)
+	} else {
+		fmt.Fprintf(w, "  status:  %d (%dms)\n", r.StatusCode, r.ElapsedMS)
+	}
+	if r.Location != "" {
+		fmt.Fprintf(w, "  location: %s\n", r.Location)
+	}
+	if r.Via != "" {
+		fmt.Fprintf(w, "  via:     %s\n", r.Via)
+	}
+	if r.Server != "" {
+		fmt.Fprintf(w, "  server:  %s\n", r.Server)
+	}
+	fmt.Fprintf(w, "  %s\n", r.Reason)
+}
+
+// captiveExitCode returns 1 when a portal is detected or the probe failed, so
+// scripts can gate on connectivity; a clear or merely proxied link returns 0.
+func captiveExitCode(r captiveportal.Result) int {
+	if r.Portal || r.Error != "" {
+		return 1
+	}
+	return 0
+}
+
+func jsonExit(r captiveportal.Result) int {
+	return captiveExitCode(r)
+}
+
+func defaultCaptiveFetcher(ctx context.Context, url string) (captiveportal.Response, error) {
+	client := &http.Client{
+		// Never follow redirects: a captive portal's redirect is the signal.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return captiveportal.Response{}, err
+	}
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		return captiveportal.Response{}, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, captiveBodyCap))
+	return captiveportal.Response{
+		StatusCode: resp.StatusCode,
+		Location:   resp.Header.Get("Location"),
+		Via:        resp.Header.Get("Via"),
+		Server:     resp.Header.Get("Server"),
+		Body:       string(body),
+		ElapsedMS:  time.Since(start).Milliseconds(),
+	}, nil
+}

--- a/cmd/spectra/network_captive_test.go
+++ b/cmd/spectra/network_captive_test.go
@@ -14,7 +14,7 @@ func captiveFetcher(resp captiveportal.Response) captiveportal.Fetcher {
 }
 
 func TestRunNetworkCaptiveClearExit0(t *testing.T) {
-	fetch := captiveFetcher(captiveportal.Response{StatusCode: 200, Body: "<TITLE>Success</TITLE>"})
+	fetch := captiveFetcher(captiveportal.Response{StatusCode: 200, Body: "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>"})
 	var out, errBuf bytes.Buffer
 	if code := runNetworkCaptiveWithIO(nil, &out, &errBuf, fetch); code != 0 {
 		t.Fatalf("exit = %d, want 0 for a clear link", code)
@@ -36,7 +36,7 @@ func TestRunNetworkCaptivePortalExit1(t *testing.T) {
 }
 
 func TestRunNetworkCaptiveRejectsArgs(t *testing.T) {
-	fetch := captiveFetcher(captiveportal.Response{StatusCode: 200, Body: "<TITLE>Success</TITLE>"})
+	fetch := captiveFetcher(captiveportal.Response{StatusCode: 200, Body: "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>"})
 	var out, errBuf bytes.Buffer
 	if code := runNetworkCaptiveWithIO([]string{"extra"}, &out, &errBuf, fetch); code != 2 {
 		t.Fatalf("exit = %d, want 2", code)
@@ -44,7 +44,7 @@ func TestRunNetworkCaptiveRejectsArgs(t *testing.T) {
 }
 
 func TestRunNetworkCaptiveJSON(t *testing.T) {
-	fetch := captiveFetcher(captiveportal.Response{StatusCode: 200, Body: "<TITLE>Success</TITLE>"})
+	fetch := captiveFetcher(captiveportal.Response{StatusCode: 200, Body: "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>"})
 	var out, errBuf bytes.Buffer
 	if code := runNetworkCaptiveWithIO([]string{"--json"}, &out, &errBuf, fetch); code != 0 {
 		t.Fatalf("exit = %d", code)

--- a/cmd/spectra/network_captive_test.go
+++ b/cmd/spectra/network_captive_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/captiveportal"
+)
+
+func captiveFetcher(resp captiveportal.Response) captiveportal.Fetcher {
+	return func(context.Context, string) (captiveportal.Response, error) { return resp, nil }
+}
+
+func TestRunNetworkCaptiveClearExit0(t *testing.T) {
+	fetch := captiveFetcher(captiveportal.Response{StatusCode: 200, Body: "<TITLE>Success</TITLE>"})
+	var out, errBuf bytes.Buffer
+	if code := runNetworkCaptiveWithIO(nil, &out, &errBuf, fetch); code != 0 {
+		t.Fatalf("exit = %d, want 0 for a clear link", code)
+	}
+	if !strings.Contains(out.String(), "CLEAR") {
+		t.Errorf("expected CLEAR verdict, got:\n%s", out.String())
+	}
+}
+
+func TestRunNetworkCaptivePortalExit1(t *testing.T) {
+	fetch := captiveFetcher(captiveportal.Response{StatusCode: 302, Location: "https://login"})
+	var out, errBuf bytes.Buffer
+	if code := runNetworkCaptiveWithIO(nil, &out, &errBuf, fetch); code != 1 {
+		t.Fatalf("exit = %d, want 1 for a captive portal", code)
+	}
+	if !strings.Contains(out.String(), "CAPTIVE PORTAL") {
+		t.Errorf("expected CAPTIVE PORTAL verdict, got:\n%s", out.String())
+	}
+}
+
+func TestRunNetworkCaptiveRejectsArgs(t *testing.T) {
+	fetch := captiveFetcher(captiveportal.Response{StatusCode: 200, Body: "<TITLE>Success</TITLE>"})
+	var out, errBuf bytes.Buffer
+	if code := runNetworkCaptiveWithIO([]string{"extra"}, &out, &errBuf, fetch); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+}
+
+func TestRunNetworkCaptiveJSON(t *testing.T) {
+	fetch := captiveFetcher(captiveportal.Response{StatusCode: 200, Body: "<TITLE>Success</TITLE>"})
+	var out, errBuf bytes.Buffer
+	if code := runNetworkCaptiveWithIO([]string{"--json"}, &out, &errBuf, fetch); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"portal"`) {
+		t.Errorf("expected JSON output, got:\n%s", out.String())
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -438,6 +438,18 @@ recovered from the verification error so the chain is still captured and
 explained (`trust=UNTRUSTED trust_error=…`) rather than hidden behind a
 handshake failure.
 
+`spectra network captive` replicates Apple's captive-portal probe: it GETs
+`http://captive.apple.com/hotspot-detect.html` over plain HTTP **without
+following redirects**, with a short timeout and a bounded body read, and
+classifies the link. It reports `CLEAR` only when the response is `200` with
+Apple's canonical success page. It flags a `CAPTIVE PORTAL` when the probe is
+redirected (3xx + Location), returns `511 Network Authentication Required`, or
+returns `200` with a body that isn't the success page — the pattern of a hotel
+or airport login gate that makes a dead link look "up". A `Via` (or proxy
+`Server`) header marks the link as `PROXIED` even when the success page is
+returned, revealing a transparent proxy. The command exits non-zero when a
+portal is detected or the probe fails, so scripts can gate on real connectivity.
+
 ### Examples
 
 ```bash
@@ -447,6 +459,8 @@ spectra network connections --proto tcp --state established
 spectra network diagnose --app /Applications/Slack.app
 spectra network diagnose --pid 412
 spectra network diagnose --app /Applications/Slack.app --ports 443 api.example.com
+spectra network captive
+spectra network captive --json
 spectra network capture start --interface en0 --duration 30s --proto tcp --host api.example.com --port 443
 spectra network capture stop --summarize netcap-1
 spectra network capture summarize --json /var/tmp/spectra-netcap/501/netcap-1.pcap

--- a/internal/captiveportal/captiveportal.go
+++ b/internal/captiveportal/captiveportal.go
@@ -1,0 +1,93 @@
+// Package captiveportal replicates Apple's captive-portal probe: it fetches the
+// well-known hotspot-detect page over plain HTTP without following redirects
+// and classifies the response as a clear link, a captive portal, or a link
+// behind a transparent proxy.
+package captiveportal
+
+import (
+	"context"
+	"strings"
+)
+
+// ProbeURL is Apple's captive-detection endpoint; a clear link returns the
+// canonical success page below.
+const ProbeURL = "http://captive.apple.com/hotspot-detect.html"
+
+// successMarker is the distinctive content of Apple's success page
+// (<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>).
+const successMarker = "<TITLE>Success</TITLE>"
+
+// Response is the subset of an HTTP response the classifier needs. It is
+// produced by the injected Fetcher so classification can be tested offline.
+type Response struct {
+	StatusCode int
+	Location   string // Location header (for redirects)
+	Via        string // Via header (proxy chain)
+	Server     string // Server header
+	Body       string // response body (bounded by the fetcher)
+	ElapsedMS  int64
+}
+
+// Fetcher performs the plain-HTTP probe GET without following redirects.
+type Fetcher func(ctx context.Context, url string) (Response, error)
+
+// Result is the captive-portal verdict for one probe.
+type Result struct {
+	URL        string `json:"url"`
+	StatusCode int    `json:"status_code,omitempty"`
+	Portal     bool   `json:"portal"`
+	Proxied    bool   `json:"proxied,omitempty"`
+	Reason     string `json:"reason"`
+	Location   string `json:"location,omitempty"`
+	Via        string `json:"via,omitempty"`
+	Server     string `json:"server,omitempty"`
+	ElapsedMS  int64  `json:"elapsed_ms,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+// Probe runs the captive-portal check using fetch and returns the verdict.
+func Probe(ctx context.Context, fetch Fetcher) Result {
+	res := Result{URL: ProbeURL}
+	resp, err := fetch(ctx, ProbeURL)
+	if err != nil {
+		res.Error = err.Error()
+		res.Reason = "probe request failed — the link may be down or fully blocked"
+		return res
+	}
+	res.StatusCode = resp.StatusCode
+	res.Location = resp.Location
+	res.Via = resp.Via
+	res.Server = resp.Server
+	res.ElapsedMS = resp.ElapsedMS
+	res.Portal, res.Proxied, res.Reason = classify(resp)
+	return res
+}
+
+// classify decides whether a probe response indicates a captive portal and/or a
+// transparent proxy.
+func classify(resp Response) (portal, proxied bool, reason string) {
+	proxied = resp.Via != ""
+
+	switch {
+	case resp.StatusCode >= 300 && resp.StatusCode < 400:
+		return true, proxied, "redirected to a portal login page: " + orNone(resp.Location)
+	case resp.StatusCode == 511:
+		return true, proxied, "511 Network Authentication Required — captive portal"
+	case resp.StatusCode == 200 && strings.Contains(resp.Body, successMarker):
+		if proxied {
+			return false, true, "clear, but the response passed through a proxy (Via: " + resp.Via + ")"
+		}
+		return false, false, "clear — Apple success page returned, no captive portal"
+	case resp.StatusCode == 200:
+		return true, proxied, "200 OK but the body is not Apple's success page — a portal is likely serving its own page"
+	default:
+		return true, proxied, "unexpected status; treat the link as captive until it returns the success page"
+	}
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(no Location header)"
+	}
+	return s
+}

--- a/internal/captiveportal/captiveportal.go
+++ b/internal/captiveportal/captiveportal.go
@@ -13,9 +13,17 @@ import (
 // canonical success page below.
 const ProbeURL = "http://captive.apple.com/hotspot-detect.html"
 
-// successMarker is the distinctive content of Apple's success page
-// (<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>).
-const successMarker = "<TITLE>Success</TITLE>"
+// successPage is the exact body Apple serves for a clear link. A captive portal
+// can embed the <TITLE>Success</TITLE> fragment in its own login page, so the
+// whole normalized body must match — a substring check is not enough.
+const successPage = "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>"
+
+// proxyServerMarkers are substrings of a Server header that point at a proxy or
+// interception product (matched case-insensitively).
+var proxyServerMarkers = []string{
+	"squid", "proxy", "zscaler", "bluecoat", "blue coat",
+	"forcepoint", "netskope", "mcafee", "fortigate", "fortiproxy",
+}
 
 // Response is the subset of an HTTP response the classifier needs. It is
 // produced by the injected Fetcher so classification can be tested offline.
@@ -66,16 +74,16 @@ func Probe(ctx context.Context, fetch Fetcher) Result {
 // classify decides whether a probe response indicates a captive portal and/or a
 // transparent proxy.
 func classify(resp Response) (portal, proxied bool, reason string) {
-	proxied = resp.Via != ""
+	proxied = resp.Via != "" || serverLooksLikeProxy(resp.Server)
 
 	switch {
 	case resp.StatusCode >= 300 && resp.StatusCode < 400:
 		return true, proxied, "redirected to a portal login page: " + orNone(resp.Location)
 	case resp.StatusCode == 511:
 		return true, proxied, "511 Network Authentication Required — captive portal"
-	case resp.StatusCode == 200 && strings.Contains(resp.Body, successMarker):
+	case resp.StatusCode == 200 && isSuccessPage(resp.Body):
 		if proxied {
-			return false, true, "clear, but the response passed through a proxy (Via: " + resp.Via + ")"
+			return false, true, "clear, but the response passed through a proxy (" + proxyDetail(resp) + ")"
 		}
 		return false, false, "clear — Apple success page returned, no captive portal"
 	case resp.StatusCode == 200:
@@ -83,6 +91,29 @@ func classify(resp Response) (portal, proxied bool, reason string) {
 	default:
 		return true, proxied, "unexpected status; treat the link as captive until it returns the success page"
 	}
+}
+
+// isSuccessPage reports whether the body is exactly Apple's success page once
+// surrounding whitespace is trimmed.
+func isSuccessPage(body string) bool {
+	return strings.TrimSpace(body) == successPage
+}
+
+func serverLooksLikeProxy(server string) bool {
+	s := strings.ToLower(server)
+	for _, m := range proxyServerMarkers {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+	return false
+}
+
+func proxyDetail(resp Response) string {
+	if resp.Via != "" {
+		return "Via: " + resp.Via
+	}
+	return "Server: " + resp.Server
 }
 
 func orNone(s string) string {

--- a/internal/captiveportal/captiveportal_test.go
+++ b/internal/captiveportal/captiveportal_test.go
@@ -39,6 +39,27 @@ func TestProbe200WithLoginBody(t *testing.T) {
 	}
 }
 
+func TestProbeMarkerFragmentIsNotSuccess(t *testing.T) {
+	// A portal that embeds the success title in its own login page must not
+	// pass as CLEAR.
+	body := "<html><head><TITLE>Success</TITLE></head><body>Please log in to continue</body></html>"
+	r := Probe(context.Background(), fetcher(Response{StatusCode: 200, Body: body}, nil))
+	if !r.Portal {
+		t.Error("a body containing the marker but not the exact success page must be a portal")
+	}
+}
+
+func TestProbeProxyServerHeader(t *testing.T) {
+	// A clear success page whose Server header names a proxy product is PROXIED.
+	r := Probe(context.Background(), fetcher(Response{StatusCode: 200, Body: successBody, Server: "ZScaler/1.0"}, nil))
+	if r.Portal {
+		t.Error("a success page is not a portal")
+	}
+	if !r.Proxied {
+		t.Error("a proxy-product Server header must mark the link PROXIED even without a Via header")
+	}
+}
+
 func TestProbe511(t *testing.T) {
 	r := Probe(context.Background(), fetcher(Response{StatusCode: 511}, nil))
 	if !r.Portal {

--- a/internal/captiveportal/captiveportal_test.go
+++ b/internal/captiveportal/captiveportal_test.go
@@ -1,0 +1,74 @@
+package captiveportal
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+const successBody = "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>\n"
+
+func fetcher(resp Response, err error) Fetcher {
+	return func(context.Context, string) (Response, error) { return resp, err }
+}
+
+func TestProbeClear(t *testing.T) {
+	r := Probe(context.Background(), fetcher(Response{StatusCode: 200, Body: successBody, ElapsedMS: 12}, nil))
+	if r.Portal || r.Proxied {
+		t.Errorf("expected a clear link, got portal=%v proxied=%v", r.Portal, r.Proxied)
+	}
+	if r.StatusCode != 200 {
+		t.Errorf("status = %d", r.StatusCode)
+	}
+}
+
+func TestProbeRedirectPortal(t *testing.T) {
+	r := Probe(context.Background(), fetcher(Response{StatusCode: 302, Location: "https://portal.hotel.example/login"}, nil))
+	if !r.Portal {
+		t.Fatal("a 3xx redirect must be flagged as a captive portal")
+	}
+	if r.Location != "https://portal.hotel.example/login" {
+		t.Errorf("location = %q", r.Location)
+	}
+}
+
+func TestProbe200WithLoginBody(t *testing.T) {
+	r := Probe(context.Background(), fetcher(Response{StatusCode: 200, Body: "<html><body>Please sign in to WiFi</body></html>"}, nil))
+	if !r.Portal {
+		t.Error("200 with a non-success body must be flagged as a captive portal")
+	}
+}
+
+func TestProbe511(t *testing.T) {
+	r := Probe(context.Background(), fetcher(Response{StatusCode: 511}, nil))
+	if !r.Portal {
+		t.Error("511 must be flagged as a captive portal")
+	}
+}
+
+func TestProbeProxiedButClear(t *testing.T) {
+	r := Probe(context.Background(), fetcher(Response{StatusCode: 200, Body: successBody, Via: "1.1 proxy.corp"}, nil))
+	if r.Portal {
+		t.Error("a success page behind a proxy is not a captive portal")
+	}
+	if !r.Proxied || r.Via != "1.1 proxy.corp" {
+		t.Errorf("expected proxied with the Via header, got proxied=%v via=%q", r.Proxied, r.Via)
+	}
+}
+
+func TestProbeFetchError(t *testing.T) {
+	r := Probe(context.Background(), fetcher(Response{}, errors.New("dial tcp: no route to host")))
+	if r.Error == "" {
+		t.Error("a fetch failure must be recorded")
+	}
+	if r.Portal {
+		t.Error("a hard fetch failure is an error, not a portal verdict")
+	}
+}
+
+func TestProbeUnexpectedStatus(t *testing.T) {
+	r := Probe(context.Background(), fetcher(Response{StatusCode: 403}, nil))
+	if !r.Portal {
+		t.Error("an unexpected status should be treated as captive until it returns success")
+	}
+}


### PR DESCRIPTION
## What

`spectra network captive` — replicates the captive-portal probe macOS runs in the background, so Spectra can tell a genuinely-up link from a hotel/airport gate that hijacks every request. `network diagnose` otherwise reports a healthy-looking link (DNS resolves, interface has an IP) that is actually captive.

## How

- **`internal/captiveportal`** GETs `http://captive.apple.com/hotspot-detect.html` over **plain HTTP without following redirects** and classifies:
  - **CLEAR** — `200` with Apple's canonical success page (`<TITLE>Success</TITLE>`).
  - **CAPTIVE PORTAL** — a 3xx redirect (+ Location), `511 Network Authentication Required`, or `200` with a body that isn't the success page (a portal serving its own login page with 200), or any other unexpected status.
  - **PROXIED** — a `Via` (or proxy `Server`) header is present even when the success page returns, revealing a transparent proxy.
  It reports status, redirect location, proxy headers, elapsed time, and a human reason. The HTTP fetch is injected (`Fetcher`), so classification is tested offline.
- **`spectra network captive [--json]`** — a no-redirect client with a 5s timeout and a 64 KiB bounded body read. Exits non-zero when a portal is detected or the probe fails, so scripts can gate on real connectivity.

## Testing

Classifier unit tests: clear success page, 3xx redirect (portal + location), 200-with-login-body, 511, proxied-but-clear (Via set, not a portal), fetch error (recorded as error, not a portal verdict), and an unexpected status. CLI tests: CLEAR→exit 0, portal→exit 1, arg rejection→exit 2, `--json`. `make vet complexity lint security docs-validate test` green (61 pkgs). Smoke-tested on a live network (returned PROXIED via an Apple edge node, success page intact). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #403
