### PR TITLE
vmmap: spectra vmmap — per-process memory composition by region (dirty/resident/swapped)

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -71,6 +71,7 @@ func subcommandList() []subcommand {
 		{"sample", "Collect a user-space CPU sample of a running process", runSample},
 		{"symbolicate", "Resolve raw stack addresses to symbol + file:line via atos", runSymbolicate},
 		{"spindump", "Capture and summarize a per-thread stack report (heaviest stacks)", runSpindump},
+		{"vmmap", "Summarize a process's memory composition by region (dirty/resident/swapped)", runVmmap},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/cmd/spectra/vmmap.go
+++ b/cmd/spectra/vmmap.go
@@ -31,6 +31,10 @@ func runVmmapWithIO(args []string, stdout, stderr io.Writer, runner vmmapRunner)
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	if *top < 0 {
+		fmt.Fprintln(stderr, "vmmap: --top must be >= 0 (0 means all regions)")
+		return 2
+	}
 	if fs.NArg() != 1 {
 		fmt.Fprintln(stderr, "usage: spectra vmmap [--top <n>] [--json] <pid>")
 		return 2
@@ -91,5 +95,10 @@ func printVmmap(w io.Writer, pid int, s vmmap.Summary) {
 }
 
 func defaultVmmapRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	if err != nil {
+		// Return out too: the caller inspects it to detect a permission failure.
+		return out, fmt.Errorf("vmmap --summary: %w", err)
+	}
+	return out, nil
 }

--- a/cmd/spectra/vmmap.go
+++ b/cmd/spectra/vmmap.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/vmmap"
+)
+
+const vmmapBin = "/usr/bin/vmmap"
+
+// vmmapRunner runs a command and returns its combined output.
+type vmmapRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func runVmmap(args []string) int {
+	return runVmmapWithIO(args, os.Stdout, os.Stderr, defaultVmmapRunner)
+}
+
+func runVmmapWithIO(args []string, stdout, stderr io.Writer, runner vmmapRunner) int {
+	fs := flag.NewFlagSet("spectra vmmap", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	top := fs.Int("top", 8, "Show the top N region types by dirty size (0 for all)")
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "usage: spectra vmmap [--top <n>] [--json] <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil || pid <= 0 {
+		fmt.Fprintf(stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	out, err := runner(context.Background(), vmmapBin, "--summary", strconv.Itoa(pid))
+	if err != nil {
+		if isVmmapPermission(string(out)) {
+			fmt.Fprintf(stderr, "vmmap: not permitted for PID %d — it likely belongs to another user; re-run as root (sudo)\n", pid)
+			return 1
+		}
+		fmt.Fprintf(stderr, "vmmap failed for PID %d: %v\n", pid, err)
+		return 1
+	}
+	if isVmmapPermission(string(out)) {
+		fmt.Fprintf(stderr, "vmmap: not permitted for PID %d — it likely belongs to another user; re-run as root (sudo)\n", pid)
+		return 1
+	}
+
+	summary := vmmap.Parse(string(out), *top)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(summary)
+		return 0
+	}
+	printVmmap(stdout, pid, summary)
+	return 0
+}
+
+func isVmmapPermission(out string) bool {
+	l := strings.ToLower(out)
+	return strings.Contains(l, "not permitted") || strings.Contains(l, "unable to access") ||
+		strings.Contains(l, "resource must be") || strings.Contains(l, "only root")
+}
+
+func printVmmap(w io.Writer, pid int, s vmmap.Summary) {
+	fmt.Fprintf(w, "=== vmmap composition (pid %d) ===\n", pid)
+	fmt.Fprintf(w, "footprint: %s", humanSize(s.FootprintBytes))
+	if s.FootprintPeakBytes > 0 {
+		fmt.Fprintf(w, " (peak %s)", humanSize(s.FootprintPeakBytes))
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  %-30s %10s %10s %10s %10s\n", "REGION", "VIRTUAL", "RESIDENT", "DIRTY", "SWAPPED")
+	for _, r := range s.Regions {
+		fmt.Fprintf(w, "  %-30s %10s %10s %10s %10s\n",
+			truncate(r.Type, 30), humanSize(r.VirtualBytes), humanSize(r.ResidentBytes),
+			humanSize(r.DirtyBytes), humanSize(r.SwappedBytes))
+	}
+	fmt.Fprintf(w, "  %-30s %10s %10s %10s %10s\n", "TOTAL",
+		humanSize(s.TotalVirtualBytes), humanSize(s.TotalResidentBytes),
+		humanSize(s.TotalDirtyBytes), humanSize(s.TotalSwappedBytes))
+}
+
+func defaultVmmapRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}

--- a/cmd/spectra/vmmap_test.go
+++ b/cmd/spectra/vmmap_test.go
@@ -60,10 +60,21 @@ func TestRunVmmapPermissionMessage(t *testing.T) {
 
 func TestRunVmmapArgValidation(t *testing.T) {
 	runner := vmmapRunnerReturning(vmmapCLIOut, nil)
-	for _, args := range [][]string{{}, {"notapid"}, {"0"}, {"1", "2"}} {
+	for _, args := range [][]string{{}, {"notapid"}, {"0"}, {"1", "2"}, {"--top", "-1", "4012"}} {
 		var out, errBuf bytes.Buffer
 		if code := runVmmapWithIO(args, &out, &errBuf, runner); code != 2 {
 			t.Errorf("args %v: exit = %d, want 2", args, code)
 		}
+	}
+}
+
+func TestRunVmmapGenericError(t *testing.T) {
+	runner := vmmapRunnerReturning("", errors.New("vmmap --summary: exit status 1"))
+	var out, errBuf bytes.Buffer
+	if code := runVmmapWithIO([]string{"4012"}, &out, &errBuf, runner); code != 1 {
+		t.Fatalf("exit = %d, want 1 on a runner error", code)
+	}
+	if !strings.Contains(errBuf.String(), "failed") {
+		t.Errorf("expected a failure message, got: %q", errBuf.String())
 	}
 }

--- a/cmd/spectra/vmmap_test.go
+++ b/cmd/spectra/vmmap_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const vmmapCLIOut = `Physical footprint:         1665K
+Physical footprint (peak):  1681K
+
+REGION TYPE                        SIZE     SIZE     SIZE     SIZE
+===========                     ======= ========    =====  =======
+MALLOC_SMALL                      40.0M     304K     304K       0K
+Stack                             8176K      32K      32K       0K
+===========                     ======= ========    =====  =======
+TOTAL                            929.0M   263.9M    1681K       0K
+`
+
+func vmmapRunnerReturning(out string, err error) vmmapRunner {
+	return func(context.Context, string, ...string) ([]byte, error) { return []byte(out), err }
+}
+
+func TestRunVmmapHuman(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runVmmapWithIO([]string{"4012"}, &out, &errBuf, vmmapRunnerReturning(vmmapCLIOut, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "MALLOC_SMALL") || !strings.Contains(s, "footprint") || !strings.Contains(s, "TOTAL") {
+		t.Errorf("expected composition summary, got:\n%s", s)
+	}
+}
+
+func TestRunVmmapJSON(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runVmmapWithIO([]string{"--json", "4012"}, &out, &errBuf, vmmapRunnerReturning(vmmapCLIOut, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"regions"`) || !strings.Contains(out.String(), `"dirty_bytes"`) {
+		t.Errorf("expected JSON, got:\n%s", out.String())
+	}
+}
+
+func TestRunVmmapPermissionMessage(t *testing.T) {
+	runner := vmmapRunnerReturning("vmmap: Unable to access process. Not permitted.\n", errors.New("exit status 1"))
+	var out, errBuf bytes.Buffer
+	code := runVmmapWithIO([]string{"4012"}, &out, &errBuf, runner)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "root") {
+		t.Errorf("expected a root/sudo hint, got: %q", errBuf.String())
+	}
+}
+
+func TestRunVmmapArgValidation(t *testing.T) {
+	runner := vmmapRunnerReturning(vmmapCLIOut, nil)
+	for _, args := range [][]string{{}, {"notapid"}, {"0"}, {"1", "2"}} {
+		var out, errBuf bytes.Buffer
+		if code := runVmmapWithIO(args, &out, &errBuf, runner); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -413,6 +413,25 @@ spectra spindump --input /tmp/foo.spindump.txt
 spectra spindump --sudo --out /tmp/foo.txt --json 4012
 ```
 
+## `spectra vmmap`
+
+Summarizes a process's memory composition from `vmmap --summary` — a footprint
+number has no shape on its own, and the raw table is a wall of columns. It
+reports the physical footprint and its peak, then per region type the
+virtual / resident / dirty / swapped sizes, ranked by dirty size (the real
+memory cost), top `--top` (default 8), plus the TOTAL row. `vmmap --summary`
+works without root for a same-user process; for another user's process it needs
+root, so a permission failure is reported as "re-run as root (sudo)". `--json`
+emits the structured result.
+
+### Examples
+
+```bash
+spectra vmmap 4012
+spectra vmmap --top 15 4012
+spectra vmmap --json 4012
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/vmmap/vmmap.go
+++ b/internal/vmmap/vmmap.go
@@ -1,0 +1,142 @@
+// Package vmmap summarizes a process's memory composition from `vmmap
+// --summary` output. A footprint number has no shape on its own; this parses
+// the REGION TYPE table into per-region virtual/resident/dirty/swapped sizes so
+// "where is this process's memory" is answerable at a glance. It reads only.
+package vmmap
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Region is one row of the vmmap region-type summary.
+type Region struct {
+	Type          string `json:"type"`
+	VirtualBytes  int64  `json:"virtual_bytes"`
+	ResidentBytes int64  `json:"resident_bytes"`
+	DirtyBytes    int64  `json:"dirty_bytes"`
+	SwappedBytes  int64  `json:"swapped_bytes"`
+}
+
+// Summary is the parsed memory composition of a process.
+type Summary struct {
+	FootprintBytes     int64    `json:"footprint_bytes"`
+	FootprintPeakBytes int64    `json:"footprint_peak_bytes,omitempty"`
+	Regions            []Region `json:"regions"`
+	TotalVirtualBytes  int64    `json:"total_virtual_bytes"`
+	TotalResidentBytes int64    `json:"total_resident_bytes"`
+	TotalDirtyBytes    int64    `json:"total_dirty_bytes"`
+	TotalSwappedBytes  int64    `json:"total_swapped_bytes"`
+}
+
+var (
+	footprintLine     = regexp.MustCompile(`^Physical footprint:\s+(\S+)`)
+	footprintPeakLine = regexp.MustCompile(`^Physical footprint \(peak\):\s+(\S+)`)
+	sizeToken         = regexp.MustCompile(`^\d+(\.\d+)?[KMGTB]?$`)
+)
+
+// Parse turns `vmmap --summary` output into a Summary. topN keeps only the
+// heaviest-by-dirty region rows (0 keeps all).
+func Parse(out string, topN int) Summary {
+	var s Summary
+	inTable := false
+
+	for _, line := range strings.Split(out, "\n") {
+		if m := footprintPeakLine.FindStringSubmatch(line); m != nil {
+			s.FootprintPeakBytes = parseSize(m[1])
+			continue
+		}
+		if m := footprintLine.FindStringSubmatch(line); m != nil {
+			s.FootprintBytes = parseSize(m[1])
+			continue
+		}
+		if strings.HasPrefix(line, "REGION TYPE") {
+			inTable = true
+			continue
+		}
+		if !inTable {
+			continue
+		}
+		name, sizes, ok := parseRegionRow(line)
+		if !ok {
+			continue
+		}
+		if name == "TOTAL" {
+			s.TotalVirtualBytes, s.TotalResidentBytes = sizes[0], sizes[1]
+			s.TotalDirtyBytes, s.TotalSwappedBytes = sizes[2], sizes[3]
+			break // the region table ends at TOTAL; a second table follows
+		}
+		s.Regions = append(s.Regions, Region{
+			Type: name, VirtualBytes: sizes[0], ResidentBytes: sizes[1],
+			DirtyBytes: sizes[2], SwappedBytes: sizes[3],
+		})
+	}
+
+	sort.SliceStable(s.Regions, func(i, j int) bool {
+		if s.Regions[i].DirtyBytes != s.Regions[j].DirtyBytes {
+			return s.Regions[i].DirtyBytes > s.Regions[j].DirtyBytes
+		}
+		return s.Regions[i].Type < s.Regions[j].Type
+	})
+	if topN > 0 && len(s.Regions) > topN {
+		s.Regions = s.Regions[:topN]
+	}
+	return s
+}
+
+// parseRegionRow splits a region-table row into its type name and the first
+// four size columns (virtual, resident, dirty, swapped). The type name may
+// contain spaces, so the split point is the first run of four consecutive size
+// tokens.
+func parseRegionRow(line string) (name string, sizes [4]int64, ok bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 5 {
+		return "", sizes, false
+	}
+	for i := 0; i+4 <= len(fields); i++ {
+		if i == 0 {
+			continue // a row always has a name before its numbers
+		}
+		if isSize(fields[i]) && isSize(fields[i+1]) && isSize(fields[i+2]) && isSize(fields[i+3]) {
+			name = strings.Join(fields[:i], " ")
+			for j := 0; j < 4; j++ {
+				sizes[j] = parseSize(fields[i+j])
+			}
+			return name, sizes, true
+		}
+	}
+	return "", sizes, false
+}
+
+func isSize(s string) bool { return sizeToken.MatchString(s) }
+
+// parseSize converts a vmmap size token like "128.0M" or "16K" into bytes.
+func parseSize(s string) int64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	mult := int64(1)
+	switch s[len(s)-1] {
+	case 'K':
+		mult = 1 << 10
+	case 'M':
+		mult = 1 << 20
+	case 'G':
+		mult = 1 << 30
+	case 'T':
+		mult = 1 << 40
+	case 'B':
+		mult = 1
+	}
+	if mult != 1 || s[len(s)-1] == 'B' {
+		s = s[:len(s)-1]
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return int64(v * float64(mult))
+}

--- a/internal/vmmap/vmmap_test.go
+++ b/internal/vmmap/vmmap_test.go
@@ -1,0 +1,90 @@
+package vmmap
+
+import "testing"
+
+const sampleSummary = `Process:         Foo [4012]
+Physical footprint:         1665K
+Physical footprint (peak):  1681K
+
+                                VIRTUAL RESIDENT    DIRTY  SWAPPED VOLATILE   NONVOL    EMPTY   REGION
+REGION TYPE                        SIZE     SIZE     SIZE     SIZE     SIZE     SIZE     SIZE    COUNT (non-coalesced)
+===========                     ======= ========    =====  ======= ========   ======    =====  =======
+MALLOC guard page                   96K       0K       0K       0K       0K       0K       0K        6
+MALLOC_SMALL                      40.0M     304K     304K       0K       0K       0K       0K        5         see MALLOC ZONE table below
+Stack                             8176K      32K      32K       0K       0K       0K       0K        1
+__DATA                             232K     232K     148K       0K       0K       0K       0K       46
+unused but dirty shlib __DATA      112K     112K     112K       0K       0K       0K       0K       32
+===========                     ======= ========    =====  ======= ========   ======    =====  =======
+TOTAL                            929.0M   263.9M    1681K       8K       0K      16K       0K      299
+                                 VIRTUAL   RESIDENT      DIRTY    SWAPPED ALLOCATION
+MALLOC ZONE                         SIZE       SIZE       SIZE       SIZE      COUNT
+DefaultMallocZone_0x1              176.0M       752K       752K         0K       2747
+`
+
+func TestParseFootprintAndTotal(t *testing.T) {
+	s := Parse(sampleSummary, 0)
+	if s.FootprintBytes != 1665*1024 {
+		t.Errorf("footprint = %d", s.FootprintBytes)
+	}
+	if s.FootprintPeakBytes != 1681*1024 {
+		t.Errorf("peak = %d", s.FootprintPeakBytes)
+	}
+	if s.TotalDirtyBytes != 1681*1024 || s.TotalSwappedBytes != 8*1024 {
+		t.Errorf("totals dirty=%d swapped=%d", s.TotalDirtyBytes, s.TotalSwappedBytes)
+	}
+}
+
+func TestParseRegionsRankedByDirtyAndNamesWithSpaces(t *testing.T) {
+	s := Parse(sampleSummary, 0)
+	// The MALLOC ZONE table after TOTAL must not be parsed as regions.
+	for _, r := range s.Regions {
+		if r.Type == "DefaultMallocZone_0x1" || r.Type == "TOTAL" {
+			t.Errorf("region table bled past TOTAL: %q", r.Type)
+		}
+	}
+	// Ranked by dirty desc: MALLOC_SMALL (304K) first.
+	if s.Regions[0].Type != "MALLOC_SMALL" || s.Regions[0].DirtyBytes != 304*1024 {
+		t.Errorf("top region = %+v", s.Regions[0])
+	}
+	// A space-containing type name must be preserved and its sizes parsed.
+	if !hasRegion(s.Regions, "unused but dirty shlib __DATA", 112*1024) {
+		t.Errorf("space-named region not parsed: %+v", s.Regions)
+	}
+	// MALLOC_SMALL's virtual is 40.0M.
+	if s.Regions[0].VirtualBytes != int64(40.0*float64(1<<20)) {
+		t.Errorf("MALLOC_SMALL virtual = %d", s.Regions[0].VirtualBytes)
+	}
+}
+
+func TestParseTopN(t *testing.T) {
+	s := Parse(sampleSummary, 2)
+	if len(s.Regions) != 2 {
+		t.Errorf("topN=2 gave %d regions", len(s.Regions))
+	}
+}
+
+func TestParseSizes(t *testing.T) {
+	cases := map[string]int64{
+		"0K":     0,
+		"16K":    16 * 1024,
+		"128.0M": int64(128.0 * float64(1<<20)),
+		"2G":     2 * (1 << 30),
+		"512B":   512,
+		"":       0,
+		"junk":   0,
+	}
+	for in, want := range cases {
+		if got := parseSize(in); got != want {
+			t.Errorf("parseSize(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func hasRegion(rs []Region, typ string, dirty int64) bool {
+	for _, r := range rs {
+		if r.Type == typ && r.DirtyBytes == dirty {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

`spectra vmmap <pid>` — summarizes a process's **memory composition** from `vmmap --summary`: where its footprint actually lives (dirty malloc, mapped files, stacks, shared libraries), instead of a shapeless "2 GB". **Phase-A item 3** of the native-capture line.

## How

- **`internal/vmmap`** parses the `REGION TYPE` table into per-region virtual / resident / **dirty** / swapped bytes. It handles the two hard parts: region type names that contain spaces (`unused but dirty shlib __DATA`) — split at the first run of four consecutive size tokens — and `128.0M` / `8176K` / `0K`-style size tokens. It also reads the physical footprint + peak and the `TOTAL` row, ranks regions by dirty size, and stops at `TOTAL` so the second `MALLOC ZONE` table isn't mis-parsed as regions.
- **`spectra vmmap [--top n] [--json] <pid>`** — runs `/usr/bin/vmmap --summary` (absolute path) through an injected runner. `vmmap --summary` works without root for a same-user process; another user's process needs root, so a permission failure is surfaced as "re-run as root (sudo)".

## Testing

Parser tests against canned `vmmap --summary` output: footprint + peak, the TOTAL row (incl. non-zero swapped), dirty-ranked regions, a space-containing region name preserved, `--top N` truncation, the trailing MALLOC ZONE table excluded, and size-token parsing (`0K`/`16K`/`128.0M`/`2G`/`512B`/empty/junk). CLI tests: human + JSON output, the permission message, and arg validation. **Smoke-tested live** against a same-user process (footprint, dirty-ranked regions, and TOTAL all correct). `make vet complexity lint security docs-validate test` green (64 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #409
