### PR TITLE
rules: jvm-oom-dump-disabled — flag tuned JVMs with no heap-dump-on-OOM

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -209,6 +209,7 @@ Implemented rules:
 - `jvm-heap-vs-system`
 - `jvm-gc-pressure`
 - `jvm-metaspace-pressure`
+- `jvm-oom-dump-disabled`
 - `jdk-major-version-drift`
 - `java-home-mismatch`
 - `library-storage-footprint`

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -28,6 +28,7 @@ func V1Catalog() []Rule {
 		ruleUpdatesStaleMajorPrepared(),
 		ruleJVMGCPressure(),
 		ruleJVMMetaspacePressure(),
+		ruleJVMOOMDumpDisabled(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),
 		ruleStorageFootprint(),
@@ -242,6 +243,43 @@ func ruleJVMMetaspacePressure() Rule {
 						Fix: "Raise -XX:CompressedClassSpaceSize, or investigate a classloader leak.",
 					})
 				}
+			}
+			return findings
+		},
+	}
+}
+
+// ruleJVMOOMDumpDisabled flags a tuned, long-running JVM that has not enabled
+// -XX:+HeapDumpOnOutOfMemoryError. An OutOfMemoryError is frequently
+// non-reproducible; without an automatic dump at the moment of failure, the
+// evidence is lost. Gated to processes that look like real services (explicit
+// -Xmx, not dev tooling) so it stays quiet on a developer machine.
+func ruleJVMOOMDumpDisabled() Rule {
+	return Rule{
+		ID:       "jvm-oom-dump-disabled",
+		Severity: SeverityLow,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			profiles := BuiltinProfiles()
+			var findings []Finding
+			for _, j := range s.JVMs {
+				f := FactsFor(j)
+				if f.HeapDumpOnOOM {
+					continue // already captures a dump on OOM
+				}
+				if f.XmxBytes <= 0 {
+					continue // untuned / likely transient; don't nag
+				}
+				profile := MatchProfile(j, profiles)
+				if HasTag(profile, TagLauncher) || HasTag(profile, TagIDE) || HasTag(profile, TagBuildToolDaemon) {
+					continue // dev tooling, not a service needing OOM post-mortems
+				}
+				findings = append(findings, Finding{
+					RuleID:   "jvm-oom-dump-disabled",
+					Severity: SeverityLow,
+					Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
+					Message:  "No -XX:+HeapDumpOnOutOfMemoryError: an OutOfMemoryError will terminate this JVM with no heap dump for post-mortem analysis.",
+					Fix:      "Add -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=<dir> so an OOM writes a heap dump automatically.",
+				})
 			}
 			return findings
 		},

--- a/internal/rules/oom_dump_test.go
+++ b/internal/rules/oom_dump_test.go
@@ -1,0 +1,58 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+func TestJVMOOMDumpDisabledFiresForTunedService(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       10,
+		MainClass: "com.acme.Server",
+		VMArgs:    "-Xmx512m",
+	}}
+	findings := ruleJVMOOMDumpDisabled().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].RuleID != "jvm-oom-dump-disabled" || findings[0].Severity != SeverityLow {
+		t.Fatalf("finding = %+v", findings[0])
+	}
+}
+
+func TestJVMOOMDumpDisabledNoFireWhenEnabled(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{
+		PID:       10,
+		MainClass: "com.acme.Server",
+		VMArgs:    "-Xmx512m -XX:+HeapDumpOnOutOfMemoryError",
+	}}
+	if f := ruleJVMOOMDumpDisabled().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding when the flag is set, got %v", f)
+	}
+}
+
+func TestJVMOOMDumpDisabledNoFireWithoutXmx(t *testing.T) {
+	s := baseSnap()
+	// Untuned / likely transient CLI JVM: no -Xmx -> don't nag.
+	s.JVMs = []jvm.Info{{PID: 10, MainClass: "com.acme.OneShot", VMArgs: "-Dfoo=bar"}}
+	if f := ruleJVMOOMDumpDisabled().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding without -Xmx, got %v", f)
+	}
+}
+
+func TestJVMOOMDumpDisabledNoFireForDevTooling(t *testing.T) {
+	s := baseSnap()
+	// Gradle daemon (build-tool-daemon profile) with a tuned heap and no flag
+	// must be excluded as dev tooling.
+	s.JVMs = []jvm.Info{{
+		PID:       10,
+		MainClass: "org.gradle.launcher.daemon.bootstrap.GradleDaemon",
+		VMArgs:    "-Xmx2g",
+	}}
+	if f := ruleJVMOOMDumpDisabled().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding for a build-tool daemon, got %v", f)
+	}
+}


### PR DESCRIPTION
Closes #427.

## What

`VMArgsFacts.HeapDumpOnOOM` (from `-XX:+HeapDumpOnOutOfMemoryError`) was parsed but **no rule consumed it**. `jvm explain` only reports the *good* case (`oom-heap-dump-enabled`); there was no signal for the consequential *missing* case — a tuned JVM that dies on `OutOfMemoryError` leaving **no heap dump** for post-mortem. An OOM is frequently non-reproducible, so if the dump wasn't written at the moment of failure, the evidence is gone.

New low-severity `jvm-oom-dump-disabled` rule.

## Noise gating

Fires only when the flag is absent **and** the JVM looks like a tuned, long-running service rather than dev tooling:
- explicit `-Xmx` set (`XmxBytes > 0`), and
- not a launcher / IDE / build-tool-daemon profile (`TagLauncher`/`TagIDE`/`TagBuildToolDaemon`).

This keeps it quiet on a developer machine full of Gradle/IDE JVMs while still catching real services. Severity is `low` — it's an advisory posture gap, not an active fault.

## Tests

`oom_dump_test.go`: fires for a tuned service JVM without the flag; no-fire when the flag is present; no-fire without `-Xmx`; no-fire for a Gradle-daemon (build-tool) profile. Rule listed in `recommendations-engine.md`.

Out of scope (follow-ups): detecting OOM events by scanning logs/crash reports, and reacting to an existing orphaned `.hprof`.