### PR TITLE
rules: jvm-gc-algorithm — flag SerialGC on large heaps and Epsilon no-op GC

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -211,6 +211,7 @@ Implemented rules:
 - `jvm-metaspace-pressure`
 - `jvm-oom-dump-disabled`
 - `jvm-rss-exceeds-heap`
+- `jvm-gc-algorithm`
 - `jdk-major-version-drift`
 - `java-home-mismatch`
 - `library-storage-footprint`

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -31,6 +31,7 @@ func V1Catalog() []Rule {
 		ruleJVMMetaspacePressure(),
 		ruleJVMOOMDumpDisabled(),
 		ruleJVMRSSExceedsHeap(),
+		ruleJVMGCAlgorithm(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),
 		ruleStorageFootprint(),
@@ -354,6 +355,59 @@ func processByPID(procs []process.Info, pid int) (process.Info, bool) {
 		}
 	}
 	return process.Info{}, false
+}
+
+// GC-algorithm thresholds for jvm-gc-algorithm.
+const (
+	// serialGCLargeHeapMinXmxBytes is the -Xmx above which SerialGC's
+	// single-threaded stop-the-world pauses become a real problem.
+	serialGCLargeHeapMinXmxBytes int64 = 2 * 1024 * 1024 * 1024 // 2 GiB
+	// serialGCMinCores is the core count above which a parallel/concurrent
+	// collector could do meaningfully better than SerialGC.
+	serialGCMinCores = 2
+)
+
+// ruleJVMGCAlgorithm flags GC-collector choices that are almost always a
+// misconfiguration: Epsilon (a no-op collector that guarantees an eventual OOM)
+// and SerialGC on a large heap (single-threaded, long stop-the-world pauses).
+// The unconditional serial-gc note in `jvm explain` stays informational; this
+// rule only fires in the genuinely problematic cases and feeds issue tracking.
+func ruleJVMGCAlgorithm() Rule {
+	return Rule{
+		ID:       "jvm-gc-algorithm",
+		Severity: SeverityMedium,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			cores := s.Host.CPUCores
+			var findings []Finding
+			for _, j := range s.JVMs {
+				f := FactsFor(j)
+				subject := fmt.Sprintf("PID %d (%s)", j.PID, j.MainClass)
+				switch f.GCAlgorithm {
+				case "Epsilon":
+					findings = append(findings, Finding{
+						RuleID:   "jvm-gc-algorithm",
+						Severity: SeverityMedium,
+						Subject:  subject,
+						Message:  "Epsilon (no-op) GC never reclaims memory; the JVM will OutOfMemoryError once the heap fills.",
+						Fix:      "Use a real collector (G1/Parallel/Z) unless this process is a deliberate short-lived allocation benchmark.",
+					})
+				case "Serial":
+					if f.XmxBytes >= serialGCLargeHeapMinXmxBytes && cores >= serialGCMinCores {
+						findings = append(findings, Finding{
+							RuleID:   "jvm-gc-algorithm",
+							Severity: SeverityMedium,
+							Subject:  subject,
+							Message: fmt.Sprintf(
+								"SerialGC with a %d MiB heap on %d cores causes long stop-the-world pauses; SerialGC is single-threaded.",
+								f.XmxBytes/(1024*1024), cores),
+							Fix: "Switch to G1 (-XX:+UseG1GC) or Parallel (-XX:+UseParallelGC) for a multi-core, large-heap workload.",
+						})
+					}
+				}
+			}
+			return findings
+		},
+	}
 }
 
 // ruleJDKMajorVersionDrift fires when more than one installed JDK shares

--- a/internal/rules/gc_algorithm_test.go
+++ b/internal/rules/gc_algorithm_test.go
@@ -1,0 +1,62 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+)
+
+func TestJVMGCAlgorithmEpsilonFires(t *testing.T) {
+	s := baseSnap()
+	s.Host.CPUCores = 8
+	s.JVMs = []jvm.Info{{PID: 10, MainClass: "bench.App", VMArgs: "-XX:+UseEpsilonGC -Xmx512m"}}
+	findings := ruleJVMGCAlgorithm().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 Epsilon finding, got %d: %v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].Message, "Epsilon") {
+		t.Fatalf("message = %q", findings[0].Message)
+	}
+}
+
+func TestJVMGCAlgorithmSerialLargeHeapFires(t *testing.T) {
+	s := baseSnap()
+	s.Host.CPUCores = 8
+	s.JVMs = []jvm.Info{{PID: 10, MainClass: "svc.App", VMArgs: "-XX:+UseSerialGC -Xmx4g"}}
+	findings := ruleJVMGCAlgorithm().MatchFn(s)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 SerialGC finding, got %d: %v", len(findings), findings)
+	}
+	if findings[0].Severity != SeverityMedium || !strings.Contains(findings[0].Message, "SerialGC") {
+		t.Fatalf("finding = %+v", findings[0])
+	}
+}
+
+func TestJVMGCAlgorithmSerialSmallHeapNoFire(t *testing.T) {
+	s := baseSnap()
+	s.Host.CPUCores = 8
+	// Small desktop helper: SerialGC with a modest heap is legitimate.
+	s.JVMs = []jvm.Info{{PID: 10, VMArgs: "-XX:+UseSerialGC -Xmx256m"}}
+	if f := ruleJVMGCAlgorithm().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding for small-heap SerialGC, got %v", f)
+	}
+}
+
+func TestJVMGCAlgorithmSerialLargeHeapSingleCoreNoFire(t *testing.T) {
+	s := baseSnap()
+	s.Host.CPUCores = 1 // a parallel collector can't help on a single core
+	s.JVMs = []jvm.Info{{PID: 10, VMArgs: "-XX:+UseSerialGC -Xmx4g"}}
+	if f := ruleJVMGCAlgorithm().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding on a single-core host, got %v", f)
+	}
+}
+
+func TestJVMGCAlgorithmG1NoFire(t *testing.T) {
+	s := baseSnap()
+	s.Host.CPUCores = 8
+	s.JVMs = []jvm.Info{{PID: 10, VMArgs: "-XX:+UseG1GC -Xmx8g"}}
+	if f := ruleJVMGCAlgorithm().MatchFn(s); len(f) != 0 {
+		t.Fatalf("expected no finding for G1, got %v", f)
+	}
+}


### PR DESCRIPTION
Closes #432.

## What

`VMArgsFacts.GCAlgorithm` was parsed (Serial/Parallel/G1/Z/Shenandoah/Epsilon) but **no rule consumed it**. New medium-severity `jvm-gc-algorithm` rule for the two GC-choice cases that are almost always a misconfiguration:

- **Epsilon** — a no-op collector that never reclaims memory, so the JVM will `OutOfMemoryError` once the heap fills. Fires unconditionally.
- **SerialGC on a large heap** — single-threaded, long stop-the-world pauses. Fires only when `-Xmx >= 2 GiB` **and** host cores `>= 2`, so it stays quiet on small desktop-helper JVMs and truly single-core hosts.

The unconditional `serial-gc` note in `jvm explain` stays informational; this rule fires only in the genuinely problematic cases and feeds the issue lifecycle.

## Tests

`gc_algorithm_test.go`: Epsilon fires; Serial+large-heap fires; Serial+small-heap no-fire; Serial+large-heap on a single-core host no-fire; G1 no-fire. Rule listed in `recommendations-engine.md`.