### PR TITLE
spindump: spectra spindump — capture and summarize per-thread stack reports (heaviest stacks)

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -70,6 +70,7 @@ func subcommandList() []subcommand {
 		{"schedule", "Schedule periodic snapshot capture via a launchd agent", runSchedule},
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
 		{"symbolicate", "Resolve raw stack addresses to symbol + file:line via atos", runSymbolicate},
+		{"spindump", "Capture and summarize a per-thread stack report (heaviest stacks)", runSpindump},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/cmd/spectra/spindump.go
+++ b/cmd/spectra/spindump.go
@@ -14,14 +14,33 @@ import (
 	"github.com/kaeawc/spectra/internal/spindump"
 )
 
+// Absolute paths to the macOS utilities, so PATH cannot substitute them.
+const (
+	spindumpBin = "/usr/sbin/spindump"
+	sudoBin     = "/usr/bin/sudo"
+)
+
 // spindumpRunner runs a command and returns its combined output.
 type spindumpRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
 
-func runSpindump(args []string) int {
-	return runSpindumpWithIO(args, os.Stdout, os.Stderr, defaultSpindumpRunner)
+// spindumpDeps injects command execution and filesystem access so the command
+// is testable without a real capture or real files.
+type spindumpDeps struct {
+	run       spindumpRunner
+	readFile  func(path string) ([]byte, error)
+	writeFile func(path string, data []byte, perm os.FileMode) error
 }
 
-func runSpindumpWithIO(args []string, stdout, stderr io.Writer, runner spindumpRunner) int {
+func runSpindump(args []string) int {
+	deps := spindumpDeps{
+		run:       defaultSpindumpRunner,
+		readFile:  os.ReadFile,
+		writeFile: os.WriteFile,
+	}
+	return runSpindumpWithIO(args, os.Stdout, os.Stderr, deps)
+}
+
+func runSpindumpWithIO(args []string, stdout, stderr io.Writer, deps spindumpDeps) int {
 	fs := flag.NewFlagSet("spectra spindump", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	input := fs.String("input", "", "Parse an existing spindump report file instead of capturing")
@@ -39,7 +58,11 @@ func runSpindumpWithIO(args []string, stdout, stderr io.Writer, runner spindumpR
 			fmt.Fprintln(stderr, "spindump: pass either --input or a pid, not both")
 			return 2
 		}
-		data, err := os.ReadFile(*input)
+		if *out != "" {
+			fmt.Fprintln(stderr, "spindump: --out has no effect with --input (the report already exists)")
+			return 2
+		}
+		data, err := deps.readFile(*input)
 		if err != nil {
 			fmt.Fprintf(stderr, "spindump: read %s: %v\n", *input, err)
 			return 1
@@ -55,13 +78,13 @@ func runSpindumpWithIO(args []string, stdout, stderr io.Writer, runner spindumpR
 			fmt.Fprintf(stderr, "invalid PID %q\n", fs.Arg(0))
 			return 2
 		}
-		report, err = captureSpindump(runner, pid, *duration, *sudo)
+		report, err = captureSpindump(deps.run, pid, *duration, *sudo)
 		if err != nil {
 			fmt.Fprintf(stderr, "%v\n", err)
 			return 1
 		}
 		if *out != "" {
-			if err := os.WriteFile(*out, []byte(report), 0o600); err != nil {
+			if err := deps.writeFile(*out, []byte(report), 0o600); err != nil {
 				fmt.Fprintf(stderr, "spindump: write %s: %v\n", *out, err)
 				return 1
 			}
@@ -80,11 +103,11 @@ func runSpindumpWithIO(args []string, stdout, stderr io.Writer, runner spindumpR
 }
 
 func captureSpindump(runner spindumpRunner, pid, duration int, sudo bool) (string, error) {
-	name := "spindump"
+	name := spindumpBin
 	args := []string{strconv.Itoa(pid), strconv.Itoa(duration), "-stdout"}
 	if sudo {
 		args = append([]string{name}, args...)
-		name = "sudo"
+		name = sudoBin
 	}
 	out, err := runner(context.Background(), name, args...)
 	if err != nil {

--- a/cmd/spectra/spindump.go
+++ b/cmd/spectra/spindump.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/spindump"
+)
+
+// spindumpRunner runs a command and returns its combined output.
+type spindumpRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func runSpindump(args []string) int {
+	return runSpindumpWithIO(args, os.Stdout, os.Stderr, defaultSpindumpRunner)
+}
+
+func runSpindumpWithIO(args []string, stdout, stderr io.Writer, runner spindumpRunner) int {
+	fs := flag.NewFlagSet("spectra spindump", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	input := fs.String("input", "", "Parse an existing spindump report file instead of capturing")
+	duration := fs.Int("duration", 2, "Capture duration in seconds")
+	sudo := fs.Bool("sudo", false, "Prepend sudo (spindump requires root to sample a live process)")
+	out := fs.String("out", "", "Also write the raw report to this file")
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	var report string
+	if *input != "" {
+		if fs.NArg() != 0 {
+			fmt.Fprintln(stderr, "spindump: pass either --input or a pid, not both")
+			return 2
+		}
+		data, err := os.ReadFile(*input)
+		if err != nil {
+			fmt.Fprintf(stderr, "spindump: read %s: %v\n", *input, err)
+			return 1
+		}
+		report = string(data)
+	} else {
+		if fs.NArg() != 1 {
+			fmt.Fprintln(stderr, "usage: spectra spindump [--duration <s>] [--sudo] [--out <file>] <pid>   (or --input <file>)")
+			return 2
+		}
+		pid, err := strconv.Atoi(fs.Arg(0))
+		if err != nil || pid <= 0 {
+			fmt.Fprintf(stderr, "invalid PID %q\n", fs.Arg(0))
+			return 2
+		}
+		report, err = captureSpindump(runner, pid, *duration, *sudo)
+		if err != nil {
+			fmt.Fprintf(stderr, "%v\n", err)
+			return 1
+		}
+		if *out != "" {
+			if err := os.WriteFile(*out, []byte(report), 0o600); err != nil {
+				fmt.Fprintf(stderr, "spindump: write %s: %v\n", *out, err)
+				return 1
+			}
+		}
+	}
+
+	parsed := spindump.Parse(report)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(parsed)
+		return 0
+	}
+	printSpindump(stdout, parsed)
+	return 0
+}
+
+func captureSpindump(runner spindumpRunner, pid, duration int, sudo bool) (string, error) {
+	name := "spindump"
+	args := []string{strconv.Itoa(pid), strconv.Itoa(duration), "-stdout"}
+	if sudo {
+		args = append([]string{name}, args...)
+		name = "sudo"
+	}
+	out, err := runner(context.Background(), name, args...)
+	if err != nil {
+		if strings.Contains(string(out), "must be run as root") || strings.Contains(err.Error(), "must be run as root") {
+			return "", fmt.Errorf("spindump requires root — re-run with --sudo (or as root)")
+		}
+		return "", fmt.Errorf("spindump capture failed: %w", err)
+	}
+	if strings.Contains(string(out), "must be run as root") {
+		return "", fmt.Errorf("spindump requires root — re-run with --sudo (or as root)")
+	}
+	return string(out), nil
+}
+
+func printSpindump(w io.Writer, r spindump.Report) {
+	fmt.Fprint(w, "=== spindump summary ===\n")
+	if r.Duration != "" {
+		fmt.Fprintf(w, "duration: %s\n", r.Duration)
+	}
+	if len(r.Processes) == 0 {
+		fmt.Fprintln(w, "  (no processes parsed)")
+		return
+	}
+	for _, p := range r.Processes {
+		fmt.Fprintf(w, "  %s [%d]\n", p.Name, p.PID)
+		for _, f := range p.Heaviest {
+			fmt.Fprintf(w, "    %6d  %s\n", f.Samples, truncate(f.Symbol, 72))
+		}
+	}
+}
+
+func defaultSpindumpRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}

--- a/cmd/spectra/spindump_test.go
+++ b/cmd/spectra/spindump_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const cliReport = `Duration:         2.0s
+
+Process:          Foo [4012]
+  100  Thread_1
+    100  main + 1 (Foo + 1) [0x1]
+      90  work + 2 (Foo + 2) [0x2]
+`
+
+func TestRunSpindumpInput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.txt")
+	if err := os.WriteFile(path, []byte(cliReport), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out, errBuf bytes.Buffer
+	code := runSpindumpWithIO([]string{"--input", path}, &out, &errBuf, failRunner)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "Foo [4012]") || !strings.Contains(out.String(), "work") {
+		t.Errorf("expected parsed summary, got:\n%s", out.String())
+	}
+}
+
+func TestRunSpindumpCapture(t *testing.T) {
+	runner := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		return []byte(cliReport), nil
+	}
+	var out, errBuf bytes.Buffer
+	code := runSpindumpWithIO([]string{"--duration", "1", "4012"}, &out, &errBuf, runner)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "Foo [4012]") {
+		t.Errorf("expected captured summary, got:\n%s", out.String())
+	}
+}
+
+func TestRunSpindumpRootErrorMessage(t *testing.T) {
+	runner := func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("spindump must be run as root when sampling the live system\n"), errors.New("exit status 1")
+	}
+	var out, errBuf bytes.Buffer
+	code := runSpindumpWithIO([]string{"4012"}, &out, &errBuf, runner)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "--sudo") {
+		t.Errorf("expected a --sudo hint on the root error, got: %q", errBuf.String())
+	}
+}
+
+func TestRunSpindumpSudoPrefixesCommand(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	runner := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotName, gotArgs = name, args
+		return []byte(cliReport), nil
+	}
+	var out, errBuf bytes.Buffer
+	if code := runSpindumpWithIO([]string{"--sudo", "4012"}, &out, &errBuf, runner); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if gotName != "sudo" || len(gotArgs) == 0 || gotArgs[0] != "spindump" {
+		t.Errorf("expected `sudo spindump ...`, got name=%q args=%v", gotName, gotArgs)
+	}
+}
+
+func TestRunSpindumpArgValidation(t *testing.T) {
+	cases := [][]string{
+		{},                        // no pid, no input
+		{"notapid"},               // bad pid
+		{"--input", "/f", "4012"}, // both input and pid
+	}
+	for _, args := range cases {
+		var out, errBuf bytes.Buffer
+		if code := runSpindumpWithIO(args, &out, &errBuf, failRunner); code != 2 && code != 1 {
+			t.Errorf("args %v: exit = %d, want non-zero usage/error", args, code)
+		}
+	}
+}
+
+func failRunner(context.Context, string, ...string) ([]byte, error) {
+	return nil, errors.New("runner should not be called")
+}

--- a/cmd/spectra/spindump_test.go
+++ b/cmd/spectra/spindump_test.go
@@ -5,10 +5,29 @@ import (
 	"context"
 	"errors"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// testDeps builds spindumpDeps whose runner is the given func and whose
+// filesystem is served from an in-memory map.
+func testDeps(run spindumpRunner, files map[string]string, written map[string]string) spindumpDeps {
+	return spindumpDeps{
+		run: run,
+		readFile: func(path string) ([]byte, error) {
+			if v, ok := files[path]; ok {
+				return []byte(v), nil
+			}
+			return nil, os.ErrNotExist
+		},
+		writeFile: func(path string, data []byte, _ os.FileMode) error {
+			if written != nil {
+				written[path] = string(data)
+			}
+			return nil
+		},
+	}
+}
 
 const cliReport = `Duration:         2.0s
 
@@ -19,13 +38,9 @@ Process:          Foo [4012]
 `
 
 func TestRunSpindumpInput(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "report.txt")
-	if err := os.WriteFile(path, []byte(cliReport), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	deps := testDeps(failRunner, map[string]string{"/reports/report.txt": cliReport}, nil)
 	var out, errBuf bytes.Buffer
-	code := runSpindumpWithIO([]string{"--input", path}, &out, &errBuf, failRunner)
+	code := runSpindumpWithIO([]string{"--input", "/reports/report.txt"}, &out, &errBuf, deps)
 	if code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
 	}
@@ -34,17 +49,22 @@ func TestRunSpindumpInput(t *testing.T) {
 	}
 }
 
-func TestRunSpindumpCapture(t *testing.T) {
+func TestRunSpindumpCaptureWritesOut(t *testing.T) {
+	written := map[string]string{}
 	runner := func(_ context.Context, name string, args ...string) ([]byte, error) {
 		return []byte(cliReport), nil
 	}
+	deps := testDeps(runner, nil, written)
 	var out, errBuf bytes.Buffer
-	code := runSpindumpWithIO([]string{"--duration", "1", "4012"}, &out, &errBuf, runner)
+	code := runSpindumpWithIO([]string{"--duration", "1", "--out", "/tmp/raw.txt", "4012"}, &out, &errBuf, deps)
 	if code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
 	}
 	if !strings.Contains(out.String(), "Foo [4012]") {
 		t.Errorf("expected captured summary, got:\n%s", out.String())
+	}
+	if written["/tmp/raw.txt"] != cliReport {
+		t.Errorf("--out did not save the raw report: %q", written["/tmp/raw.txt"])
 	}
 }
 
@@ -53,7 +73,7 @@ func TestRunSpindumpRootErrorMessage(t *testing.T) {
 		return []byte("spindump must be run as root when sampling the live system\n"), errors.New("exit status 1")
 	}
 	var out, errBuf bytes.Buffer
-	code := runSpindumpWithIO([]string{"4012"}, &out, &errBuf, runner)
+	code := runSpindumpWithIO([]string{"4012"}, &out, &errBuf, testDeps(runner, nil, nil))
 	if code != 1 {
 		t.Fatalf("exit = %d, want 1", code)
 	}
@@ -62,7 +82,7 @@ func TestRunSpindumpRootErrorMessage(t *testing.T) {
 	}
 }
 
-func TestRunSpindumpSudoPrefixesCommand(t *testing.T) {
+func TestRunSpindumpSudoUsesAbsolutePaths(t *testing.T) {
 	var gotName string
 	var gotArgs []string
 	runner := func(_ context.Context, name string, args ...string) ([]byte, error) {
@@ -70,15 +90,24 @@ func TestRunSpindumpSudoPrefixesCommand(t *testing.T) {
 		return []byte(cliReport), nil
 	}
 	var out, errBuf bytes.Buffer
-	if code := runSpindumpWithIO([]string{"--sudo", "4012"}, &out, &errBuf, runner); code != 0 {
+	if code := runSpindumpWithIO([]string{"--sudo", "4012"}, &out, &errBuf, testDeps(runner, nil, nil)); code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
-	if gotName != "sudo" || len(gotArgs) == 0 || gotArgs[0] != "spindump" {
-		t.Errorf("expected `sudo spindump ...`, got name=%q args=%v", gotName, gotArgs)
+	if gotName != sudoBin || len(gotArgs) == 0 || gotArgs[0] != spindumpBin {
+		t.Errorf("expected `%s %s ...`, got name=%q args=%v", sudoBin, spindumpBin, gotName, gotArgs)
+	}
+}
+
+func TestRunSpindumpRejectsOutWithInput(t *testing.T) {
+	deps := testDeps(failRunner, map[string]string{"/f": cliReport}, map[string]string{})
+	var out, errBuf bytes.Buffer
+	if code := runSpindumpWithIO([]string{"--input", "/f", "--out", "/o"}, &out, &errBuf, deps); code != 2 {
+		t.Fatalf("exit = %d, want 2 for --out with --input", code)
 	}
 }
 
 func TestRunSpindumpArgValidation(t *testing.T) {
+	deps := testDeps(failRunner, nil, nil)
 	cases := [][]string{
 		{},                        // no pid, no input
 		{"notapid"},               // bad pid
@@ -86,7 +115,7 @@ func TestRunSpindumpArgValidation(t *testing.T) {
 	}
 	for _, args := range cases {
 		var out, errBuf bytes.Buffer
-		if code := runSpindumpWithIO(args, &out, &errBuf, failRunner); code != 2 && code != 1 {
+		if code := runSpindumpWithIO(args, &out, &errBuf, deps); code != 2 && code != 1 {
 			t.Errorf("args %v: exit = %d, want non-zero usage/error", args, code)
 		}
 	}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -391,6 +391,28 @@ spectra symbolicate -o ./Some.app.dSYM -l 0x10a400000 --arch arm64 --json 0x10a4
 lldb-derived-addresses.txt | spectra symbolicate -o ./Some -l 0x10a400000
 ```
 
+## `spectra spindump`
+
+Captures and summarizes a `spindump` report — per-thread call trees with
+per-frame sample counts — which is otherwise hundreds of lines of indented text.
+The parser is the core and works two ways: `--input <file>` parses a report you
+already have (no root), and `spectra spindump <pid>` captures one. Because
+`spindump` must run as root to sample a live process, `--sudo` prepends `sudo`,
+and a permission failure is reported as "run with --sudo (or as root)" rather
+than a raw error. The summary shows the capture duration and, per process, its
+name, pid, and the heaviest symbols (top frames by sample count, with thread and
+dispatch-queue headers excluded). `--out <file>` also saves the raw report; raw
+frame addresses can be fed through `spectra symbolicate`. `--json` emits the
+structured result.
+
+### Examples
+
+```bash
+spectra spindump --duration 3 --sudo 4012
+spectra spindump --input /tmp/foo.spindump.txt
+spectra spindump --sudo --out /tmp/foo.txt --json 4012
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/spindump/spindump.go
+++ b/internal/spindump/spindump.go
@@ -1,0 +1,127 @@
+// Package spindump captures and summarizes macOS spindump reports — per-thread
+// call trees with per-frame sample counts. The raw report is hundreds of lines
+// of indented text; this package parses it into the heaviest symbols per
+// process so a wedged or busy process can be triaged at a glance.
+package spindump
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Frame is one symbol and how many samples landed on it.
+type Frame struct {
+	Symbol  string `json:"symbol"`
+	Samples int    `json:"samples"`
+}
+
+// ProcessReport summarizes one process in a spindump report.
+type ProcessReport struct {
+	Name     string  `json:"name"`
+	PID      int     `json:"pid"`
+	Heaviest []Frame `json:"heaviest,omitempty"`
+}
+
+// Report is the parsed summary of a whole spindump report.
+type Report struct {
+	Duration  string          `json:"duration,omitempty"`
+	Processes []ProcessReport `json:"processes"`
+}
+
+// defaultTopFrames is how many hot symbols to keep per process.
+const defaultTopFrames = 5
+
+var (
+	processHeader = regexp.MustCompile(`^Process:\s+(.+?)\s+\[(\d+)\]`)
+	durationLine  = regexp.MustCompile(`^Duration:\s+(.+)$`)
+	// frameLine matches an indented "  <samples>  <rest>" call-tree line.
+	frameLine = regexp.MustCompile(`^(\s+)(\d+)\s+(.*\S)\s*$`)
+	// offsetSuffix matches a trailing " + 1234" byte offset on a symbol.
+	offsetSuffix = regexp.MustCompile(`\s+\+\s+\d+$`)
+)
+
+// Parse turns a raw spindump report into a summary.
+func Parse(report string) Report {
+	var rep Report
+	var cur *ProcessReport
+	// samplesBySymbol accumulates the max sample count seen per symbol for the
+	// current process.
+	var samplesBySymbol map[string]int
+
+	flush := func() {
+		if cur != nil {
+			cur.Heaviest = topFrames(samplesBySymbol, defaultTopFrames)
+			rep.Processes = append(rep.Processes, *cur)
+		}
+	}
+
+	for _, line := range strings.Split(report, "\n") {
+		if m := durationLine.FindStringSubmatch(line); m != nil && rep.Duration == "" {
+			rep.Duration = strings.TrimSpace(m[1])
+			continue
+		}
+		if m := processHeader.FindStringSubmatch(line); m != nil {
+			flush()
+			pid, _ := strconv.Atoi(m[2])
+			cur = &ProcessReport{Name: strings.TrimSpace(m[1]), PID: pid}
+			samplesBySymbol = map[string]int{}
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		if m := frameLine.FindStringSubmatch(line); m != nil {
+			samples, _ := strconv.Atoi(m[2])
+			sym := frameSymbol(m[3])
+			if sym == "" || isThreadHeader(m[3]) {
+				continue
+			}
+			if samples > samplesBySymbol[sym] {
+				samplesBySymbol[sym] = samples
+			}
+		}
+	}
+	flush()
+	return rep
+}
+
+// frameSymbol extracts the symbol name from a call-tree frame's text, dropping
+// the "(Image + off)" qualifier, the "[0x...]" address, and a trailing byte
+// offset.
+func frameSymbol(rest string) string {
+	if i := strings.Index(rest, " ("); i >= 0 {
+		rest = rest[:i]
+	}
+	if i := strings.Index(rest, " ["); i >= 0 {
+		rest = rest[:i]
+	}
+	rest = offsetSuffix.ReplaceAllString(rest, "")
+	return strings.TrimSpace(rest)
+}
+
+// isThreadHeader reports whether a frame's text is actually a thread or
+// dispatch-queue header rather than a real stack frame.
+func isThreadHeader(rest string) bool {
+	return strings.Contains(rest, "Thread_") ||
+		strings.Contains(rest, "DispatchQueue") ||
+		strings.HasPrefix(rest, "Thread ")
+}
+
+func topFrames(bySymbol map[string]int, n int) []Frame {
+	frames := make([]Frame, 0, len(bySymbol))
+	for sym, samples := range bySymbol {
+		frames = append(frames, Frame{Symbol: sym, Samples: samples})
+	}
+	sort.SliceStable(frames, func(i, j int) bool {
+		if frames[i].Samples != frames[j].Samples {
+			return frames[i].Samples > frames[j].Samples
+		}
+		return frames[i].Symbol < frames[j].Symbol
+	})
+	if len(frames) > n {
+		frames = frames[:n]
+	}
+	return frames
+}

--- a/internal/spindump/spindump.go
+++ b/internal/spindump/spindump.go
@@ -65,7 +65,7 @@ func Parse(report string) Report {
 		if m := processHeader.FindStringSubmatch(line); m != nil {
 			flush()
 			pid, _ := strconv.Atoi(m[2])
-			cur = &ProcessReport{Name: strings.TrimSpace(m[1]), PID: pid}
+			cur = &ProcessReport{Name: sanitize(strings.TrimSpace(m[1])), PID: pid}
 			samplesBySymbol = map[string]int{}
 			continue
 		}
@@ -98,7 +98,22 @@ func frameSymbol(rest string) string {
 		rest = rest[:i]
 	}
 	rest = offsetSuffix.ReplaceAllString(rest, "")
-	return strings.TrimSpace(rest)
+	return sanitize(strings.TrimSpace(rest))
+}
+
+// sanitize removes terminal control bytes from text taken from a report, so an
+// untrusted report cannot inject escape sequences into the terminal or JSON.
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t':
+			return ' '
+		case r < 0x20 || r == 0x7f:
+			return -1
+		default:
+			return r
+		}
+	}, s)
 }
 
 // isThreadHeader reports whether a frame's text is actually a thread or

--- a/internal/spindump/spindump_test.go
+++ b/internal/spindump/spindump_test.go
@@ -1,0 +1,95 @@
+package spindump
+
+import "testing"
+
+const sampleReport = `Date/Time:        2026-08-30 12:00:00 -0700
+Duration:         2.01s
+Steps:            201
+
+Process:          Foo [4012]
+Path:             /Applications/Foo.app/Contents/MacOS/Foo
+Architecture:     arm64
+
+  201  Thread_1001   DispatchQueue_1: com.apple.main-thread  (serial)
+    201  start + 1903 (dyld + 21631) [0x1a2b3c4d]
+      201  main + 128 (Foo + 4096) [0x104a01000]
+        150  -[Renderer draw:] + 44 (Foo + 8192) [0x104a02000]
+          150  CGContextFillRects + 12 (CoreGraphics + 100) [0x1b0000000]
+        51  -[Renderer idle] + 8 (Foo + 9000) [0x104a03000]
+
+Process:          bar [55]
+Path:             /usr/bin/bar
+
+  40  Thread_2002
+    40  poll + 10 (libsystem_kernel.dylib + 20) [0x1c0000000]
+`
+
+func TestParseProcessesAndDuration(t *testing.T) {
+	rep := Parse(sampleReport)
+	if rep.Duration != "2.01s" {
+		t.Errorf("duration = %q", rep.Duration)
+	}
+	if len(rep.Processes) != 2 {
+		t.Fatalf("processes = %d, want 2", len(rep.Processes))
+	}
+	foo := rep.Processes[0]
+	if foo.Name != "Foo" || foo.PID != 4012 {
+		t.Errorf("foo header = %q [%d]", foo.Name, foo.PID)
+	}
+}
+
+func TestParseHeaviestRankedAndThreadHeadersExcluded(t *testing.T) {
+	rep := Parse(sampleReport)
+	foo := rep.Processes[0]
+	if len(foo.Heaviest) == 0 {
+		t.Fatal("expected heaviest frames for Foo")
+	}
+	// The hottest symbol should be one of the 201-sample frames, never the
+	// thread/dispatch-queue header.
+	for _, f := range foo.Heaviest {
+		if f.Symbol == "" || containsThreadMarker(f.Symbol) {
+			t.Errorf("thread header leaked into hotspots: %q", f.Symbol)
+		}
+	}
+	top := foo.Heaviest[0]
+	if top.Samples != 201 {
+		t.Errorf("top samples = %d, want 201 (%q)", top.Samples, top.Symbol)
+	}
+	// Symbols must be stripped of the (Image + off), [addr], and "+ off" noise.
+	if !hasSymbol(foo.Heaviest, "-[Renderer draw:]", 150) {
+		t.Errorf("expected a clean -[Renderer draw:] frame at 150 samples, got %+v", foo.Heaviest)
+	}
+}
+
+func TestParseEmptyReport(t *testing.T) {
+	if rep := Parse(""); len(rep.Processes) != 0 {
+		t.Errorf("empty report should have no processes, got %+v", rep.Processes)
+	}
+}
+
+func containsThreadMarker(s string) bool {
+	return isThreadHeader(s)
+}
+
+func hasSymbol(frames []Frame, sym string, samples int) bool {
+	for _, f := range frames {
+		if f.Symbol == sym && f.Samples == samples {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFrameSymbolStripping(t *testing.T) {
+	cases := map[string]string{
+		"main + 128 (Foo + 4096) [0x104a01000]":         "main",
+		"-[Renderer draw:] + 44 (Foo + 8192) [0x1]":     "-[Renderer draw:]",
+		"poll + 10 (libsystem_kernel.dylib + 20) [0x1]": "poll",
+		"symbol_without_qualifiers":                     "symbol_without_qualifiers",
+	}
+	for in, want := range cases {
+		if got := frameSymbol(in); got != want {
+			t.Errorf("frameSymbol(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/spindump/spindump_test.go
+++ b/internal/spindump/spindump_test.go
@@ -1,6 +1,9 @@
 package spindump
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const sampleReport = `Date/Time:        2026-08-30 12:00:00 -0700
 Duration:         2.01s
@@ -58,6 +61,24 @@ func TestParseHeaviestRankedAndThreadHeadersExcluded(t *testing.T) {
 	// Symbols must be stripped of the (Image + off), [addr], and "+ off" noise.
 	if !hasSymbol(foo.Heaviest, "-[Renderer draw:]", 150) {
 		t.Errorf("expected a clean -[Renderer draw:] frame at 150 samples, got %+v", foo.Heaviest)
+	}
+}
+
+func TestParseStripsControlBytes(t *testing.T) {
+	// A report whose process name and a frame carry terminal escape bytes must
+	// come out sanitized.
+	report := "Process:          Ev\x1b[31mil [7]\n  9  Thread_1\n    9  bad\x07sym + 1 (X + 1) [0x1]\n"
+	rep := Parse(report)
+	if len(rep.Processes) != 1 {
+		t.Fatalf("processes = %d", len(rep.Processes))
+	}
+	if strings.ContainsRune(rep.Processes[0].Name, 0x1b) {
+		t.Errorf("process name still has an escape byte: %q", rep.Processes[0].Name)
+	}
+	for _, f := range rep.Processes[0].Heaviest {
+		if strings.ContainsRune(f.Symbol, 0x07) {
+			t.Errorf("symbol still has a control byte: %q", f.Symbol)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

`spectra spindump` — captures and summarizes a `spindump` report (per-thread call trees with per-frame sample counts) into the **heaviest symbols per process**, so a wedged/busy process is triageable at a glance instead of scrolling hundreds of indented lines. **Phase-A item 2** of the native-capture line (after `symbolicate`).

## How

- **`internal/spindump`** parses a report into per-process heaviest symbols: it reads the `Duration:` and `Process: Name [pid]` headers, walks the indented `  <samples>  <frame>` call-tree lines, strips the `(Image + off)` / `[addr]` / trailing `+ off` noise to a clean symbol, **excludes** thread/dispatch-queue headers from the ranking, and keeps the top frames by sample count. The parser is the core and needs no root.
- **`spectra spindump`** — `--input <file>` parses an existing report (no root, fully testable); `<pid>` captures via `spindump <pid> <dur> -stdout` through an **injected runner**. Since `spindump` requires root, `--sudo` prepends `sudo` and a permission failure is surfaced as a clear "run with --sudo (or as root)" message, not a raw error. `--out` saves the raw report (whose addresses can feed `spectra symbolicate`); `--json` for structured output.

## Testing

Parser tests against a canned two-process report: duration + process headers, heaviest-frame ranking with the 201-sample hot frame on top, thread/dispatch-queue headers excluded from hotspots, clean symbol stripping, and an empty report. CLI tests: `--input`, capture via fake runner, the root-error `--sudo` hint, `sudo` command prefixing, and arg validation. `make vet complexity lint security docs-validate test` green (63 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

## Scope note

Wiring capture through the privileged helper (so it works without `sudo` when the helper is installed) is a deliberate follow-on, kept separate to avoid a helper-protocol change buried mid-sequence.

Closes #407
