### PR TITLE
Add Nebula peer discovery source for remote hosts and fan

### DIFF
--- a/cmd/spectra/discover_nebula.go
+++ b/cmd/spectra/discover_nebula.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// selectDiscoverProvider maps the --discover-via value to the peer source used
+// by `spectra hosts` and `spectra fan`. The default, "auto", attempts every
+// source and merges the results, so plain `--discover` finds peers whether the
+// host is on Tailscale, a Nebula mesh, or both. Tailscale queries a live
+// coordination server; Nebula has no such peer list, so its source of truth is
+// the set of signed host certs (see discoverNebulaPeers).
+func selectDiscoverProvider(via string) error {
+	switch strings.ToLower(strings.TrimSpace(via)) {
+	case "", "auto", "both", "all":
+		fanDiscoverPeers = discoverAllPeers
+	case "tailscale":
+		fanDiscoverPeers = discoverTailscalePeers
+	case "nebula":
+		fanDiscoverPeers = discoverNebulaPeers
+	default:
+		return fmt.Errorf("unknown --discover-via %q (want auto, tailscale, or nebula)", via)
+	}
+	return nil
+}
+
+// discoverAllPeers merges every discovery source, deduping by target string. A
+// source that fails (Tailscale not installed, no Nebula certs on disk) is
+// tolerated: its error is only surfaced when *every* source failed and no peers
+// were found, so a Tailscale-only or Nebula-only host still discovers cleanly.
+func discoverAllPeers() ([]string, error) {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	var errs []error
+	merge := func(peers []string, err error) {
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
+		for _, peer := range peers {
+			if _, ok := seen[peer]; ok {
+				continue
+			}
+			seen[peer] = struct{}{}
+			out = append(out, peer)
+		}
+	}
+	merge(discoverTailscalePeers())
+	merge(discoverNebulaPeers())
+	sort.Strings(out)
+	if len(out) == 0 && len(errs) > 0 {
+		return nil, fmt.Errorf("discover peers: all sources failed: %w", errors.Join(errs...))
+	}
+	return out, nil
+}
+
+// nebulaCertsDir is the directory scanned for signed Nebula host certs.
+// $SPECTRA_NEBULA_CERTS overrides the default of ~/.nebula.
+func nebulaCertsDir() (string, error) {
+	if dir := strings.TrimSpace(os.Getenv("SPECTRA_NEBULA_CERTS")); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".nebula"), nil
+}
+
+// discoverNebulaPeers enumerates signed host certs and returns their overlay
+// IPs. Nebula exposes no live peer list, so cert membership is the source of
+// truth: every host you can reach has a cert signed by the mesh CA. The
+// --discover-daemons probe then narrows this to hosts actually running a
+// Spectra daemon. Overlay IPs are returned rather than names because Nebula
+// has no MagicDNS; parseConnectTarget dials a bare IP directly.
+func discoverNebulaPeers() ([]string, error) {
+	dir, err := nebulaCertsDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read nebula certs %s: %w", dir, err)
+	}
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || name == "ca.crt" || !strings.HasSuffix(name, ".crt") {
+			continue
+		}
+		ip, err := nebulaCertIP(filepath.Join(dir, name))
+		if err != nil || ip == "" {
+			// Skip unreadable or CA certs rather than failing the whole listing.
+			continue
+		}
+		seen[ip] = struct{}{}
+	}
+	hosts := make([]string, 0, len(seen))
+	for ip := range seen {
+		hosts = append(hosts, ip)
+	}
+	sort.Strings(hosts)
+	return hosts, nil
+}
+
+// nebulaCertIP returns the bare overlay IP from a signed Nebula cert, dropping
+// the CIDR mask so parseConnectTarget can dial it. Empty string means the cert
+// carries no usable host IP (for example a CA cert).
+func nebulaCertIP(path string) (string, error) {
+	raw, err := runNebulaCertPrint(path)
+	if err != nil {
+		return "", err
+	}
+	var payload struct {
+		Details struct {
+			IsCa bool     `json:"isCa"`
+			Ips  []string `json:"ips"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return "", err
+	}
+	if payload.Details.IsCa || len(payload.Details.Ips) == 0 {
+		return "", nil
+	}
+	ip := strings.TrimSpace(payload.Details.Ips[0])
+	if idx := strings.IndexByte(ip, '/'); idx >= 0 {
+		ip = ip[:idx]
+	}
+	return ip, nil
+}
+
+// runNebulaCertPrint is the seam tests replace; production shells out to the
+// nebula-cert binary that ships with Nebula.
+var runNebulaCertPrint = func(path string) ([]byte, error) {
+	return exec.Command("nebula-cert", "print", "-json", "-path", path).Output()
+}

--- a/cmd/spectra/discover_nebula_test.go
+++ b/cmd/spectra/discover_nebula_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeNebulaCert(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("cert-"+name), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// fakeNebulaCertPrint returns a nebula-cert-shaped JSON payload keyed on the
+// cert filename so tests can control each cert's overlay IP independently.
+func fakeNebulaCertPrint(t *testing.T, byBase map[string]string, isCa map[string]bool) func(string) ([]byte, error) {
+	t.Helper()
+	return func(path string) ([]byte, error) {
+		base := filepath.Base(path)
+		ip, ok := byBase[base]
+		if !ok {
+			return nil, fmt.Errorf("no fake cert for %s", base)
+		}
+		payload := map[string]any{
+			"details": map[string]any{
+				"isCa": isCa[base],
+				"ips":  []string{ip},
+			},
+		}
+		return json.Marshal(payload)
+	}
+}
+
+func TestDiscoverNebulaPeersFromCertDir(t *testing.T) {
+	dir := t.TempDir()
+	writeNebulaCert(t, dir, "your-mac.crt")
+	writeNebulaCert(t, dir, "work-mac.crt")
+	writeNebulaCert(t, dir, "ca.crt")    // skipped by name
+	writeNebulaCert(t, dir, "notes.txt") // skipped: wrong suffix
+	writeNebulaCert(t, dir, "lighthouse.crt")
+
+	t.Setenv("SPECTRA_NEBULA_CERTS", dir)
+	orig := runNebulaCertPrint
+	runNebulaCertPrint = fakeNebulaCertPrint(t,
+		map[string]string{
+			"your-mac.crt":   "192.168.100.10/24",
+			"work-mac.crt":   "192.168.100.11/24",
+			"lighthouse.crt": "192.168.100.1/24",
+		},
+		nil,
+	)
+	t.Cleanup(func() { runNebulaCertPrint = orig })
+
+	peers, err := discoverNebulaPeers()
+	if err != nil {
+		t.Fatalf("discoverNebulaPeers = %v", err)
+	}
+	want := []string{"192.168.100.1", "192.168.100.10", "192.168.100.11"}
+	if !reflect.DeepEqual(peers, want) {
+		t.Fatalf("peers = %v, want %v", peers, want)
+	}
+}
+
+func TestDiscoverNebulaPeersSkipsCAAndUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	writeNebulaCert(t, dir, "self-ca.crt")
+	writeNebulaCert(t, dir, "broken.crt")
+	writeNebulaCert(t, dir, "work-mac.crt")
+
+	t.Setenv("SPECTRA_NEBULA_CERTS", dir)
+	orig := runNebulaCertPrint
+	runNebulaCertPrint = func(path string) ([]byte, error) {
+		switch filepath.Base(path) {
+		case "self-ca.crt":
+			return json.Marshal(map[string]any{"details": map[string]any{"isCa": true, "ips": []string{"192.168.100.1/24"}}})
+		case "broken.crt":
+			return nil, fmt.Errorf("boom")
+		case "work-mac.crt":
+			return json.Marshal(map[string]any{"details": map[string]any{"ips": []string{"192.168.100.11/24"}}})
+		}
+		return nil, fmt.Errorf("unexpected %s", path)
+	}
+	t.Cleanup(func() { runNebulaCertPrint = orig })
+
+	peers, err := discoverNebulaPeers()
+	if err != nil {
+		t.Fatalf("discoverNebulaPeers = %v", err)
+	}
+	want := []string{"192.168.100.11"}
+	if !reflect.DeepEqual(peers, want) {
+		t.Fatalf("peers = %v, want %v", peers, want)
+	}
+}
+
+func TestDiscoverNebulaPeersMissingDir(t *testing.T) {
+	t.Setenv("SPECTRA_NEBULA_CERTS", filepath.Join(t.TempDir(), "does-not-exist"))
+	if _, err := discoverNebulaPeers(); err == nil {
+		t.Fatal("expected error for missing cert dir")
+	}
+}
+
+func TestSelectDiscoverProvider(t *testing.T) {
+	orig := fanDiscoverPeers
+	t.Cleanup(func() { fanDiscoverPeers = orig })
+
+	cases := []struct {
+		via  string
+		want func() ([]string, error)
+	}{
+		{"nebula", discoverNebulaPeers},
+		{"tailscale", discoverTailscalePeers},
+		{"", discoverAllPeers},
+		{"auto", discoverAllPeers},
+		{"both", discoverAllPeers},
+	}
+	for _, tc := range cases {
+		if err := selectDiscoverProvider(tc.via); err != nil {
+			t.Fatalf("%q: %v", tc.via, err)
+		}
+		if reflect.ValueOf(fanDiscoverPeers).Pointer() != reflect.ValueOf(tc.want).Pointer() {
+			t.Fatalf("via %q selected the wrong provider", tc.via)
+		}
+	}
+
+	if err := selectDiscoverProvider("wireguard"); err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestDiscoverAllPeersMergesSources(t *testing.T) {
+	dir := t.TempDir()
+	writeNebulaCert(t, dir, "work-mac.crt")
+	t.Setenv("SPECTRA_NEBULA_CERTS", dir)
+
+	origCert := runNebulaCertPrint
+	runNebulaCertPrint = fakeNebulaCertPrint(t,
+		map[string]string{"work-mac.crt": "192.168.100.11/24"}, nil)
+	t.Cleanup(func() { runNebulaCertPrint = origCert })
+
+	origTS := runTailscaleStatus
+	runTailscaleStatus = func() ([]byte, error) {
+		return json.Marshal(map[string]any{
+			"Peers": map[string]map[string]string{
+				"a": {"DNSName": "alice.tailnet.example"},
+			},
+		})
+	}
+	t.Cleanup(func() { runTailscaleStatus = origTS })
+
+	peers, err := discoverAllPeers()
+	if err != nil {
+		t.Fatalf("discoverAllPeers = %v", err)
+	}
+	want := []string{"192.168.100.11", "alice.tailnet.example"}
+	if !reflect.DeepEqual(peers, want) {
+		t.Fatalf("peers = %v, want %v", peers, want)
+	}
+}
+
+func TestDiscoverAllPeersToleratesOneFailedSource(t *testing.T) {
+	// No Nebula certs on disk (dir missing) — that source errors, but Tailscale
+	// still yields a peer, so discoverAllPeers succeeds.
+	t.Setenv("SPECTRA_NEBULA_CERTS", filepath.Join(t.TempDir(), "absent"))
+
+	origTS := runTailscaleStatus
+	runTailscaleStatus = func() ([]byte, error) {
+		return json.Marshal(map[string]any{
+			"Peers": map[string]map[string]string{
+				"a": {"HostName": "work-mac"},
+			},
+		})
+	}
+	t.Cleanup(func() { runTailscaleStatus = origTS })
+
+	peers, err := discoverAllPeers()
+	if err != nil {
+		t.Fatalf("discoverAllPeers = %v", err)
+	}
+	if !reflect.DeepEqual(peers, []string{"work-mac"}) {
+		t.Fatalf("peers = %v, want [work-mac]", peers)
+	}
+}
+
+func TestDiscoverAllPeersErrorsWhenAllSourcesFail(t *testing.T) {
+	t.Setenv("SPECTRA_NEBULA_CERTS", filepath.Join(t.TempDir(), "absent"))
+
+	origTS := runTailscaleStatus
+	runTailscaleStatus = func() ([]byte, error) { return nil, fmt.Errorf("tailscale missing") }
+	t.Cleanup(func() { runTailscaleStatus = origTS })
+
+	if _, err := discoverAllPeers(); err == nil {
+		t.Fatal("expected error when every source fails")
+	}
+}

--- a/cmd/spectra/fan.go
+++ b/cmd/spectra/fan.go
@@ -45,9 +45,15 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 	timeout := fs.Duration("timeout", 3*time.Second, "Dial/read timeout per target")
 	hosts := fs.String("hosts", "", "Comma-separated daemon targets; defaults to discovered hosts")
 	probe := fs.Bool("probe", false, "When discovering hosts, skip entries that fail a health check")
-	discoverHosts := fs.Bool("discover", false, "Include tailscale peers from tailscale status --json")
-	discoverDaemons := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from Tailscale peers")
+	discoverHosts := fs.Bool("discover", false, "Include peers discovered from the --discover-via source")
+	discoverDaemons := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from discovered peers")
+	discoverVia := fs.String("discover-via", "auto", "Peer discovery source: auto (both), tailscale, or nebula")
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if err := selectDiscoverProvider(*discoverVia); err != nil {
+		fmt.Fprintln(stderr, err)
+		printFanUsage(stderr)
 		return 2
 	}
 
@@ -92,7 +98,7 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 }
 
 func printFanUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: spectra fan [--hosts host-a,host-b] [--probe] [--discover|--discover-daemons] [status|host|jvm|processes|network|storage|power|rules]")
+	fmt.Fprintln(w, "usage: spectra fan [--hosts host-a,host-b] [--probe] [--discover|--discover-daemons] [--discover-via auto|tailscale|nebula] [status|host|jvm|processes|network|storage|power|rules]")
 	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] inspect <App.app>")
 	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] call <method> [json-params]")
 }

--- a/cmd/spectra/hosts.go
+++ b/cmd/spectra/hosts.go
@@ -39,13 +39,18 @@ func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLi
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON")
 	probeFlag := fs.Bool("probe", false, "Probe each known host and report reachability")
-	discoverFlag := fs.Bool("discover", false, "Merge tailscale peer discovery from `tailscale status --json`")
-	discoverDaemonsFlag := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from Tailscale peers")
+	discoverFlag := fs.Bool("discover", false, "Merge peer discovery from the --discover-via source")
+	discoverDaemonsFlag := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from discovered peers")
+	discoverViaFlag := fs.String("discover-via", "auto", "Peer discovery source: auto (both), tailscale, or nebula")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: spectra hosts [--json] [--probe] [--discover|--discover-daemons]")
+		fmt.Fprintln(stderr, "usage: spectra hosts [--json] [--probe] [--discover|--discover-daemons] [--discover-via auto|tailscale|nebula]")
+		return 2
+	}
+	if err := selectDiscoverProvider(*discoverViaFlag); err != nil {
+		fmt.Fprintln(stderr, err)
 		return 2
 	}
 

--- a/cmd/spectra/rules.go
+++ b/cmd/spectra/rules.go
@@ -59,6 +59,7 @@ func runRules(args []string) int {
 		fmt.Fprintf(os.Stderr, "rules: %v\n", err)
 		return 1
 	}
+	attachCLIHistory(&snap)
 	findings := rules.Evaluate(snap, catalog)
 
 	if *asJSON {
@@ -222,6 +223,25 @@ func resolveRulesConfigPath(configPath string) (path string, explicit bool) {
 		return configPath, true
 	}
 	return "spectra.yml", false
+}
+
+// attachCLIHistory opens the local samples store, persists the current
+// JVM samples and loads recent history so trend-aware rules engage when
+// `spectra rules` is invoked. Failure is silent: history is an enhancement.
+func attachCLIHistory(snap *snapshot.Snapshot) {
+	if len(snap.JVMs) == 0 {
+		return
+	}
+	dbPath, err := store.DefaultPath()
+	if err != nil {
+		return
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	db.AttachJVMHistory(context.Background(), snap)
 }
 
 func loadStoredSnapshot(id string) (*snapshot.Snapshot, error) {

--- a/cmd/spectra/rules.go
+++ b/cmd/spectra/rules.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/rules"
 	"github.com/kaeawc/spectra/internal/snapshot"
@@ -49,12 +50,22 @@ func runRules(args []string) int {
 			SpectraVersion: version,
 			DetectOpts:     detect.Options{},
 		}
-		// Reuse the persistent on-disk detect cache so per-app inspection
-		// (codesign, plist, framework scan) is amortized across CLI calls.
-		// Cache key is content-addressed (Info.plist + first 64 KiB of exe),
-		// so an entry invalidates automatically when the bundle changes.
+		// Reuse the persistent on-disk caches so per-app inspection
+		// (detect: codesign + plist + framework scan), toolchain enumeration,
+		// and the ~/Library walk in storage state are amortized across CLI
+		// calls. Cache writes go through async writers so the main collection
+		// loop never blocks on disk I/O.
 		if cacheStores != nil {
+			detectWriter := cache.NewAsyncWriter(cacheStores.Detect, 64, 2)
+			toolchainWriter := cache.NewAsyncWriter(cacheStores.Toolchain, 8, 1)
+			storageWriter := cache.NewAsyncWriter(cacheStores.Storage, 8, 1)
+			defer detectWriter.Close()
+			defer toolchainWriter.Close()
+			defer storageWriter.Close()
 			opts.DetectStore = cacheStores.Detect
+			opts.DetectWriter = detectWriter
+			opts.ToolchainCache = cache.NewTTLStore(cacheStores.Toolchain, toolchainWriter)
+			opts.StorageCache = cache.NewTTLStore(cacheStores.Storage, storageWriter)
 		}
 		snap = snapshot.Build(context.Background(), opts)
 	}

--- a/cmd/spectra/rules.go
+++ b/cmd/spectra/rules.go
@@ -45,10 +45,18 @@ func runRules(args []string) int {
 		}
 		snap = *s
 	} else {
-		snap = snapshot.Build(context.Background(), snapshot.Options{
+		opts := snapshot.Options{
 			SpectraVersion: version,
 			DetectOpts:     detect.Options{},
-		})
+		}
+		// Reuse the persistent on-disk detect cache so per-app inspection
+		// (codesign, plist, framework scan) is amortized across CLI calls.
+		// Cache key is content-addressed (Info.plist + first 64 KiB of exe),
+		// so an entry invalidates automatically when the bundle changes.
+		if cacheStores != nil {
+			opts.DetectStore = cacheStores.Detect
+		}
+		snap = snapshot.Build(context.Background(), opts)
 	}
 
 	catalog, err := loadRuleCatalogWithOptions(ruleCatalogOptions{

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -136,6 +136,30 @@ spectra fan --discover status
 spectra fan --discover-daemons status
 ```
 
+### Discovery source
+
+`--discover` and `--discover-daemons` default to `--discover-via auto`, which
+attempts every source and merges the results: a Tailscale-only host, a
+Nebula-only host, and a host on both all discover cleanly, and a source that is
+absent (no `tailscale`, no Nebula certs) is skipped rather than treated as an
+error. Pass `--discover-via tailscale` or `--discover-via nebula` to force a
+single source.
+
+- **Tailscale** reads peers from `tailscale status --json`.
+- **Nebula** has no live peer list, so the source of truth is the signed host
+  certs: Spectra enumerates `~/.nebula` (override with `SPECTRA_NEBULA_CERTS`),
+  runs `nebula-cert print -json` on each `*.crt`, and returns their overlay IPs.
+  Because Nebula has no MagicDNS, discovery yields IPs rather than names.
+
+`--discover-daemons` then narrows the merged set to hosts actually running a
+Spectra daemon.
+
+```bash
+spectra hosts --discover                        # auto: Tailscale + Nebula
+spectra hosts --discover-daemons --discover-via nebula
+spectra fan --discover-via tailscale jvm
+```
+
 The client makes parallel RPC calls to each daemon and aggregates
 results locally into one JSON envelope. The remaining intended shape is:
 

--- a/internal/cache/kinds.go
+++ b/internal/cache/kinds.go
@@ -3,24 +3,28 @@ package cache
 // Well-known cache kind names. Each must match the subdirectory name under
 // the versioned root. Using constants avoids typos across callers.
 const (
-	KindDetect  = "detect"
-	KindHprof   = "hprof"
-	KindJFR     = "jfr"
-	KindThreads = "threads"
-	KindSamples = "samples"
-	KindNetcap  = "netcap"
+	KindDetect    = "detect"
+	KindHprof     = "hprof"
+	KindJFR       = "jfr"
+	KindThreads   = "threads"
+	KindSamples   = "samples"
+	KindNetcap    = "netcap"
+	KindToolchain = "toolchain"
+	KindStorage   = "storage"
 )
 
 // Stores holds the concrete ShardedStore instances for every kind.
 // Callers that need to read or write a specific kind use these directly;
 // the Registry is only for CLI-level stats/clear.
 type Stores struct {
-	Detect  *ShardedStore
-	Hprof   *ShardedStore
-	JFR     *ShardedStore
-	Threads *ShardedStore
-	Samples *ShardedStore
-	Netcap  *ShardedStore
+	Detect    *ShardedStore
+	Hprof     *ShardedStore
+	JFR       *ShardedStore
+	Threads   *ShardedStore
+	Samples   *ShardedStore
+	Netcap    *ShardedStore
+	Toolchain *ShardedStore
+	Storage   *ShardedStore
 }
 
 // NewStores creates all ShardedStores under versionedRoot and registers
@@ -32,11 +36,13 @@ func NewStores(versionedRoot string, reg *Registry) *Stores {
 		return s
 	}
 	return &Stores{
-		Detect:  mk(KindDetect),
-		Hprof:   mk(KindHprof),
-		JFR:     mk(KindJFR),
-		Threads: mk(KindThreads),
-		Samples: mk(KindSamples),
-		Netcap:  mk(KindNetcap),
+		Detect:    mk(KindDetect),
+		Hprof:     mk(KindHprof),
+		JFR:       mk(KindJFR),
+		Threads:   mk(KindThreads),
+		Samples:   mk(KindSamples),
+		Netcap:    mk(KindNetcap),
+		Toolchain: mk(KindToolchain),
+		Storage:   mk(KindStorage),
 	}
 }

--- a/internal/cache/ttl.go
+++ b/internal/cache/ttl.go
@@ -1,0 +1,67 @@
+package cache
+
+import (
+	"encoding/binary"
+	"errors"
+	"time"
+)
+
+// TTLStore wraps a ShardedStore with a time-based freshness check, so
+// non-content-addressed cache entries (whole-collector outputs that
+// snapshot a moment of host state) can be reused for a bounded window.
+//
+// Layout: the on-disk blob is "<8-byte big-endian unix-nano expires_at><payload>"
+// so a Get can decide freshness without unmarshaling the payload.
+//
+// Writes go through an AsyncWriter; if the queue is full the writer falls
+// back to a synchronous Put internally, so callers never block on cache I/O.
+type TTLStore struct {
+	store  *ShardedStore
+	writer *AsyncWriter
+	clock  func() time.Time
+}
+
+// NewTTLStore returns a TTL wrapper. writer may be nil for synchronous-only
+// writes; pass NewAsyncWriter(store, ...) to make writes non-blocking.
+func NewTTLStore(store *ShardedStore, writer *AsyncWriter) *TTLStore {
+	return &TTLStore{store: store, writer: writer, clock: time.Now}
+}
+
+// SetClock overrides the time source for tests.
+func (t *TTLStore) SetClock(clk func() time.Time) { t.clock = clk }
+
+// Get returns the cached payload if it exists and has not expired. ok=false
+// covers all "no usable cache" cases: missing, malformed, expired.
+func (t *TTLStore) Get(key []byte) (payload []byte, ok bool) {
+	if t == nil || t.store == nil {
+		return nil, false
+	}
+	blob, present, err := t.store.Get(key)
+	if err != nil || !present || len(blob) < 8 {
+		return nil, false
+	}
+	expiresAt := time.Unix(0, int64(binary.BigEndian.Uint64(blob[:8])))
+	if !t.clock().Before(expiresAt) {
+		return nil, false
+	}
+	out := make([]byte, len(blob)-8)
+	copy(out, blob[8:])
+	return out, true
+}
+
+// Put stores payload with a freshness window of ttl. Errors from a sync
+// fallback are returned; async writes are fire-and-forget per AsyncWriter.
+func (t *TTLStore) Put(key, payload []byte, ttl time.Duration) error {
+	if t == nil || t.store == nil {
+		return errors.New("ttl store: nil backing store")
+	}
+	expiresAt := t.clock().Add(ttl).UnixNano()
+	blob := make([]byte, 8+len(payload))
+	binary.BigEndian.PutUint64(blob[:8], uint64(expiresAt))
+	copy(blob[8:], payload)
+	if t.writer != nil {
+		t.writer.Write(key, blob)
+		return nil
+	}
+	return t.store.Put(key, blob)
+}

--- a/internal/cache/ttl_test.go
+++ b/internal/cache/ttl_test.go
@@ -1,0 +1,73 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTTLStore_HitWithinTTL(t *testing.T) {
+	s := NewShardedStore(t.TempDir(), "ttl-test")
+	ts := NewTTLStore(s, nil)
+	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	ts.SetClock(func() time.Time { return now })
+
+	key := Key([]byte("k"))
+	if err := ts.Put(key, []byte("hello"), time.Minute); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok := ts.Get(key)
+	if !ok || string(got) != "hello" {
+		t.Errorf("Get within TTL: got=%q ok=%v want hello/true", got, ok)
+	}
+}
+
+func TestTTLStore_MissAfterTTL(t *testing.T) {
+	s := NewShardedStore(t.TempDir(), "ttl-test")
+	ts := NewTTLStore(s, nil)
+	t0 := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	clock := t0
+	ts.SetClock(func() time.Time { return clock })
+
+	key := Key([]byte("k"))
+	_ = ts.Put(key, []byte("hello"), 30*time.Second)
+
+	clock = t0.Add(31 * time.Second)
+	if _, ok := ts.Get(key); ok {
+		t.Error("expected miss after TTL elapsed")
+	}
+}
+
+func TestTTLStore_MissOnUnknownKey(t *testing.T) {
+	ts := NewTTLStore(NewShardedStore(t.TempDir(), "ttl-test"), nil)
+	if _, ok := ts.Get(Key([]byte("nonexistent"))); ok {
+		t.Error("expected miss for unknown key")
+	}
+}
+
+func TestTTLStore_AsyncWriterPath(t *testing.T) {
+	s := NewShardedStore(t.TempDir(), "ttl-test")
+	w := NewAsyncWriter(s, 4, 1)
+	defer w.Close()
+
+	ts := NewTTLStore(s, w)
+	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	ts.SetClock(func() time.Time { return now })
+
+	key := Key([]byte("async"))
+	if err := ts.Put(key, []byte("payload"), time.Minute); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	// Drain the queue.
+	w.Close()
+	got, ok := ts.Get(key)
+	if !ok || string(got) != "payload" {
+		t.Errorf("async path: got=%q ok=%v want payload/true", got, ok)
+	}
+}
+
+func TestTTLStore_NilSafeGet(t *testing.T) {
+	var ts *TTLStore
+	if _, ok := ts.Get(Key([]byte("k"))); ok {
+		t.Error("nil receiver Get should miss")
+	}
+}

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -1,14 +1,14 @@
-// Package jsonrpc implements Content-Length-framed JSON-RPC 2.0 transport primitives.
+// Package jsonrpc implements newline-delimited JSON-RPC 2.0 transport primitives,
+// matching the MCP stdio transport: each message is a single JSON object on its
+// own line, terminated by '\n'. Embedded newlines are not permitted in payloads.
 package jsonrpc
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"log/slog"
-	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/kaeawc/spectra/internal/logger"
@@ -62,59 +62,40 @@ type Notification struct {
 	Params  interface{} `json:"params,omitempty"`
 }
 
-// ReadMessage reads a single JSON-RPC body from Content-Length framing.
+// ReadMessage reads a single newline-delimited JSON-RPC body. Blank lines are
+// skipped so stray whitespace from a peer does not abort the loop.
 func ReadMessage(r *bufio.Reader) ([]byte, error) {
-	var contentLength int
-	headerDone := false
-
 	for {
-		line, err := r.ReadString('\n')
-		if err != nil {
+		line, err := r.ReadBytes('\n')
+		if len(line) == 0 && err != nil {
 			return nil, err
 		}
-		line = strings.TrimRight(line, "\r\n")
-		if line == "" {
-			headerDone = true
-			break
-		}
-		if strings.HasPrefix(line, "Content-Length: ") {
-			trim := strings.TrimPrefix(line, "Content-Length: ")
-			contentLength, err = strconv.Atoi(trim)
+		trimmed := bytes.TrimRight(line, "\r\n")
+		if len(trimmed) == 0 {
 			if err != nil {
-				return nil, fmt.Errorf("parse Content-Length %q: %w", trim, err)
+				return nil, err
 			}
+			continue
 		}
+		return trimmed, nil
 	}
-	if !headerDone {
-		return nil, fmt.Errorf("unexpected EOF while reading headers")
-	}
-	if contentLength <= 0 {
-		return nil, fmt.Errorf("invalid content-length %d", contentLength)
-	}
-	body := make([]byte, contentLength)
-	_, err := io.ReadFull(r, body)
-	if err != nil {
-		return nil, err
-	}
-	return body, nil
 }
 
-// WriteMessage serializes and writes one Message with Content-Length framing.
+// WriteMessage serializes msg as one newline-terminated JSON object.
 func WriteMessage(w io.Writer, mu *sync.Mutex, msg any) {
 	payload, err := json.Marshal(msg)
 	if err != nil {
 		pkgLog.Error("jsonrpc marshal failed", "err", err)
 		return
 	}
-	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(payload))
 	mu.Lock()
 	defer mu.Unlock()
-	if _, err := w.Write([]byte(header)); err != nil {
-		pkgLog.Error("jsonrpc write header failed", "err", err)
-		return
-	}
 	if _, err := w.Write(payload); err != nil {
 		pkgLog.Error("jsonrpc write body failed", "err", err)
+		return
+	}
+	if _, err := w.Write([]byte{'\n'}); err != nil {
+		pkgLog.Error("jsonrpc write newline failed", "err", err)
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -215,6 +215,7 @@ func (s *Server) collectTriage(p triageParams) ([]string, []string, map[string]i
 	if p.Symptom != "" {
 		evidence = append(evidence, "symptom: "+p.Symptom)
 	}
+	hasTarget := p.AppPath != "" || p.PID > 0 || p.BundleID != ""
 	if p.AppPath != "" {
 		evidence, next = s.collectTriageApp(p, evidence, next, rawOut)
 	}
@@ -224,11 +225,21 @@ func (s *Server) collectTriage(p triageParams) ([]string, []string, map[string]i
 	if p.BundleID != "" {
 		evidence = s.collectTriageBundle(p, evidence, rawOut)
 	}
-	findings, err := s.evaluateLiveRules("")
-	if err == nil && len(findings) > 0 {
-		evidence = append(evidence, summarizeFindings(findings, 5)...)
-		rawOut["findings"] = findings
-		next = append(next, "Use diagnose include_raw=true for the full rules output.")
+	// When triage has no target (pure symptom or empty call), the global
+	// rules pass is the only way to surface anything actionable. With a
+	// target, skip the full snapshot cost — the per-target collectors above
+	// already gathered what was asked for, and global findings would be
+	// noise relative to the explicit target. Direct callers to diagnose
+	// when they want host-wide context.
+	if !hasTarget {
+		findings, err := s.evaluateLiveRules("")
+		if err == nil && len(findings) > 0 {
+			evidence = append(evidence, summarizeFindings(findings, 5)...)
+			rawOut["findings"] = findings
+			next = append(next, "Use diagnose include_raw=true for the full rules output.")
+		}
+	} else {
+		next = append(next, "Use diagnose for host-wide rule findings; this triage was scoped to your target.")
 	}
 	if len(next) == 0 {
 		next = append(next, "Use snapshot operation=create store=true to preserve current state for later diffing.")

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1208,7 +1208,48 @@ func (s *Server) evaluateRules(snapshotID, config string) (snapshot.Snapshot, []
 	if err != nil {
 		return snap, nil, err
 	}
+	// Best-effort: persist current JVMs as samples and read recent history
+	// back into the snapshot so trend-aware rules see a multi-sample window.
+	// Failure here is non-fatal; rules degrade to point-in-time checks.
+	attachJVMHistory(&snap)
 	return snap, rules.Evaluate(snap, catalog), nil
+}
+
+// attachJVMHistory persists the current snapshot's JVMs into the samples
+// store and loads recent samples for each PID into snap.JVMHistory.
+// Errors are silently absorbed: history is an enhancement, not a contract.
+func attachJVMHistory(snap *snapshot.Snapshot) {
+	if len(snap.JVMs) == 0 {
+		return
+	}
+	db, err := openStore()
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	now := snap.TakenAt
+	if now.IsZero() {
+		now = time.Now()
+	}
+	current := make([]snapshot.JVMSample, 0, len(snap.JVMs))
+	for _, j := range snap.JVMs {
+		if sm, ok := snapshot.JVMSampleFrom(j, now); ok {
+			current = append(current, sm)
+		}
+	}
+	_ = db.SaveJVMSamples(ctx, current)
+
+	var history snapshot.JVMHistory
+	for _, j := range snap.JVMs {
+		samples, err := db.GetRecentJVMSamples(ctx, j.PID, 0)
+		if err != nil {
+			continue
+		}
+		history = append(history, samples...)
+	}
+	snap.JVMHistory = history
 }
 
 func persistFindings(snap snapshot.Snapshot, findings []rules.Finding) ([]string, error) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1215,9 +1215,9 @@ func (s *Server) evaluateRules(snapshotID, config string) (snapshot.Snapshot, []
 	return snap, rules.Evaluate(snap, catalog), nil
 }
 
-// attachJVMHistory persists the current snapshot's JVMs into the samples
-// store and loads recent samples for each PID into snap.JVMHistory.
-// Errors are silently absorbed: history is an enhancement, not a contract.
+// attachJVMHistory opens the local samples store, calls AttachJVMHistory,
+// and closes the connection. Failure is silent — history is an enhancement,
+// not a contract.
 func attachJVMHistory(snap *snapshot.Snapshot) {
 	if len(snap.JVMs) == 0 {
 		return
@@ -1227,29 +1227,7 @@ func attachJVMHistory(snap *snapshot.Snapshot) {
 		return
 	}
 	defer db.Close()
-	ctx := context.Background()
-
-	now := snap.TakenAt
-	if now.IsZero() {
-		now = time.Now()
-	}
-	current := make([]snapshot.JVMSample, 0, len(snap.JVMs))
-	for _, j := range snap.JVMs {
-		if sm, ok := snapshot.JVMSampleFrom(j, now); ok {
-			current = append(current, sm)
-		}
-	}
-	_ = db.SaveJVMSamples(ctx, current)
-
-	var history snapshot.JVMHistory
-	for _, j := range snap.JVMs {
-		samples, err := db.GetRecentJVMSamples(ctx, j.PID, 0)
-		if err != nil {
-			continue
-		}
-		history = append(history, samples...)
-	}
-	snap.JVMHistory = history
+	db.AttachJVMHistory(context.Background(), snap)
 }
 
 func persistFindings(snap snapshot.Snapshot, findings []rules.Finding) ([]string, error) {

--- a/internal/process/deep.go
+++ b/internal/process/deep.go
@@ -31,6 +31,7 @@ type deepResult struct {
 	fdCount       int
 	listenPorts   []int
 	outboundConns []string
+	logFiles      []string
 }
 
 // parseLSOFDeep merges lsof output into the procs slice in-place.
@@ -82,6 +83,50 @@ func recordLSOFLine(idx map[int]int, results map[int]*deepResult, line string) {
 	if len(fields) >= 9 && strings.EqualFold(fields[7], "TCP") {
 		recordTCPName(r, strings.Join(fields[8:], " "))
 	}
+	if len(fields) >= 9 && strings.EqualFold(fields[4], "REG") && fdIsWritable(fd) {
+		recordLogFile(r, strings.Join(fields[8:], " "))
+	}
+}
+
+// fdIsWritable reports whether the lsof FD column indicates write access.
+// Examples: "12u" (read-write), "13w" (write-only) → true; "9r" → false.
+// Numeric-only FDs without a mode flag are skipped (rare on macOS lsof).
+func fdIsWritable(fd string) bool {
+	if fd == "" {
+		return false
+	}
+	last := fd[len(fd)-1]
+	return last == 'w' || last == 'u'
+}
+
+// isLogShapedPath returns true when path looks like an application log:
+// a file under a "/Logs/" directory, or with a .log extension. Avoids
+// false positives like .gitignore'd "/Frameworks/Network.framework/"
+// by requiring the segment match exactly.
+func isLogShapedPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	if strings.HasSuffix(path, ".log") {
+		return true
+	}
+	// "/Logs/" as a path segment, not just substring (avoids "Dialogs/").
+	if strings.Contains(path, "/Logs/") {
+		return true
+	}
+	return false
+}
+
+func recordLogFile(r *deepResult, name string) {
+	// lsof can append flags like "(deleted)" after the path; trim from first space.
+	path := name
+	if sp := strings.Index(path, " "); sp >= 0 {
+		path = path[:sp]
+	}
+	if !isLogShapedPath(path) {
+		return
+	}
+	r.logFiles = append(r.logFiles, path)
 }
 
 func recordTCPName(r *deepResult, name string) {
@@ -134,5 +179,23 @@ func applyDeepResults(procs []Info, idx map[int]int, results map[int]*deepResult
 			sort.Strings(r.outboundConns)
 			procs[i].OutboundConnections = r.outboundConns
 		}
+		if len(r.logFiles) > 0 {
+			sort.Strings(r.logFiles)
+			procs[i].LogFiles = uniqStrings(r.logFiles)
+		}
 	}
+}
+
+// uniqStrings returns s with consecutive duplicates removed (input must be sorted).
+func uniqStrings(s []string) []string {
+	if len(s) <= 1 {
+		return s
+	}
+	out := s[:1]
+	for _, v := range s[1:] {
+		if v != out[len(out)-1] {
+			out = append(out, v)
+		}
+	}
+	return out
 }

--- a/internal/process/deep_test.go
+++ b/internal/process/deep_test.go
@@ -68,6 +68,57 @@ func TestParseLSOFDeepOutboundConnections(t *testing.T) {
 	}
 }
 
+func TestParseLSOFDeepLogFiles(t *testing.T) {
+	// fixture has Slack writing to /tmp/slack.log on FDs 1w and 2w (duplicates).
+	// bash has only /dev/tty (CHR, not REG, not log-shaped).
+	procs := []Info{
+		{PID: 412, Command: "Slack"},
+		{PID: 999, Command: "bash"},
+	}
+	parseLSOFDeep(procs, lsofDeepFixture)
+
+	if len(procs[0].LogFiles) != 1 || procs[0].LogFiles[0] != "/tmp/slack.log" {
+		t.Errorf("Slack LogFiles = %v, want [/tmp/slack.log]", procs[0].LogFiles)
+	}
+	if len(procs[1].LogFiles) != 0 {
+		t.Errorf("bash LogFiles = %v, want []", procs[1].LogFiles)
+	}
+}
+
+func TestIsLogShapedPath(t *testing.T) {
+	cases := map[string]bool{
+		"/tmp/slack.log":                                       true,
+		"/Users/foo/Library/Logs/Slack/main.log":               true,
+		"/Users/foo/Library/Application Support/Slack/Logs/x":  true,
+		"/var/log/system.log":                                  true,
+		"/Users/foo/Documents/Catalogs/index":                  false, // "Catalogs/", not "Logs/"
+		"/Users/foo/work/Dialogs/notes":                        false, // "Dialogs/", not "Logs/"
+		"/Applications/Slack.app/Contents/MacOS/Slack":         false,
+		"":                                                     false,
+	}
+	for in, want := range cases {
+		if got := isLogShapedPath(in); got != want {
+			t.Errorf("isLogShapedPath(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestFdIsWritable(t *testing.T) {
+	cases := map[string]bool{
+		"1w":  true,
+		"12u": true,
+		"9r":  false,
+		"":    false,
+		"cwd": false,
+		"txt": false,
+	}
+	for in, want := range cases {
+		if got := fdIsWritable(in); got != want {
+			t.Errorf("fdIsWritable(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
 func TestParseLSOFDeepUnknownPIDSkipped(t *testing.T) {
 	// PID 999 not in procs — should not panic or produce errors.
 	procs := []Info{{PID: 412, Command: "Slack"}}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -37,6 +37,7 @@ type Info struct {
 	OpenFDs             int      `json:"open_fds,omitempty"`             // open file descriptor count
 	ListeningPorts      []int    `json:"listening_ports,omitempty"`      // TCP ports this process listens on
 	OutboundConnections []string `json:"outbound_connections,omitempty"` // active TCP remote addresses (host:port)
+	LogFiles            []string `json:"log_files,omitempty"`            // writable log-shaped files this process holds open
 
 	// AppPath is set when the process's executable path starts with a known
 	// .app bundle path. Populated only when CollectAll is called with a set

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
@@ -112,7 +111,9 @@ func ruleJVMHeapVsSystemRAM() Rule {
 
 // ruleJVMGCPressure fires when a one-shot jstat snapshot suggests the JVM is
 // under memory pressure: old generation is nearly full or full GC has already
-// consumed meaningful wall time.
+// consumed meaningful wall time. The rule consults VM args before firing —
+// when -XX:MaxHeapFreeRatio is set low (Toolbox-style "tight by design"),
+// near-full old-gen is the configured steady state and is suppressed.
 func ruleJVMGCPressure() Rule {
 	return Rule{
 		ID:       "jvm-gc-pressure",
@@ -123,17 +124,18 @@ func ruleJVMGCPressure() Rule {
 				if j.GC == nil {
 					continue
 				}
-				if pct := oldGenUsedPct(j.GC); pct >= 90 {
+				args := FactsFor(j)
+				if OldGenHigh(j) && !TightHeapByDesign(args) {
 					findings = append(findings, Finding{
 						RuleID:   "jvm-gc-pressure",
 						Severity: SeverityMedium,
 						Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
-						Message:  fmt.Sprintf("Old generation is %.0f%% full; allocation pressure may trigger frequent full GC.", pct),
+						Message:  fmt.Sprintf("Old generation is %.0f%% full; allocation pressure may trigger frequent full GC.", OldGenUsedPct(j)),
 						Fix:      "Inspect heap histogram/JFR allocation events and reduce live-set size or adjust heap sizing.",
 					})
 					continue
 				}
-				if j.GC.FGC >= 5 && j.GC.FGCT >= 1 {
+				if FullGCBurst(j) {
 					findings = append(findings, Finding{
 						RuleID:   "jvm-gc-pressure",
 						Severity: SeverityMedium,
@@ -146,13 +148,6 @@ func ruleJVMGCPressure() Rule {
 			return findings
 		},
 	}
-}
-
-func oldGenUsedPct(stats *jvm.GCStats) float64 {
-	if stats == nil || stats.OC <= 0 {
-		return 0
-	}
-	return stats.OU * 100 / stats.OC
 }
 
 // ruleJDKMajorVersionDrift fires when more than one installed JDK shares

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -166,7 +166,13 @@ func ruleJVMGCPressure() Rule {
 					})
 					continue
 				}
-				if FullGCBurst(j) {
+				// Cumulative full-GC time can look high simply because the JVM is
+				// configured to GC frequently (Serial + low MaxHeapFreeRatio is the
+				// canonical pattern). Apply the same suppressors before firing.
+				burstFires := FullGCBurst(j) &&
+					!TightHeapByDesign(args) &&
+					!HasTag(profile, TagTightHeapExpected)
+				if burstFires {
 					findings = append(findings, Finding{
 						RuleID:   "jvm-gc-pressure",
 						Severity: SeverityMedium,

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -111,26 +111,32 @@ func ruleJVMHeapVsSystemRAM() Rule {
 
 // ruleJVMGCPressure fires when a one-shot jstat snapshot suggests the JVM is
 // under memory pressure: old generation is nearly full or full GC has already
-// consumed meaningful wall time. The rule consults VM args before firing —
-// when -XX:MaxHeapFreeRatio is set low (Toolbox-style "tight by design"),
-// near-full old-gen is the configured steady state and is suppressed.
+// consumed meaningful wall time. The rule consults three orthogonal signals
+// before firing on level:
 //
-// When trend history is available for the PID, the rule additionally requires
-// that old-gen occupancy be rising — a steady high level is consistent with a
-// healthy app at its working size; rising occupancy is what predicts trouble.
-// Without trend history, behavior degrades gracefully to the level check.
+//  1. VM args — -XX:MaxHeapFreeRatio low ("tight by design").
+//  2. App profile — known apps tagged tight_heap_expected (Toolbox, Gradle
+//     daemon) where near-full old-gen is the operating point.
+//  3. Trend history — when ≥3 samples exist, require a rising slope.
+//
+// Each signal is a sufficient suppressor; the level finding fires only when
+// none of them explain the high occupancy.
 func ruleJVMGCPressure() Rule {
 	return Rule{
 		ID:       "jvm-gc-pressure",
 		Severity: SeverityMedium,
 		MatchFn: func(s snapshot.Snapshot) []Finding {
+			profiles := BuiltinProfiles()
 			var findings []Finding
 			for _, j := range s.JVMs {
 				if j.GC == nil {
 					continue
 				}
 				args := FactsFor(j)
-				levelFires := OldGenHigh(j) && !TightHeapByDesign(args)
+				profile := MatchProfile(j, profiles)
+				levelFires := OldGenHigh(j) &&
+					!TightHeapByDesign(args) &&
+					!HasTag(profile, TagTightHeapExpected)
 				if levelFires {
 					if HasTrendFor(s.JVMHistory, j.PID) && !RisingOldGenFor(s.JVMHistory, j.PID) {
 						// We have enough history to say this is steady-state, not pressure.

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -73,6 +73,11 @@ func ruleJVMEOLVersion() Rule {
 
 // ruleJVMHeapVsSystemRAM fires when a running JVM's -Xmx setting allocates
 // more than 60% of system RAM, which can cause OS-level swap pressure.
+//
+// When the JVM matches a profile tagged large_heap_expected (IntelliJ-family
+// IDEs), the finding is demoted from high to medium: the swap-pressure risk
+// is real but the user opted in by configuring the IDE's vmoptions. We
+// recalibrate severity rather than suppress so the signal is still visible.
 func ruleJVMHeapVsSystemRAM() Rule {
 	return Rule{
 		ID:       "jvm-heap-vs-system",
@@ -84,6 +89,7 @@ func ruleJVMHeapVsSystemRAM() Rule {
 				return nil
 			}
 			ramMBInt := int64(ramMB)
+			profiles := BuiltinProfiles()
 			var findings []Finding
 			for _, j := range s.JVMs {
 				if j.VMArgs == "" {
@@ -94,15 +100,22 @@ func ruleJVMHeapVsSystemRAM() Rule {
 					continue
 				}
 				pct := xmxMB * 100 / ramMBInt
-				if pct > 60 {
-					findings = append(findings, Finding{
-						RuleID:   "jvm-heap-vs-system",
-						Severity: SeverityHigh,
-						Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
-						Message:  fmt.Sprintf("-Xmx%dMB is %d%% of system RAM (%dMB). Swap thrashing likely under GC pressure.", xmxMB, pct, ramMBInt),
-						Fix:      "Reduce -Xmx, or if this is intentional ensure sufficient swap headroom.",
-					})
+				if pct <= 60 {
+					continue
 				}
+				severity := SeverityHigh
+				message := fmt.Sprintf("-Xmx%dMB is %d%% of system RAM (%dMB). Swap thrashing likely under GC pressure.", xmxMB, pct, ramMBInt)
+				if HasTag(MatchProfile(j, profiles), TagLargeHeapExpected) {
+					severity = SeverityMedium
+					message = fmt.Sprintf("-Xmx%dMB is %d%% of system RAM (%dMB). High but expected for this app; ensure swap headroom.", xmxMB, pct, ramMBInt)
+				}
+				findings = append(findings, Finding{
+					RuleID:   "jvm-heap-vs-system",
+					Severity: severity,
+					Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
+					Message:  message,
+					Fix:      "Reduce -Xmx, or if this is intentional ensure sufficient swap headroom.",
+				})
 			}
 			return findings
 		},

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -114,6 +114,11 @@ func ruleJVMHeapVsSystemRAM() Rule {
 // consumed meaningful wall time. The rule consults VM args before firing —
 // when -XX:MaxHeapFreeRatio is set low (Toolbox-style "tight by design"),
 // near-full old-gen is the configured steady state and is suppressed.
+//
+// When trend history is available for the PID, the rule additionally requires
+// that old-gen occupancy be rising — a steady high level is consistent with a
+// healthy app at its working size; rising occupancy is what predicts trouble.
+// Without trend history, behavior degrades gracefully to the level check.
 func ruleJVMGCPressure() Rule {
 	return Rule{
 		ID:       "jvm-gc-pressure",
@@ -125,7 +130,14 @@ func ruleJVMGCPressure() Rule {
 					continue
 				}
 				args := FactsFor(j)
-				if OldGenHigh(j) && !TightHeapByDesign(args) {
+				levelFires := OldGenHigh(j) && !TightHeapByDesign(args)
+				if levelFires {
+					if HasTrendFor(s.JVMHistory, j.PID) && !RisingOldGenFor(s.JVMHistory, j.PID) {
+						// We have enough history to say this is steady-state, not pressure.
+						levelFires = false
+					}
+				}
+				if levelFires {
 					findings = append(findings, Finding{
 						RuleID:   "jvm-gc-pressure",
 						Severity: SeverityMedium,

--- a/internal/rules/history.go
+++ b/internal/rules/history.go
@@ -1,0 +1,44 @@
+package rules
+
+import "github.com/kaeawc/spectra/internal/snapshot"
+
+// History-aware predicates that operate on snapshot.JVMHistory.
+//
+// Design note: these are deliberately simple. A trend is "rising" when there
+// are enough samples and the delta between the first and last sample exceeds
+// a threshold. v1 ignores noise/jitter — the cost of a missed rising trend
+// is one cycle of delayed alerting; the cost of a false rising signal is a
+// regression of the very behavior we're trying to fix.
+
+// MinTrendSamples is the minimum number of samples needed before any trend
+// predicate can fire. Below this, "no opinion" (returns false) is correct.
+const MinTrendSamples = 3
+
+// MinOldGenRiseDelta is the percentage-points rise required between the
+// oldest and newest sample in a window for an old-gen trend to count as
+// "rising". 5pp over a few minutes is meaningful in a healthy heap.
+const MinOldGenRiseDelta = 5.0
+
+// RisingOldGenFor reports whether old-gen occupancy is rising for pid in the
+// given history. Returns false when there is no history, fewer than
+// MinTrendSamples observations, or the delta is below MinOldGenRiseDelta.
+//
+// "Rising" here is intentionally a coarse first/last comparison; it does not
+// require monotonic increase. Most allocation pressure shows as a clear net
+// gain over a short window, and tighter shape detection can come later.
+func RisingOldGenFor(h snapshot.JVMHistory, pid int) bool {
+	samples := h.SamplesFor(pid)
+	if len(samples) < MinTrendSamples {
+		return false
+	}
+	first := samples[0].OldGenPct
+	last := samples[len(samples)-1].OldGenPct
+	return last-first >= MinOldGenRiseDelta
+}
+
+// HasTrendFor reports whether there are enough samples for trend predicates
+// to be meaningful. Rules use this to decide whether to apply a trend gate
+// or fall back to point-in-time checks.
+func HasTrendFor(h snapshot.JVMHistory, pid int) bool {
+	return len(h.SamplesFor(pid)) >= MinTrendSamples
+}

--- a/internal/rules/history_test.go
+++ b/internal/rules/history_test.go
@@ -1,0 +1,79 @@
+package rules
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+// helper: build N samples for one PID, with linearly interpolated OldGenPct.
+func samples(pid int, n int, startPct, endPct float64) snapshot.JVMHistory {
+	out := make(snapshot.JVMHistory, n)
+	step := 0.0
+	if n > 1 {
+		step = (endPct - startPct) / float64(n-1)
+	}
+	now := time.Now()
+	for i := 0; i < n; i++ {
+		out[i] = snapshot.JVMSample{
+			PID:       pid,
+			At:        now.Add(time.Duration(i-n) * time.Minute),
+			OldGenPct: startPct + step*float64(i),
+		}
+	}
+	return out
+}
+
+func TestRisingOldGenFor_NoHistory(t *testing.T) {
+	if RisingOldGenFor(nil, 10) {
+		t.Error("nil history should not report rising")
+	}
+}
+
+func TestRisingOldGenFor_TooFewSamples(t *testing.T) {
+	h := samples(10, 2, 50, 95) // huge delta but only 2 samples
+	if RisingOldGenFor(h, 10) {
+		t.Error("only 2 samples should not be enough for trend")
+	}
+}
+
+func TestRisingOldGenFor_RisingTrend(t *testing.T) {
+	h := samples(10, 5, 70, 95) // 25pp rise across 5 samples
+	if !RisingOldGenFor(h, 10) {
+		t.Error("70 -> 95 across 5 samples should be rising")
+	}
+}
+
+func TestRisingOldGenFor_FlatTrend(t *testing.T) {
+	h := samples(10, 5, 95, 96) // flat near ceiling
+	if RisingOldGenFor(h, 10) {
+		t.Error("95 -> 96 should not be rising (below MinOldGenRiseDelta)")
+	}
+}
+
+func TestRisingOldGenFor_FallingTrend(t *testing.T) {
+	h := samples(10, 5, 95, 70) // falling
+	if RisingOldGenFor(h, 10) {
+		t.Error("95 -> 70 should not be rising")
+	}
+}
+
+func TestRisingOldGenFor_OtherPID(t *testing.T) {
+	h := samples(10, 5, 70, 95)
+	if RisingOldGenFor(h, 99) {
+		t.Error("trend for another PID should not match")
+	}
+}
+
+func TestHasTrendFor(t *testing.T) {
+	if HasTrendFor(nil, 10) {
+		t.Error("nil history → no trend")
+	}
+	if HasTrendFor(samples(10, 2, 50, 60), 10) {
+		t.Error("2 samples → not enough")
+	}
+	if !HasTrendFor(samples(10, 3, 50, 60), 10) {
+		t.Error("3 samples → enough")
+	}
+}

--- a/internal/rules/jvm_facts.go
+++ b/internal/rules/jvm_facts.go
@@ -1,0 +1,130 @@
+package rules
+
+import (
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+// VMArgsFacts is the parsed view of jvm.Info.VMArgs.
+//
+// Sentinel values: -1 means "flag not present in args"; 0 is a valid value.
+// Sizes are in bytes; the parser normalizes k/m/g suffixes.
+type VMArgsFacts struct {
+	XmxBytes int64
+	XmsBytes int64
+
+	MaxHeapFreeRatio     int
+	MinHeapFreeRatio     int
+	MaxMetaspaceFreeRatio int
+	MinMetaspaceFreeRatio int
+
+	GCAlgorithm   string
+	NMTEnabled    bool
+	HeapDumpOnOOM bool
+
+	Raw string
+}
+
+// ParseVMArgs builds a VMArgsFacts from a raw VM args string.
+// An empty string returns a zero-value facts with all -1 ratios.
+func ParseVMArgs(raw string) VMArgsFacts {
+	f := VMArgsFacts{
+		MaxHeapFreeRatio:      -1,
+		MinHeapFreeRatio:      -1,
+		MaxMetaspaceFreeRatio: -1,
+		MinMetaspaceFreeRatio: -1,
+		Raw:                   raw,
+	}
+	if raw == "" {
+		return f
+	}
+	for _, tok := range strings.Fields(raw) {
+		switch {
+		case strings.HasPrefix(tok, "-Xmx"):
+			f.XmxBytes = parseSizeSuffix(tok[len("-Xmx"):])
+		case strings.HasPrefix(tok, "-Xms"):
+			f.XmsBytes = parseSizeSuffix(tok[len("-Xms"):])
+		case strings.HasPrefix(tok, "-XX:MaxHeapFreeRatio="):
+			f.MaxHeapFreeRatio = atoiOrNeg1(tok[len("-XX:MaxHeapFreeRatio="):])
+		case strings.HasPrefix(tok, "-XX:MinHeapFreeRatio="):
+			f.MinHeapFreeRatio = atoiOrNeg1(tok[len("-XX:MinHeapFreeRatio="):])
+		case strings.HasPrefix(tok, "-XX:MaxMetaspaceFreeRatio="):
+			f.MaxMetaspaceFreeRatio = atoiOrNeg1(tok[len("-XX:MaxMetaspaceFreeRatio="):])
+		case strings.HasPrefix(tok, "-XX:MinMetaspaceFreeRatio="):
+			f.MinMetaspaceFreeRatio = atoiOrNeg1(tok[len("-XX:MinMetaspaceFreeRatio="):])
+		case tok == "-XX:+UseSerialGC":
+			f.GCAlgorithm = "Serial"
+		case tok == "-XX:+UseParallelGC":
+			f.GCAlgorithm = "Parallel"
+		case tok == "-XX:+UseG1GC":
+			f.GCAlgorithm = "G1"
+		case tok == "-XX:+UseZGC":
+			f.GCAlgorithm = "Z"
+		case tok == "-XX:+UseShenandoahGC":
+			f.GCAlgorithm = "Shenandoah"
+		case tok == "-XX:+UseEpsilonGC":
+			f.GCAlgorithm = "Epsilon"
+		case strings.HasPrefix(tok, "-XX:NativeMemoryTracking="):
+			v := tok[len("-XX:NativeMemoryTracking="):]
+			f.NMTEnabled = v == "summary" || v == "detail"
+		case tok == "-XX:+HeapDumpOnOutOfMemoryError":
+			f.HeapDumpOnOOM = true
+		}
+	}
+	return f
+}
+
+// parseSizeSuffix interprets a size with optional k/m/g/t suffix and returns bytes.
+// Returns 0 on parse failure.
+func parseSizeSuffix(raw string) int64 {
+	if raw == "" {
+		return 0
+	}
+	mult := int64(1)
+	last := raw[len(raw)-1]
+	digits := raw
+	switch last {
+	case 'k', 'K':
+		mult = 1024
+		digits = raw[:len(raw)-1]
+	case 'm', 'M':
+		mult = 1024 * 1024
+		digits = raw[:len(raw)-1]
+	case 'g', 'G':
+		mult = 1024 * 1024 * 1024
+		digits = raw[:len(raw)-1]
+	case 't', 'T':
+		mult = 1024 * 1024 * 1024 * 1024
+		digits = raw[:len(raw)-1]
+	}
+	n := int64(atoi(digits))
+	if n == 0 {
+		return 0
+	}
+	return n * mult
+}
+
+func atoiOrNeg1(s string) int {
+	if s == "" {
+		return -1
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return -1
+		}
+	}
+	return atoi(s)
+}
+
+// XmxMB returns the parsed Xmx heap ceiling in MiB, or 0 if not set.
+// Convenience for callers that want the legacy parseXmxMB behavior.
+func (f VMArgsFacts) XmxMB() int64 {
+	if f.XmxBytes <= 0 {
+		return 0
+	}
+	return f.XmxBytes / (1024 * 1024)
+}
+
+// FactsFor builds a VMArgsFacts directly from a jvm.Info.
+func FactsFor(j jvm.Info) VMArgsFacts { return ParseVMArgs(j.VMArgs) }

--- a/internal/rules/jvm_facts_test.go
+++ b/internal/rules/jvm_facts_test.go
@@ -1,0 +1,101 @@
+package rules
+
+import "testing"
+
+func TestParseVMArgs_Empty(t *testing.T) {
+	f := ParseVMArgs("")
+	if f.XmxBytes != 0 || f.XmsBytes != 0 {
+		t.Fatalf("expected zero sizes, got %+v", f)
+	}
+	if f.MaxHeapFreeRatio != -1 || f.MinHeapFreeRatio != -1 {
+		t.Fatalf("expected -1 ratios, got %+v", f)
+	}
+	if f.GCAlgorithm != "" || f.NMTEnabled || f.HeapDumpOnOOM {
+		t.Fatalf("expected zero defaults, got %+v", f)
+	}
+}
+
+func TestParseVMArgs_JetBrainsToolbox(t *testing.T) {
+	args := "-Xmx190m -Xms8m -Xss384k -XX:+UnlockExperimentalVMOptions " +
+		"-XX:+CreateCoredumpOnCrash -XX:MetaspaceSize=16m -XX:MinMetaspaceFreeRatio=10 " +
+		"-XX:MaxMetaspaceFreeRatio=10 -XX:+UseCompressedOops -XX:+UseCompressedClassPointers " +
+		"-XX:+UseSerialGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=10 " +
+		"-XX:-ShrinkHeapInSteps -XX:+HeapDumpOnOutOfMemoryError"
+	f := ParseVMArgs(args)
+	if f.XmxBytes != 190*1024*1024 {
+		t.Errorf("XmxBytes = %d, want %d", f.XmxBytes, 190*1024*1024)
+	}
+	if f.XmsBytes != 8*1024*1024 {
+		t.Errorf("XmsBytes = %d, want %d", f.XmsBytes, 8*1024*1024)
+	}
+	if f.MaxHeapFreeRatio != 10 || f.MinHeapFreeRatio != 10 {
+		t.Errorf("HeapFreeRatio = (%d,%d), want (10,10)", f.MinHeapFreeRatio, f.MaxHeapFreeRatio)
+	}
+	if f.MaxMetaspaceFreeRatio != 10 || f.MinMetaspaceFreeRatio != 10 {
+		t.Errorf("MetaspaceFreeRatio = (%d,%d), want (10,10)", f.MinMetaspaceFreeRatio, f.MaxMetaspaceFreeRatio)
+	}
+	if f.GCAlgorithm != "Serial" {
+		t.Errorf("GCAlgorithm = %q, want Serial", f.GCAlgorithm)
+	}
+	if !f.HeapDumpOnOOM {
+		t.Error("HeapDumpOnOOM should be true")
+	}
+	if f.NMTEnabled {
+		t.Error("NMTEnabled should be false (not set)")
+	}
+}
+
+func TestParseVMArgs_GAlgorithms(t *testing.T) {
+	cases := map[string]string{
+		"-XX:+UseG1GC":         "G1",
+		"-XX:+UseZGC":          "Z",
+		"-XX:+UseParallelGC":   "Parallel",
+		"-XX:+UseShenandoahGC": "Shenandoah",
+		"-XX:+UseEpsilonGC":    "Epsilon",
+	}
+	for in, want := range cases {
+		if got := ParseVMArgs(in).GCAlgorithm; got != want {
+			t.Errorf("ParseVMArgs(%q).GCAlgorithm = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseVMArgs_NMT(t *testing.T) {
+	if !ParseVMArgs("-XX:NativeMemoryTracking=summary").NMTEnabled {
+		t.Error("summary should enable NMT")
+	}
+	if !ParseVMArgs("-XX:NativeMemoryTracking=detail").NMTEnabled {
+		t.Error("detail should enable NMT")
+	}
+	if ParseVMArgs("-XX:NativeMemoryTracking=off").NMTEnabled {
+		t.Error("off should leave NMT disabled")
+	}
+}
+
+func TestParseSizeSuffix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{"190m", 190 * 1024 * 1024},
+		{"2g", 2 * 1024 * 1024 * 1024},
+		{"512K", 512 * 1024},
+		{"4G", 4 * 1024 * 1024 * 1024},
+		{"1024", 1024}, // no suffix → bare bytes
+		{"", 0},
+	}
+	for _, c := range cases {
+		if got := parseSizeSuffix(c.in); got != c.want {
+			t.Errorf("parseSizeSuffix(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestVMArgsFacts_XmxMB(t *testing.T) {
+	if got := ParseVMArgs("-Xmx2g").XmxMB(); got != 2048 {
+		t.Errorf("XmxMB(-Xmx2g) = %d, want 2048", got)
+	}
+	if got := ParseVMArgs("").XmxMB(); got != 0 {
+		t.Errorf("XmxMB(empty) = %d, want 0", got)
+	}
+}

--- a/internal/rules/predicates.go
+++ b/internal/rules/predicates.go
@@ -1,0 +1,60 @@
+package rules
+
+import "github.com/kaeawc/spectra/internal/jvm"
+
+// Composable predicates over JVM facts. Rules combine these instead of
+// re-implementing thresholds, so a fact like "this heap is tight by design"
+// is computed once and shared.
+
+// Threshold defaults. Centralized so rules don't drift apart on the
+// boundary between "elevated" and "alarming."
+const (
+	// OldGenHighPct is the level above which old-gen occupancy is reported
+	// as a finding *unless* something else explains it (tight-by-design,
+	// flat trend, launcher profile).
+	OldGenHighPct = 90.0
+
+	// TightHeapMaxFreeRatio: if -XX:MaxHeapFreeRatio is at or below this,
+	// the JVM is configured to keep the heap intentionally close to full.
+	// JetBrains Toolbox sets this to 10; Gradle daemon defaults to 70.
+	TightHeapMaxFreeRatio = 20
+
+	// FullGCBurstCount / Seconds is the bar for considering accumulated
+	// full GC time meaningful in a one-shot snapshot.
+	FullGCBurstCount   = 5
+	FullGCBurstSeconds = 1.0
+)
+
+// OldGenUsedPct returns the old-gen occupancy percent for a JVM, or 0 if
+// no GC stats are available. Centralized so every rule computes it identically.
+func OldGenUsedPct(j jvm.Info) float64 {
+	if j.GC == nil || j.GC.OC <= 0 {
+		return 0
+	}
+	return j.GC.OU * 100 / j.GC.OC
+}
+
+// OldGenHigh reports whether old-gen occupancy is above OldGenHighPct.
+func OldGenHigh(j jvm.Info) bool { return OldGenUsedPct(j) >= OldGenHighPct }
+
+// TightHeapByDesign reports whether the JVM is configured to keep the
+// heap intentionally close to full via -XX:MaxHeapFreeRatio. A small
+// MaxHeapFreeRatio tells the JVM not to grow free space, which means
+// "near-full" is the steady-state target — not pressure.
+func TightHeapByDesign(f VMArgsFacts) bool {
+	return f.MaxHeapFreeRatio > 0 && f.MaxHeapFreeRatio <= TightHeapMaxFreeRatio
+}
+
+// TightMetaspaceByDesign mirrors TightHeapByDesign for metaspace sizing.
+func TightMetaspaceByDesign(f VMArgsFacts) bool {
+	return f.MaxMetaspaceFreeRatio > 0 && f.MaxMetaspaceFreeRatio <= TightHeapMaxFreeRatio
+}
+
+// FullGCBurst reports whether full GC has accumulated meaningful pause
+// time in this snapshot (count and wall-time both above thresholds).
+func FullGCBurst(j jvm.Info) bool {
+	if j.GC == nil {
+		return false
+	}
+	return j.GC.FGC >= FullGCBurstCount && j.GC.FGCT >= FullGCBurstSeconds
+}

--- a/internal/rules/predicates_test.go
+++ b/internal/rules/predicates_test.go
@@ -1,0 +1,73 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+func TestOldGenUsedPct(t *testing.T) {
+	cases := []struct {
+		name string
+		j    jvm.Info
+		want float64
+	}{
+		{"nil GC", jvm.Info{}, 0},
+		{"zero capacity", jvm.Info{GC: &jvm.GCStats{OC: 0, OU: 100}}, 0},
+		{"half full", jvm.Info{GC: &jvm.GCStats{OC: 1000, OU: 500}}, 50},
+		{"96 percent", jvm.Info{GC: &jvm.GCStats{OC: 1000, OU: 960}}, 96},
+	}
+	for _, c := range cases {
+		if got := OldGenUsedPct(c.j); got != c.want {
+			t.Errorf("%s: OldGenUsedPct = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestOldGenHigh(t *testing.T) {
+	if !OldGenHigh(jvm.Info{GC: &jvm.GCStats{OC: 1000, OU: 925}}) {
+		t.Error("92.5% should be high")
+	}
+	if OldGenHigh(jvm.Info{GC: &jvm.GCStats{OC: 1000, OU: 800}}) {
+		t.Error("80% should not be high")
+	}
+}
+
+func TestTightHeapByDesign(t *testing.T) {
+	if !TightHeapByDesign(ParseVMArgs("-XX:MaxHeapFreeRatio=10")) {
+		t.Error("MaxHeapFreeRatio=10 (Toolbox) should be tight by design")
+	}
+	if !TightHeapByDesign(ParseVMArgs("-XX:MaxHeapFreeRatio=20")) {
+		t.Error("MaxHeapFreeRatio=20 (boundary) should be tight by design")
+	}
+	if TightHeapByDesign(ParseVMArgs("-XX:MaxHeapFreeRatio=70")) {
+		t.Error("MaxHeapFreeRatio=70 (default G1) should NOT be tight by design")
+	}
+	if TightHeapByDesign(ParseVMArgs("")) {
+		t.Error("absent flag should NOT be tight by design")
+	}
+}
+
+func TestTightMetaspaceByDesign(t *testing.T) {
+	if !TightMetaspaceByDesign(ParseVMArgs("-XX:MaxMetaspaceFreeRatio=10")) {
+		t.Error("MaxMetaspaceFreeRatio=10 should be tight by design")
+	}
+	if TightMetaspaceByDesign(ParseVMArgs("")) {
+		t.Error("absent flag should NOT be tight by design")
+	}
+}
+
+func TestFullGCBurst(t *testing.T) {
+	if FullGCBurst(jvm.Info{}) {
+		t.Error("nil GC should not be a burst")
+	}
+	if FullGCBurst(jvm.Info{GC: &jvm.GCStats{FGC: 4, FGCT: 2.0}}) {
+		t.Error("4 GCs should not be a burst")
+	}
+	if !FullGCBurst(jvm.Info{GC: &jvm.GCStats{FGC: 7, FGCT: 1.8}}) {
+		t.Error("7 GCs / 1.8s should be a burst")
+	}
+	if FullGCBurst(jvm.Info{GC: &jvm.GCStats{FGC: 7, FGCT: 0.5}}) {
+		t.Error("7 GCs / 0.5s should NOT be a burst (pause too small)")
+	}
+}

--- a/internal/rules/profile.go
+++ b/internal/rules/profile.go
@@ -35,6 +35,7 @@ type AppProfile struct {
 // Common tag names. Centralized so rule code and tests don't drift.
 const (
 	TagTightHeapExpected = "tight_heap_expected"
+	TagLargeHeapExpected = "large_heap_expected"
 	TagLauncher          = "launcher"
 	TagBuildToolDaemon   = "build_tool_daemon"
 	TagIDE               = "ide"
@@ -54,14 +55,14 @@ func BuiltinProfiles() []AppProfile {
 			ID:                "intellij-idea",
 			Name:              "IntelliJ IDEA",
 			MainClassContains: "com.intellij.idea.main",
-			Tags:              []string{TagIDE},
+			Tags:              []string{TagIDE, TagLargeHeapExpected},
 		},
 		{
 			ID:                "android-studio",
 			Name:              "Android Studio",
 			JavaHomeContains:  "android studio.app",
 			MainClassContains: "com.intellij.idea.main",
-			Tags:              []string{TagIDE},
+			Tags:              []string{TagIDE, TagLargeHeapExpected},
 		},
 		{
 			ID:                "gradle-daemon",

--- a/internal/rules/profile.go
+++ b/internal/rules/profile.go
@@ -1,0 +1,132 @@
+package rules
+
+import (
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+// AppProfile classifies a running JVM as a known application kind so rules
+// can recalibrate (or suppress) generic findings based on what the app is,
+// not just what its metrics look like at one moment.
+//
+// A profile is a tuple of optional matchers — empty matchers are skipped,
+// non-empty matchers must all pass. Matching is conservative: prefer a
+// false negative over a false positive, since a misattributed profile
+// would silence legitimate findings.
+type AppProfile struct {
+	ID   string
+	Name string
+
+	// MainClassContains: if non-empty, jvm.Info.MainClass must contain this
+	// substring (case-insensitive).
+	MainClassContains string
+
+	// JavaHomeContains: if non-empty, jvm.Info.JavaHome must contain this
+	// substring (case-insensitive).
+	JavaHomeContains string
+
+	// VMArgsHas: every entry must appear as a substring in jvm.Info.VMArgs.
+	VMArgsHas []string
+
+	Tags []string
+}
+
+// Common tag names. Centralized so rule code and tests don't drift.
+const (
+	TagTightHeapExpected = "tight_heap_expected"
+	TagLauncher          = "launcher"
+	TagBuildToolDaemon   = "build_tool_daemon"
+	TagIDE               = "ide"
+)
+
+// BuiltinProfiles returns the in-tree catalog. Keep this list short and
+// well-justified; vague matchers cause silent suppression bugs.
+func BuiltinProfiles() []AppProfile {
+	return []AppProfile{
+		{
+			ID:               "jetbrains-toolbox",
+			Name:             "JetBrains Toolbox",
+			JavaHomeContains: "jetbrains toolbox.app",
+			Tags:             []string{TagLauncher, TagTightHeapExpected},
+		},
+		{
+			ID:                "intellij-idea",
+			Name:              "IntelliJ IDEA",
+			MainClassContains: "com.intellij.idea.main",
+			Tags:              []string{TagIDE},
+		},
+		{
+			ID:                "android-studio",
+			Name:              "Android Studio",
+			JavaHomeContains:  "android studio.app",
+			MainClassContains: "com.intellij.idea.main",
+			Tags:              []string{TagIDE},
+		},
+		{
+			ID:                "gradle-daemon",
+			Name:              "Gradle Daemon",
+			MainClassContains: "org.gradle.launcher.daemon",
+			Tags:              []string{TagBuildToolDaemon, TagTightHeapExpected},
+		},
+		{
+			ID:                "bazel-server",
+			Name:              "Bazel Server",
+			MainClassContains: "com.google.devtools.build.lib.bazel.bazelserver",
+			Tags:              []string{TagBuildToolDaemon},
+		},
+	}
+}
+
+// MatchProfile returns the first profile in catalog that matches j, or nil.
+// Use BuiltinProfiles() as catalog unless you have user overrides loaded.
+func MatchProfile(j jvm.Info, catalog []AppProfile) *AppProfile {
+	for i := range catalog {
+		p := &catalog[i]
+		if !matchesProfile(j, p) {
+			continue
+		}
+		return p
+	}
+	return nil
+}
+
+func matchesProfile(j jvm.Info, p *AppProfile) bool {
+	if p.MainClassContains == "" && p.JavaHomeContains == "" && len(p.VMArgsHas) == 0 {
+		return false // a profile with zero matchers should never match
+	}
+	if p.MainClassContains != "" {
+		if !containsFold(j.MainClass, p.MainClassContains) {
+			return false
+		}
+	}
+	if p.JavaHomeContains != "" {
+		if !containsFold(j.JavaHome, p.JavaHomeContains) {
+			return false
+		}
+	}
+	for _, needle := range p.VMArgsHas {
+		if !strings.Contains(j.VMArgs, needle) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasTag reports whether the profile carries the named tag. Nil profiles
+// have no tags — callers can pass MatchProfile's result directly.
+func HasTag(p *AppProfile, tag string) bool {
+	if p == nil {
+		return false
+	}
+	for _, t := range p.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(haystack, needle string) bool {
+	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+}

--- a/internal/rules/profile_test.go
+++ b/internal/rules/profile_test.go
@@ -1,0 +1,83 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+func TestMatchProfile_JetBrainsToolbox(t *testing.T) {
+	j := jvm.Info{
+		PID:      1127,
+		JavaHome: "/Applications/JetBrains Toolbox.app/Contents/jre/Contents/Home",
+	}
+	got := MatchProfile(j, BuiltinProfiles())
+	if got == nil || got.ID != "jetbrains-toolbox" {
+		t.Fatalf("expected jetbrains-toolbox, got %v", got)
+	}
+	if !HasTag(got, TagTightHeapExpected) {
+		t.Errorf("toolbox should carry tight_heap_expected tag")
+	}
+	if !HasTag(got, TagLauncher) {
+		t.Errorf("toolbox should carry launcher tag")
+	}
+}
+
+func TestMatchProfile_GradleDaemon(t *testing.T) {
+	j := jvm.Info{
+		PID:       9001,
+		MainClass: "org.gradle.launcher.daemon.bootstrap.GradleDaemon",
+	}
+	got := MatchProfile(j, BuiltinProfiles())
+	if got == nil || got.ID != "gradle-daemon" {
+		t.Fatalf("expected gradle-daemon, got %v", got)
+	}
+	if !HasTag(got, TagBuildToolDaemon) {
+		t.Errorf("gradle daemon should carry build_tool_daemon tag")
+	}
+}
+
+func TestMatchProfile_NoMatch(t *testing.T) {
+	j := jvm.Info{PID: 1, MainClass: "com.example.MyServer", JavaHome: "/opt/java"}
+	if got := MatchProfile(j, BuiltinProfiles()); got != nil {
+		t.Errorf("plain server should not match any builtin profile, got %v", got)
+	}
+}
+
+func TestMatchProfile_AllMatchersMustHold(t *testing.T) {
+	// Android Studio requires BOTH java home and main class.
+	jOnlyHome := jvm.Info{JavaHome: "/Applications/Android Studio.app/Contents/jbr/Contents/Home"}
+	if got := MatchProfile(jOnlyHome, BuiltinProfiles()); got != nil && got.ID == "android-studio" {
+		t.Errorf("android-studio should require main class match too, got %v", got)
+	}
+}
+
+func TestMatchProfile_EmptyProfileNeverMatches(t *testing.T) {
+	empty := []AppProfile{{ID: "empty"}}
+	j := jvm.Info{MainClass: "anything", JavaHome: "/anywhere", VMArgs: "-Xmx2g"}
+	if got := MatchProfile(j, empty); got != nil {
+		t.Errorf("a profile with zero matchers must never match, got %v", got)
+	}
+}
+
+func TestHasTag_Nil(t *testing.T) {
+	if HasTag(nil, TagTightHeapExpected) {
+		t.Error("HasTag(nil, ...) must be false")
+	}
+}
+
+func TestMatchProfile_VMArgsHas(t *testing.T) {
+	catalog := []AppProfile{{
+		ID:        "kotlin-compose",
+		VMArgsHas: []string{"-Dskiko.metal", "-Xmx190m"},
+		Tags:      []string{"compose-desktop"},
+	}}
+	matching := jvm.Info{VMArgs: "-Xmx190m -Dskiko.metal.gpu.priority=integrated"}
+	if got := MatchProfile(matching, catalog); got == nil {
+		t.Error("expected match when both vmargs needles present")
+	}
+	missingOne := jvm.Info{VMArgs: "-Xmx190m"}
+	if got := MatchProfile(missingOne, catalog); got != nil {
+		t.Error("expected no match when one vmargs needle absent")
+	}
+}

--- a/internal/rules/profile_yaml.go
+++ b/internal/rules/profile_yaml.go
@@ -1,0 +1,168 @@
+package rules
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// YAMLProfileSpec is the external profile format. Mirrors AppProfile but uses
+// YAML naming conventions and is decoded with strict (KnownFields) parsing.
+type YAMLProfileSpec struct {
+	ID                string   `yaml:"id"`
+	Name              string   `yaml:"name"`
+	MainClassContains string   `yaml:"main_class_contains,omitempty"`
+	JavaHomeContains  string   `yaml:"java_home_contains,omitempty"`
+	VMArgsHas         []string `yaml:"vm_args_has,omitempty"`
+	Tags              []string `yaml:"tags,omitempty"`
+}
+
+// LoadProfilesFromYAML parses zero or more YAML profile files. Each file may
+// be a top-level list or {profiles: [...]}. Returns the merged list in input
+// order; duplicate-ID handling is the caller's responsibility (use
+// MergeProfiles to override builtins explicitly).
+func LoadProfilesFromYAML(paths []string) ([]AppProfile, error) {
+	var out []AppProfile
+	for _, path := range paths {
+		specs, err := loadProfileSpecs(path)
+		if err != nil {
+			return nil, err
+		}
+		for _, spec := range specs {
+			profile, err := compileProfile(spec, path)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, profile)
+		}
+	}
+	return out, nil
+}
+
+func loadProfileSpecs(path string) ([]YAMLProfileSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var root yaml.Node
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&root); err != nil {
+		return nil, fmt.Errorf("%s: parse YAML: %w", path, err)
+	}
+	if len(root.Content) == 0 {
+		return nil, nil
+	}
+	listNode, err := profilesListNode(root.Content[0])
+	if err != nil {
+		return nil, fmt.Errorf("%s:%d: %w", path, root.Content[0].Line, err)
+	}
+	var specs []YAMLProfileSpec
+	for _, child := range listNode.Content {
+		if err := rejectUnknownProfileFields(child); err != nil {
+			return nil, fmt.Errorf("%s:%d: %w", path, child.Line, err)
+		}
+		var spec YAMLProfileSpec
+		if err := child.Decode(&spec); err != nil {
+			return nil, fmt.Errorf("%s:%d: %w", path, child.Line, err)
+		}
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+func rejectUnknownProfileFields(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("profile must be a mapping")
+	}
+	allowed := map[string]struct{}{
+		"id":                  {},
+		"name":                {},
+		"main_class_contains": {},
+		"java_home_contains":  {},
+		"vm_args_has":         {},
+		"tags":                {},
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		if _, ok := allowed[key]; !ok {
+			return fmt.Errorf("unknown profile field %q", key)
+		}
+	}
+	return nil
+}
+
+func profilesListNode(root *yaml.Node) (*yaml.Node, error) {
+	switch root.Kind {
+	case yaml.SequenceNode:
+		return root, nil
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(root.Content); i += 2 {
+			if root.Content[i].Value == "profiles" {
+				if root.Content[i+1].Kind != yaml.SequenceNode {
+					return nil, fmt.Errorf("profiles must be a list")
+				}
+				return root.Content[i+1], nil
+			}
+		}
+		return nil, fmt.Errorf("top-level mapping must contain profiles")
+	default:
+		return nil, fmt.Errorf("top-level YAML must be a profile list or {profiles: [...]}")
+	}
+}
+
+func compileProfile(spec YAMLProfileSpec, source string) (AppProfile, error) {
+	if strings.TrimSpace(spec.ID) == "" {
+		return AppProfile{}, fmt.Errorf("%s: profile is missing id", source)
+	}
+	if spec.MainClassContains == "" && spec.JavaHomeContains == "" && len(spec.VMArgsHas) == 0 {
+		return AppProfile{}, fmt.Errorf("%s: profile %q has no matchers (would never match)", source, spec.ID)
+	}
+	return AppProfile{
+		ID:                spec.ID,
+		Name:              spec.Name,
+		MainClassContains: spec.MainClassContains,
+		JavaHomeContains:  spec.JavaHomeContains,
+		VMArgsHas:         append([]string(nil), spec.VMArgsHas...),
+		Tags:              append([]string(nil), spec.Tags...),
+	}, nil
+}
+
+// MergeProfiles returns base with extension merged in. Extension entries with
+// IDs that already exist in base replace the base entries (user wins). Order
+// is preserved: replaced entries keep their slot, new entries are appended.
+func MergeProfiles(base, extension []AppProfile) []AppProfile {
+	if len(extension) == 0 {
+		return base
+	}
+	indexByID := make(map[string]int, len(base))
+	out := append([]AppProfile(nil), base...)
+	for i, p := range out {
+		indexByID[p.ID] = i
+	}
+	for _, p := range extension {
+		if idx, ok := indexByID[p.ID]; ok {
+			out[idx] = p
+			continue
+		}
+		indexByID[p.ID] = len(out)
+		out = append(out, p)
+	}
+	return out
+}
+
+// ResolveProfileCatalog returns the effective profile catalog: builtin merged
+// with profiles loaded from paths. Pass nil paths to get builtins only.
+func ResolveProfileCatalog(paths []string) ([]AppProfile, error) {
+	if len(paths) == 0 {
+		return BuiltinProfiles(), nil
+	}
+	user, err := LoadProfilesFromYAML(paths)
+	if err != nil {
+		return nil, err
+	}
+	return MergeProfiles(BuiltinProfiles(), user), nil
+}

--- a/internal/rules/profile_yaml_test.go
+++ b/internal/rules/profile_yaml_test.go
@@ -1,0 +1,157 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+func writeYAML(t *testing.T, name, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func TestLoadProfilesFromYAML_TopLevelList(t *testing.T) {
+	path := writeYAML(t, "profiles.yml", `
+- id: my-server
+  name: Acme App Server
+  main_class_contains: com.acme.server.Main
+  tags: [tight_heap_expected]
+- id: ephemeral-tool
+  java_home_contains: /tmp/ephemeral
+  tags: [build_tool_daemon]
+`)
+	got, err := LoadProfilesFromYAML([]string{path})
+	if err != nil {
+		t.Fatalf("LoadProfilesFromYAML: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(got))
+	}
+	if got[0].ID != "my-server" || got[0].MainClassContains != "com.acme.server.Main" {
+		t.Errorf("first profile: %+v", got[0])
+	}
+	if !HasTag(&got[0], TagTightHeapExpected) {
+		t.Errorf("first profile should have tight_heap_expected")
+	}
+}
+
+func TestLoadProfilesFromYAML_MappingWithProfilesKey(t *testing.T) {
+	path := writeYAML(t, "profiles.yml", `
+profiles:
+  - id: only-one
+    java_home_contains: /opt/only
+    tags: [ide]
+`)
+	got, err := LoadProfilesFromYAML([]string{path})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "only-one" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestLoadProfilesFromYAML_RejectsNoMatchers(t *testing.T) {
+	path := writeYAML(t, "profiles.yml", `
+- id: phantom
+  name: Phantom
+  tags: [danger]
+`)
+	if _, err := LoadProfilesFromYAML([]string{path}); err == nil {
+		t.Error("expected error for profile with no matchers")
+	}
+}
+
+func TestLoadProfilesFromYAML_RejectsMissingID(t *testing.T) {
+	path := writeYAML(t, "profiles.yml", `
+- main_class_contains: x
+  tags: [a]
+`)
+	if _, err := LoadProfilesFromYAML([]string{path}); err == nil {
+		t.Error("expected error for profile missing id")
+	}
+}
+
+func TestLoadProfilesFromYAML_RejectsUnknownField(t *testing.T) {
+	// strict YAML: unknown fields error out
+	path := writeYAML(t, "profiles.yml", `
+- id: x
+  main_class_contains: y
+  bogus_field: 1
+`)
+	if _, err := LoadProfilesFromYAML([]string{path}); err == nil {
+		t.Error("expected strict YAML error for unknown field")
+	}
+}
+
+func TestMergeProfiles_UserOverridesBuiltinByID(t *testing.T) {
+	user := []AppProfile{{
+		ID:               "jetbrains-toolbox",
+		Name:             "MY Toolbox Override",
+		JavaHomeContains: "different-path",
+		Tags:             []string{"my_tag"},
+	}}
+	merged := MergeProfiles(BuiltinProfiles(), user)
+	for _, p := range merged {
+		if p.ID == "jetbrains-toolbox" {
+			if p.Name != "MY Toolbox Override" || !HasTag(&p, "my_tag") {
+				t.Errorf("user override didn't replace builtin: %+v", p)
+			}
+			return
+		}
+	}
+	t.Error("jetbrains-toolbox not present after merge")
+}
+
+func TestMergeProfiles_AppendsNew(t *testing.T) {
+	user := []AppProfile{{
+		ID:                "custom-server",
+		MainClassContains: "com.example",
+		Tags:              []string{"x"},
+	}}
+	merged := MergeProfiles(BuiltinProfiles(), user)
+	if len(merged) != len(BuiltinProfiles())+1 {
+		t.Fatalf("expected %d profiles, got %d", len(BuiltinProfiles())+1, len(merged))
+	}
+	if merged[len(merged)-1].ID != "custom-server" {
+		t.Errorf("custom profile should be appended last")
+	}
+}
+
+func TestResolveProfileCatalog_NoPaths(t *testing.T) {
+	got, err := ResolveProfileCatalog(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != len(BuiltinProfiles()) {
+		t.Errorf("nil paths should yield builtins only")
+	}
+}
+
+func TestResolveProfileCatalog_EndToEndMatching(t *testing.T) {
+	path := writeYAML(t, "profiles.yml", `
+- id: acme-runtime
+  main_class_contains: com.acme.Runtime
+  tags: [tight_heap_expected]
+`)
+	catalog, err := ResolveProfileCatalog([]string{path})
+	if err != nil {
+		t.Fatalf("ResolveProfileCatalog: %v", err)
+	}
+	j := jvm.Info{MainClass: "com.acme.Runtime$App"}
+	got := MatchProfile(j, catalog)
+	if got == nil || got.ID != "acme-runtime" {
+		t.Fatalf("expected acme-runtime match, got %v", got)
+	}
+	if !HasTag(got, TagTightHeapExpected) {
+		t.Error("acme-runtime should carry tight_heap_expected from YAML")
+	}
+}

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -236,6 +236,22 @@ func TestJVMGCPressureSuppressedByFlatTrend(t *testing.T) {
 	}
 }
 
+// FullGCBurst branch is also suppressed when the suppressors apply.
+// 166 full GCs over a 5-day uptime is normal for SerialGC with a low
+// MaxHeapFreeRatio (Toolbox's actual configuration in the wild).
+func TestJVMGCPressureFullGCBurstSuppressedForTightHeap(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:      1127,
+		JavaHome: "/Applications/JetBrains Toolbox.app/Contents/jre/Contents/Home",
+		VMArgs:   "-Xmx190m -XX:+UseSerialGC -XX:MaxHeapFreeRatio=10",
+		GC:       &jvm.GCStats{OC: 1000, OU: 600, FGC: 166, FGCT: 10.1}, // burst threshold met
+	}}
+	if findings := ruleJVMGCPressure().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("FGC burst should be suppressed for tight-heap JVMs, got %v", findings)
+	}
+}
+
 // Profile-based suppression: a Toolbox JVM identified by JavaHome — even
 // without the explicit -XX:MaxHeapFreeRatio flag in vmargs — must be
 // suppressed because the profile catalog tags it tight_heap_expected.

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -214,6 +214,38 @@ func TestJVMGCPressureSuppressedByFlatTrend(t *testing.T) {
 	}
 }
 
+// Profile-based suppression: a Toolbox JVM identified by JavaHome — even
+// without the explicit -XX:MaxHeapFreeRatio flag in vmargs — must be
+// suppressed because the profile catalog tags it tight_heap_expected.
+func TestJVMGCPressureSuppressedByProfileTag(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       1127,
+		MainClass: "JetBrains Toolbox",
+		JavaHome:  "/Applications/JetBrains Toolbox.app/Contents/jre/Contents/Home",
+		// no -XX:MaxHeapFreeRatio in args
+		VMArgs: "-Xmx190m -XX:+UseSerialGC",
+		GC:     &jvm.GCStats{OC: 67648, OU: 64650},
+	}}
+	if findings := ruleJVMGCPressure().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("toolbox profile should suppress finding via tag, got %v", findings)
+	}
+}
+
+// Profile-based suppression for Gradle daemon (matched by main class).
+func TestJVMGCPressureSuppressedForGradleDaemon(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       9001,
+		MainClass: "org.gradle.launcher.daemon.bootstrap.GradleDaemon",
+		VMArgs:    "-Xmx512m",
+		GC:        &jvm.GCStats{OC: 1000, OU: 950},
+	}}
+	if findings := ruleJVMGCPressure().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("gradle daemon should be suppressed via profile, got %v", findings)
+	}
+}
+
 // Trend gating: when history shows a rising old gen, fire even if the level
 // rule alone would have fired (this is the leak-suspect case).
 func TestJVMGCPressureFiresOnRisingTrend(t *testing.T) {

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,6 +118,27 @@ func TestJVMHeapVsSystemNoFire(t *testing.T) {
 	s.JVMs = []jvm.Info{{PID: 1, VMArgs: "-Xmx2g"}} // 12.5% → ok
 	if findings := ruleJVMHeapVsSystemRAM().MatchFn(s); len(findings) != 0 {
 		t.Errorf("expected no findings for -Xmx2g on 16 GiB, got %v", findings)
+	}
+}
+
+// IDE-family JVMs are tagged large_heap_expected — the rule still fires but
+// at medium severity to communicate "noted, not alarming."
+func TestJVMHeapVsSystemDemotedForIDE(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       2222,
+		MainClass: "com.intellij.idea.Main",
+		VMArgs:    "-Xmx12g",
+	}}
+	findings := ruleJVMHeapVsSystemRAM().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityMedium {
+		t.Errorf("severity = %q, want medium for IDE", findings[0].Severity)
+	}
+	if !strings.Contains(findings[0].Message, "expected for this app") {
+		t.Errorf("message should be recalibrated, got %q", findings[0].Message)
 	}
 }
 

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -159,6 +159,36 @@ func TestJVMGCPressureNoFire(t *testing.T) {
 	}
 }
 
+// Regression: JetBrains Toolbox sits at >90% old-gen by design via
+// -XX:MaxHeapFreeRatio=10. The old surface-level rule fired on every
+// snapshot; the composed rule must suppress it.
+func TestJVMGCPressureSuppressedForTightHeapByDesign(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       1127,
+		MainClass: "JetBrains Toolbox",
+		VMArgs:    "-Xmx190m -XX:+UseSerialGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=10",
+		GC:        &jvm.GCStats{OC: 67648, OU: 64650},
+	}}
+	if findings := ruleJVMGCPressure().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("tight-heap-by-design should suppress old-gen finding, got %v", findings)
+	}
+}
+
+// Companion: same heap occupancy WITHOUT the tight-heap flags must still fire.
+func TestJVMGCPressureFiresWhenNotTightByDesign(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       2000,
+		MainClass: "real.App",
+		VMArgs:    "-Xmx2g -XX:+UseG1GC",
+		GC:        &jvm.GCStats{OC: 67648, OU: 64650},
+	}}
+	if findings := ruleJVMGCPressure().MatchFn(s); len(findings) != 1 {
+		t.Fatalf("expected 1 finding without tight-heap config, got %d: %v", len(findings), findings)
+	}
+}
+
 // --- jdk-major-version-drift ---
 
 func TestJDKDriftFires(t *testing.T) {

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/detect"
 	"github.com/kaeawc/spectra/internal/jvm"
@@ -186,6 +187,53 @@ func TestJVMGCPressureFiresWhenNotTightByDesign(t *testing.T) {
 	}}
 	if findings := ruleJVMGCPressure().MatchFn(s); len(findings) != 1 {
 		t.Fatalf("expected 1 finding without tight-heap config, got %d: %v", len(findings), findings)
+	}
+}
+
+// Trend gating: when history shows a flat-but-high old gen, suppress.
+// This is the steady-state-at-working-size case (e.g. a JVM operating at
+// its real working set, not actually leaking).
+func TestJVMGCPressureSuppressedByFlatTrend(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       2001,
+		MainClass: "steady.App",
+		VMArgs:    "-Xmx2g -XX:+UseG1GC",
+		GC:        &jvm.GCStats{OC: 1000, OU: 950},
+	}}
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		s.JVMHistory = append(s.JVMHistory, snapshot.JVMSample{
+			PID:       2001,
+			At:        now.Add(time.Duration(i-5) * time.Minute),
+			OldGenPct: 94 + float64(i)*0.2, // 94 -> 94.8, well below MinOldGenRiseDelta
+		})
+	}
+	if findings := ruleJVMGCPressure().MatchFn(s); len(findings) != 0 {
+		t.Fatalf("flat trend should suppress finding, got %v", findings)
+	}
+}
+
+// Trend gating: when history shows a rising old gen, fire even if the level
+// rule alone would have fired (this is the leak-suspect case).
+func TestJVMGCPressureFiresOnRisingTrend(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       2002,
+		MainClass: "leaky.App",
+		VMArgs:    "-Xmx2g -XX:+UseG1GC",
+		GC:        &jvm.GCStats{OC: 1000, OU: 950},
+	}}
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		s.JVMHistory = append(s.JVMHistory, snapshot.JVMSample{
+			PID:       2002,
+			At:        now.Add(time.Duration(i-5) * time.Minute),
+			OldGenPct: 70 + float64(i)*6, // 70 -> 94, clearly rising
+		})
+	}
+	if findings := ruleJVMGCPressure().MatchFn(s); len(findings) != 1 {
+		t.Fatalf("rising trend should fire, got %d findings: %v", len(findings), findings)
 	}
 }
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -444,6 +444,7 @@ func snapshotLoop(ctx context.Context, version string, db *store.DB, history *li
 			_ = db.SaveLoginItems(ctx, snap.ID, store.LoginItemsFromSnapshot(snap))
 			_ = db.SaveGrantedPerms(ctx, snap.ID, store.GrantedPermsFromSnapshot(snap))
 			_, _ = db.PruneSnapshots(ctx, 100)
+			_, _ = db.PruneJVMSamples(ctx, 7)
 		}
 	}
 }

--- a/internal/snapshot/cached_collectors.go
+++ b/internal/snapshot/cached_collectors.go
@@ -1,0 +1,89 @@
+package snapshot
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/cache"
+	"github.com/kaeawc/spectra/internal/storagestate"
+	"github.com/kaeawc/spectra/internal/toolchain"
+)
+
+// Default TTLs for the slow but slow-changing collectors.
+const (
+	toolchainCacheTTL = 5 * time.Minute
+	storageCacheTTL   = 30 * time.Second
+)
+
+// collectToolchainCached returns toolchain.Toolchains, serving from cache
+// when fresh and falling through to the live collector on miss.
+//
+// The cache key is content-addressed by the input paths so distinct test
+// homes / brew roots / JDK roots don't share an entry. Cache writes go
+// through the TTLStore's AsyncWriter when one was configured, so they
+// never block the main collection loop.
+func collectToolchainCached(ctx context.Context, opts toolchain.CollectOptions, ttl *cache.TTLStore) toolchain.Toolchains {
+	if ttl == nil {
+		return toolchain.Collect(ctx, opts)
+	}
+	key := toolchainCacheKey(opts)
+	if blob, ok := ttl.Get(key); ok {
+		var t toolchain.Toolchains
+		if err := json.Unmarshal(blob, &t); err == nil {
+			return t
+		}
+	}
+	t := toolchain.Collect(ctx, opts)
+	if blob, err := json.Marshal(t); err == nil {
+		_ = ttl.Put(key, blob, toolchainCacheTTL)
+	}
+	return t
+}
+
+// collectStorageCached mirrors collectToolchainCached for storagestate.
+func collectStorageCached(opts storagestate.CollectOptions, ttl *cache.TTLStore) storagestate.State {
+	if ttl == nil {
+		return storagestate.Collect(opts)
+	}
+	key := storageCacheKey(opts)
+	if blob, ok := ttl.Get(key); ok {
+		var s storagestate.State
+		if err := json.Unmarshal(blob, &s); err == nil {
+			return s
+		}
+	}
+	s := storagestate.Collect(opts)
+	if blob, err := json.Marshal(s); err == nil {
+		_ = ttl.Put(key, blob, storageCacheTTL)
+	}
+	return s
+}
+
+// toolchainCacheKey hashes the cache-relevant inputs (path roots) so distinct
+// configurations don't collide. Output bytes are a SHA-256 digest.
+func toolchainCacheKey(opts toolchain.CollectOptions) []byte {
+	parts := []string{
+		"toolchain",
+		opts.Home,
+		strings.Join(opts.BrewCellars, "|"),
+		opts.SystemJVMRoot,
+		opts.UserJVMRoot,
+	}
+	h := sha256.New()
+	h.Write([]byte(strings.Join(parts, "\x00")))
+	return h.Sum(nil)
+}
+
+func storageCacheKey(opts storagestate.CollectOptions) []byte {
+	parts := []string{
+		"storage",
+		opts.Home,
+		strings.Join(opts.AppPaths, "|"),
+	}
+	h := sha256.New()
+	h.Write([]byte(strings.Join(parts, "\x00")))
+	return h.Sum(nil)
+}

--- a/internal/snapshot/jvm_history.go
+++ b/internal/snapshot/jvm_history.go
@@ -1,6 +1,10 @@
 package snapshot
 
-import "time"
+import (
+	"time"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
 
 // JVMSample is one historical point of JVM observability for a single PID.
 // It is a deliberately compact subset of jvm.Info — enough to compute
@@ -9,9 +13,30 @@ type JVMSample struct {
 	PID       int       `json:"pid"`
 	At        time.Time `json:"at"`
 	OldGenPct float64   `json:"old_gen_pct"`
-	FGC       int       `json:"fgc"`     // cumulative full-GC count
+	FGC       int64     `json:"fgc"`     // cumulative full-GC count
 	FGCT      float64   `json:"fgct"`    // cumulative full-GC seconds
 	HeapMB    int64     `json:"heap_mb"` // jstat OC + EC + survivor in MiB; 0 if unknown
+}
+
+// JVMSampleFrom builds a sample from a live jvm.Info reading. Returns ok=false
+// when the JVM has no GC stats yet (collection failed or hasn't run).
+func JVMSampleFrom(j jvm.Info, at time.Time) (JVMSample, bool) {
+	if j.GC == nil {
+		return JVMSample{}, false
+	}
+	var oldGenPct float64
+	if j.GC.OC > 0 {
+		oldGenPct = j.GC.OU * 100 / j.GC.OC
+	}
+	heapKiB := j.GC.OC + j.GC.EC + j.GC.S0C + j.GC.S1C
+	return JVMSample{
+		PID:       j.PID,
+		At:        at.UTC(),
+		OldGenPct: oldGenPct,
+		FGC:       j.GC.FGC,
+		FGCT:      j.GC.FGCT,
+		HeapMB:    int64(heapKiB) / 1024,
+	}, true
 }
 
 // JVMHistory is a slice of JVMSamples in chronological order (oldest first).

--- a/internal/snapshot/jvm_history.go
+++ b/internal/snapshot/jvm_history.go
@@ -1,0 +1,36 @@
+package snapshot
+
+import "time"
+
+// JVMSample is one historical point of JVM observability for a single PID.
+// It is a deliberately compact subset of jvm.Info — enough to compute
+// trend slopes without re-deserializing whole snapshots.
+type JVMSample struct {
+	PID       int       `json:"pid"`
+	At        time.Time `json:"at"`
+	OldGenPct float64   `json:"old_gen_pct"`
+	FGC       int       `json:"fgc"`     // cumulative full-GC count
+	FGCT      float64   `json:"fgct"`    // cumulative full-GC seconds
+	HeapMB    int64     `json:"heap_mb"` // jstat OC + EC + survivor in MiB; 0 if unknown
+}
+
+// JVMHistory is a slice of JVMSamples in chronological order (oldest first).
+// Empty / nil is the legitimate "no history available" state — callers must
+// treat absence as "fall back to point-in-time rules", not as an error.
+type JVMHistory []JVMSample
+
+// SamplesFor returns just the samples for one PID, preserving order.
+// Returns nil (not empty slice) when there are zero matches so callers can
+// branch on `samples == nil` to mean "no history."
+func (h JVMHistory) SamplesFor(pid int) []JVMSample {
+	if len(h) == 0 {
+		return nil
+	}
+	var out []JVMSample
+	for _, s := range h {
+		if s.PID == pid {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/snapshot/jvm_history_test.go
+++ b/internal/snapshot/jvm_history_test.go
@@ -1,0 +1,39 @@
+package snapshot
+
+import (
+	"testing"
+	"time"
+)
+
+func TestJVMHistory_SamplesFor(t *testing.T) {
+	now := time.Now()
+	h := JVMHistory{
+		{PID: 10, At: now.Add(-3 * time.Minute), OldGenPct: 70},
+		{PID: 11, At: now.Add(-3 * time.Minute), OldGenPct: 50},
+		{PID: 10, At: now.Add(-2 * time.Minute), OldGenPct: 80},
+		{PID: 10, At: now.Add(-1 * time.Minute), OldGenPct: 90},
+	}
+	got := h.SamplesFor(10)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 samples for PID 10, got %d", len(got))
+	}
+	for i, want := range []float64{70, 80, 90} {
+		if got[i].OldGenPct != want {
+			t.Errorf("sample %d: OldGenPct = %v, want %v", i, got[i].OldGenPct, want)
+		}
+	}
+}
+
+func TestJVMHistory_SamplesForNoMatch(t *testing.T) {
+	h := JVMHistory{{PID: 10, OldGenPct: 50}}
+	if got := h.SamplesFor(99); got != nil {
+		t.Errorf("expected nil for missing PID, got %v", got)
+	}
+}
+
+func TestJVMHistory_SamplesForEmpty(t *testing.T) {
+	var h JVMHistory
+	if got := h.SamplesFor(10); got != nil {
+		t.Errorf("expected nil from empty history, got %v", got)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -46,6 +46,11 @@ type Snapshot struct {
 
 	JVMs             []jvm.Info          `json:"jvms,omitempty"`
 	RuntimeTelemetry []telemetry.Process `json:"runtime_telemetry,omitempty"`
+
+	// JVMHistory is recent per-PID JVM samples (oldest first) populated by
+	// callers that have access to a snapshot store. Optional: rules that
+	// don't see history fall back to point-in-time checks.
+	JVMHistory JVMHistory `json:"jvm_history,omitempty"`
 }
 
 // Options configure a snapshot Build.

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -134,6 +134,17 @@ type Options struct {
 	// DetectWriter optionally writes detect-cache misses asynchronously.
 	// DetectStore must also be set; nil writes synchronously.
 	DetectWriter *cache.AsyncWriter
+
+	// ToolchainCache is a TTL cache for the toolchain.Toolchains JSON.
+	// Toolchains rarely change within a session; a 5-minute TTL is enough
+	// to amortize repeated rules invocations.
+	ToolchainCache *cache.TTLStore
+
+	// StorageCache is a TTL cache for storagestate.State JSON. Storage walks
+	// can be slow (~Library on a developer machine is large); a 30-second
+	// TTL keeps results meaningfully fresh while collapsing close-together
+	// invocations.
+	StorageCache *cache.TTLStore
 }
 
 // Build assembles a Snapshot by running every collector in parallel and
@@ -178,7 +189,7 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	}
 	go func() {
 		defer wg.Done()
-		s.Toolchains = toolchain.Collect(ctx, opts.ToolchainOpts)
+		s.Toolchains = collectToolchainCached(ctx, opts.ToolchainOpts, opts.ToolchainCache)
 	}()
 	go func() {
 		defer wg.Done()
@@ -195,7 +206,7 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	if !opts.SkipStorage {
 		go func() {
 			defer wg.Done()
-			s.Storage = storagestate.Collect(opts.StorageOpts)
+			s.Storage = collectStorageCached(opts.StorageOpts, opts.StorageCache)
 		}()
 	}
 

--- a/internal/storagestate/logs.go
+++ b/internal/storagestate/logs.go
@@ -1,0 +1,112 @@
+package storagestate
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// LogFile is one log-shaped file discovered on disk. Owner is best-effort
+// attribution to the macOS app bundle the file lives under (e.g. "Slack");
+// it is empty for files whose path doesn't match a recognizable owner.
+type LogFile struct {
+	Path      string    `json:"path"`
+	Owner     string    `json:"owner,omitempty"`
+	SizeBytes int64     `json:"size_bytes"`
+	ModTime   time.Time `json:"mtime"`
+}
+
+// CollectLogFiles walks well-known macOS log directories and returns each
+// log-shaped regular file. A file is "log-shaped" if it sits under a /Logs/
+// directory or has a .log suffix.
+//
+// Roots scanned:
+//   - $HOME/Library/Logs
+//   - $HOME/Library/Application Support/<app>/Logs (1 level deep)
+//   - /Library/Logs
+//   - /var/log
+//
+// Heavy directories (Application Support) are walked one level deep to
+// keep cost bounded; per-app subtree scanning belongs in the demand-driven
+// inspect_app path, not the default snapshot.
+func CollectLogFiles(home string) []LogFile {
+	var out []LogFile
+	roots := []string{
+		filepath.Join(home, "Library", "Logs"),
+		"/Library/Logs",
+		"/var/log",
+	}
+	for _, root := range roots {
+		out = append(out, walkLogs(root, "")...)
+	}
+	out = append(out, walkAppSupportLogs(filepath.Join(home, "Library", "Application Support"))...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].SizeBytes != out[j].SizeBytes {
+			return out[i].SizeBytes > out[j].SizeBytes
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out
+}
+
+// walkLogs recursively scans a single log root, returning log-shaped files.
+// owner, when non-empty, is attached to every result (for Application
+// Support attribution). Symlinks are not followed.
+func walkLogs(root, owner string) []LogFile {
+	var out []LogFile
+	filepath.Walk(root, func(path string, fi os.FileInfo, err error) error { //nolint:errcheck
+		if err != nil {
+			return nil // tolerate permission errors silently
+		}
+		if fi == nil || fi.IsDir() {
+			return nil
+		}
+		if !isLogShapedFile(path) {
+			return nil
+		}
+		out = append(out, LogFile{
+			Path:      path,
+			Owner:     owner,
+			SizeBytes: diskBytes(fi),
+			ModTime:   fi.ModTime(),
+		})
+		return nil
+	})
+	return out
+}
+
+// walkAppSupportLogs scans ~/Library/Application Support/<app>/Logs for each
+// top-level app directory. Other subdirectories are ignored to keep cost low.
+func walkAppSupportLogs(appSupport string) []LogFile {
+	entries, err := os.ReadDir(appSupport)
+	if err != nil {
+		return nil
+	}
+	var out []LogFile
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		owner := e.Name()
+		logsDir := filepath.Join(appSupport, owner, "Logs")
+		out = append(out, walkLogs(logsDir, owner)...)
+	}
+	return out
+}
+
+// isLogShapedFile classifies a file path as log-like. Same predicate as the
+// process-deep heuristic so output is consistent across the two paths.
+func isLogShapedFile(path string) bool {
+	if path == "" {
+		return false
+	}
+	if strings.HasSuffix(path, ".log") {
+		return true
+	}
+	if strings.Contains(path, "/Logs/") {
+		return true
+	}
+	return false
+}

--- a/internal/storagestate/logs_test.go
+++ b/internal/storagestate/logs_test.go
@@ -1,0 +1,91 @@
+package storagestate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCollectLogFiles(t *testing.T) {
+	home := t.TempDir()
+
+	// $HOME/Library/Logs/Foo/foo.log
+	mustWrite(t, filepath.Join(home, "Library", "Logs", "Foo", "foo.log"), "log")
+	// $HOME/Library/Logs/Bar/bar.txt — under /Logs/ so still counts
+	mustWrite(t, filepath.Join(home, "Library", "Logs", "Bar", "bar.txt"), "log")
+	// $HOME/Library/Application Support/Slack/Logs/main.log — owner=Slack
+	mustWrite(t, filepath.Join(home, "Library", "Application Support", "Slack", "Logs", "main.log"), "log")
+	// $HOME/Library/Application Support/Slack/Cache/x — NOT under Logs, skip
+	mustWrite(t, filepath.Join(home, "Library", "Application Support", "Slack", "Cache", "x.bin"), "data")
+	// non-log file under user library — skip
+	mustWrite(t, filepath.Join(home, "Library", "Logs", "Foo", "readme.txt"), "txt")
+
+	files := CollectLogFiles(home)
+
+	got := map[string]string{}
+	for _, f := range files {
+		got[f.Path] = f.Owner
+	}
+
+	want := map[string]string{
+		filepath.Join(home, "Library", "Logs", "Foo", "foo.log"):                            "",
+		filepath.Join(home, "Library", "Logs", "Bar", "bar.txt"):                            "",
+		filepath.Join(home, "Library", "Application Support", "Slack", "Logs", "main.log"): "Slack",
+	}
+
+	for path, owner := range want {
+		if gotOwner, ok := got[path]; !ok {
+			t.Errorf("missing %q from results", path)
+		} else if gotOwner != owner {
+			t.Errorf("%q: owner = %q, want %q", path, gotOwner, owner)
+		}
+	}
+	if got[filepath.Join(home, "Library", "Application Support", "Slack", "Cache", "x.bin")] != "" {
+		// the empty-string default could mask a false positive; assert the path simply isn't present
+		for _, f := range files {
+			if f.Path == filepath.Join(home, "Library", "Application Support", "Slack", "Cache", "x.bin") {
+				t.Errorf("non-log file should not appear in results")
+			}
+		}
+	}
+}
+
+func TestCollectLogFiles_SortedBySizeDesc(t *testing.T) {
+	home := t.TempDir()
+	mustWrite(t, filepath.Join(home, "Library", "Logs", "small.log"), "x")
+	mustWrite(t, filepath.Join(home, "Library", "Logs", "big.log"), "xxxxxxxxxxxxxxxxxxxx")
+
+	files := CollectLogFiles(home)
+	if len(files) < 2 {
+		t.Fatalf("expected ≥2 files, got %d", len(files))
+	}
+	if files[0].SizeBytes < files[1].SizeBytes {
+		t.Errorf("results should be sorted size-desc, got %d before %d", files[0].SizeBytes, files[1].SizeBytes)
+	}
+}
+
+func TestIsLogShapedFile(t *testing.T) {
+	cases := map[string]bool{
+		"/Users/foo/Library/Logs/x.log":               true,
+		"/Users/foo/Library/Logs/sub/notes.txt":       true, // under /Logs/
+		"/Users/foo/Library/Caches/myapp/cache.bin":   false,
+		"/Users/foo/work/Catalogs/index":              false, // similar but distinct segment
+		"/var/log/system.log":                          true,
+		"":                                             false,
+	}
+	for in, want := range cases {
+		if got := isLogShapedFile(in); got != want {
+			t.Errorf("isLogShapedFile(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/storagestate/storagestate.go
+++ b/internal/storagestate/storagestate.go
@@ -17,6 +17,7 @@ type State struct {
 	UserLibraryBytes int64     `json:"user_library_bytes"`
 	AppCachesBytes   int64     `json:"app_caches_bytes"`
 	LargestApps      []AppSize `json:"largest_apps,omitempty"`
+	LogFiles         []LogFile `json:"log_files,omitempty"`
 }
 
 // Volume is one mounted filesystem.
@@ -82,6 +83,7 @@ func Collect(opts CollectOptions) State {
 	if len(opts.AppPaths) > 0 {
 		s.LargestApps = topApps(opts.AppPaths, opts.LargestAppsN)
 	}
+	s.LogFiles = CollectLogFiles(opts.Home)
 	return s
 }
 

--- a/internal/store/jvm_samples_test.go
+++ b/internal/store/jvm_samples_test.go
@@ -97,3 +97,47 @@ func TestSaveJVMSamples_Idempotent(t *testing.T) {
 		t.Errorf("upsert should overwrite, got %v", got)
 	}
 }
+
+// Parallel diagnose calls landing within the same wall-clock second must
+// produce distinct rows because at_nano is the timestamp granularity.
+func TestSaveJVMSamples_SubSecondDistinct(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	one := snapshot.JVMSample{PID: 1, At: base.Add(100_000), OldGenPct: 60}     // +100µs
+	two := snapshot.JVMSample{PID: 1, At: base.Add(200_000), OldGenPct: 65}     // +200µs
+	three := snapshot.JVMSample{PID: 1, At: base.Add(300_000), OldGenPct: 70}   // +300µs
+	if err := db.SaveJVMSamples(ctx, []snapshot.JVMSample{one, two, three}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := db.GetRecentJVMSamples(ctx, 1, 0)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 distinct sub-second rows, got %d", len(got))
+	}
+}
+
+func TestPruneJVMSamples(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	old1 := snapshot.JVMSample{PID: 1, At: now.Add(-30 * 24 * time.Hour), OldGenPct: 10}
+	old2 := snapshot.JVMSample{PID: 1, At: now.Add(-10 * 24 * time.Hour), OldGenPct: 20}
+	recent := snapshot.JVMSample{PID: 1, At: now.Add(-1 * time.Hour), OldGenPct: 90}
+	if err := db.SaveJVMSamples(ctx, []snapshot.JVMSample{old1, old2, recent}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	deleted, err := db.PruneJVMSamples(ctx, 7)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("expected 2 deleted, got %d", deleted)
+	}
+	got, _ := db.GetRecentJVMSamples(ctx, 1, 0)
+	if len(got) != 1 || got[0].OldGenPct != 90 {
+		t.Errorf("only the recent row should survive, got %v", got)
+	}
+}

--- a/internal/store/jvm_samples_test.go
+++ b/internal/store/jvm_samples_test.go
@@ -1,0 +1,99 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func TestSaveAndGetJVMSamples(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	base := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	samples := []snapshot.JVMSample{
+		{PID: 1127, At: base, OldGenPct: 70, FGC: 100, FGCT: 5.0, HeapMB: 190},
+		{PID: 1127, At: base.Add(time.Minute), OldGenPct: 80, FGC: 102, FGCT: 5.4},
+		{PID: 1127, At: base.Add(2 * time.Minute), OldGenPct: 90, FGC: 105, FGCT: 5.9},
+		{PID: 999, At: base.Add(time.Minute), OldGenPct: 30}, // unrelated PID
+	}
+	if err := db.SaveJVMSamples(ctx, samples); err != nil {
+		t.Fatalf("SaveJVMSamples: %v", err)
+	}
+
+	got, err := db.GetRecentJVMSamples(ctx, 1127, 0)
+	if err != nil {
+		t.Fatalf("GetRecentJVMSamples: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 samples for PID 1127, got %d", len(got))
+	}
+	for i, want := range []float64{70, 80, 90} {
+		if got[i].OldGenPct != want {
+			t.Errorf("sample %d: OldGenPct = %v, want %v", i, got[i].OldGenPct, want)
+		}
+	}
+	if got[0].HeapMB != 190 {
+		t.Errorf("HeapMB roundtrip failed: %v", got[0].HeapMB)
+	}
+	if !got[0].At.Equal(base) {
+		t.Errorf("At roundtrip failed: got %v want %v", got[0].At, base)
+	}
+}
+
+func TestGetRecentJVMSamples_Limit(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < 10; i++ {
+		if err := db.SaveJVMSamples(ctx, []snapshot.JVMSample{{
+			PID: 7, At: base.Add(time.Duration(i) * time.Minute), OldGenPct: float64(i * 10),
+		}}); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+	}
+	got, err := db.GetRecentJVMSamples(ctx, 7, 3)
+	if err != nil {
+		t.Fatalf("GetRecentJVMSamples: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 samples, got %d", len(got))
+	}
+	// Should be the 3 newest, in oldest-first order: pcts 70, 80, 90.
+	for i, want := range []float64{70, 80, 90} {
+		if got[i].OldGenPct != want {
+			t.Errorf("sample %d: OldGenPct = %v, want %v", i, got[i].OldGenPct, want)
+		}
+	}
+}
+
+func TestGetRecentJVMSamples_None(t *testing.T) {
+	db := openTestDB(t)
+	got, err := db.GetRecentJVMSamples(context.Background(), 12345, 0)
+	if err != nil {
+		t.Fatalf("GetRecentJVMSamples: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for PID with no samples, got %v", got)
+	}
+}
+
+func TestSaveJVMSamples_Idempotent(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	at := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	first := snapshot.JVMSample{PID: 1, At: at, OldGenPct: 50}
+	updated := snapshot.JVMSample{PID: 1, At: at, OldGenPct: 95} // same key
+	if err := db.SaveJVMSamples(ctx, []snapshot.JVMSample{first}); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if err := db.SaveJVMSamples(ctx, []snapshot.JVMSample{updated}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, _ := db.GetRecentJVMSamples(ctx, 1, 0)
+	if len(got) != 1 || got[0].OldGenPct != 95 {
+		t.Errorf("upsert should overwrite, got %v", got)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -900,6 +900,42 @@ func (s *DB) GetRecentJVMSamples(ctx context.Context, pid, limit int) ([]snapsho
 	return out, nil
 }
 
+// AttachJVMHistory persists the current snapshot's JVMs as samples and
+// loads recent samples per PID into snap.JVMHistory so trend-aware rules
+// see a multi-sample window. Errors are accumulated but never abort the
+// caller — history is an enhancement, not a contract; rules degrade to
+// point-in-time checks when nothing is loaded.
+//
+// The snapshot's TakenAt is used as the sample timestamp when set, so
+// historical snapshots replayed against the store don't get a time.Now()
+// stamp that would corrupt trend ordering.
+func (s *DB) AttachJVMHistory(ctx context.Context, snap *snapshot.Snapshot) {
+	if snap == nil || len(snap.JVMs) == 0 {
+		return
+	}
+	now := snap.TakenAt
+	if now.IsZero() {
+		now = time.Now()
+	}
+	current := make([]snapshot.JVMSample, 0, len(snap.JVMs))
+	for _, j := range snap.JVMs {
+		if sm, ok := snapshot.JVMSampleFrom(j, now); ok {
+			current = append(current, sm)
+		}
+	}
+	_ = s.SaveJVMSamples(ctx, current)
+
+	var history snapshot.JVMHistory
+	for _, j := range snap.JVMs {
+		samples, err := s.GetRecentJVMSamples(ctx, j.PID, 0)
+		if err != nil {
+			continue
+		}
+		history = append(history, samples...)
+	}
+	snap.JVMHistory = history
+}
+
 // PruneJVMSamples deletes jvm_samples rows older than keepDays. Returns the
 // number of rows removed. keepDays <= 0 keeps the default of 7 days.
 func (s *DB) PruneJVMSamples(ctx context.Context, keepDays int) (int64, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kaeawc/spectra/internal/clock"
 	"github.com/kaeawc/spectra/internal/idgen"
+	"github.com/kaeawc/spectra/internal/snapshot"
 
 	_ "modernc.org/sqlite" // register "sqlite" driver
 )
@@ -209,6 +210,18 @@ CREATE TABLE IF NOT EXISTS process_metrics (
 );
 
 CREATE INDEX IF NOT EXISTS idx_process_metrics_pid ON process_metrics(pid, minute_at DESC);
+
+CREATE TABLE IF NOT EXISTS jvm_samples (
+    pid          INTEGER NOT NULL,
+    at_unix      INTEGER NOT NULL,
+    old_gen_pct  REAL NOT NULL DEFAULT 0,
+    fgc          INTEGER NOT NULL DEFAULT 0,
+    fgct         REAL NOT NULL DEFAULT 0,
+    heap_mb      INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pid, at_unix)
+);
+
+CREATE INDEX IF NOT EXISTS idx_jvm_samples_pid ON jvm_samples(pid, at_unix DESC);
 
 CREATE TABLE IF NOT EXISTS issues (
     id                     TEXT PRIMARY KEY,
@@ -787,6 +800,73 @@ type ProcessMetricRow struct {
 	AvgCPUPct   float64
 	MaxCPUPct   float64
 	SampleCount int
+}
+
+// SaveJVMSamples upserts compact per-PID JVM samples used by trend-aware
+// rules. Existing rows for the same (pid, at_unix) are overwritten so a
+// re-run within the same second is idempotent.
+func (s *DB) SaveJVMSamples(ctx context.Context, samples []snapshot.JVMSample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	for _, sm := range samples {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO jvm_samples (pid, at_unix, old_gen_pct, fgc, fgct, heap_mb)
+			VALUES (?,?,?,?,?,?)
+			ON CONFLICT(pid, at_unix) DO UPDATE SET
+			    old_gen_pct=excluded.old_gen_pct,
+			    fgc=excluded.fgc,
+			    fgct=excluded.fgct,
+			    heap_mb=excluded.heap_mb`,
+			sm.PID, sm.At.UTC().Unix(), sm.OldGenPct, sm.FGC, sm.FGCT, sm.HeapMB,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetRecentJVMSamples returns up to limit JVM samples for pid, ordered
+// oldest-first so callers can hand the slice straight to trend predicates.
+// Pass limit=0 for the default cap (60 samples).
+func (s *DB) GetRecentJVMSamples(ctx context.Context, pid, limit int) ([]snapshot.JVMSample, error) {
+	if limit <= 0 {
+		limit = 60
+	}
+	// Pull newest-first so LIMIT applies to the most recent rows, then reverse.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT pid, at_unix, old_gen_pct, fgc, fgct, heap_mb
+		FROM jvm_samples WHERE pid=?
+		ORDER BY at_unix DESC LIMIT ?`, pid, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []snapshot.JVMSample
+	for rows.Next() {
+		var sm snapshot.JVMSample
+		var atUnix int64
+		if err := rows.Scan(&sm.PID, &atUnix, &sm.OldGenPct, &sm.FGC, &sm.FGCT, &sm.HeapMB); err != nil {
+			return nil, err
+		}
+		sm.At = time.Unix(atUnix, 0).UTC()
+		out = append(out, sm)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Reverse to oldest-first.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out, nil
 }
 
 // PruneSnapshots deletes live snapshots beyond the retention limit for each

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -101,12 +101,42 @@ func (s *DB) applyPragmas() error {
 // migrate creates tables that don't yet exist. Idempotent.
 // Also adds new columns to existing tables when the schema evolves.
 func (s *DB) migrate() error {
+	// jvm_samples shipped briefly with second-resolution at_unix. Drop the
+	// old shape so the new nanosecond schema applies — no real users yet.
+	if hasJVMSamplesAtUnix(s.db) {
+		if _, err := s.db.Exec(`DROP TABLE IF EXISTS jvm_samples`); err != nil {
+			return err
+		}
+	}
 	if _, err := s.db.Exec(schema); err != nil {
 		return err
 	}
 	// Add snapshot_json column if this is an existing DB without it.
 	_, _ = s.db.Exec(`ALTER TABLE snapshots ADD COLUMN snapshot_json TEXT`)
 	return nil
+}
+
+// hasJVMSamplesAtUnix reports whether jvm_samples exists with the legacy
+// at_unix column. Used only by migrate() to decide whether to recreate it.
+func hasJVMSamplesAtUnix(db *sql.DB) bool {
+	rows, err := db.Query(`PRAGMA table_info(jvm_samples)`)
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false
+		}
+		if name == "at_unix" {
+			return true
+		}
+	}
+	return false
 }
 
 const schema = `
@@ -213,15 +243,15 @@ CREATE INDEX IF NOT EXISTS idx_process_metrics_pid ON process_metrics(pid, minut
 
 CREATE TABLE IF NOT EXISTS jvm_samples (
     pid          INTEGER NOT NULL,
-    at_unix      INTEGER NOT NULL,
+    at_nano      INTEGER NOT NULL,
     old_gen_pct  REAL NOT NULL DEFAULT 0,
     fgc          INTEGER NOT NULL DEFAULT 0,
     fgct         REAL NOT NULL DEFAULT 0,
     heap_mb      INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (pid, at_unix)
+    PRIMARY KEY (pid, at_nano)
 );
 
-CREATE INDEX IF NOT EXISTS idx_jvm_samples_pid ON jvm_samples(pid, at_unix DESC);
+CREATE INDEX IF NOT EXISTS idx_jvm_samples_pid ON jvm_samples(pid, at_nano DESC);
 
 CREATE TABLE IF NOT EXISTS issues (
     id                     TEXT PRIMARY KEY,
@@ -803,8 +833,9 @@ type ProcessMetricRow struct {
 }
 
 // SaveJVMSamples upserts compact per-PID JVM samples used by trend-aware
-// rules. Existing rows for the same (pid, at_unix) are overwritten so a
-// re-run within the same second is idempotent.
+// rules. Timestamps are stored as nanoseconds so two parallel diagnose
+// calls within the same wall-clock second produce distinct rows; the
+// upsert clause keeps reruns at literally the same instant idempotent.
 func (s *DB) SaveJVMSamples(ctx context.Context, samples []snapshot.JVMSample) error {
 	if len(samples) == 0 {
 		return nil
@@ -816,14 +847,14 @@ func (s *DB) SaveJVMSamples(ctx context.Context, samples []snapshot.JVMSample) e
 	defer tx.Rollback() //nolint:errcheck
 	for _, sm := range samples {
 		_, err := tx.ExecContext(ctx, `
-			INSERT INTO jvm_samples (pid, at_unix, old_gen_pct, fgc, fgct, heap_mb)
+			INSERT INTO jvm_samples (pid, at_nano, old_gen_pct, fgc, fgct, heap_mb)
 			VALUES (?,?,?,?,?,?)
-			ON CONFLICT(pid, at_unix) DO UPDATE SET
+			ON CONFLICT(pid, at_nano) DO UPDATE SET
 			    old_gen_pct=excluded.old_gen_pct,
 			    fgc=excluded.fgc,
 			    fgct=excluded.fgct,
 			    heap_mb=excluded.heap_mb`,
-			sm.PID, sm.At.UTC().Unix(), sm.OldGenPct, sm.FGC, sm.FGCT, sm.HeapMB,
+			sm.PID, sm.At.UTC().UnixNano(), sm.OldGenPct, sm.FGC, sm.FGCT, sm.HeapMB,
 		)
 		if err != nil {
 			return err
@@ -841,9 +872,9 @@ func (s *DB) GetRecentJVMSamples(ctx context.Context, pid, limit int) ([]snapsho
 	}
 	// Pull newest-first so LIMIT applies to the most recent rows, then reverse.
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT pid, at_unix, old_gen_pct, fgc, fgct, heap_mb
+		SELECT pid, at_nano, old_gen_pct, fgc, fgct, heap_mb
 		FROM jvm_samples WHERE pid=?
-		ORDER BY at_unix DESC LIMIT ?`, pid, limit,
+		ORDER BY at_nano DESC LIMIT ?`, pid, limit,
 	)
 	if err != nil {
 		return nil, err
@@ -852,11 +883,11 @@ func (s *DB) GetRecentJVMSamples(ctx context.Context, pid, limit int) ([]snapsho
 	var out []snapshot.JVMSample
 	for rows.Next() {
 		var sm snapshot.JVMSample
-		var atUnix int64
-		if err := rows.Scan(&sm.PID, &atUnix, &sm.OldGenPct, &sm.FGC, &sm.FGCT, &sm.HeapMB); err != nil {
+		var atNano int64
+		if err := rows.Scan(&sm.PID, &atNano, &sm.OldGenPct, &sm.FGC, &sm.FGCT, &sm.HeapMB); err != nil {
 			return nil, err
 		}
-		sm.At = time.Unix(atUnix, 0).UTC()
+		sm.At = time.Unix(0, atNano).UTC()
 		out = append(out, sm)
 	}
 	if err := rows.Err(); err != nil {
@@ -867,6 +898,20 @@ func (s *DB) GetRecentJVMSamples(ctx context.Context, pid, limit int) ([]snapsho
 		out[i], out[j] = out[j], out[i]
 	}
 	return out, nil
+}
+
+// PruneJVMSamples deletes jvm_samples rows older than keepDays. Returns the
+// number of rows removed. keepDays <= 0 keeps the default of 7 days.
+func (s *DB) PruneJVMSamples(ctx context.Context, keepDays int) (int64, error) {
+	if keepDays <= 0 {
+		keepDays = 7
+	}
+	cutoff := time.Now().UTC().Add(-time.Duration(keepDays) * 24 * time.Hour).UnixNano()
+	res, err := s.db.ExecContext(ctx, `DELETE FROM jvm_samples WHERE at_nano < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }
 
 // PruneSnapshots deletes live snapshots beyond the retention limit for each


### PR DESCRIPTION
## Summary

Adds a **Nebula** peer-discovery source to `spectra hosts` and `spectra fan`, so
remote debugging works over a Nebula overlay, not just Tailscale.

- `--discover` / `--discover-daemons` gain a `--discover-via auto|tailscale|nebula`
  selector. The default, **`auto`**, attempts every source and merges the
  results — plain `--discover` now finds peers whether the host is on Tailscale,
  a Nebula mesh, or both. A source that is absent (no `tailscale` binary, no
  Nebula certs on disk) is skipped rather than treated as an error; an error
  surfaces only when *every* source fails.
- Nebula has no live peer list, so `discoverNebulaPeers` uses the signed host
  certs as the source of truth: it enumerates `~/.nebula` (override with
  `SPECTRA_NEBULA_CERTS`), runs `nebula-cert print -json` on each `*.crt`, and
  returns the overlay IPs. `--discover-daemons` then narrows the merged set to
  hosts actually running a Spectra daemon.

Because Nebula has no MagicDNS, discovery yields overlay **IPs** rather than
names, and cert presence means *membership*, not *liveness* — which is exactly
why it pairs with `--discover-daemons`. Both trade-offs are documented in
`docs/operations/remote.md`.

Usage:

```bash
spectra hosts --discover                          # auto: Tailscale + Nebula
spectra hosts --discover-daemons --discover-via nebula
spectra fan --discover-via nebula jvm
```

## Type

- [x] New feature

## Testing

- [x] Added unit tests (`discover_nebula_test.go`: cert-dir discovery, CA/unreadable
      skipping, missing-dir error, provider selection, multi-source merge,
      single-source-failure tolerance, all-sources-fail error)
- [x] `go build ./...`, `go vet ./...`, `go test ./cmd/spectra/... ./internal/serve/...` pass
- [ ] Manually exercised end-to-end against a live Nebula mesh (not yet — no mesh stood up)

## Checklist

- [x] No new `go vet` warnings
- [x] `gofmt -s` clean
- [x] No new `gocyclo` violations (checked against the CI gate, `-over 15`)
- [x] No new `gosec` findings (`Issues: 0`)
- [x] `go mod tidy` is clean (no new dependencies)

## Reviewer notes

- The discovery seam is the existing package-level `fanDiscoverPeers` var;
  `selectDiscoverProvider` swaps it per invocation, matching the codebase's
  existing global-var injection pattern (`runTailscaleStatus`, `fanProbeTarget`).
- `runNebulaCertPrint` is the injectable seam for `nebula-cert`; tests never
  shell out.
- This branch had not been pushed before, so the PR also carries earlier
  unmerged commits (JVM sample persistence/retention, MCP NDJSON framing,
  rules/detect caching, user app profiles). None are in `main` yet. If you'd
  prefer the Nebula change isolated on its own branch, say so and I'll split it.
