### PR TITLE
db: SQLite engine for database inspection — zero new deps, end-to-end tested

### DIFF
--- a/cmd/spectra/db.go
+++ b/cmd/spectra/db.go
@@ -67,6 +67,7 @@ func runDBDiscover(args []string) int {
 	discovery := dbinspect.Discovery{
 		Connections: dbinspect.DiscoverConnections(netstate.CollectConnections(netstate.DefaultRunner)),
 		Env:         dbinspect.DiscoverEnv(os.Getenv),
+		SQLiteFiles: dbinspect.DiscoverSQLiteFiles(dbinspect.DefaultRunner),
 	}
 
 	if *asJSON {
@@ -218,8 +219,8 @@ func runDBSample(args []string) int {
 
 func printDBDiscovery(d dbinspect.Discovery) {
 	fmt.Println("=== Database discovery ===")
-	if len(d.Connections) == 0 && len(d.Env) == 0 {
-		fmt.Println("no database connections or connection env vars found")
+	if len(d.Connections) == 0 && len(d.Env) == 0 && len(d.SQLiteFiles) == 0 {
+		fmt.Println("no database connections, connection env vars, or open sqlite files found")
 		return
 	}
 	if len(d.Connections) > 0 {
@@ -239,6 +240,14 @@ func printDBDiscovery(d dbinspect.Discovery) {
 				engine = fmt.Sprintf(" (%s)", h.Engine)
 			}
 			fmt.Printf("  %-16s %s%s\n", h.Name, h.Value, engine)
+		}
+	}
+	if len(d.SQLiteFiles) > 0 {
+		fmt.Printf("\nopen sqlite files (%d):\n", len(d.SQLiteFiles))
+		fmt.Printf("  %-7s  %-20s  %s\n", "PID", "COMMAND", "PATH")
+		fmt.Println("  " + strings.Repeat("-", 76))
+		for _, f := range d.SQLiteFiles {
+			fmt.Printf("  %-7d  %-20s  %s\n", f.PID, truncate(f.Command, 20), f.Path)
 		}
 	}
 }

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -38,7 +38,7 @@ func subcommandList() []subcommand {
 		{"list", "Inspect every .app under /Applications", runList},
 		{"snapshot", "Capture a structured snapshot of host + installed apps", runSnapshot},
 		{"jvm", "List or inspect running JVM processes", runJVM},
-		{"db", "Discover and inspect databases apps connect to (read-only; postgres, mysql)", runDB},
+		{"db", "Discover and inspect databases apps connect to (read-only; postgres, mysql, sqlite)", runDB},
 		{"toolchain", "Show installed language runtimes and package managers", runToolchain},
 		{"network", "Show current network state (routes, DNS, VPN, proxy, listening ports)", runNetwork},
 		{"power", "Show current battery and thermal state", runPower},

--- a/docs/inspection/databases.md
+++ b/docs/inspection/databases.md
@@ -7,13 +7,16 @@ growing latency, a foreign key that explains a cascade of deletes. `spectra
 db` connects directly with credentials you already have and reads that
 picture without disturbing the running workload.
 
-PostgreSQL is supported via [pgx](https://github.com/jackc/pgx) and
+PostgreSQL is supported via [pgx](https://github.com/jackc/pgx),
 MySQL/MariaDB via [go-sql-driver](https://github.com/go-sql-driver/mysql),
-both behind the same engine-neutral report types in `internal/dbinspect`.
-The engine is inferred from the DSN: `postgres://` / `postgresql://` URLs
-and libpq keyword form select postgres, `mysql://` URLs and go-sql-driver's
-`user:pass@tcp(host:port)/db` form select mysql. SQLite inspection is a
-planned follow-on.
+and SQLite via [modernc.org/sqlite](https://gitlab.com/cznic/sqlite) —
+spectra's own storage driver, so SQLite support adds no dependency. All
+three sit behind the same engine-neutral report types in
+`internal/dbinspect`. The engine is inferred from the DSN: `postgres://` /
+`postgresql://` URLs and libpq keyword form select postgres, `mysql://`
+URLs and go-sql-driver's `user:pass@tcp(host:port)/db` form select mysql,
+and `sqlite://` URLs, `file:` URIs, or a bare path ending in `.db` /
+`.sqlite` / `.sqlite3` select sqlite.
 
 ## Non-disruptive by construction
 
@@ -38,18 +41,24 @@ then bound waits best-effort (`max_execution_time` on MySQL,
 connection pool is capped at one connection so those session settings
 govern every query.
 
+SQLite files open with `mode=ro` (refuses writes at the file layer), the
+`query_only` pragma (refuses them at the statement layer), and a 2s busy
+timeout so inspection fails fast rather than holding locks against the
+application that owns the file.
+
 Structural reads use only the engine's catalog (`pg_catalog` and
-`pg_stat_*` on postgres, `information_schema` on mysql). Row counts are
-estimates (`reltuples`/`n_live_tup`, `table_rows`) — spectra never issues
-`COUNT(*)` or any other full-table scan. Every caller-supplied filter is a
-bind parameter; the one place an identifier is interpolated (row sampling)
-resolves the name through the catalog first (`to_regclass` against
-`pg_class`, or `information_schema.TABLES`) and quote-escapes the catalog's
-own spelling.
+`pg_stat_*` on postgres, `information_schema` on mysql, `sqlite_schema`
+and pragma functions on sqlite). Row counts are estimates
+(`reltuples`/`n_live_tup`, `table_rows`, `sqlite_stat1`) — spectra never
+issues `COUNT(*)` or any other full-table scan. Every caller-supplied
+filter is a bind parameter; the one place an identifier is interpolated
+(row sampling) resolves the name through the catalog first (`to_regclass`
+against `pg_class`, `information_schema.TABLES`, or `sqlite_schema`) and
+quote-escapes the catalog's own spelling.
 
 ## Discovering that an app uses a database
 
-`spectra db discover` combines two signals:
+`spectra db discover` combines three signals:
 
 - **Live sockets** — active connections whose remote port is a well-known
   database port (5432/5433/6432 postgres, 3306/3307 mysql), from the same
@@ -59,6 +68,10 @@ own spelling.
   `POSTGRES_URL`, `PGHOST`, `PGUSER`, `PGPASSWORD`, ...), never the full
   environment. Passwords and URL credentials are redacted before they reach
   output or logs.
+- **Open SQLite files** — regular-file handles whose path ends in a
+  database suffix (`.db`, `.sqlite`, `.sqlite3`), from one host-wide
+  `lsof` pass, with WAL/SHM/journal sidecars folded into their database
+  path and PID+command attribution.
 
 ## CLI
 
@@ -85,7 +98,9 @@ keyword DSN forms work. Every subcommand takes `--json`.
   `pg_stat_user_tables`: sequential vs index scans, live/dead row
   estimates, total size, last (auto)vacuum and analyze. On mysql it is
   `information_schema.TABLES` row and size estimates — scan counters need
-  `performance_schema` and are left zero.
+  `performance_schema` and are left zero. On sqlite, row estimates come
+  from `sqlite_stat1` (present after `ANALYZE`) and sizes from the
+  `dbstat` virtual table when the build ships it.
 - `sample` — up to N rows (default 10, capped at 500) from one table.
 
 ## Row data is sensitive

--- a/docs/inspection/live-data-sources.md
+++ b/docs/inspection/live-data-sources.md
@@ -139,6 +139,8 @@ JDK path, Spectra also records `jdk_install_id`, `jdk_source`, and
 |---|---|---|---|---|
 | `lsof -i -P -n` remote ports 5432/3306/... | which apps hold sockets to database servers | user | shared with connections collector | `db.discover` |
 | connection env-var allowlist (`DATABASE_URL`, `PG*`, ...) | connection hints, credentials redacted | user | free | `db.discover` |
+| `lsof -nP` REG handles with database suffixes | which apps hold SQLite files open (WAL/SHM folded in) | user | one host-wide lsof pass | `db.discover` |
+| `sqlite_schema` + pragma functions via modernc.org/sqlite (mode=ro, query_only) | sqlite schema, columns, indexes, foreign keys, stat1 row estimates | file read access | one read-only connection | `db.overview`, `db.schema`, `db.relations`, `db.stats` |
 | `pg_catalog` + `pg_stat_*` via pgx (read-only session) | schema, columns, indexes, foreign keys, table health estimates | database credentials | one connection, catalog reads only | `db.overview`, `db.schema`, `db.relations`, `db.stats` |
 | `information_schema` via go-sql-driver (read-only session) | mysql/mariadb schema, columns, indexes, foreign keys, size estimates | database credentials | one connection, catalog reads only | `db.overview`, `db.schema`, `db.relations`, `db.stats` |
 | `SELECT * ... LIMIT n` via pgx or go-sql-driver | bounded row sample | database credentials + `confirm_sensitive` | one bounded query | `db.sample` artifact |

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -356,9 +356,9 @@ spectra runtime --json 4012
 
 Discovers databases that apps on this host connect to, then inspects them
 read-only: schema, foreign-key relationships, and per-table health stats.
-PostgreSQL and MySQL/MariaDB are supported; the engine is inferred from the
-DSN (`postgres://` / `mysql://` URLs, go-sql-driver's `user@tcp(host)/db`
-form, or libpq keyword form). Sessions are forced read-only with statement
+PostgreSQL, MySQL/MariaDB, and SQLite are supported; the engine is inferred from the
+DSN (`postgres://` / `mysql://` / `sqlite://` URLs, go-sql-driver's `user@tcp(host)/db`
+form, a bare `.db`/`.sqlite` path, or libpq keyword form). Sessions are forced read-only with statement
 and lock timeouts, so inspection cannot write or stall the server.
 Connection strings resolve from `--dsn`, then `SPECTRA_DB_DSN`, then
 `DATABASE_URL`, then libpq `PG*` env vars. `sample` reads row data, which

--- a/internal/dbinspect/discover.go
+++ b/internal/dbinspect/discover.go
@@ -27,10 +27,12 @@ type EnvHint struct {
 }
 
 // Discovery aggregates every clue that the host (or an app on it) uses a
-// database: live sockets to known server ports plus connection env vars.
+// database: live sockets to known server ports, connection env vars, and
+// SQLite database files held open by running processes.
 type Discovery struct {
-	Connections []Candidate `json:"connections,omitempty"`
-	Env         []EnvHint   `json:"env,omitempty"`
+	Connections []Candidate     `json:"connections,omitempty"`
+	Env         []EnvHint       `json:"env,omitempty"`
+	SQLiteFiles []FileCandidate `json:"sqlite_files,omitempty"`
 }
 
 // wellKnownPorts maps default server ports to engines. 6432 is pgbouncer,

--- a/internal/dbinspect/discover_files.go
+++ b/internal/dbinspect/discover_files.go
@@ -1,0 +1,88 @@
+package dbinspect
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// CmdRunner runs an external command and returns combined stdout. Injected
+// so tests can replay lsof fixtures.
+type CmdRunner func(name string, args ...string) ([]byte, error)
+
+// DefaultRunner runs the real command.
+func DefaultRunner(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// FileCandidate is one SQLite database file a running process holds open.
+type FileCandidate struct {
+	Engine  Engine `json:"engine"`
+	PID     int    `json:"pid,omitempty"`
+	Command string `json:"command,omitempty"`
+	Path    string `json:"path"`
+}
+
+// sqliteSidecarSuffixes are trimmed before matching so a process holding
+// only the WAL or SHM still points at its database file.
+var sqliteSidecarSuffixes = []string{"-wal", "-shm", "-journal"}
+
+// DiscoverSQLiteFiles scans open regular files for SQLite database paths.
+// One host-wide `lsof -nP` call, the same primitive the connections
+// collector uses; sidecar (-wal/-shm/-journal) handles are folded into
+// their database path, and duplicate pid+path pairs collapse.
+func DiscoverSQLiteFiles(run CmdRunner) []FileCandidate {
+	out, err := run("lsof", "-nP")
+	if err != nil {
+		return nil
+	}
+	return parseLSOFSQLiteFiles(string(out))
+}
+
+// parseLSOFSQLiteFiles extracts SQLite file candidates from `lsof -nP`
+// output. Column order: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME;
+// NAME may contain spaces, so it is the join of the trailing fields.
+func parseLSOFSQLiteFiles(out string) []FileCandidate {
+	var candidates []FileCandidate
+	seen := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 9 || fields[4] != "REG" {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[1])
+		if err != nil {
+			continue
+		}
+		path := sqliteDatabasePath(strings.Join(fields[8:], " "))
+		if path == "" {
+			continue
+		}
+		key := fields[1] + "\x00" + path
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		candidates = append(candidates, FileCandidate{
+			Engine:  EngineSQLite,
+			PID:     pid,
+			Command: fields[0],
+			Path:    path,
+		})
+	}
+	return candidates
+}
+
+// sqliteDatabasePath returns the database path an open file points at, or
+// "" when the file doesn't look like an SQLite database.
+func sqliteDatabasePath(name string) string {
+	for _, sidecar := range sqliteSidecarSuffixes {
+		name = strings.TrimSuffix(name, sidecar)
+	}
+	for _, suffix := range sqliteFileSuffixes {
+		if strings.HasSuffix(name, suffix) {
+			return name
+		}
+	}
+	return ""
+}

--- a/internal/dbinspect/dispatch.go
+++ b/internal/dbinspect/dispatch.go
@@ -5,9 +5,35 @@ import (
 	"strings"
 )
 
+// engineOps binds one engine's connector and collectors. New engines add a
+// registry entry rather than growing per-function switches.
+type engineOps struct {
+	connect   ConnectFn
+	overview  func(ctx context.Context, dsn string, o Options) (*Overview, error)
+	schema    func(ctx context.Context, dsn, schema string, o Options) (*SchemaReport, error)
+	relations func(ctx context.Context, dsn, schema string, o Options) (*RelationsReport, error)
+	stats     func(ctx context.Context, dsn, schema string, o Options) (*StatsReport, error)
+	sample    func(ctx context.Context, dsn, table string, limit int, o Options) (*SampleReport, error)
+}
+
+func opsFor(engine Engine) engineOps {
+	switch engine {
+	case EngineMySQL:
+		return engineOps{ConnectMySQL, mysqlOverview, mysqlSchema, mysqlRelations, mysqlStats, mysqlSample}
+	case EngineSQLite:
+		return engineOps{ConnectSQLite, sqliteOverview, sqliteSchema, sqliteRelations, sqliteStats, sqliteSample}
+	default:
+		return engineOps{ConnectPostgres, postgresOverview, postgresSchema, postgresRelations, postgresStats, postgresSample}
+	}
+}
+
+// sqliteFileSuffixes mark a bare path as an SQLite database.
+var sqliteFileSuffixes = []string{".db", ".sqlite", ".sqlite3", ".db3"}
+
 // resolveEngine picks the engine for a DSN: an explicit Options.Engine wins,
-// then the URL scheme, then the go-sql-driver "user@tcp(host)/db" form.
-// Everything else — libpq keyword form, bare PG* env fallback — is postgres.
+// then the URL scheme, then the go-sql-driver "user@tcp(host)/db" form, then
+// a bare path with an SQLite file suffix. Everything else — libpq keyword
+// form, bare PG* env fallback — is postgres.
 func resolveEngine(dsn string, o Options) Engine {
 	if o.Engine != "" {
 		return o.Engine
@@ -18,65 +44,50 @@ func resolveEngine(dsn string, o Options) Engine {
 	if strings.Contains(dsn, "@tcp(") || strings.Contains(dsn, "@unix(") {
 		return EngineMySQL
 	}
+	for _, suffix := range sqliteFileSuffixes {
+		if strings.HasSuffix(dsn, suffix) {
+			return EngineSQLite
+		}
+	}
 	return EnginePostgres
 }
 
-// connectorFor fills Options.Connect with the engine's built-in connector
-// when the caller didn't inject one.
-func connectorFor(o Options, engine Engine) Options {
-	if o.Connect != nil {
-		return o
+// resolve picks the ops for a DSN and fills Options.Connect with the
+// engine's built-in connector when the caller didn't inject one.
+func resolve(dsn string, o Options) (engineOps, Options) {
+	ops := opsFor(resolveEngine(dsn, o))
+	if o.Connect == nil {
+		o.Connect = ops.connect
 	}
-	if engine == EngineMySQL {
-		o.Connect = ConnectMySQL
-	} else {
-		o.Connect = ConnectPostgres
-	}
-	return o
+	return ops, o
 }
 
 // CollectOverview returns server, database, and session facts plus a count
 // of tables per user schema.
 func CollectOverview(ctx context.Context, dsn string, o Options) (*Overview, error) {
-	engine := resolveEngine(dsn, o)
-	o = connectorFor(o, engine)
-	if engine == EngineMySQL {
-		return mysqlOverview(ctx, dsn, o)
-	}
-	return postgresOverview(ctx, dsn, o)
+	ops, o := resolve(dsn, o)
+	return ops.overview(ctx, dsn, o)
 }
 
 // CollectSchema returns every user relation with its columns and indexes.
 // Pass schema to limit scope to one schema, or "" for all user schemas.
 func CollectSchema(ctx context.Context, dsn, schema string, o Options) (*SchemaReport, error) {
-	engine := resolveEngine(dsn, o)
-	o = connectorFor(o, engine)
-	if engine == EngineMySQL {
-		return mysqlSchema(ctx, dsn, schema, o)
-	}
-	return postgresSchema(ctx, dsn, schema, o)
+	ops, o := resolve(dsn, o)
+	return ops.schema(ctx, dsn, schema, o)
 }
 
 // CollectRelations returns every foreign-key relationship whose referencing
 // table is in scope. Pass schema to limit scope, or "" for all user schemas.
 func CollectRelations(ctx context.Context, dsn, schema string, o Options) (*RelationsReport, error) {
-	engine := resolveEngine(dsn, o)
-	o = connectorFor(o, engine)
-	if engine == EngineMySQL {
-		return mysqlRelations(ctx, dsn, schema, o)
-	}
-	return postgresRelations(ctx, dsn, schema, o)
+	ops, o := resolve(dsn, o)
+	return ops.relations(ctx, dsn, schema, o)
 }
 
 // CollectStats returns per-table health, largest tables first. Row counts
 // are engine estimates — no COUNT(*) is issued.
 func CollectStats(ctx context.Context, dsn, schema string, o Options) (*StatsReport, error) {
-	engine := resolveEngine(dsn, o)
-	o = connectorFor(o, engine)
-	if engine == EngineMySQL {
-		return mysqlStats(ctx, dsn, schema, o)
-	}
-	return postgresStats(ctx, dsn, schema, o)
+	ops, o := resolve(dsn, o)
+	return ops.stats(ctx, dsn, schema, o)
 }
 
 // SampleTable reads up to limit rows from one table. limit defaults to 10
@@ -89,10 +100,6 @@ func SampleTable(ctx context.Context, dsn, table string, limit int, o Options) (
 	if limit > maxSampleLimit {
 		limit = maxSampleLimit
 	}
-	engine := resolveEngine(dsn, o)
-	o = connectorFor(o, engine)
-	if engine == EngineMySQL {
-		return mysqlSample(ctx, dsn, table, limit, o)
-	}
-	return postgresSample(ctx, dsn, table, limit, o)
+	ops, o := resolve(dsn, o)
+	return ops.sample(ctx, dsn, table, limit, o)
 }

--- a/internal/dbinspect/sqlite.go
+++ b/internal/dbinspect/sqlite.go
@@ -1,0 +1,375 @@
+package dbinspect
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// SQLite catalog reads use sqlite_schema and pragma table-valued functions
+// only. There is a single schema ("main"; ATTACH is never issued), so a
+// schema filter other than "" or "main" yields an empty report. Identifiers
+// interpolated into SQL (sampling) are resolved against sqlite_schema first
+// and then double-quote-escaped.
+
+const sqliteMainSchema = "main"
+
+// sqliteSchemaInScope reports whether the caller's schema filter matches
+// the only schema an un-attached SQLite database has.
+func sqliteSchemaInScope(schema string) bool {
+	return schema == "" || schema == sqliteMainSchema
+}
+
+const sqliteOverviewQuery = `
+SELECT sqlite_version(),
+       IFNULL((SELECT file FROM pragma_database_list() WHERE name = 'main'), ''),
+       (SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()),
+       (SELECT query_only FROM pragma_query_only()),
+       (SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite\_%' ESCAPE '\')`
+
+func sqliteOverview(ctx context.Context, dsn string, o Options) (*Overview, error) {
+	out := &Overview{Engine: EngineSQLite}
+	err := withConn(ctx, dsn, o, func(ctx context.Context, conn Conn) error {
+		rows, err := conn.Query(ctx, sqliteOverviewQuery)
+		if err != nil {
+			return fmt.Errorf("dbinspect: sqlite overview query: %w", err)
+		}
+		defer rows.Close()
+		if !rows.Next() {
+			return fmt.Errorf("dbinspect: sqlite overview query returned no rows: %w", rows.Err())
+		}
+		var queryOnly, tableCount int64
+		if err := rows.Scan(&out.ServerVersion, &out.Database, &out.SizeBytes,
+			&queryOnly, &tableCount); err != nil {
+			return fmt.Errorf("dbinspect: scan sqlite overview: %w", err)
+		}
+		out.ReadOnlySession = queryOnly == 1
+		out.Schemas = []SchemaSummary{{Name: sqliteMainSchema, TableCount: int(tableCount)}}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+const sqliteTablesQuery = `
+SELECT name, type FROM sqlite_schema
+WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite\_%' ESCAPE '\'
+ORDER BY name`
+
+const sqliteColumnsQuery = `
+SELECT name, IFNULL(type, ''), "notnull", IFNULL(dflt_value, ''), pk
+FROM pragma_table_info(?)`
+
+const sqliteIndexListQuery = `
+SELECT il.name, il."unique", il.origin, IFNULL(m.sql, '')
+FROM pragma_index_list(?) il
+LEFT JOIN sqlite_schema m ON m.name = il.name AND m.type = 'index'
+ORDER BY il.name`
+
+func sqliteSchema(ctx context.Context, dsn, schema string, o Options) (*SchemaReport, error) {
+	out := &SchemaReport{Engine: EngineSQLite}
+	if !sqliteSchemaInScope(schema) {
+		return out, nil
+	}
+	err := withConn(ctx, dsn, o, func(ctx context.Context, conn Conn) error {
+		tables, err := collectSQLiteTables(ctx, conn)
+		if err != nil {
+			return err
+		}
+		for _, t := range tables {
+			if err := attachSQLiteColumns(ctx, conn, t); err != nil {
+				return err
+			}
+			if err := attachSQLiteIndexes(ctx, conn, t); err != nil {
+				return err
+			}
+			out.Tables = append(out.Tables, *t)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func collectSQLiteTables(ctx context.Context, conn Conn) ([]*Table, error) {
+	rows, err := conn.Query(ctx, sqliteTablesQuery)
+	if err != nil {
+		return nil, fmt.Errorf("dbinspect: sqlite tables query: %w", err)
+	}
+	defer rows.Close()
+	var out []*Table
+	for rows.Next() {
+		t := &Table{Schema: sqliteMainSchema}
+		if err := rows.Scan(&t.Name, &t.Kind); err != nil {
+			return nil, fmt.Errorf("dbinspect: scan sqlite table: %w", err)
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+func attachSQLiteColumns(ctx context.Context, conn Conn, t *Table) error {
+	rows, err := conn.Query(ctx, sqliteColumnsQuery, t.Name)
+	if err != nil {
+		return fmt.Errorf("dbinspect: sqlite columns for %s: %w", t.Name, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var col Column
+		var notNull, pk int64
+		if err := rows.Scan(&col.Name, &col.Type, &notNull, &col.Default, &pk); err != nil {
+			return fmt.Errorf("dbinspect: scan sqlite column: %w", err)
+		}
+		col.Nullable = notNull == 0
+		col.PrimaryKey = pk > 0
+		t.Columns = append(t.Columns, col)
+	}
+	return rows.Err()
+}
+
+func attachSQLiteIndexes(ctx context.Context, conn Conn, t *Table) error {
+	rows, err := conn.Query(ctx, sqliteIndexListQuery, t.Name)
+	if err != nil {
+		return fmt.Errorf("dbinspect: sqlite indexes for %s: %w", t.Name, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var idx Index
+		var unique int64
+		var origin, sqlText string
+		if err := rows.Scan(&idx.Name, &unique, &origin, &sqlText); err != nil {
+			return fmt.Errorf("dbinspect: scan sqlite index: %w", err)
+		}
+		idx.Unique = unique == 1
+		// origin: "c" = CREATE INDEX, "u" = UNIQUE constraint, "pk" = primary key.
+		idx.Primary = origin == "pk"
+		idx.Definition = sqlText
+		if idx.Definition == "" {
+			idx.Definition = "auto index (" + origin + ")"
+		}
+		t.Indexes = append(t.Indexes, idx)
+	}
+	return rows.Err()
+}
+
+const sqliteForeignKeysQuery = `
+SELECT id, "table", "from", IFNULL("to", ''), on_delete, on_update
+FROM pragma_foreign_key_list(?)
+ORDER BY id, seq`
+
+func sqliteRelations(ctx context.Context, dsn, schema string, o Options) (*RelationsReport, error) {
+	out := &RelationsReport{Engine: EngineSQLite}
+	if !sqliteSchemaInScope(schema) {
+		return out, nil
+	}
+	err := withConn(ctx, dsn, o, func(ctx context.Context, conn Conn) error {
+		tables, err := collectSQLiteTables(ctx, conn)
+		if err != nil {
+			return err
+		}
+		for _, t := range tables {
+			if t.Kind != "table" {
+				continue
+			}
+			fks, err := collectSQLiteForeignKeys(ctx, conn, t.Name)
+			if err != nil {
+				return err
+			}
+			out.ForeignKeys = append(out.ForeignKeys, fks...)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// collectSQLiteForeignKeys reads one table's foreign keys; rows arrive one
+// per column ordered by (id, seq), so consecutive rows with the same id
+// fold into one composite key. SQLite FKs are unnamed — names are
+// synthesized as <table>_fk_<id>.
+func collectSQLiteForeignKeys(ctx context.Context, conn Conn, table string) ([]ForeignKey, error) {
+	rows, err := conn.Query(ctx, sqliteForeignKeysQuery, table)
+	if err != nil {
+		return nil, fmt.Errorf("dbinspect: sqlite foreign keys for %s: %w", table, err)
+	}
+	defer rows.Close()
+	var out []ForeignKey
+	lastID := int64(-1)
+	for rows.Next() {
+		var id int64
+		var toTable, fromCol, toCol, onDelete, onUpdate string
+		if err := rows.Scan(&id, &toTable, &fromCol, &toCol, &onDelete, &onUpdate); err != nil {
+			return nil, fmt.Errorf("dbinspect: scan sqlite foreign key: %w", err)
+		}
+		if id != lastID {
+			out = append(out, ForeignKey{
+				Name:       fmt.Sprintf("%s_fk_%d", table, id),
+				FromSchema: sqliteMainSchema,
+				FromTable:  table,
+				ToSchema:   sqliteMainSchema,
+				ToTable:    toTable,
+				OnDelete:   strings.ToLower(onDelete),
+				OnUpdate:   strings.ToLower(onUpdate),
+			})
+			lastID = id
+		}
+		fk := &out[len(out)-1]
+		fk.FromColumns = append(fk.FromColumns, fromCol)
+		if toCol != "" {
+			fk.ToColumns = append(fk.ToColumns, toCol)
+		}
+	}
+	return out, rows.Err()
+}
+
+// sqliteDBStatQuery aggregates on-disk bytes per table from the dbstat
+// virtual table. Not every build ships dbstat, so callers treat a query
+// error as "sizes unavailable", not failure.
+const sqliteDBStatQuery = `
+SELECT name, CAST(SUM(pgsize) AS INTEGER) FROM dbstat GROUP BY name`
+
+// sqliteStat1Query reads ANALYZE output when present; the first integer in
+// stat is the approximate row count.
+const sqliteStat1Query = `
+SELECT tbl, CAST(stat AS TEXT) FROM sqlite_stat1`
+
+func sqliteStats(ctx context.Context, dsn, schema string, o Options) (*StatsReport, error) {
+	out := &StatsReport{Engine: EngineSQLite}
+	if !sqliteSchemaInScope(schema) {
+		return out, nil
+	}
+	err := withConn(ctx, dsn, o, func(ctx context.Context, conn Conn) error {
+		tables, err := collectSQLiteTables(ctx, conn)
+		if err != nil {
+			return err
+		}
+		sizes := sqliteNameValues(ctx, conn, sqliteDBStatQuery, parseInt64)
+		rowEstimates := sqliteNameValues(ctx, conn, sqliteStat1Query, parseStatRows)
+		for _, t := range tables {
+			if t.Kind != "table" {
+				continue
+			}
+			out.Tables = append(out.Tables, TableStats{
+				Schema:     sqliteMainSchema,
+				Name:       t.Name,
+				LiveRows:   rowEstimates[t.Name],
+				TotalBytes: sizes[t.Name],
+			})
+		}
+		sort.SliceStable(out.Tables, func(i, j int) bool {
+			return out.Tables[i].TotalBytes > out.Tables[j].TotalBytes
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// sqliteNameValues runs an optional (name, value) query — dbstat or
+// sqlite_stat1 — folding values per name with max. A query error returns an
+// empty map: both sources are optional extras, absent on many databases.
+func sqliteNameValues(ctx context.Context, conn Conn, query string, parse func(string) int64) map[string]int64 {
+	rows, err := conn.Query(ctx, query)
+	if err != nil {
+		return map[string]int64{}
+	}
+	defer rows.Close()
+	out := map[string]int64{}
+	for rows.Next() {
+		var name, value string
+		if err := rows.Scan(&name, &value); err != nil {
+			return out
+		}
+		if v := parse(value); v > out[name] {
+			out[name] = v
+		}
+	}
+	return out
+}
+
+func parseInt64(s string) int64 {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// parseStatRows extracts the leading integer of an sqlite_stat1 stat value
+// ("10000 12 3" → 10000).
+func parseStatRows(stat string) int64 {
+	first, _, _ := strings.Cut(strings.TrimSpace(stat), " ")
+	return parseInt64(first)
+}
+
+const sqliteResolveTableQuery = `
+SELECT name FROM sqlite_schema
+WHERE type IN ('table', 'view') AND name = ?`
+
+func sqliteSample(ctx context.Context, dsn, table string, limit int, o Options) (*SampleReport, error) {
+	out := &SampleReport{Engine: EngineSQLite, Schema: sqliteMainSchema, Limit: limit}
+	err := withConn(ctx, dsn, o, func(ctx context.Context, conn Conn) error {
+		name, err := resolveSQLiteTable(ctx, conn, table)
+		if err != nil {
+			return err
+		}
+		out.Table = name
+		// The identifier comes from sqlite_schema via resolveSQLiteTable,
+		// then is quote-escaped; the limit is a bind parameter.
+		query := "SELECT * FROM " + quoteIdent(name) + " LIMIT ?"
+		rows, err := conn.Query(ctx, query, out.Limit)
+		if err != nil {
+			return fmt.Errorf("dbinspect: sample %s: %w", name, err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			values, err := rows.Values()
+			if err != nil {
+				return fmt.Errorf("dbinspect: read sample row: %w", err)
+			}
+			row := make([]any, len(values))
+			for i, v := range values {
+				row[i] = displayValue(v)
+			}
+			out.Rows = append(out.Rows, row)
+		}
+		out.Columns = rows.Columns()
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// resolveSQLiteTable maps "table" or "main.table" to the catalog's own
+// spelling via sqlite_schema.
+func resolveSQLiteTable(ctx context.Context, conn Conn, table string) (string, error) {
+	name := strings.TrimPrefix(table, sqliteMainSchema+".")
+	rows, err := conn.Query(ctx, sqliteResolveTableQuery, name)
+	if err != nil {
+		return "", fmt.Errorf("dbinspect: resolve table %q: %w", table, err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return "", fmt.Errorf("dbinspect: resolve table %q: %w", table, err)
+		}
+		return "", fmt.Errorf("dbinspect: table %q not found", table)
+	}
+	var resolved string
+	if err := rows.Scan(&resolved); err != nil {
+		return "", fmt.Errorf("dbinspect: scan resolved table: %w", err)
+	}
+	return resolved, nil
+}

--- a/internal/dbinspect/sqlite_conn.go
+++ b/internal/dbinspect/sqlite_conn.go
@@ -1,0 +1,74 @@
+package dbinspect
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+
+	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver
+)
+
+// ConnectSQLite opens a single read-only connection to an SQLite database
+// file through modernc.org/sqlite (pure Go, already spectra's own storage
+// driver). The DSN may be sqlite://<path>, a file: URI, or a bare path.
+// The connection is opened mode=ro with query_only forced, so nothing can
+// write, and a short busy timeout so inspection fails fast instead of
+// holding locks against the owning application.
+func ConnectSQLite(ctx context.Context, dsn string) (Conn, error) {
+	driverDSN, err := sqliteDriverDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", driverDSN)
+	if err != nil {
+		return nil, fmt.Errorf("dbinspect: open %s: %w", RedactDSN(dsn), err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	// Opening is lazy; ping now so a missing or unreadable file fails here
+	// with a clear error instead of on the first catalog query.
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("dbinspect: open sqlite database %s: %w", RedactDSN(dsn), err)
+	}
+	return sqlConn{db}, nil
+}
+
+// sqliteReadOnlyParams force the read-only session. mode=ro refuses writes
+// at the file layer; query_only refuses them at the statement layer; the
+// busy timeout bounds lock waits against the owning app.
+const sqliteReadOnlyParams = "mode=ro&_pragma=query_only(1)&_pragma=busy_timeout(2000)"
+
+// sqliteDriverDSN converts sqlite:// URLs, file: URIs, and bare paths into
+// a modernc.org/sqlite DSN with the read-only parameters forced on.
+func sqliteDriverDSN(dsn string) (string, error) {
+	path := dsn
+	switch {
+	case strings.HasPrefix(dsn, "sqlite://"):
+		u, err := url.Parse(dsn)
+		if err != nil {
+			return "", fmt.Errorf("dbinspect: parse dsn %s: %w", RedactDSN(dsn), err)
+		}
+		// sqlite:///abs/path parses as empty host + /abs/path; a relative
+		// sqlite://some.db parses as host "some.db".
+		path = u.Path
+		if path == "" {
+			path = u.Host
+		} else if u.Host != "" {
+			path = u.Host + path
+		}
+	case strings.HasPrefix(dsn, "file:"):
+		path = strings.TrimPrefix(dsn, "file:")
+		// Drop any caller query params: the forced read-only set below is
+		// not negotiable, and mode=rw must not survive.
+		if idx := strings.IndexByte(path, '?'); idx >= 0 {
+			path = path[:idx]
+		}
+	}
+	if path == "" {
+		return "", fmt.Errorf("dbinspect: sqlite dsn %s has no file path", RedactDSN(dsn))
+	}
+	return "file:" + path + "?" + sqliteReadOnlyParams, nil
+}

--- a/internal/dbinspect/sqlite_test.go
+++ b/internal/dbinspect/sqlite_test.go
@@ -1,0 +1,260 @@
+package dbinspect
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSQLiteDriverDSN(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"absolute url", "sqlite:///var/db/app.db",
+			"file:/var/db/app.db?" + sqliteReadOnlyParams, false},
+		{"relative url", "sqlite://app.db",
+			"file:app.db?" + sqliteReadOnlyParams, false},
+		{"file uri drops caller params", "file:/var/db/app.db?mode=rw",
+			"file:/var/db/app.db?" + sqliteReadOnlyParams, false},
+		{"bare path", "/var/db/app.sqlite3",
+			"file:/var/db/app.sqlite3?" + sqliteReadOnlyParams, false},
+		{"empty", "", "", true},
+	}
+	for _, tt := range tests {
+		got, err := sqliteDriverDSN(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected error, got %q", tt.name, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tt.name, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("%s: sqliteDriverDSN(%q) = %q, want %q", tt.name, tt.in, got, tt.want)
+		}
+	}
+}
+
+// createSQLiteFixture writes a real database file: two tables, a composite
+// of PK/nullable/default column shapes, an index, a view, a foreign key,
+// rows, and ANALYZE output.
+func createSQLiteFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "app.db")
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	stmts := []string{
+		`CREATE TABLE customers (id INTEGER PRIMARY KEY, email TEXT NOT NULL)`,
+		`CREATE TABLE orders (
+			id INTEGER PRIMARY KEY,
+			customer_id INTEGER NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+			note TEXT DEFAULT 'pending',
+			payload BLOB
+		)`,
+		`CREATE INDEX idx_orders_customer ON orders(customer_id)`,
+		`CREATE VIEW order_emails AS
+			SELECT o.id, c.email FROM orders o JOIN customers c ON c.id = o.customer_id`,
+		`INSERT INTO customers (id, email) VALUES (1, 'a@example.com'), (2, 'b@example.com')`,
+		`INSERT INTO orders (id, customer_id, note, payload) VALUES
+			(1, 1, 'first', X'DEAD'), (2, 2, NULL, NULL)`,
+		`ANALYZE`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("fixture %q: %v", stmt, err)
+		}
+	}
+	return path
+}
+
+func TestSQLiteOverviewEndToEnd(t *testing.T) {
+	t.Parallel()
+	path := createSQLiteFixture(t)
+	got, err := CollectOverview(context.Background(), path, Options{})
+	if err != nil {
+		t.Fatalf("CollectOverview: %v", err)
+	}
+	if got.Engine != EngineSQLite || got.ServerVersion == "" {
+		t.Errorf("unexpected overview basics: %+v", got)
+	}
+	if !got.ReadOnlySession {
+		t.Error("query_only not reported for the session")
+	}
+	if got.SizeBytes <= 0 {
+		t.Errorf("size not computed: %d", got.SizeBytes)
+	}
+	if len(got.Schemas) != 1 || got.Schemas[0].Name != "main" || got.Schemas[0].TableCount != 2 {
+		t.Errorf("unexpected schemas: %+v", got.Schemas)
+	}
+}
+
+func TestSQLiteSchemaEndToEnd(t *testing.T) {
+	t.Parallel()
+	path := createSQLiteFixture(t)
+	got, err := CollectSchema(context.Background(), "sqlite://"+path, "", Options{})
+	if err != nil {
+		t.Fatalf("CollectSchema: %v", err)
+	}
+	byName := map[string]Table{}
+	for _, tbl := range got.Tables {
+		byName[tbl.Name] = tbl
+	}
+	if len(byName) != 3 {
+		t.Fatalf("expected customers, orders, order_emails; got %+v", got.Tables)
+	}
+	orders := byName["orders"]
+	if orders.Kind != "table" || len(orders.Columns) != 4 {
+		t.Fatalf("unexpected orders table: %+v", orders)
+	}
+	// INTEGER PRIMARY KEY is a rowid alias; pragma_table_info reports it
+	// notnull=0 even though it can never be NULL, so only pk is asserted.
+	if !orders.Columns[0].PrimaryKey {
+		t.Errorf("id column flags wrong: %+v", orders.Columns[0])
+	}
+	if orders.Columns[1].Nullable || orders.Columns[1].PrimaryKey {
+		t.Errorf("customer_id column flags wrong: %+v", orders.Columns[1])
+	}
+	if orders.Columns[2].Default != "'pending'" || !orders.Columns[2].Nullable {
+		t.Errorf("note column wrong: %+v", orders.Columns[2])
+	}
+	var idx *Index
+	for i := range orders.Indexes {
+		if orders.Indexes[i].Name == "idx_orders_customer" {
+			idx = &orders.Indexes[i]
+		}
+	}
+	if idx == nil || idx.Unique || !strings.Contains(idx.Definition, "CREATE INDEX") {
+		t.Errorf("index missing or wrong: %+v", orders.Indexes)
+	}
+	if byName["order_emails"].Kind != "view" {
+		t.Errorf("view not classified: %+v", byName["order_emails"])
+	}
+	if empty, err := CollectSchema(context.Background(), path, "other", Options{}); err != nil || len(empty.Tables) != 0 {
+		t.Errorf("non-main schema filter should be empty: %+v, %v", empty, err)
+	}
+}
+
+func TestSQLiteRelationsEndToEnd(t *testing.T) {
+	t.Parallel()
+	path := createSQLiteFixture(t)
+	got, err := CollectRelations(context.Background(), path, "", Options{})
+	if err != nil {
+		t.Fatalf("CollectRelations: %v", err)
+	}
+	if len(got.ForeignKeys) != 1 {
+		t.Fatalf("expected 1 foreign key, got %+v", got.ForeignKeys)
+	}
+	fk := got.ForeignKeys[0]
+	if fk.FromTable != "orders" || fk.ToTable != "customers" || fk.OnDelete != "cascade" {
+		t.Errorf("unexpected foreign key: %+v", fk)
+	}
+	if len(fk.FromColumns) != 1 || fk.FromColumns[0] != "customer_id" {
+		t.Errorf("unexpected columns: %+v", fk)
+	}
+}
+
+func TestSQLiteStatsEndToEnd(t *testing.T) {
+	t.Parallel()
+	path := createSQLiteFixture(t)
+	got, err := CollectStats(context.Background(), path, "", Options{})
+	if err != nil {
+		t.Fatalf("CollectStats: %v", err)
+	}
+	rows := map[string]TableStats{}
+	for _, s := range got.Tables {
+		rows[s.Name] = s
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected stats for 2 tables, got %+v", got.Tables)
+	}
+	// orders has an index, so ANALYZE recorded a row estimate for it.
+	if rows["orders"].LiveRows != 2 {
+		t.Errorf("orders row estimate = %d, want 2 (from sqlite_stat1)", rows["orders"].LiveRows)
+	}
+}
+
+func TestSQLiteSampleEndToEnd(t *testing.T) {
+	t.Parallel()
+	path := createSQLiteFixture(t)
+	got, err := SampleTable(context.Background(), path, "main.orders", 0, Options{})
+	if err != nil {
+		t.Fatalf("SampleTable: %v", err)
+	}
+	if got.Schema != "main" || got.Table != "orders" || got.Limit != 10 {
+		t.Errorf("unexpected report basics: %+v", got)
+	}
+	if len(got.Columns) != 4 || got.Columns[3] != "payload" {
+		t.Errorf("unexpected columns: %+v", got.Columns)
+	}
+	if len(got.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %+v", got.Rows)
+	}
+	if got.Rows[0][3] != `\xdead` {
+		t.Errorf("blob not hex-rendered: %+v", got.Rows[0])
+	}
+	if got.Rows[1][2] != nil {
+		t.Errorf("NULL not preserved: %+v", got.Rows[1])
+	}
+	if _, err := SampleTable(context.Background(), path, "nope", 5, Options{}); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error, got %v", err)
+	}
+}
+
+func TestSQLiteSessionRefusesWrites(t *testing.T) {
+	t.Parallel()
+	path := createSQLiteFixture(t)
+	conn, err := ConnectSQLite(context.Background(), path)
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	defer func() { _ = conn.Close(context.Background()) }()
+	rows, err := conn.Query(context.Background(), "DELETE FROM orders")
+	if err == nil {
+		rows.Close()
+		t.Fatal("write through read-only session unexpectedly succeeded")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "readonly") &&
+		!strings.Contains(strings.ToLower(err.Error()), "read-only") {
+		t.Errorf("expected readonly refusal, got: %v", err)
+	}
+}
+
+func TestSQLiteConnectMissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := ConnectSQLite(context.Background(), filepath.Join(t.TempDir(), "missing.db"))
+	if err == nil {
+		t.Fatal("expected error opening missing database file")
+	}
+}
+
+func TestParseLSOFSQLiteFiles(t *testing.T) {
+	t.Parallel()
+	const out = `COMMAND   PID  USER   FD   TYPE  DEVICE  SIZE/OFF  NODE NAME
+notes     314  alice  12u  REG   1,4     32768     99   /Users/alice/Library/Group Containers/notes.sqlite
+notes     314  alice  13u  REG   1,4     8192      100  /Users/alice/Library/Group Containers/notes.sqlite-wal
+chrome    512  alice  40u  REG   1,4     4096      101  /Users/alice/Library/Caches/History.db
+chrome    512  alice  41u  IPv4  0xdead  0t0       TCP  1.2.3.4:443 (ESTABLISHED)
+daemon    600  root   5u   REG   1,4     1024      102  /var/log/system.log`
+	got := parseLSOFSQLiteFiles(out)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 candidates, got %+v", got)
+	}
+	if got[0].Path != "/Users/alice/Library/Group Containers/notes.sqlite" || got[0].PID != 314 {
+		t.Errorf("space-containing path or sidecar dedup wrong: %+v", got[0])
+	}
+	if got[1].Command != "chrome" || got[1].Path != "/Users/alice/Library/Caches/History.db" {
+		t.Errorf("unexpected second candidate: %+v", got[1])
+	}
+}

--- a/internal/mcp/collectors.go
+++ b/internal/mcp/collectors.go
@@ -83,9 +83,10 @@ type ToolchainCollector interface {
 
 // DBInspector opens read-only sessions against databases an application
 // under debug talks to. Live-socket discovery goes through NetworkCollector;
-// this interface covers env discovery and the catalog reads.
+// this interface covers env and open-file discovery plus the catalog reads.
 type DBInspector interface {
 	DiscoverDBEnv() []dbinspect.EnvHint
+	DiscoverSQLiteFiles() []dbinspect.FileCandidate
 	Overview(ctx context.Context, dsn string) (*dbinspect.Overview, error)
 	Schema(ctx context.Context, dsn, schema string) (*dbinspect.SchemaReport, error)
 	Relations(ctx context.Context, dsn, schema string) (*dbinspect.RelationsReport, error)
@@ -179,6 +180,10 @@ type defaultDBInspector struct{}
 
 func (defaultDBInspector) DiscoverDBEnv() []dbinspect.EnvHint {
 	return dbinspect.DiscoverEnv(os.Getenv)
+}
+
+func (defaultDBInspector) DiscoverSQLiteFiles() []dbinspect.FileCandidate {
+	return dbinspect.DiscoverSQLiteFiles(dbinspect.DefaultRunner)
 }
 
 func (defaultDBInspector) Overview(ctx context.Context, dsn string) (*dbinspect.Overview, error) {

--- a/internal/mcp/db_test.go
+++ b/internal/mcp/db_test.go
@@ -21,6 +21,10 @@ func (f *fakeDBInspector) DiscoverDBEnv() []dbinspect.EnvHint {
 	return []dbinspect.EnvHint{{Name: "DATABASE_URL", Value: "postgres://app:[redacted]@db/orders", Engine: dbinspect.EnginePostgres}}
 }
 
+func (f *fakeDBInspector) DiscoverSQLiteFiles() []dbinspect.FileCandidate {
+	return []dbinspect.FileCandidate{{Engine: dbinspect.EngineSQLite, PID: 200, Command: "notes-app", Path: "/Users/x/Library/notes.sqlite"}}
+}
+
 func (f *fakeDBInspector) Overview(context.Context, string) (*dbinspect.Overview, error) {
 	return f.overview, nil
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -44,7 +44,7 @@ func toolDefinitions() []ToolDefinition {
 		operationToolDef("process", "Live processes. Ops: list, tree, by_app, sample. Ask: \"What is using memory?\" \"Sample PID 123.\"", []string{"list", "tree", "history", "sample", "by_app"}),
 		operationToolDef("jvm", "JVM debug. Ops: list, inspect, explain, thread_dump, gc_stats, vm_memory, heap_histogram, heap_dump, flamegraph, attach. Ops that require the spectra agent (auto-attached by default): mbeans, mbean_read (needs mbean_name+attribute), mbean_invoke (needs mbean_name+mbean_operation), probe. Pass auto_attach=false to opt out. Ask: \"Why is PID 123 using heap?\"", []string{"list", "inspect", "explain", "thread_dump", "gc_stats", "vm_memory", "heap_histogram", "heap_dump", "flamegraph", "attach", "mbeans", "mbean_read", "mbean_invoke", "probe"}),
 		operationToolDef("network", "Network state and sockets. Ops: state, connections, by_app, diagnose. Ask: \"What is this app connected to?\"", []string{"state", "connections", "by_app", "firewall", "diagnose", "capture_start", "capture_stop"}),
-		operationToolDef("db", "Read-only database inspection (postgres, mysql). Ops: discover, overview, schema, relations, stats, sample. Ask: \"What database does this app use?\" \"Show its schema.\"", []string{"discover", "overview", "schema", "relations", "stats", "sample"}),
+		operationToolDef("db", "Read-only database inspection (postgres, mysql, sqlite). Ops: discover, overview, schema, relations, stats, sample. Ask: \"What database does this app use?\" \"Show its schema.\"", []string{"discover", "overview", "schema", "relations", "stats", "sample"}),
 		operationToolDef("toolchain", "Dev tools and drift. Ops: scan, jdk, runtimes, build_tools, brew, drift. Ask: \"Which JDKs are installed?\"", []string{"scan", "jdk", "runtimes", "build_tools", "brew", "drift"}),
 		operationToolDef("issues", "Persisted findings. Ops: check, list, acknowledge, dismiss, record_fix, fix_history. Ask: \"What issues are open?\"", []string{"check", "list", "acknowledge", "dismiss", "record_fix", "fix_history"}),
 		operationToolDef("remote", "Call a Spectra daemon or list known hosts. Ops: health, hosts, rpc, fanout. Ask: \"Check host health.\" \"What hosts do we know about?\"", []string{"health", "hosts", "rpc", "triage", "fanout"}),
@@ -1124,9 +1124,10 @@ func (s *Server) toolDB(raw json.RawMessage) ToolResult {
 	case "discover", "":
 		conns := dbinspect.DiscoverConnections(s.collect.Network.CollectConnections())
 		env := s.collect.DB.DiscoverDBEnv()
+		files := s.collect.DB.DiscoverSQLiteFiles()
 		return toolText(toolEnvelope{
-			Summary:   fmt.Sprintf("found %d live database connection(s) and %d connection env var(s)", len(conns), len(env)),
-			Raw:       dbinspect.Discovery{Connections: conns, Env: env},
+			Summary:   fmt.Sprintf("found %d live database connection(s), %d connection env var(s), and %d open sqlite file(s)", len(conns), len(env), len(files)),
+			Raw:       dbinspect.Discovery{Connections: conns, Env: env, SQLiteFiles: files},
 			Timestamp: s.now(),
 		})
 	case "overview":

--- a/internal/serve/db.go
+++ b/internal/serve/db.go
@@ -35,11 +35,13 @@ func decodeDBParams(method string, params json.RawMessage) (dbParams, error) {
 // db.sample additionally requires confirm_sensitive because row data may
 // contain customer PII.
 func registerDBHandlers(d *rpc.Dispatcher, artifactRecorder artifact.Recorder, artifactPolicy artifact.Policy, log logger.Logger) {
-	// db.discover — live sockets to database ports plus connection env vars.
+	// db.discover — live sockets to database ports, connection env vars, and
+	// open SQLite database files.
 	d.Register("db.discover", func(_ json.RawMessage) (any, error) {
 		return dbinspect.Discovery{
 			Connections: dbinspect.DiscoverConnections(netstate.CollectConnections(netstate.DefaultRunner)),
 			Env:         dbinspect.DiscoverEnv(os.Getenv),
+			SQLiteFiles: dbinspect.DiscoverSQLiteFiles(dbinspect.DefaultRunner),
 		}, nil
 	})
 


### PR DESCRIPTION
Closes #417

Adds SQLite support to the database inspection engine (#413, #414) — with **zero new dependencies**: it rides `modernc.org/sqlite`, already spectra's own storage driver. No new commands, flags, RPCs, or tool operations.

## Read-only at two layers

SQLite files open with `mode=ro` (write refusal at the file layer) **and** the `query_only` pragma (refusal at the statement layer), plus a 2s busy timeout so inspection fails fast rather than holding locks against the application that owns the file. A missing/unreadable file fails at connect with a clear error, not on the first catalog query.

## Engine dispatch becomes a registry

With three engines, the per-function if-chains in `dispatch.go` collapse into a single `engineOps` registry — the queued MongoDB engine (and anything after) is one entry plus its collectors. DSN inference now also recognizes `sqlite://` URLs, `file:` URIs, and bare paths ending in `.db`/`.sqlite`/`.sqlite3`/`.db3`.

## Inspection surface

- `overview` — sqlite version, file path, `page_count × page_size` size, `query_only` state, table count.
- `schema` — tables/views from `sqlite_schema`, columns from `pragma_table_info` (pk, nullability, defaults), indexes from `pragma_index_list` joined to their `CREATE INDEX` sql.
- `relations` — `pragma_foreign_key_list` per table, composite keys folded by id; SQLite FKs are unnamed so names are synthesized as `<table>_fk_<id>`.
- `stats` — row estimates from `sqlite_stat1` (present after `ANALYZE`), sizes from the `dbstat` virtual table when the build ships it; both degrade gracefully to zero when absent. Never `COUNT(*)`.
- `sample` — identifier resolved through `sqlite_schema` then quote-escaped, limit bound; same `confirm_sensitive` + `db_sample` artifact gate as the other engines.

## Discovery gains a third signal

Alongside live sockets and env vars, `db discover` now finds **open SQLite files**: one host-wide `lsof -nP` pass filtered to regular-file handles with database suffixes, WAL/SHM/journal sidecars folded into their database path, deduped per pid+path, with PID and command attribution.

## Testing

Because SQLite needs no server, this engine gets what postgres/mysql couldn't: **true end-to-end tests in CI** against real database files — fixture with tables/view/index/FK/rows/`ANALYZE`, then every collector exercised through the real connector, including a write-refusal test proving the read-only session and a missing-file connect test. Plus unit tests for DSN conversion and lsof parsing (space-containing paths, sidecar dedup). One real SQLite quirk surfaced and is documented in the test: `INTEGER PRIMARY KEY` rowid aliases report `notnull=0` in `pragma_table_info`.

Full suite with `-race`, `golangci-lint`, `gocyclo`, and `make docs-validate` green locally; CLI smoke-tested against a real file (overview/relations/sample all correct).
