### PR TITLE
rules: jvm-metaspace-pressure — flag metaspace approaching a configured ceiling

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -208,6 +208,7 @@ Implemented rules:
 - `jvm-eol-version`
 - `jvm-heap-vs-system`
 - `jvm-gc-pressure`
+- `jvm-metaspace-pressure`
 - `jdk-major-version-drift`
 - `java-home-mismatch`
 - `library-storage-footprint`

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -305,8 +305,9 @@ purpose-built for the workflow that exists today:
 - **Persistent.** Thread dumps and JFR recordings can be stored in the blob
   cache; heap dumps are written as explicit `.hprof` artifacts.
 - **Catalog-driven.** Recommendations engine fires JVM-specific rules
-  (EOL versions, heap-vs-RAM ratios, GC pressure) the same way as
-  every other inspection ([../design/recommendations-engine.md](../design/recommendations-engine.md)).
+  (EOL versions, heap-vs-RAM ratios, GC pressure, metaspace approaching a
+  configured ceiling) the same way as every other inspection
+  ([../design/recommendations-engine.md](../design/recommendations-engine.md)).
 
 ## Implementation status
 

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -216,11 +216,15 @@ func ruleJVMMetaspacePressure() Rule {
 			for _, j := range s.JVMs {
 				f := FactsFor(j)
 				subject := fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass)
+				// Metaspace and compressed class space are distinct exhaustion
+				// paths that can both trip for one PID; give each a distinct
+				// Subject so the issue catalog keys them as separate issues
+				// (identity is rule_id + machine_uuid + subject).
 				if pct, ok := MetaspaceCeilingPct(j, f); ok && pct >= MetaspaceNearLimitPct {
 					findings = append(findings, Finding{
 						RuleID:   "jvm-metaspace-pressure",
 						Severity: SeverityMedium,
-						Subject:  subject,
+						Subject:  subject + " (Metaspace)",
 						Message: fmt.Sprintf(
 							"Metaspace is %.0f%% of the -XX:MaxMetaspaceSize ceiling (%dMB); approaching OutOfMemoryError: Metaspace.",
 							pct, f.MaxMetaspaceSizeBytes/(1024*1024)),
@@ -231,7 +235,7 @@ func ruleJVMMetaspacePressure() Rule {
 					findings = append(findings, Finding{
 						RuleID:   "jvm-metaspace-pressure",
 						Severity: SeverityMedium,
-						Subject:  subject,
+						Subject:  subject + " (Compressed class space)",
 						Message: fmt.Sprintf(
 							"Compressed class space is %.0f%% of the -XX:CompressedClassSpaceSize ceiling (%dMB); approaching OutOfMemoryError: Compressed class space.",
 							pct, f.CompressedClassSpaceSizeBytes/(1024*1024)),

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -27,6 +27,7 @@ func V1Catalog() []Rule {
 		ruleBackupDestinationlessSchedulerLeak(),
 		ruleUpdatesStaleMajorPrepared(),
 		ruleJVMGCPressure(),
+		ruleJVMMetaspacePressure(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),
 		ruleStorageFootprint(),
@@ -194,6 +195,47 @@ func ruleJVMGCPressure() Rule {
 						Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
 						Message:  fmt.Sprintf("%d full GCs have consumed %.1fs; check for old-gen pressure or promotion failures.", j.GC.FGC, j.GC.FGCT),
 						Fix:      "Capture a JFR recording or heap histogram to identify allocation hot spots and retained objects.",
+					})
+				}
+			}
+			return findings
+		},
+	}
+}
+
+// ruleJVMMetaspacePressure fires when used class-metadata space is approaching
+// a configured hard ceiling, which precedes OutOfMemoryError: Metaspace (or
+// Compressed class space). It only fires when the relevant ceiling flag is set;
+// unbounded metaspace growth (no ceiling) is a trend signal handled elsewhere.
+func ruleJVMMetaspacePressure() Rule {
+	return Rule{
+		ID:       "jvm-metaspace-pressure",
+		Severity: SeverityMedium,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, j := range s.JVMs {
+				f := FactsFor(j)
+				subject := fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass)
+				if pct, ok := MetaspaceCeilingPct(j, f); ok && pct >= MetaspaceNearLimitPct {
+					findings = append(findings, Finding{
+						RuleID:   "jvm-metaspace-pressure",
+						Severity: SeverityMedium,
+						Subject:  subject,
+						Message: fmt.Sprintf(
+							"Metaspace is %.0f%% of the -XX:MaxMetaspaceSize ceiling (%dMB); approaching OutOfMemoryError: Metaspace.",
+							pct, f.MaxMetaspaceSizeBytes/(1024*1024)),
+						Fix: "Raise -XX:MaxMetaspaceSize, or investigate a classloader leak (loaded-class count rising after workload quiescence).",
+					})
+				}
+				if pct, ok := CompressedClassCeilingPct(j, f); ok && pct >= MetaspaceNearLimitPct {
+					findings = append(findings, Finding{
+						RuleID:   "jvm-metaspace-pressure",
+						Severity: SeverityMedium,
+						Subject:  subject,
+						Message: fmt.Sprintf(
+							"Compressed class space is %.0f%% of the -XX:CompressedClassSpaceSize ceiling (%dMB); approaching OutOfMemoryError: Compressed class space.",
+							pct, f.CompressedClassSpaceSizeBytes/(1024*1024)),
+						Fix: "Raise -XX:CompressedClassSpaceSize, or investigate a classloader leak.",
 					})
 				}
 			}

--- a/internal/rules/jvm_facts.go
+++ b/internal/rules/jvm_facts.go
@@ -14,6 +14,11 @@ type VMArgsFacts struct {
 	XmxBytes int64
 	XmsBytes int64
 
+	// Class-metadata ceilings. 0 means "flag not present" — metaspace and
+	// compressed class space are effectively unbounded by default on 64-bit.
+	MaxMetaspaceSizeBytes         int64
+	CompressedClassSpaceSizeBytes int64
+
 	MaxHeapFreeRatio      int
 	MinHeapFreeRatio      int
 	MaxMetaspaceFreeRatio int
@@ -70,6 +75,10 @@ func applyVMArgToken(f *VMArgsFacts, tok string) bool {
 		f.XmxBytes = parseSizeSuffix(tok[len("-Xmx"):])
 	case strings.HasPrefix(tok, "-Xms"):
 		f.XmsBytes = parseSizeSuffix(tok[len("-Xms"):])
+	case strings.HasPrefix(tok, "-XX:MaxMetaspaceSize="):
+		f.MaxMetaspaceSizeBytes = parseSizeSuffix(tok[len("-XX:MaxMetaspaceSize="):])
+	case strings.HasPrefix(tok, "-XX:CompressedClassSpaceSize="):
+		f.CompressedClassSpaceSizeBytes = parseSizeSuffix(tok[len("-XX:CompressedClassSpaceSize="):])
 	case strings.HasPrefix(tok, "-XX:MaxHeapFreeRatio="):
 		f.MaxHeapFreeRatio = atoiOrNeg1(tok[len("-XX:MaxHeapFreeRatio="):])
 	case strings.HasPrefix(tok, "-XX:MinHeapFreeRatio="):

--- a/internal/rules/metaspace_test.go
+++ b/internal/rules/metaspace_test.go
@@ -65,6 +65,30 @@ func TestJVMMetaspacePressureFiresForCompressedClassSpace(t *testing.T) {
 	}
 }
 
+func TestJVMMetaspacePressureBothCeilingsDistinctIdentities(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       10,
+		MainClass: "both.App",
+		VMArgs:    "-XX:MaxMetaspaceSize=256m -XX:CompressedClassSpaceSize=64m",
+		GC:        &jvm.GCStats{MC: 245000, MU: 240000, CCSC: 62000, CCSU: 61000},
+	}}
+	findings := ruleJVMMetaspacePressure().MatchFn(s)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (metaspace + compressed class space), got %d: %v", len(findings), findings)
+	}
+	// Both share the rule ID but must have distinct subjects so the issue
+	// catalog (keyed by rule_id + machine_uuid + subject) tracks them separately.
+	if findings[0].Subject == findings[1].Subject {
+		t.Fatalf("findings must have distinct subjects, both = %q", findings[0].Subject)
+	}
+	for _, f := range findings {
+		if !strings.Contains(f.Subject, "Metaspace") && !strings.Contains(f.Subject, "Compressed class space") {
+			t.Errorf("subject should name the affected space: %q", f.Subject)
+		}
+	}
+}
+
 func TestParseVMArgsMetaspaceCeilings(t *testing.T) {
 	f := ParseVMArgs("-XX:MaxMetaspaceSize=512m -XX:CompressedClassSpaceSize=128m")
 	if f.MaxMetaspaceSizeBytes != 512*1024*1024 {

--- a/internal/rules/metaspace_test.go
+++ b/internal/rules/metaspace_test.go
@@ -1,0 +1,80 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+func TestJVMMetaspacePressureFiresNearMaxMetaspaceSize(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       10,
+		MainClass: "leak.App",
+		VMArgs:    "-XX:MaxMetaspaceSize=256m",
+		// 240000 KiB used = ~234 MiB, ~91% of the 256 MiB ceiling.
+		GC: &jvm.GCStats{MC: 245000, MU: 240000},
+	}}
+	findings := ruleJVMMetaspacePressure().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 metaspace finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].RuleID != "jvm-metaspace-pressure" || findings[0].Severity != SeverityMedium {
+		t.Fatalf("finding = %+v", findings[0])
+	}
+	if !strings.Contains(findings[0].Message, "MaxMetaspaceSize") {
+		t.Fatalf("message should name the ceiling: %q", findings[0].Message)
+	}
+}
+
+func TestJVMMetaspacePressureNoFireWhenCeilingUnset(t *testing.T) {
+	s := baseSnap()
+	// High MU/MC ratio but no configured ceiling -> committed just tracks used;
+	// this must NOT fire (it would be pure noise).
+	s.JVMs = []jvm.Info{{PID: 10, VMArgs: "-Xmx1g", GC: &jvm.GCStats{MC: 250000, MU: 249000}}}
+	if f := ruleJVMMetaspacePressure().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no findings without a ceiling, got %v", f)
+	}
+}
+
+func TestJVMMetaspacePressureNoFireBelowThreshold(t *testing.T) {
+	s := baseSnap()
+	// 200000 KiB used = ~195 MiB, ~76% of the 256 MiB ceiling -> below 90%.
+	s.JVMs = []jvm.Info{{PID: 10, VMArgs: "-XX:MaxMetaspaceSize=256m", GC: &jvm.GCStats{MC: 210000, MU: 200000}}}
+	if f := ruleJVMMetaspacePressure().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no findings below threshold, got %v", f)
+	}
+}
+
+func TestJVMMetaspacePressureFiresForCompressedClassSpace(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       10,
+		MainClass: "ccs.App",
+		VMArgs:    "-XX:CompressedClassSpaceSize=64m",
+		// 61000 KiB used = ~59.6 MiB, ~93% of the 64 MiB ceiling.
+		GC: &jvm.GCStats{CCSC: 62000, CCSU: 61000},
+	}}
+	findings := ruleJVMMetaspacePressure().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 compressed-class-space finding, got %d: %v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Message, "Compressed class space") {
+		t.Fatalf("message should name compressed class space: %q", findings[0].Message)
+	}
+}
+
+func TestParseVMArgsMetaspaceCeilings(t *testing.T) {
+	f := ParseVMArgs("-XX:MaxMetaspaceSize=512m -XX:CompressedClassSpaceSize=128m")
+	if f.MaxMetaspaceSizeBytes != 512*1024*1024 {
+		t.Errorf("MaxMetaspaceSizeBytes = %d, want %d", f.MaxMetaspaceSizeBytes, 512*1024*1024)
+	}
+	if f.CompressedClassSpaceSizeBytes != 128*1024*1024 {
+		t.Errorf("CompressedClassSpaceSizeBytes = %d, want %d", f.CompressedClassSpaceSizeBytes, 128*1024*1024)
+	}
+	// Unset -> 0 sentinel.
+	if empty := ParseVMArgs("-Xmx1g"); empty.MaxMetaspaceSizeBytes != 0 || empty.CompressedClassSpaceSizeBytes != 0 {
+		t.Errorf("unset ceilings should be 0, got %+v", empty)
+	}
+}

--- a/internal/rules/predicates.go
+++ b/internal/rules/predicates.go
@@ -37,6 +37,38 @@ func OldGenUsedPct(j jvm.Info) float64 {
 // OldGenHigh reports whether old-gen occupancy is above OldGenHighPct.
 func OldGenHigh(j jvm.Info) bool { return OldGenUsedPct(j) >= OldGenHighPct }
 
+// MetaspaceNearLimitPct is the used-vs-configured-ceiling occupancy above
+// which class-metadata space is reported as pressure. Approaching a hard
+// ceiling risks OutOfMemoryError: Metaspace / Compressed class space.
+//
+// Note this is deliberately measured against the *configured ceiling*
+// (-XX:MaxMetaspaceSize / -XX:CompressedClassSpaceSize), not committed
+// capacity: committed metaspace (jstat MC) tracks used (MU) by design and
+// sits near 100% normally, so a used/committed ratio would be pure noise.
+const MetaspaceNearLimitPct = 90.0
+
+// MetaspaceCeilingPct returns used metaspace as a percent of the configured
+// -XX:MaxMetaspaceSize ceiling. ok is false when the ceiling is unset or the
+// counters are missing, in which case the point-in-time ratio is meaningless
+// (unbounded metaspace growth is a trend signal, not a snapshot one).
+func MetaspaceCeilingPct(j jvm.Info, f VMArgsFacts) (pct float64, ok bool) {
+	if f.MaxMetaspaceSizeBytes <= 0 || j.GC == nil || j.GC.MU <= 0 {
+		return 0, false
+	}
+	usedBytes := j.GC.MU * 1024 // jstat MU is KiB
+	return usedBytes * 100 / float64(f.MaxMetaspaceSizeBytes), true
+}
+
+// CompressedClassCeilingPct mirrors MetaspaceCeilingPct for the compressed
+// class space and its -XX:CompressedClassSpaceSize ceiling.
+func CompressedClassCeilingPct(j jvm.Info, f VMArgsFacts) (pct float64, ok bool) {
+	if f.CompressedClassSpaceSizeBytes <= 0 || j.GC == nil || j.GC.CCSU <= 0 {
+		return 0, false
+	}
+	usedBytes := j.GC.CCSU * 1024 // jstat CCSU is KiB
+	return usedBytes * 100 / float64(f.CompressedClassSpaceSizeBytes), true
+}
+
 // TightHeapByDesign reports whether the JVM is configured to keep the
 // heap intentionally close to full via -XX:MaxHeapFreeRatio. A small
 // MaxHeapFreeRatio tells the JVM not to grow free space, which means


### PR DESCRIPTION
Closes #423.

## What

Spectra collected metaspace counters (`MC/MU/CCSC/CCSU`) but **no rule fired on them**, and the metaspace ceiling flags were unparsed. This adds:

- **Flag parsing** — `-XX:MaxMetaspaceSize` and `-XX:CompressedClassSpaceSize` into `VMArgsFacts` (reusing `parseSizeSuffix`; `0` = unset).
- **Predicates** — `MetaspaceCeilingPct` / `CompressedClassCeilingPct`, measuring used space against the configured hard ceiling.
- **Rule `jvm-metaspace-pressure`** — fires when used metaspace ≥ 90% of `-XX:MaxMetaspaceSize`, or compressed class space ≥ 90% of `-XX:CompressedClassSpaceSize`, naming the imminent OOM variant.

## Why used-vs-ceiling, not MU/MC

A `MU/MC` (used-vs-committed) rule would be noise: committed metaspace tracks used by design and sits near 100% normally, growing on demand toward the ceiling. The clean point-in-time signal is **used approaching the configured hard ceiling** → imminent `OutOfMemoryError: Metaspace` / `Compressed class space`. The rule therefore only fires when the relevant ceiling flag is set.

Unbounded-growth metaspace leaks (no ceiling configured) genuinely need trend data and are left to a follow-up (requires a `JVMSample` metaspace field + store migration). Deliberately **not** wiring `TightMetaspaceByDesign` — it keys on `MaxMetaspaceFreeRatio` (committed-vs-used elasticity), irrelevant to a hard-ceiling rule.

## Tests

`metaspace_test.go`: fires near `MaxMetaspaceSize`; no-fire when the ceiling is unset (the noise case); no-fire below threshold; compressed-class-space path; and `ParseVMArgs` ceiling parsing incl. the unset sentinel.

Docs updated: rule listed in `recommendations-engine.md` and mentioned in `inspection/jvm.md`.