### PR TITLE
rules: jvm-rss-exceeds-heap — surface off-heap/native memory via RSS vs committed heap

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -210,6 +210,7 @@ Implemented rules:
 - `jvm-gc-pressure`
 - `jvm-metaspace-pressure`
 - `jvm-oom-dump-disabled`
+- `jvm-rss-exceeds-heap`
 - `jdk-major-version-drift`
 - `java-home-mismatch`
 - `library-storage-footprint`

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/toolchain"
 )
@@ -29,6 +30,7 @@ func V1Catalog() []Rule {
 		ruleJVMGCPressure(),
 		ruleJVMMetaspacePressure(),
 		ruleJVMOOMDumpDisabled(),
+		ruleJVMRSSExceedsHeap(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),
 		ruleStorageFootprint(),
@@ -284,6 +286,74 @@ func ruleJVMOOMDumpDisabled() Rule {
 			return findings
 		},
 	}
+}
+
+// Native-excess thresholds for jvm-rss-exceeds-heap.
+const (
+	// nativeExcessFloorKiB is the absolute off-heap footprint (RSS minus committed
+	// heap+metadata) above which the gap is worth surfacing. Set high enough to
+	// absorb the normal native overhead — shared libraries, JIT code cache (which
+	// jstat committed does not include), and thread stacks.
+	nativeExcessFloorKiB int64 = 1024 * 1024 // 1 GiB
+	// nativeExcessRatio is the minimum multiple of committed managed memory the
+	// RSS must reach, so a large-heap JVM (whose RSS is naturally large) does not
+	// trip on the absolute floor alone.
+	nativeExcessRatio = 2.0
+)
+
+// ruleJVMRSSExceedsHeap correlates a JVM's process RSS with its committed heap +
+// class metadata. When resident memory greatly exceeds what the heap accounts
+// for, the excess is off-heap/native (direct buffers, thread stacks, JNI, mmap,
+// or a native leak) — a symptom heap-only tools cannot see. Conservative dual
+// thresholds keep it quiet on JVMs with ordinary native overhead.
+func ruleJVMRSSExceedsHeap() Rule {
+	return Rule{
+		ID:       "jvm-rss-exceeds-heap",
+		Severity: SeverityLow,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, j := range s.JVMs {
+				if j.GC == nil {
+					continue
+				}
+				committedKiB := int64(j.GC.OC + j.GC.EC + j.GC.S0C + j.GC.S1C + j.GC.MC + j.GC.CCSC)
+				if committedKiB <= 0 {
+					continue
+				}
+				proc, ok := processByPID(s.Processes, j.PID)
+				if !ok || proc.RSSKiB <= 0 {
+					continue
+				}
+				excessKiB := proc.RSSKiB - committedKiB
+				if excessKiB < nativeExcessFloorKiB {
+					continue
+				}
+				if float64(proc.RSSKiB) < float64(committedKiB)*nativeExcessRatio {
+					continue
+				}
+				findings = append(findings, Finding{
+					RuleID:   "jvm-rss-exceeds-heap",
+					Severity: SeverityLow,
+					Subject:  fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass),
+					Message: fmt.Sprintf(
+						"Resident set is %d MiB, %.1fx the JVM's committed heap+metadata (%d MiB); ~%d MiB is off-heap/native.",
+						proc.RSSKiB/1024, float64(proc.RSSKiB)/float64(committedKiB), committedKiB/1024, excessKiB/1024),
+					Fix: "Attribute native memory with `jcmd <pid> VM.native_memory summary` (needs -XX:NativeMemoryTracking=summary); check direct byte buffers, thread-stack count, and JNI/native libraries.",
+				})
+			}
+			return findings
+		},
+	}
+}
+
+// processByPID returns the process with the given PID, or ok=false if none.
+func processByPID(procs []process.Info, pid int) (process.Info, bool) {
+	for _, p := range procs {
+		if p.PID == pid {
+			return p, true
+		}
+	}
+	return process.Info{}, false
 }
 
 // ruleJDKMajorVersionDrift fires when more than one installed JDK shares

--- a/internal/rules/rss_heap_test.go
+++ b/internal/rules/rss_heap_test.go
@@ -1,0 +1,63 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+func TestJVMRSSExceedsHeapFiresOnNativeExcess(t *testing.T) {
+	s := baseSnap()
+	// Committed ~195 MiB, RSS ~1269 MiB -> ~1074 MiB off-heap, 6.5x committed.
+	s.JVMs = []jvm.Info{{PID: 10, MainClass: "svc.App", GC: &jvm.GCStats{OC: 200000}}}
+	s.Processes = []process.Info{{PID: 10, RSSKiB: 1300000}}
+	findings := ruleJVMRSSExceedsHeap().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].RuleID != "jvm-rss-exceeds-heap" || findings[0].Severity != SeverityLow {
+		t.Fatalf("finding = %+v", findings[0])
+	}
+	if !strings.Contains(findings[0].Message, "off-heap/native") {
+		t.Fatalf("message = %q", findings[0].Message)
+	}
+}
+
+func TestJVMRSSExceedsHeapNoFireWhenRSSNearHeap(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{PID: 10, GC: &jvm.GCStats{OC: 200000}}}
+	s.Processes = []process.Info{{PID: 10, RSSKiB: 250000}} // excess ~49 MiB, below floor
+	if f := ruleJVMRSSExceedsHeap().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding when RSS ~ committed, got %v", f)
+	}
+}
+
+func TestJVMRSSExceedsHeapNoFireForLargeHeapUnderRatio(t *testing.T) {
+	s := baseSnap()
+	// Committed ~3.8 GiB, RSS ~5.0 GiB: excess > 1 GiB but only 1.3x -> ratio guard.
+	s.JVMs = []jvm.Info{{PID: 10, GC: &jvm.GCStats{OC: 4000000}}}
+	s.Processes = []process.Info{{PID: 10, RSSKiB: 5200000}}
+	if f := ruleJVMRSSExceedsHeap().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding below the ratio, got %v", f)
+	}
+}
+
+func TestJVMRSSExceedsHeapNoFireWhenNoProcessMatch(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{PID: 10, GC: &jvm.GCStats{OC: 200000}}}
+	s.Processes = []process.Info{{PID: 99, RSSKiB: 1300000}} // different PID
+	if f := ruleJVMRSSExceedsHeap().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding without a PID match, got %v", f)
+	}
+}
+
+func TestJVMRSSExceedsHeapNoFireWithoutGC(t *testing.T) {
+	s := baseSnap()
+	s.JVMs = []jvm.Info{{PID: 10}} // no GC stats
+	s.Processes = []process.Info{{PID: 10, RSSKiB: 1300000}}
+	if f := ruleJVMRSSExceedsHeap().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding without GC stats, got %v", f)
+	}
+}


### PR DESCRIPTION
Closes #429.

## What

Spectra collected JVM heap/metaspace counters (`snapshot.JVMs`) and per-process RSS (`snapshot.Processes`) but never **joined** them. A JVM whose resident set far exceeds its committed heap + class metadata is the classic **off-heap / native memory** symptom — direct byte buffers, thread stacks, JNI, mmap, or a native leak — and it's invisible to heap-only tools (VisualVM, MAT, JProfiler all look inside the heap).

New low-severity `jvm-rss-exceeds-heap` rule joins JVM→process by PID and compares RSS to committed managed memory (`OC + EC + S0C + S1C + MC + CCSC` from jstat).

## Conservative thresholds

Fires only when **both**:
- absolute native excess `RSS - committed >= 1 GiB`, and
- `RSS >= 2x committed` (ratio guard so large-heap JVMs, whose RSS is naturally large, don't trip).

The 1 GiB floor also absorbs the JIT code cache, which jstat committed excludes — so code cache isn't misread as a leak. The oversized-`-Xmx`-vs-RSS direction is deliberately out of scope (needs steady-state/trend; a young JVM legitimately has low RSS against a high `-Xmx`).

## Tests

`rss_heap_test.go`: fires on large native excess; no-fire when RSS ≈ committed; no-fire for a large-heap JVM under the ratio; no-fire when no process matches the PID; no-fire without GC stats. Adds a `processByPID` helper. Rule listed in `recommendations-engine.md`. `Fix` points at `jcmd VM.native_memory summary` (NMT).