### PR TITLE
rules: project JVM GC detail, class, and history facts into the CEL/YAML rule model

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -177,8 +177,19 @@ app.bundle_id, app.version, app.runtime, app.architectures, app.entitlements,
   app.granted_perms, app.storage.total_bytes, app.helpers, app.frameworks, ...
 process.pid, process.rss_kib, process.cpu_pct, process.command
 jvm.version, jvm.vendor, jvm.max_heap_mb, jvm.gc_count, jvm.thread_count
+jvm.gc.{oc,ou,mc,mu,ec,eu,s0c,s1c,s0u,s1u,ccsc,ccsu,ygc,ygct,fgc,fgct,gct},
+  jvm.gc.{old_gen_used_pct, metaspace_used_pct, full_gc_count, full_gc_time_s,
+  young_gc_count}
+jvm.classes.{loaded, unloaded, loaded_kib, unloaded_kib, class_load_time}
+jvm.history.{sample_count, has_trend, rising_old_gen, old_gen_pct_first,
+  old_gen_pct_last, fgc_first, fgc_last, heap_mb_first, heap_mb_last}
 toolchain.brew_formulae[], toolchain.jdks[], toolchain.node_versions[]
 ```
+
+`jvm.gc` and `jvm.classes` are `null` when the corresponding `jstat` reading
+was not collected; guard with e.g. `jvm.gc != null`. `jvm.history` is always
+present (zero-valued when there are no samples), so `jvm.history.rising_old_gen`
+is null-safe; require real trend data with `jvm.history.sample_count > 0`.
 
 Baseline-diff inputs (`diff.added_apps[]`, `diff.removed_apps[]`,
 `diff.changed_versions[]`) are **not** part of the single-snapshot projection

--- a/internal/rules/projection.go
+++ b/internal/rules/projection.go
@@ -21,7 +21,7 @@ func SnapshotActivation(s snapshot.Snapshot) map[string]any {
 		"host":       projectHost(s.Host),
 		"apps":       projectApps(s.Apps),
 		"processes":  projectProcesses(s.Processes),
-		"jvms":       projectJVMs(s.JVMs),
+		"jvms":       projectJVMs(s.JVMs, s.JVMHistory),
 		"toolchains": projectToolchains(s.Toolchains),
 		"network":    s.Network,
 		"storage":    s.Storage,
@@ -113,7 +113,7 @@ func projectProcesses(processes []process.Info) []any {
 	return out
 }
 
-func projectJVMs(jvms []jvm.Info) []any {
+func projectJVMs(jvms []jvm.Info, history snapshot.JVMHistory) []any {
 	out := make([]any, 0, len(jvms))
 	for _, info := range jvms {
 		out = append(out, map[string]any{
@@ -133,6 +133,8 @@ func projectJVMs(jvms []jvm.Info) []any {
 			"sys_props":      info.SysProps,
 			"gc_count":       gcCount(info.GC),
 			"gc":             projectGC(info.GC),
+			"classes":        projectClasses(info.Classes),
+			"history":        projectJVMHistory(history, info.PID),
 		})
 	}
 	return out
@@ -153,19 +155,90 @@ func projectGC(gc *jvm.GCStats) any {
 	if gc == nil {
 		return nil
 	}
-	return map[string]any{
+	m := map[string]any{
 		"ygc":  gc.YGC,
 		"ygct": gc.YGCT,
 		"fgc":  gc.FGC,
 		"fgct": gc.FGCT,
 		"gct":  gc.GCT,
+		"s0c":  gc.S0C,
+		"s1c":  gc.S1C,
+		"s0u":  gc.S0U,
+		"s1u":  gc.S1U,
 		"ec":   gc.EC,
 		"eu":   gc.EU,
 		"oc":   gc.OC,
 		"ou":   gc.OU,
 		"mc":   gc.MC,
 		"mu":   gc.MU,
+		"ccsc": gc.CCSC,
+		"ccsu": gc.CCSU,
+		// Convenience aliases so external rules read the same names the
+		// built-in Go rules use.
+		"full_gc_count":  gc.FGC,
+		"full_gc_time_s": gc.FGCT,
+		"young_gc_count": gc.YGC,
 	}
+	// Derived occupancy percentages. Kept identical to the predicate math in
+	// predicates.go (OldGenUsedPct / metaspace) so external and built-in rules
+	// agree on the same thresholds.
+	if gc.OC > 0 {
+		m["old_gen_used_pct"] = gc.OU * 100 / gc.OC
+	} else {
+		m["old_gen_used_pct"] = 0.0
+	}
+	if gc.MC > 0 {
+		m["metaspace_used_pct"] = gc.MU * 100 / gc.MC
+	} else {
+		m["metaspace_used_pct"] = 0.0
+	}
+	return m
+}
+
+// projectClasses exposes the jstat -class counters to external rules.
+func projectClasses(c *jvm.ClassStats) any {
+	if c == nil {
+		return nil
+	}
+	return map[string]any{
+		"loaded":          c.Loaded,
+		"unloaded":        c.Unloaded,
+		"loaded_kib":      c.LoadedKiB,
+		"unloaded_kib":    c.UnloadedKiB,
+		"class_load_time": c.ClassLoadTime,
+	}
+}
+
+// projectJVMHistory summarizes the per-PID trend samples so a rule can gate on
+// a rising heap without walking a raw sample slice in CEL.
+//
+// Unlike gc/classes (which are nil when the reading was not collected), history
+// is ALWAYS a map with the same key set — zero-valued when there are no samples
+// for the PID. This keeps `item.history.rising_old_gen` null-safe in CEL and
+// lets a rule require data explicitly with `item.history.sample_count > 0`.
+func projectJVMHistory(history snapshot.JVMHistory, pid int) map[string]any {
+	samples := history.SamplesFor(pid)
+	m := map[string]any{
+		"sample_count":      len(samples),
+		"has_trend":         HasTrendFor(history, pid),
+		"rising_old_gen":    RisingOldGenFor(history, pid),
+		"old_gen_pct_first": 0.0,
+		"old_gen_pct_last":  0.0,
+		"fgc_first":         int64(0),
+		"fgc_last":          int64(0),
+		"heap_mb_first":     int64(0),
+		"heap_mb_last":      int64(0),
+	}
+	if len(samples) > 0 {
+		first, last := samples[0], samples[len(samples)-1]
+		m["old_gen_pct_first"] = first.OldGenPct
+		m["old_gen_pct_last"] = last.OldGenPct
+		m["fgc_first"] = first.FGC
+		m["fgc_last"] = last.FGC
+		m["heap_mb_first"] = first.HeapMB
+		m["heap_mb_last"] = last.HeapMB
+	}
+	return m
 }
 
 func projectToolchains(t toolchain.Toolchains) map[string]any {

--- a/internal/rules/projection_jvm_test.go
+++ b/internal/rules/projection_jvm_test.go
@@ -44,6 +44,113 @@ func TestSnapshotActivationJVMWithoutGC(t *testing.T) {
 	}
 }
 
+func TestSnapshotActivationProjectsGCDerivedFields(t *testing.T) {
+	snap := snapshot.Snapshot{
+		JVMs: []jvm.Info{{
+			PID: 100,
+			GC: &jvm.GCStats{
+				S0C: 64, S1C: 64, S0U: 10, S1U: 0,
+				EC: 512, EU: 480,
+				OC: 1000, OU: 950,
+				MC: 200, MU: 180, CCSC: 40, CCSU: 30,
+				YGC: 12, FGC: 3, FGCT: 4.5,
+			},
+		}},
+	}
+	j := SnapshotActivation(snap)["jvms"].([]any)[0].(map[string]any)
+	gc, ok := j["gc"].(map[string]any)
+	if !ok {
+		t.Fatalf("gc projection missing/typed %T", j["gc"])
+	}
+	// Survivor + compressed-class-space counters must now be projected.
+	for _, k := range []string{"s0c", "s1c", "s0u", "s1u", "ccsc", "ccsu"} {
+		if _, ok := gc[k]; !ok {
+			t.Errorf("gc projection missing counter %q", k)
+		}
+	}
+	if got := gc["old_gen_used_pct"].(float64); got != 95 {
+		t.Errorf("old_gen_used_pct = %v, want 95 (950/1000)", got)
+	}
+	if got := gc["metaspace_used_pct"].(float64); got != 90 {
+		t.Errorf("metaspace_used_pct = %v, want 90 (180/200)", got)
+	}
+	if gc["full_gc_count"].(int64) != 3 || gc["full_gc_time_s"].(float64) != 4.5 {
+		t.Errorf("full_gc aliases = %v/%v", gc["full_gc_count"], gc["full_gc_time_s"])
+	}
+	if gc["young_gc_count"].(int64) != 12 {
+		t.Errorf("young_gc_count = %v, want 12", gc["young_gc_count"])
+	}
+}
+
+func TestSnapshotActivationGCDerivedZeroDivision(t *testing.T) {
+	snap := snapshot.Snapshot{
+		JVMs: []jvm.Info{{PID: 1, GC: &jvm.GCStats{OC: 0, OU: 5, MC: 0, MU: 5}}},
+	}
+	gc := SnapshotActivation(snap)["jvms"].([]any)[0].(map[string]any)["gc"].(map[string]any)
+	if gc["old_gen_used_pct"].(float64) != 0 || gc["metaspace_used_pct"].(float64) != 0 {
+		t.Fatalf("derived pcts should be 0 when capacity is 0: %#v", gc)
+	}
+}
+
+func TestSnapshotActivationProjectsClasses(t *testing.T) {
+	snap := snapshot.Snapshot{
+		JVMs: []jvm.Info{{
+			PID:     100,
+			Classes: &jvm.ClassStats{Loaded: 4200, Unloaded: 12, LoadedKiB: 8192, ClassLoadTime: 1.25},
+		}},
+	}
+	j := SnapshotActivation(snap)["jvms"].([]any)[0].(map[string]any)
+	cls, ok := j["classes"].(map[string]any)
+	if !ok {
+		t.Fatalf("classes projection missing/typed %T", j["classes"])
+	}
+	if cls["loaded"].(int64) != 4200 || cls["unloaded"].(int64) != 12 {
+		t.Fatalf("classes detail = %#v", cls)
+	}
+
+	// Absent Classes projects nil, mirroring gc's absent behavior.
+	nocls := SnapshotActivation(snapshot.Snapshot{JVMs: []jvm.Info{{PID: 2}}})
+	if nocls["jvms"].([]any)[0].(map[string]any)["classes"] != nil {
+		t.Fatal("classes should be nil when absent")
+	}
+}
+
+func TestSnapshotActivationProjectsHistory(t *testing.T) {
+	snap := snapshot.Snapshot{
+		JVMs: []jvm.Info{{PID: 100}},
+		JVMHistory: snapshot.JVMHistory{
+			{PID: 100, OldGenPct: 80, FGC: 1, HeapMB: 512},
+			{PID: 100, OldGenPct: 88, FGC: 2, HeapMB: 512},
+			{PID: 100, OldGenPct: 96, FGC: 4, HeapMB: 512},
+			{PID: 999, OldGenPct: 10}, // unrelated PID must not leak in
+		},
+	}
+	j := SnapshotActivation(snap)["jvms"].([]any)[0].(map[string]any)
+	h, ok := j["history"].(map[string]any)
+	if !ok {
+		t.Fatalf("history projection missing/typed %T", j["history"])
+	}
+	if h["sample_count"].(int) != 3 {
+		t.Errorf("sample_count = %v, want 3", h["sample_count"])
+	}
+	if h["rising_old_gen"] != true {
+		t.Errorf("rising_old_gen = %v, want true (80 -> 96)", h["rising_old_gen"])
+	}
+	if h["old_gen_pct_last"].(float64) != 96 || h["fgc_last"].(int64) != 4 {
+		t.Errorf("history last = %#v", h)
+	}
+
+	// No history for the PID -> present map with zero values (null-safe in CEL).
+	none := SnapshotActivation(snapshot.Snapshot{JVMs: []jvm.Info{{PID: 7}}})
+	nh, ok := none["jvms"].([]any)[0].(map[string]any)["history"].(map[string]any)
+	if !ok {
+		t.Fatal("history should be a present map even with no samples")
+	}
+	if nh["sample_count"].(int) != 0 || nh["rising_old_gen"] != false {
+		t.Fatalf("empty history = %#v, want sample_count 0 / rising_old_gen false", nh)
+	}
+}
+
 // TestSnapshotActivationBoundaryKeys locks the top-level external-rule keys so
 // a rename that would silently break YAML/CEL rules is caught.
 func TestSnapshotActivationBoundaryKeys(t *testing.T) {

--- a/internal/rules/yaml_test.go
+++ b/internal/rules/yaml_test.go
@@ -47,6 +47,47 @@ rules:
 	}
 }
 
+// TestYAMLRuleMatchesGCAndHistory proves the newly projected memory fields are
+// reachable from external CEL rules: a rule can gate on derived GC occupancy
+// combined with the rising-heap trend summary.
+func TestYAMLRuleMatchesGCAndHistory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rules.yml")
+	if err := os.WriteFile(path, []byte(`
+rules:
+  - id: yaml-jvm-oldgen-rising
+    severity: high
+    for_each: jvms
+    match: item.gc.old_gen_used_pct > 90 && item.history.rising_old_gen
+    subject: "jvm:{{ .item.pid }}"
+    message: "old gen high and rising"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := LoadYAMLRules([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := snapshot.Snapshot{
+		JVMs: []jvm.Info{
+			{PID: 1, GC: &jvm.GCStats{OC: 1000, OU: 950}}, // high but no history -> no match
+			{PID: 2, GC: &jvm.GCStats{OC: 1000, OU: 960}}, // high and rising -> match
+			{PID: 3, GC: &jvm.GCStats{OC: 1000, OU: 500}}, // rising but not high -> no match
+		},
+		JVMHistory: snapshot.JVMHistory{
+			{PID: 2, OldGenPct: 80}, {PID: 2, OldGenPct: 88}, {PID: 2, OldGenPct: 96},
+			{PID: 3, OldGenPct: 30}, {PID: 3, OldGenPct: 40}, {PID: 3, OldGenPct: 50},
+		},
+	}
+	findings := Evaluate(s, catalog)
+	if len(findings) != 1 {
+		t.Fatalf("len(findings) = %d, want 1: %#v", len(findings), findings)
+	}
+	if findings[0].Subject != "jvm:2" {
+		t.Fatalf("subject = %q, want jvm:2", findings[0].Subject)
+	}
+}
+
 func TestYAMLRuleHostLevel(t *testing.T) {
 	spec := YAMLRuleSpec{
 		ID:       "yaml-low-ram",


### PR DESCRIPTION
Closes #418.

## What

External CEL/YAML rules (`--rules`) could previously see only a partial `gc` counter set (no survivor or compressed-class spaces, no derived occupancy) and had **no** access to class-loading counters or per-PID trend history. That blocked an entire class of user-authored memory rules — the exact GC/metaspace/trend signals the built-in Go rules already use.

This enriches the `jvms` projection in `internal/rules/projection.go`:

- **`gc`** — adds survivor (`s0c/s1c/s0u/s1u`) and compressed-class-space (`ccsc/ccsu`) counters, plus derived `old_gen_used_pct` / `metaspace_used_pct` and `full_gc_count` / `full_gc_time_s` / `young_gc_count` aliases. Derived math is kept identical to the `predicates.go` definitions so external and built-in rules agree on thresholds.
- **`classes`** — exposes the `jstat -class` counters (loaded, unloaded, load time). `null` when not collected, mirroring `gc`.
- **`history`** — an always-present per-PID trend summary (`rising_old_gen`, `has_trend`, `sample_count`, first/last old-gen % and full-GC count). Always a map (zero-valued when there are no samples) so `item.history.rising_old_gen` is null-safe in CEL; a rule requires real data with `item.history.sample_count > 0`.

## Why always-present history vs nil

`gc`/`classes` are raw readings that may not have been collected (`nil` = absent). `history` is a summary that is always computable, so projecting it as a present map avoids CEL null-field-access errors on the common combined predicate `item.gc.old_gen_used_pct > 90 && item.history.rising_old_gen`.

## Tests

- `projection_jvm_test.go`: new gc counters + derived percentages (incl. zero-capacity guard), `classes` projection and its nil-when-absent case, and `history` (rising trend, PID isolation, empty-map when absent).
- `yaml_test.go`: end-to-end YAML rule matching `item.gc.old_gen_used_pct > 90 && item.history.rising_old_gen` across three JVMs, proving the boundary is reachable from external rules.
- Docs contract (`docs/design/recommendations-engine.md`) updated to list the new fields and the null-safety guidance.

No new built-in Go rules here — follow-ups consume these fields.