### PR TITLE
lsmp: spectra lsmp — summarize a process's Mach port table (leak detection)

### DIFF
--- a/cmd/spectra/lsmp.go
+++ b/cmd/spectra/lsmp.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/lsmp"
+)
+
+const (
+	lsmpBin     = "/usr/bin/lsmp"
+	lsmpSudoBin = "/usr/bin/sudo"
+)
+
+// lsmpRunner runs a command and returns its combined output.
+type lsmpRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func runLsmp(args []string) int {
+	return runLsmpWithIO(args, os.Stdout, os.Stderr, defaultLsmpRunner)
+}
+
+func runLsmpWithIO(args []string, stdout, stderr io.Writer, runner lsmpRunner) int {
+	fs := flag.NewFlagSet("spectra lsmp", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	sudo := fs.Bool("sudo", false, "Prepend sudo (lsmp requires root to read a task's ports)")
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "usage: spectra lsmp [--sudo] [--json] <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil || pid <= 0 {
+		fmt.Fprintf(stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	name := lsmpBin
+	cmdArgs := []string{"-p", strconv.Itoa(pid)}
+	if *sudo {
+		cmdArgs = append([]string{name}, cmdArgs...)
+		name = lsmpSudoBin
+	}
+	out, runErr := runner(context.Background(), name, cmdArgs...)
+	if isLsmpPermission(string(out)) {
+		fmt.Fprintf(stderr, "lsmp: cannot read ports for PID %d — lsmp needs root; re-run with --sudo (or as root)\n", pid)
+		return 1
+	}
+	if runErr != nil {
+		fmt.Fprintf(stderr, "lsmp failed for PID %d: %v\n", pid, runErr)
+		return 1
+	}
+
+	summary := lsmp.Parse(string(out))
+	if summary.TotalPorts == 0 {
+		fmt.Fprintf(stderr, "lsmp: no ports parsed for PID %d — if the report was empty, lsmp likely needs root (--sudo)\n", pid)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(summary)
+		return 0
+	}
+	printLsmp(stdout, pid, summary)
+	return 0
+}
+
+func isLsmpPermission(out string) bool {
+	l := strings.ToLower(out)
+	return strings.Contains(l, "task_for_pid() failed") || strings.Contains(l, "should run as root")
+}
+
+func printLsmp(w io.Writer, pid int, s lsmp.Summary) {
+	fmt.Fprintf(w, "=== lsmp Mach ports (pid %d) ===\n", pid)
+	fmt.Fprintf(w, "  total ports: %d\n", s.TotalPorts)
+	fmt.Fprintf(w, "  recv:      %d\n", s.RecvRights)
+	fmt.Fprintf(w, "  send:      %d\n", s.SendRights)
+	fmt.Fprintf(w, "  send-once: %d\n", s.SendOnceRights)
+	fmt.Fprintf(w, "  port-sets: %d\n", s.PortSets)
+	for _, n := range s.Notes {
+		fmt.Fprintf(w, "  ! %s\n", n)
+	}
+}
+
+func defaultLsmpRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	if err != nil {
+		// Return out too: the caller inspects it for a permission failure.
+		return out, fmt.Errorf("lsmp -p: %w", err)
+	}
+	return out, nil
+}

--- a/cmd/spectra/lsmp_test.go
+++ b/cmd/spectra/lsmp_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const lsmpCLIOut = `  name      ipc-object  rights
+0x107  0x1a  recv
+0x20b  0x2b  send
+0x30c  0x3c  send
+`
+
+func lsmpRunnerReturning(out string, err error) lsmpRunner {
+	return func(context.Context, string, ...string) ([]byte, error) { return []byte(out), err }
+}
+
+func TestRunLsmpHuman(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runLsmpWithIO([]string{"4012"}, &out, &errBuf, lsmpRunnerReturning(lsmpCLIOut, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "total ports: 3") || !strings.Contains(s, "send:      2") {
+		t.Errorf("expected port summary, got:\n%s", s)
+	}
+}
+
+func TestRunLsmpJSON(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runLsmpWithIO([]string{"--json", "4012"}, &out, &errBuf, lsmpRunnerReturning(lsmpCLIOut, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"send_rights"`) || !strings.Contains(out.String(), `"total_ports"`) {
+		t.Errorf("expected JSON, got:\n%s", out.String())
+	}
+}
+
+func TestRunLsmpPermission(t *testing.T) {
+	runner := lsmpRunnerReturning("warning: should run as root for best output.\ntask_for_pid() failed: (null)\n", nil)
+	var out, errBuf bytes.Buffer
+	code := runLsmpWithIO([]string{"4012"}, &out, &errBuf, runner)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "--sudo") {
+		t.Errorf("expected a --sudo hint, got: %q", errBuf.String())
+	}
+}
+
+func TestRunLsmpEmptyReport(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runLsmpWithIO([]string{"4012"}, &out, &errBuf, lsmpRunnerReturning("  name  ipc-object  rights\n", nil))
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for a report with no ports", code)
+	}
+}
+
+func TestRunLsmpSudoUsesAbsolutePaths(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	runner := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotName, gotArgs = name, args
+		return []byte(lsmpCLIOut), nil
+	}
+	var out, errBuf bytes.Buffer
+	if code := runLsmpWithIO([]string{"--sudo", "4012"}, &out, &errBuf, runner); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if gotName != lsmpSudoBin || len(gotArgs) == 0 || gotArgs[0] != lsmpBin {
+		t.Errorf("expected `%s %s ...`, got name=%q args=%v", lsmpSudoBin, lsmpBin, gotName, gotArgs)
+	}
+}
+
+func TestRunLsmpArgValidation(t *testing.T) {
+	runner := lsmpRunnerReturning(lsmpCLIOut, nil)
+	for _, args := range [][]string{{}, {"notapid"}, {"0"}, {"1", "2"}} {
+		var out, errBuf bytes.Buffer
+		if code := runLsmpWithIO(args, &out, &errBuf, runner); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}
+
+func TestRunLsmpRunnerError(t *testing.T) {
+	runner := lsmpRunnerReturning("", errors.New("lsmp -p: exit status 1"))
+	var out, errBuf bytes.Buffer
+	if code := runLsmpWithIO([]string{"4012"}, &out, &errBuf, runner); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -73,6 +73,7 @@ func subcommandList() []subcommand {
 		{"symbolicate", "Resolve raw stack addresses to symbol + file:line via atos", runSymbolicate},
 		{"spindump", "Capture and summarize a per-thread stack report (heaviest stacks)", runSpindump},
 		{"vmmap", "Summarize a process's memory composition by region (dirty/resident/swapped)", runVmmap},
+		{"lsmp", "Summarize a process's Mach port table (right counts, leak detection)", runLsmp},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -459,6 +459,25 @@ spectra vmmap --top 15 4012
 spectra vmmap --json 4012
 ```
 
+## `spectra lsmp`
+
+Summarizes a process's Mach port table from `lsmp -p`. A Mach port leak — a
+service accumulating send rights until it hits the per-task limit and wedges —
+is invisible in the raw per-port table; this counts port entries by right type
+(recv / send / send-once / port-set) and flags a suspiciously high total. The
+parser keys on the leading hex port name and the documented rights keyword, so
+column-spacing differences between macOS versions don't break it. `lsmp`
+requires root (it uses `task_for_pid`), so `--sudo` prepends `sudo` and a
+permission failure is reported as "re-run with --sudo (or as root)". `--json`
+emits the structured result.
+
+### Examples
+
+```bash
+spectra lsmp --sudo 4012
+spectra lsmp --json --sudo 4012
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/lsmp/lsmp.go
+++ b/internal/lsmp/lsmp.go
@@ -1,0 +1,73 @@
+// Package lsmp summarizes a process's Mach port table from `lsmp -p` output.
+// A Mach port leak — a service accumulating send rights until it hits the
+// per-task limit and wedges — is invisible in the raw per-port table; this
+// counts port rights by type so a leak is obvious. It reads only.
+package lsmp
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// portLeakThreshold is the total port count above which a leak note is added.
+// The per-task limit is large; a healthy process rarely holds this many.
+const portLeakThreshold = 10000
+
+// Summary is the parsed Mach port picture of a process.
+type Summary struct {
+	TotalPorts     int      `json:"total_ports"`
+	RecvRights     int      `json:"recv_rights"`
+	SendRights     int      `json:"send_rights"`
+	SendOnceRights int      `json:"send_once_rights"`
+	PortSets       int      `json:"port_sets"`
+	Notes          []string `json:"notes,omitempty"`
+}
+
+// portNameToken matches the leading hexadecimal port name that begins each
+// data row of an lsmp report.
+var portNameToken = regexp.MustCompile(`^0x[0-9a-fA-F]+$`)
+
+// Parse turns `lsmp -p` output into a rights summary. It keys on the leading
+// hex port name and the documented rights keyword, so it tolerates the
+// column-spacing differences between macOS versions.
+func Parse(out string) Summary {
+	var s Summary
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// A data row starts with a hex port name (or "-" for a port-set member).
+		if !portNameToken.MatchString(fields[0]) && fields[0] != "-" {
+			continue
+		}
+		s.TotalPorts++
+		switch rightsOf(fields) {
+		case "port-set":
+			s.PortSets++
+		case "send-once":
+			s.SendOnceRights++
+		case "send":
+			s.SendRights++
+		case "recv":
+			s.RecvRights++
+		}
+	}
+	if s.TotalPorts > portLeakThreshold {
+		s.Notes = append(s.Notes, fmt.Sprintf("high Mach port count (%d) — investigate for a port-right leak", s.TotalPorts))
+	}
+	return s
+}
+
+// rightsOf returns the documented rights keyword present in a row's fields, or
+// "" if none is found. "send-once" is checked before "send".
+func rightsOf(fields []string) string {
+	for _, f := range fields {
+		switch f {
+		case "port-set", "send-once", "send", "recv":
+			return f
+		}
+	}
+	return ""
+}

--- a/internal/lsmp/lsmp_test.go
+++ b/internal/lsmp/lsmp_test.go
@@ -1,0 +1,69 @@
+package lsmp
+
+import (
+	"strings"
+	"testing"
+)
+
+// Modeled on documented `lsmp -p` output: a header, a warning, then data rows
+// keyed by a hex port name, with the rights keyword in the row.
+const sampleReport = `  name      ipc-object    rights     flags   boost  reqs  recv  send  sonce  qlimit  msgcount  identifier  type
+--------  ----------    ------     -----   -----  ----  ----  ----  -----  ------  --------  ----------  ----
+0x00000107  0x1a2b3c4d    recv       --sN-   0      ---   1     0     0      5       0         0x0         TASK-CONTROL
+0x0000020b  0x2b3c4d5e    send       -----   0      ---   0     1     0      0       0         0xdead      SEND
+0x0000030c  0x3c4d5e6f    send       -----   0      ---   0     3     0      0       0         0xbeef      SEND
+0x0000040d  0x4d5e6f70    send-once  -----   0      ---   0     0     1      0       0         0xfeed      SEND-ONCE
+-           0x5e6f7081    port-set   -----   0      ---   0     0     0      0       0         0x0         PORT-SET
+`
+
+func TestParseCountsRights(t *testing.T) {
+	s := Parse(sampleReport)
+	if s.TotalPorts != 5 {
+		t.Errorf("total = %d, want 5", s.TotalPorts)
+	}
+	if s.RecvRights != 1 {
+		t.Errorf("recv = %d, want 1", s.RecvRights)
+	}
+	if s.SendRights != 2 {
+		t.Errorf("send = %d, want 2", s.SendRights)
+	}
+	if s.SendOnceRights != 1 {
+		t.Errorf("send-once = %d, want 1", s.SendOnceRights)
+	}
+	if s.PortSets != 1 {
+		t.Errorf("port-sets = %d, want 1", s.PortSets)
+	}
+	if len(s.Notes) != 0 {
+		t.Errorf("did not expect a leak note for a small table: %v", s.Notes)
+	}
+}
+
+func TestParseIgnoresHeadersAndWarnings(t *testing.T) {
+	report := "warning: should run as root for best output.\n" +
+		"  name  ipc-object  rights\n" +
+		"0x1  0x2  send\n"
+	s := Parse(report)
+	if s.TotalPorts != 1 || s.SendRights != 1 {
+		t.Errorf("header/warning not ignored: %+v", s)
+	}
+}
+
+func TestParseLeakNote(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < portLeakThreshold+1; i++ {
+		b.WriteString("0x1  0x2  send\n")
+	}
+	s := Parse(b.String())
+	if s.TotalPorts != portLeakThreshold+1 {
+		t.Fatalf("total = %d", s.TotalPorts)
+	}
+	if len(s.Notes) == 0 {
+		t.Error("expected a leak note above the threshold")
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	if s := Parse(""); s.TotalPorts != 0 {
+		t.Errorf("empty report should have no ports, got %+v", s)
+	}
+}


### PR DESCRIPTION
## What

`spectra lsmp <pid>` — summarizes a process's **Mach port table** so a port-right leak (a service accumulating send rights until it hits the per-task limit and wedges) is visible instead of buried in `lsmp`'s raw per-port dump. **Phase-A item 4** of the native-capture line.

## How

- **`internal/lsmp`** parses `lsmp -p` output into total port entries and counts by right type (recv / send / send-once / port-set), plus a note when the total is suspiciously high. It's deliberately **tolerant**: it keys on the leading hex port name (`0x…`, or `-` for a port-set member) and the documented rights keyword, so the column-spacing differences between macOS versions don't break it.
- **`spectra lsmp [--sudo] [--json] <pid>`** — invokes `/usr/bin/lsmp` (absolute path) through an injected runner. `lsmp` requires root (`task_for_pid`), so `--sudo` prepends `sudo`, and a permission failure (`should run as root` / `task_for_pid() failed`) — or an empty parse — is surfaced as "re-run with --sudo (or as root)" rather than a misleading zero.

## Testing

Parser tests against documented `lsmp` output: rights counting (recv/send×2/send-once/port-set), header+warning lines ignored, the leak-note threshold, and an empty report. CLI tests: human + JSON output, the permission message, empty-report handling, `sudo` absolute-path prefixing, arg validation, and a runner error. `make vet complexity lint security docs-validate test` green (66 pkgs).

## Honest limitation

`lsmp` needs root even for a same-user process (verified: `task_for_pid() failed` on our own child), so the **live capture path can't be exercised in CI**; the parser is validated against the documented `lsmp` output format. `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #415
