### PR TITLE
symbolicate: spectra symbolicate — resolve raw stack addresses to symbol + file:line via atos

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -69,6 +69,7 @@ func subcommandList() []subcommand {
 		{"install-daemon", "Install the user LaunchAgent for spectra serve", runInstallDaemonCmd},
 		{"schedule", "Schedule periodic snapshot capture via a launchd agent", runSchedule},
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
+		{"symbolicate", "Resolve raw stack addresses to symbol + file:line via atos", runSymbolicate},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/cmd/spectra/symbolicate.go
+++ b/cmd/spectra/symbolicate.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/symbolicate"
+)
+
+func runSymbolicate(args []string) int {
+	return runSymbolicateWithIO(args, os.Stdin, os.Stdout, os.Stderr, defaultSymbolicateRunner)
+}
+
+func runSymbolicateWithIO(args []string, stdin io.Reader, stdout, stderr io.Writer, runner symbolicate.Runner) int {
+	fs := flag.NewFlagSet("spectra symbolicate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	binary := fs.String("o", "", "Path to the Mach-O image or its .dSYM (required)")
+	load := fs.String("l", "", "Load address of the image, e.g. 0x1049f4000 (required)")
+	arch := fs.String("arch", "", "Architecture slice of a universal binary, e.g. arm64")
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *binary == "" || *load == "" {
+		fmt.Fprintln(stderr, "usage: spectra symbolicate -o <binary-or-dSYM> -l <load-address> [--arch <arch>] [--json] <addr>...")
+		return 2
+	}
+
+	addresses := fs.Args()
+	if len(addresses) == 0 {
+		addresses = readAddresses(stdin)
+	}
+	if len(addresses) == 0 {
+		fmt.Fprintln(stderr, "symbolicate: no addresses given (pass them as arguments or on stdin)")
+		return 2
+	}
+
+	result, err := symbolicate.Symbolicate(context.Background(), symbolicate.Request{
+		Binary:      *binary,
+		LoadAddress: *load,
+		Arch:        *arch,
+		Addresses:   addresses,
+	}, runner)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return 0
+	}
+	printSymbolicateResult(stdout, result)
+	return 0
+}
+
+func printSymbolicateResult(w io.Writer, r symbolicate.Result) {
+	fmt.Fprintf(w, "symbolicate %s @ %s", r.Binary, r.LoadAddress)
+	if r.Arch != "" {
+		fmt.Fprintf(w, " (%s)", r.Arch)
+	}
+	fmt.Fprintln(w)
+	for _, f := range r.Frames {
+		if !f.Resolved {
+			fmt.Fprintf(w, "  %s  <unresolved>\n", f.Address)
+			continue
+		}
+		line := fmt.Sprintf("  %s  %s", f.Address, f.Symbol)
+		if f.Location != "" {
+			line += "  (" + f.Location + ")"
+		}
+		fmt.Fprintln(w, line)
+	}
+}
+
+func readAddresses(r io.Reader) []string {
+	if r == nil {
+		return nil
+	}
+	var addrs []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if t := strings.TrimSpace(scanner.Text()); t != "" {
+			addrs = append(addrs, t)
+		}
+	}
+	return addrs
+}
+
+func defaultSymbolicateRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}

--- a/cmd/spectra/symbolicate_test.go
+++ b/cmd/spectra/symbolicate_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/symbolicate"
+)
+
+func fixedSymRunner(out string) symbolicate.Runner {
+	return func(context.Context, string, ...string) ([]byte, error) { return []byte(out), nil }
+}
+
+func TestRunSymbolicatePositional(t *testing.T) {
+	runner := fixedSymRunner("main (in App) (main.c:10)\n")
+	var out, errBuf bytes.Buffer
+	code := runSymbolicateWithIO([]string{"-o", "/App", "-l", "0x1000", "0x1010"}, strings.NewReader(""), &out, &errBuf, runner)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "main") || !strings.Contains(out.String(), "main.c:10") {
+		t.Errorf("expected symbolicated frame, got:\n%s", out.String())
+	}
+}
+
+func TestRunSymbolicateStdin(t *testing.T) {
+	runner := fixedSymRunner("foo (in App)\n")
+	var out, errBuf bytes.Buffer
+	code := runSymbolicateWithIO([]string{"-o", "/App", "-l", "0x1000"}, strings.NewReader("0x1010\n"), &out, &errBuf, runner)
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), "foo") {
+		t.Errorf("expected frame from stdin address, got:\n%s", out.String())
+	}
+}
+
+func TestRunSymbolicateRequiresFlags(t *testing.T) {
+	runner := fixedSymRunner("")
+	cases := [][]string{
+		{"0x1010"},                     // no -o/-l
+		{"-o", "/App", "0x1010"},       // no -l
+		{"-o", "/App", "-l", "0x1000"}, // no addresses (empty stdin)
+	}
+	for _, args := range cases {
+		var out, errBuf bytes.Buffer
+		if code := runSymbolicateWithIO(args, strings.NewReader(""), &out, &errBuf, runner); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}
+
+func TestRunSymbolicateJSON(t *testing.T) {
+	runner := fixedSymRunner("main (in App) (main.c:10)\n")
+	var out, errBuf bytes.Buffer
+	code := runSymbolicateWithIO([]string{"--json", "-o", "/App", "-l", "0x1000", "0x1010"}, strings.NewReader(""), &out, &errBuf, runner)
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"frames"`) || !strings.Contains(out.String(), `"resolved"`) {
+		t.Errorf("expected JSON, got:\n%s", out.String())
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -371,6 +371,26 @@ spectra xattr-inspect --json /Applications/Some.app
 spectra xattr-inspect ~/Downloads
 ```
 
+## `spectra symbolicate`
+
+Resolves raw stack addresses to `symbol + file:line` using `atos`, against a
+Mach-O image or its `.dSYM`. This is the enabling primitive for the
+native-capture features — a captured stack (from a core, a crash report, or a
+spindump) is just hex until it is symbolicated. Give the image with `-o`, its
+load address with `-l`, and the addresses as arguments or on stdin (one per
+line). For each address it reports the resolved symbol and `file:line` when
+`atos` provides them; an address `atos` cannot resolve (it echoes the address
+back) is reported as unresolved rather than dropped. `--arch` selects a slice of
+a universal binary. Read-only, no root.
+
+### Examples
+
+```bash
+spectra symbolicate -o /Applications/Some.app/Contents/MacOS/Some -l 0x10a400000 0x10a4b31a0 0x10a4b3200
+spectra symbolicate -o ./Some.app.dSYM -l 0x10a400000 --arch arm64 --json 0x10a4b31a0
+lldb-derived-addresses.txt | spectra symbolicate -o ./Some -l 0x10a400000
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/symbolicate/symbolicate.go
+++ b/internal/symbolicate/symbolicate.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -59,6 +60,9 @@ func Symbolicate(ctx context.Context, req Request, runner Runner) (Result, error
 	if req.LoadAddress == "" {
 		return Result{}, fmt.Errorf("symbolicate: a load address is required")
 	}
+	if !isHexAddress(req.LoadAddress) {
+		return Result{}, fmt.Errorf("symbolicate: invalid load address %q (want a hex value like 0x10a400000)", req.LoadAddress)
+	}
 	if len(req.Addresses) == 0 {
 		return Result{}, fmt.Errorf("symbolicate: at least one address is required")
 	}
@@ -80,8 +84,10 @@ func Symbolicate(ctx context.Context, req Request, runner Runner) (Result, error
 }
 
 // parseFrames pairs each input address with atos's corresponding output line.
+// atos emits exactly one line per input address, in order, so blank lines must
+// be preserved as unresolved placeholders to keep the pairing aligned.
 func parseFrames(addresses []string, out string) []Frame {
-	lines := nonEmptyLines(out)
+	lines := atosLines(out)
 	frames := make([]Frame, len(addresses))
 	for i, addr := range addresses {
 		f := Frame{Address: addr}
@@ -113,12 +119,26 @@ func parseLine(addr, line string) (symbol, location string, resolved bool) {
 	return symbol, location, resolved
 }
 
-func nonEmptyLines(s string) []string {
-	var out []string
-	for _, l := range strings.Split(s, "\n") {
-		if t := strings.TrimSpace(l); t != "" {
-			out = append(out, t)
-		}
+// atosLines splits atos output into per-address lines, dropping only the
+// trailing newline. Internal blank lines are kept so a blank line for one
+// address does not shift every later address onto the wrong symbol.
+func atosLines(s string) []string {
+	s = strings.TrimSuffix(s, "\n")
+	if s == "" {
+		return nil
 	}
-	return out
+	return strings.Split(s, "\n")
+}
+
+// isHexAddress reports whether s is a hexadecimal address, with an optional
+// 0x prefix.
+func isHexAddress(s string) bool {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "0x")
+	s = strings.TrimPrefix(s, "0X")
+	if s == "" {
+		return false
+	}
+	_, err := strconv.ParseUint(s, 16, 64)
+	return err == nil
 }

--- a/internal/symbolicate/symbolicate.go
+++ b/internal/symbolicate/symbolicate.go
@@ -1,0 +1,124 @@
+// Package symbolicate resolves raw stack addresses to symbol + file:line using
+// the macOS `atos` tool. It is the enabling primitive for the native-capture
+// features (spindump, flamegraph, hang-capture), which produce raw addresses
+// that are meaningless until symbolicated. It reads only.
+package symbolicate
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Request describes what to symbolicate.
+type Request struct {
+	// Binary is the path to the Mach-O image or its .dSYM.
+	Binary string
+	// LoadAddress is the address at which Binary was loaded (hex, e.g. 0x1049f4000).
+	LoadAddress string
+	// Arch optionally selects a slice of a universal binary (e.g. "arm64").
+	Arch string
+	// Addresses are the raw addresses to resolve.
+	Addresses []string
+}
+
+// Runner executes a command and returns its combined stdout.
+type Runner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// Frame is one resolved (or unresolved) address.
+type Frame struct {
+	Address  string `json:"address"`
+	Symbol   string `json:"symbol,omitempty"`
+	Location string `json:"location,omitempty"` // file:line
+	Raw      string `json:"raw"`
+	Resolved bool   `json:"resolved"`
+}
+
+// Result is the symbolication of a whole request.
+type Result struct {
+	Binary      string  `json:"binary"`
+	LoadAddress string  `json:"load_address"`
+	Arch        string  `json:"arch,omitempty"`
+	Frames      []Frame `json:"frames"`
+}
+
+// locationPattern captures the trailing "(File.ext:123)" atos appends.
+var locationPattern = regexp.MustCompile(`\(([^()]+:\d+)\)\s*$`)
+
+// inImagePattern matches the " (in Image)" qualifier atos inserts after the
+// symbol, which must be removed without dropping a trailing "+ offset".
+var inImagePattern = regexp.MustCompile(`\s*\(in [^)]*\)`)
+
+// Symbolicate resolves req.Addresses against req.Binary via atos (run through
+// runner) and returns a frame per address, in order.
+func Symbolicate(ctx context.Context, req Request, runner Runner) (Result, error) {
+	if req.Binary == "" {
+		return Result{}, fmt.Errorf("symbolicate: a binary or dSYM path is required")
+	}
+	if req.LoadAddress == "" {
+		return Result{}, fmt.Errorf("symbolicate: a load address is required")
+	}
+	if len(req.Addresses) == 0 {
+		return Result{}, fmt.Errorf("symbolicate: at least one address is required")
+	}
+
+	args := []string{"-o", req.Binary, "-l", req.LoadAddress}
+	if req.Arch != "" {
+		args = append(args, "-arch", req.Arch)
+	}
+	args = append(args, req.Addresses...)
+
+	out, err := runner(ctx, "atos", args...)
+	if err != nil {
+		return Result{}, fmt.Errorf("symbolicate: atos failed: %w", err)
+	}
+
+	res := Result{Binary: req.Binary, LoadAddress: req.LoadAddress, Arch: req.Arch}
+	res.Frames = parseFrames(req.Addresses, string(out))
+	return res, nil
+}
+
+// parseFrames pairs each input address with atos's corresponding output line.
+func parseFrames(addresses []string, out string) []Frame {
+	lines := nonEmptyLines(out)
+	frames := make([]Frame, len(addresses))
+	for i, addr := range addresses {
+		f := Frame{Address: addr}
+		if i < len(lines) {
+			f.Raw = lines[i]
+			f.Symbol, f.Location, f.Resolved = parseLine(addr, lines[i])
+		}
+		frames[i] = f
+	}
+	return frames
+}
+
+// parseLine splits one atos output line into a symbol and a file:line location.
+// atos echoes the raw address back when it cannot resolve it.
+func parseLine(addr, line string) (symbol, location string, resolved bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || line == addr {
+		return "", "", false
+	}
+	if m := locationPattern.FindStringSubmatch(line); m != nil {
+		location = m[1]
+		line = strings.TrimSpace(locationPattern.ReplaceAllString(line, ""))
+	}
+	// Drop the "(in Image)" qualifier atos inserts between the symbol and any
+	// trailing "+ offset", keeping the offset.
+	line = strings.TrimSpace(inImagePattern.ReplaceAllString(line, ""))
+	symbol = line
+	resolved = symbol != "" || location != ""
+	return symbol, location, resolved
+}
+
+func nonEmptyLines(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(l); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/symbolicate/symbolicate_test.go
+++ b/internal/symbolicate/symbolicate_test.go
@@ -1,0 +1,93 @@
+package symbolicate
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func runnerReturning(out string, err error) Runner {
+	return func(context.Context, string, ...string) ([]byte, error) { return []byte(out), err }
+}
+
+func TestSymbolicateParsesFrames(t *testing.T) {
+	// One ObjC frame with file:line, one C symbol with an offset, one unresolved
+	// address echoed back by atos.
+	atos := strings.Join([]string{
+		"-[AppDelegate applicationDidFinishLaunching:] (in MyApp) (AppDelegate.m:42)",
+		"main (in MyApp) + 128",
+		"0x000000010a4b31f4",
+	}, "\n")
+	req := Request{Binary: "/MyApp", LoadAddress: "0x10a400000", Addresses: []string{"0x10a4b31a0", "0x10a4b3200", "0x000000010a4b31f4"}}
+	res, err := Symbolicate(context.Background(), req, runnerReturning(atos, nil))
+	if err != nil {
+		t.Fatalf("Symbolicate: %v", err)
+	}
+	if len(res.Frames) != 3 {
+		t.Fatalf("frames = %d", len(res.Frames))
+	}
+
+	f0 := res.Frames[0]
+	if !f0.Resolved || f0.Symbol != "-[AppDelegate applicationDidFinishLaunching:]" || f0.Location != "AppDelegate.m:42" {
+		t.Errorf("frame0 = %+v", f0)
+	}
+
+	f1 := res.Frames[1]
+	if !f1.Resolved || f1.Symbol != "main + 128" || f1.Location != "" {
+		t.Errorf("frame1 = %+v", f1)
+	}
+
+	f2 := res.Frames[2]
+	if f2.Resolved {
+		t.Errorf("frame2 should be unresolved (atos echoed the address): %+v", f2)
+	}
+}
+
+func TestSymbolicatePassesArch(t *testing.T) {
+	var gotArgs []string
+	runner := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte("sym\n"), nil
+	}
+	_, err := Symbolicate(context.Background(), Request{Binary: "/b", LoadAddress: "0x1", Arch: "arm64", Addresses: []string{"0x2"}}, runner)
+	if err != nil {
+		t.Fatalf("Symbolicate: %v", err)
+	}
+	joined := strings.Join(gotArgs, " ")
+	if !strings.Contains(joined, "-arch arm64") || !strings.Contains(joined, "-o /b") || !strings.Contains(joined, "-l 0x1") {
+		t.Errorf("atos args missing expected flags: %v", gotArgs)
+	}
+}
+
+func TestSymbolicateValidation(t *testing.T) {
+	cases := []Request{
+		{LoadAddress: "0x1", Addresses: []string{"0x2"}}, // no binary
+		{Binary: "/b", Addresses: []string{"0x2"}},       // no load address
+		{Binary: "/b", LoadAddress: "0x1"},               // no addresses
+	}
+	for i, req := range cases {
+		if _, err := Symbolicate(context.Background(), req, runnerReturning("", nil)); err == nil {
+			t.Errorf("case %d: expected a validation error", i)
+		}
+	}
+}
+
+func TestSymbolicateRunnerError(t *testing.T) {
+	_, err := Symbolicate(context.Background(), Request{Binary: "/b", LoadAddress: "0x1", Addresses: []string{"0x2"}}, runnerReturning("", errors.New("atos: no such file")))
+	if err == nil {
+		t.Error("expected an error when atos fails")
+	}
+}
+
+func TestSymbolicateFewerLinesThanAddresses(t *testing.T) {
+	// atos returned only one line for two addresses; the second frame stays
+	// unresolved rather than panicking.
+	res, err := Symbolicate(context.Background(), Request{Binary: "/b", LoadAddress: "0x1", Addresses: []string{"0xa", "0xb"}}, runnerReturning("foo (in B) (F.c:1)\n", nil))
+	if err != nil {
+		t.Fatalf("Symbolicate: %v", err)
+	}
+	if !res.Frames[0].Resolved || res.Frames[1].Resolved {
+		t.Errorf("frames = %+v", res.Frames)
+	}
+}

--- a/internal/symbolicate/symbolicate_test.go
+++ b/internal/symbolicate/symbolicate_test.go
@@ -73,6 +73,40 @@ func TestSymbolicateValidation(t *testing.T) {
 	}
 }
 
+func TestSymbolicateRejectsBadLoadAddress(t *testing.T) {
+	ran := false
+	runner := func(context.Context, string, ...string) ([]byte, error) { ran = true; return nil, nil }
+	_, err := Symbolicate(context.Background(), Request{Binary: "/b", LoadAddress: "not-an-address", Addresses: []string{"0x2"}}, runner)
+	if err == nil {
+		t.Error("expected a validation error for a non-hex load address")
+	}
+	if ran {
+		t.Error("atos must not run when the load address is invalid")
+	}
+	// A bare hex value (no 0x) is still valid.
+	if _, err := Symbolicate(context.Background(), Request{Binary: "/b", LoadAddress: "10a400000", Addresses: []string{"0x2"}}, runnerReturning("s\n", nil)); err != nil {
+		t.Errorf("bare hex load address should be accepted: %v", err)
+	}
+}
+
+func TestSymbolicatePreservesBlankLines(t *testing.T) {
+	// atos returned a blank line for the middle address; the third address must
+	// still pair with symbol-C, not shift up.
+	res, err := Symbolicate(context.Background(), Request{Binary: "/b", LoadAddress: "0x1", Addresses: []string{"0xa", "0xb", "0xc"}}, runnerReturning("symbol-A\n\nsymbol-C\n", nil))
+	if err != nil {
+		t.Fatalf("Symbolicate: %v", err)
+	}
+	if res.Frames[0].Symbol != "symbol-A" {
+		t.Errorf("frame0 = %+v", res.Frames[0])
+	}
+	if res.Frames[1].Resolved {
+		t.Errorf("frame1 (blank line) should be unresolved: %+v", res.Frames[1])
+	}
+	if res.Frames[2].Symbol != "symbol-C" {
+		t.Errorf("frame2 = %+v", res.Frames[2])
+	}
+}
+
 func TestSymbolicateRunnerError(t *testing.T) {
 	_, err := Symbolicate(context.Background(), Request{Binary: "/b", LoadAddress: "0x1", Addresses: []string{"0x2"}}, runnerReturning("", errors.New("atos: no such file")))
 	if err == nil {


### PR DESCRIPTION
## What

`spectra symbolicate` — resolves raw stack addresses to `symbol + file:line` via `atos`, against a Mach-O image or its `.dSYM`. **Item 1 of the native-capture line (Phase A)** and the enabler for everything that follows: a captured stack (core, crash report, spindump) is just hex until it's symbolicated.

## How

- **`internal/symbolicate`** runs `atos -o <binary> -l <load> [-arch <arch>] <addr>...` through an **injected runner** and parses each output line into a symbol and a `file:line` location, pairing frames with the input addresses **in order**. An address `atos` can't resolve (it echoes the address back) is reported `resolved: false`, not dropped. The `(in Image)` qualifier is stripped without losing a trailing `+ offset`.
- **`spectra symbolicate -o <bin> -l <load> [--arch] [--json] <addr>...`** — addresses positional or read from stdin (one per line). Read-only, no root; validates that `-o`, `-l`, and at least one address are present.

## Testing

Parsing is unit-tested with canned `atos` output: an ObjC frame with `file:line`, a C symbol with `+ offset` (offset preserved), and an unresolved address echoed back; plus arch-flag pass-through, input validation, a runner error, and fewer output lines than addresses (no panic). CLI tests: positional, stdin, required-flag rejection, and `--json`. `make vet complexity lint security docs-validate test` green (62 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

## Note

Later Phase-A items (`spindump`/`vmmap`/`lsmp`/`malloc_history`) will feed their raw addresses through this.

Closes #405
