### PR TITLE
jvm: detect OutOfMemoryError events by scanning discovered JVM logs, classified by variant

### DIFF
--- a/docs/design/recommendations-engine.md
+++ b/docs/design/recommendations-engine.md
@@ -212,6 +212,7 @@ Implemented rules:
 - `jvm-oom-dump-disabled`
 - `jvm-rss-exceeds-heap`
 - `jvm-gc-algorithm`
+- `jvm-oom-detected`
 - `jdk-major-version-drift`
 - `java-home-mismatch`
 - `library-storage-footprint`

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -337,3 +337,8 @@ Implemented:
 13. Optional Java Attach API agent with MBean browsing, MBean attribute
     reads, zero-argument operation invocation, in-process probes, named
     counters, workflow probes, and optional Unix-domain-socket transport.
+14. OutOfMemoryError detection: bounded scanning of each running JVM's
+    deep-mode-discovered log files, classifying occurrences by variant (Java
+    heap space, GC overhead, metaspace, compressed class space, direct buffer,
+    native thread, array size, native memory) and surfacing them via the
+    `jvm-oom-detected` recommendation.

--- a/internal/oom/oom.go
+++ b/internal/oom/oom.go
@@ -1,0 +1,162 @@
+// Package oom scans log text for java.lang.OutOfMemoryError occurrences and
+// classifies them by variant. Each variant has a distinct root cause and fix,
+// so classification — not mere detection — is the point.
+//
+// The package is deliberately free of snapshot/JVM dependencies so it can be
+// unit-tested in isolation and reused by any collector.
+package oom
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+)
+
+// Variant is a classified OutOfMemoryError kind.
+type Variant string
+
+const (
+	VariantHeapSpace            Variant = "java_heap_space"
+	VariantGCOverhead           Variant = "gc_overhead_limit"
+	VariantMetaspace            Variant = "metaspace"
+	VariantCompressedClassSpace Variant = "compressed_class_space"
+	VariantDirectBuffer         Variant = "direct_buffer_memory"
+	VariantNativeThread         Variant = "native_thread"
+	VariantArraySize            Variant = "array_size_vm_limit"
+	VariantNativeMemory         Variant = "native_memory"
+	VariantUnknown              Variant = "unknown"
+)
+
+// marker is the fully-qualified exception name that anchors an occurrence.
+const marker = "java.lang.OutOfMemoryError"
+
+// Event is one OutOfMemoryError occurrence found in a scanned stream.
+type Event struct {
+	Variant Variant `json:"variant"`
+	Message string  `json:"message"` // text after the marker, trimmed
+	LineNo  int     `json:"line_no"` // 1-based line within the scanned stream
+}
+
+// Classify maps an OOM message tail to a Variant. Order matters: "compressed
+// class space" must be tested before "metaspace" (its message also mentions
+// class metadata), and the native-thread phrasing varies across JDKs.
+func Classify(msg string) Variant {
+	m := strings.ToLower(msg)
+	switch {
+	case strings.Contains(m, "compressed class space"):
+		return VariantCompressedClassSpace
+	case strings.Contains(m, "metaspace"):
+		return VariantMetaspace
+	case strings.Contains(m, "java heap space"):
+		return VariantHeapSpace
+	case strings.Contains(m, "gc overhead limit"):
+		return VariantGCOverhead
+	case strings.Contains(m, "direct buffer memory"):
+		return VariantDirectBuffer
+	case strings.Contains(m, "native thread"):
+		return VariantNativeThread
+	case strings.Contains(m, "requested array size"):
+		return VariantArraySize
+	case strings.Contains(m, "map failed"), strings.Contains(m, "out of swap"):
+		return VariantNativeMemory
+	default:
+		return VariantUnknown
+	}
+}
+
+// Human returns a readable label for the variant.
+func (v Variant) Human() string {
+	switch v {
+	case VariantHeapSpace:
+		return "Java heap space"
+	case VariantGCOverhead:
+		return "GC overhead limit exceeded"
+	case VariantMetaspace:
+		return "Metaspace"
+	case VariantCompressedClassSpace:
+		return "Compressed class space"
+	case VariantDirectBuffer:
+		return "Direct buffer memory"
+	case VariantNativeThread:
+		return "unable to create native thread"
+	case VariantArraySize:
+		return "Requested array size exceeds VM limit"
+	case VariantNativeMemory:
+		return "native memory (map failed / out of swap)"
+	default:
+		return "unknown"
+	}
+}
+
+// Remediation returns variant-specific first-step guidance.
+func (v Variant) Remediation() string {
+	switch v {
+	case VariantHeapSpace, VariantGCOverhead:
+		return "Capture a heap dump/histogram to find the retained live set; raise -Xmx only if the live set is legitimately large."
+	case VariantMetaspace, VariantCompressedClassSpace:
+		return "Investigate a classloader leak (loaded-class count rising); raise -XX:MaxMetaspaceSize / -XX:CompressedClassSpaceSize if the class count is legitimately high."
+	case VariantDirectBuffer:
+		return "Audit direct ByteBuffer / NIO usage and set -XX:MaxDirectMemorySize; direct buffers are freed only when their referents are GC'd."
+	case VariantNativeThread:
+		return "This is thread/native exhaustion, not heap: reduce thread count or raise the OS/process thread limit; check -Xss."
+	case VariantArraySize:
+		return "A single allocation exceeded the VM array-size limit — usually a bug computing a size or a corrupt length."
+	case VariantNativeMemory:
+		return "The OS could not satisfy a native mapping — check system memory/swap and native (off-heap) allocations with NMT."
+	default:
+		return "Inspect the surrounding stack trace to identify the exhausted resource."
+	}
+}
+
+// Scan reads r line by line and returns one Event per line containing the
+// OutOfMemoryError marker. It never returns an error and is safe on arbitrary
+// input.
+func Scan(r io.Reader) []Event {
+	var events []Event
+	sc := bufio.NewScanner(r)
+	// Allow long lines (stack frames, JSON logs) up to 1 MiB.
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	line := 0
+	for sc.Scan() {
+		line++
+		text := sc.Text()
+		idx := strings.Index(text, marker)
+		if idx < 0 {
+			continue
+		}
+		msg := strings.TrimSpace(text[idx+len(marker):])
+		msg = strings.TrimSpace(strings.TrimPrefix(msg, ":"))
+		events = append(events, Event{Variant: Classify(msg), Message: msg, LineNo: line})
+	}
+	return events
+}
+
+// ScanFile scans the file at path for OOM occurrences. When the file is larger
+// than maxBytes (and maxBytes > 0), only its trailing maxBytes are scanned —
+// recent OOMs sit near the end of a log, and this bounds the work. A
+// missing/unreadable file or a non-regular file returns (nil, err) / (nil, nil)
+// so callers can absorb it per the partial-snapshot contract.
+//
+// When the file is truncated to a tail, LineNo values are relative to that tail,
+// not the whole file.
+func ScanFile(path string, maxBytes int64) ([]Event, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, nil
+	}
+	if maxBytes > 0 && fi.Size() > maxBytes {
+		if _, err := f.Seek(fi.Size()-maxBytes, io.SeekStart); err != nil {
+			return nil, err
+		}
+	}
+	return Scan(f), nil
+}

--- a/internal/oom/oom_test.go
+++ b/internal/oom/oom_test.go
@@ -1,0 +1,97 @@
+package oom
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestClassifyVariants(t *testing.T) {
+	cases := map[string]Variant{
+		"Java heap space":                       VariantHeapSpace,
+		"GC overhead limit exceeded":            VariantGCOverhead,
+		"Metaspace":                             VariantMetaspace,
+		"Compressed class space":                VariantCompressedClassSpace,
+		"Direct buffer memory":                  VariantDirectBuffer,
+		"unable to create new native thread":    VariantNativeThread,
+		"Requested array size exceeds VM limit": VariantArraySize,
+		"Map failed":                            VariantNativeMemory,
+		"Out of swap space?":                    VariantNativeMemory,
+		"some brand new message":                VariantUnknown,
+	}
+	for msg, want := range cases {
+		if got := Classify(msg); got != want {
+			t.Errorf("Classify(%q) = %q, want %q", msg, got, want)
+		}
+	}
+}
+
+func TestClassifyCompressedClassBeforeMetaspace(t *testing.T) {
+	// The compressed-class-space message must not be mis-bucketed as metaspace.
+	if got := Classify("Compressed class space"); got != VariantCompressedClassSpace {
+		t.Fatalf("got %q, want compressed_class_space", got)
+	}
+}
+
+func TestScanFindsMultipleOccurrences(t *testing.T) {
+	log := strings.Join([]string{
+		"2026-08-31 10:00:00 INFO starting up",
+		`Exception in thread "main" java.lang.OutOfMemoryError: Java heap space`,
+		"\tat com.acme.App.main(App.java:12)",
+		"2026-08-31 10:05:00 WARN retry",
+		"Caused by: java.lang.OutOfMemoryError: Metaspace",
+	}, "\n")
+	events := Scan(strings.NewReader(log))
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Variant != VariantHeapSpace || events[0].LineNo != 2 {
+		t.Errorf("event 0 = %+v", events[0])
+	}
+	if events[1].Variant != VariantMetaspace || events[1].LineNo != 5 {
+		t.Errorf("event 1 = %+v", events[1])
+	}
+}
+
+func TestScanNoFalsePositiveOnPlainText(t *testing.T) {
+	if e := Scan(strings.NewReader("all good\nno errors here\n")); len(e) != 0 {
+		t.Fatalf("expected no events, got %+v", e)
+	}
+}
+
+func TestScanFileMissing(t *testing.T) {
+	if e, err := ScanFile(filepath.Join(t.TempDir(), "nope.log"), 1<<20); err == nil || e != nil {
+		t.Fatalf("missing file should return (nil, err), got (%v, %v)", e, err)
+	}
+}
+
+func TestScanFileTailBound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.log")
+	// Prefix padding, then an OOM near the end. Read a small tail that only
+	// covers the OOM line.
+	padding := strings.Repeat("x filler line to grow the file\n", 1000)
+	content := padding + "java.lang.OutOfMemoryError: Direct buffer memory\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	events, err := ScanFile(path, 128) // tiny tail
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Variant != VariantDirectBuffer {
+		t.Fatalf("tail scan = %+v", events)
+	}
+}
+
+func TestVariantHumanAndRemediationCoverAll(t *testing.T) {
+	for _, v := range []Variant{
+		VariantHeapSpace, VariantGCOverhead, VariantMetaspace, VariantCompressedClassSpace,
+		VariantDirectBuffer, VariantNativeThread, VariantArraySize, VariantNativeMemory, VariantUnknown,
+	} {
+		if v.Human() == "" || v.Remediation() == "" {
+			t.Errorf("variant %q missing Human/Remediation", v)
+		}
+	}
+}

--- a/internal/rules/catalog.go
+++ b/internal/rules/catalog.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/kaeawc/spectra/internal/oom"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/snapshot"
 	"github.com/kaeawc/spectra/internal/toolchain"
@@ -32,6 +33,7 @@ func V1Catalog() []Rule {
 		ruleJVMOOMDumpDisabled(),
 		ruleJVMRSSExceedsHeap(),
 		ruleJVMGCAlgorithm(),
+		ruleJVMOOMDetected(),
 		ruleJDKMajorVersionDrift(),
 		ruleJavaHomeMismatch(),
 		ruleStorageFootprint(),
@@ -403,6 +405,37 @@ func ruleJVMGCAlgorithm() Rule {
 							Fix: "Switch to G1 (-XX:+UseG1GC) or Parallel (-XX:+UseParallelGC) for a multi-core, large-heap workload.",
 						})
 					}
+				}
+			}
+			return findings
+		},
+	}
+}
+
+// ruleJVMOOMDetected fires when a JVM's discovered log files contain a
+// java.lang.OutOfMemoryError. The OOM variant determines the fix — they are
+// unrelated problems — so findings are keyed and messaged per variant. High
+// severity: an actual memory failure occurred (as recorded in the log).
+func ruleJVMOOMDetected() Rule {
+	return Rule{
+		ID:       "jvm-oom-detected",
+		Severity: SeverityHigh,
+		MatchFn: func(s snapshot.Snapshot) []Finding {
+			var findings []Finding
+			for _, r := range s.OOMReports {
+				seen := make(map[oom.Variant]bool)
+				for _, ev := range r.Events {
+					if seen[ev.Variant] {
+						continue // one finding per (PID, variant)
+					}
+					seen[ev.Variant] = true
+					findings = append(findings, Finding{
+						RuleID:   "jvm-oom-detected",
+						Severity: SeverityHigh,
+						Subject:  fmt.Sprintf("PID %d (%s) %s", r.PID, r.MainClass, ev.Variant),
+						Message:  fmt.Sprintf("OutOfMemoryError (%s) recorded in %s.", ev.Variant.Human(), r.LogPath),
+						Fix:      ev.Variant.Remediation(),
+					})
 				}
 			}
 			return findings

--- a/internal/rules/oom_detected_test.go
+++ b/internal/rules/oom_detected_test.go
@@ -1,0 +1,45 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/oom"
+	"github.com/kaeawc/spectra/internal/snapshot"
+)
+
+func TestJVMOOMDetectedFiresPerVariant(t *testing.T) {
+	s := baseSnap()
+	s.OOMReports = []snapshot.OOMReport{{
+		PID:       10,
+		MainClass: "svc.App",
+		LogPath:   "/tmp/app.log",
+		Events: []oom.Event{
+			{Variant: oom.VariantHeapSpace, LineNo: 2},
+			{Variant: oom.VariantHeapSpace, LineNo: 40}, // duplicate variant -> deduped
+			{Variant: oom.VariantMetaspace, LineNo: 88},
+		},
+	}}
+	findings := ruleJVMOOMDetected().MatchFn(s)
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings (heap + metaspace, heap deduped), got %d: %v", len(findings), findings)
+	}
+	for _, f := range findings {
+		if f.RuleID != "jvm-oom-detected" || f.Severity != SeverityHigh {
+			t.Fatalf("finding = %+v", f)
+		}
+		if !strings.Contains(f.Message, "/tmp/app.log") {
+			t.Errorf("message should name the log path: %q", f.Message)
+		}
+	}
+	// Distinct subjects so the issue catalog tracks the two variants separately.
+	if findings[0].Subject == findings[1].Subject {
+		t.Fatalf("findings share a subject: %q", findings[0].Subject)
+	}
+}
+
+func TestJVMOOMDetectedNoFireWhenEmpty(t *testing.T) {
+	if f := ruleJVMOOMDetected().MatchFn(baseSnap()); len(f) != 0 {
+		t.Fatalf("expected no findings with no OOM reports, got %v", f)
+	}
+}

--- a/internal/snapshot/oom.go
+++ b/internal/snapshot/oom.go
@@ -1,0 +1,63 @@
+package snapshot
+
+import (
+	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/oom"
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+// OOMReport is the set of OutOfMemoryError occurrences found in one log file
+// belonging to one running JVM.
+type OOMReport struct {
+	PID       int         `json:"pid"`
+	MainClass string      `json:"main_class,omitempty"`
+	LogPath   string      `json:"log_path"`
+	Events    []oom.Event `json:"events"`
+}
+
+// OOM scan bounds. Deep-mode log discovery can surface many files; scan a
+// bounded tail of a bounded number of them so a snapshot never blocks on a
+// pathological log directory.
+const (
+	oomMaxFilesPerProc       = 20
+	oomMaxBytesPerFile int64 = 1 << 20 // 1 MiB tail
+)
+
+// collectOOMReports scans the discovered log files of each running JVM for
+// OutOfMemoryError occurrences. It matches a JVM to its process by PID and only
+// scans that process's LogFiles, so it does no I/O when deep-mode log discovery
+// did not run (LogFiles empty). All I/O errors are absorbed per the
+// partial-snapshot contract.
+func collectOOMReports(jvms []jvm.Info, procs []process.Info) []OOMReport {
+	if len(jvms) == 0 || len(procs) == 0 {
+		return nil
+	}
+	byPID := make(map[int]process.Info, len(procs))
+	for _, p := range procs {
+		byPID[p.PID] = p
+	}
+	var reports []OOMReport
+	for _, j := range jvms {
+		p, ok := byPID[j.PID]
+		if !ok || len(p.LogFiles) == 0 {
+			continue
+		}
+		files := p.LogFiles
+		if len(files) > oomMaxFilesPerProc {
+			files = files[:oomMaxFilesPerProc]
+		}
+		for _, path := range files {
+			events, err := oom.ScanFile(path, oomMaxBytesPerFile)
+			if err != nil || len(events) == 0 {
+				continue
+			}
+			reports = append(reports, OOMReport{
+				PID:       j.PID,
+				MainClass: j.MainClass,
+				LogPath:   path,
+				Events:    events,
+			})
+		}
+	}
+	return reports
+}

--- a/internal/snapshot/oom_test.go
+++ b/internal/snapshot/oom_test.go
@@ -1,0 +1,63 @@
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/jvm"
+	"github.com/kaeawc/spectra/internal/oom"
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+func TestCollectOOMReportsFindsEventInLog(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "app.log")
+	if err := os.WriteFile(logPath, []byte("ok\njava.lang.OutOfMemoryError: Java heap space\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jvms := []jvm.Info{{PID: 10, MainClass: "svc.App"}}
+	procs := []process.Info{{PID: 10, LogFiles: []string{logPath}}}
+
+	reports := collectOOMReports(jvms, procs)
+	if len(reports) != 1 {
+		t.Fatalf("expected 1 report, got %d: %+v", len(reports), reports)
+	}
+	if reports[0].PID != 10 || reports[0].LogPath != logPath {
+		t.Fatalf("report = %+v", reports[0])
+	}
+	if len(reports[0].Events) != 1 || reports[0].Events[0].Variant != oom.VariantHeapSpace {
+		t.Fatalf("events = %+v", reports[0].Events)
+	}
+}
+
+func TestCollectOOMReportsEmptyWhenNoLogFiles(t *testing.T) {
+	// No LogFiles (non-deep mode) -> no I/O, no reports.
+	jvms := []jvm.Info{{PID: 10}}
+	procs := []process.Info{{PID: 10}}
+	if r := collectOOMReports(jvms, procs); r != nil {
+		t.Fatalf("expected nil reports without LogFiles, got %+v", r)
+	}
+}
+
+func TestCollectOOMReportsNoProcessMatch(t *testing.T) {
+	jvms := []jvm.Info{{PID: 10}}
+	procs := []process.Info{{PID: 99, LogFiles: []string{"/whatever"}}}
+	if r := collectOOMReports(jvms, procs); r != nil {
+		t.Fatalf("expected nil reports without a PID match, got %+v", r)
+	}
+}
+
+func TestCollectOOMReportsSkipsUnreadableAndCleanLogs(t *testing.T) {
+	dir := t.TempDir()
+	clean := filepath.Join(dir, "clean.log")
+	if err := os.WriteFile(clean, []byte("nothing to see\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "gone.log")
+	jvms := []jvm.Info{{PID: 10}}
+	procs := []process.Info{{PID: 10, LogFiles: []string{missing, clean}}}
+	if r := collectOOMReports(jvms, procs); r != nil {
+		t.Fatalf("expected nil reports for unreadable + clean logs, got %+v", r)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -56,6 +56,11 @@ type Snapshot struct {
 	JVMs             []jvm.Info          `json:"jvms,omitempty"`
 	RuntimeTelemetry []telemetry.Process `json:"runtime_telemetry,omitempty"`
 
+	// OOMReports records java.lang.OutOfMemoryError occurrences found in the
+	// discovered log files of running JVMs. Populated only in deep mode (when
+	// process LogFiles are available); empty otherwise.
+	OOMReports []OOMReport `json:"oom_reports,omitempty"`
+
 	// JVMHistory is recent per-PID JVM samples (oldest first) populated by
 	// callers that have access to a snapshot store. Optional: rules that
 	// don't see history fall back to point-in-time checks.
@@ -309,11 +314,23 @@ func Build(ctx context.Context, opts Options) Snapshot {
 	wg.Wait()
 	s.Warnings = warnings
 	jvm.AttributeJDKs(s.JVMs, s.Toolchains.JDKs)
-	if !opts.SkipJVMs {
-		s.RuntimeTelemetry = append(s.RuntimeTelemetry, collectJVMTelemetry(ctx, s.JVMs, opts)...)
-	}
+	finalizeJVMData(ctx, &s, opts)
 	attributeRuntimeJDKs(s.RuntimeTelemetry, s.Toolchains.JDKs)
 	return s
+}
+
+// finalizeJVMData runs the post-Wait JVM steps that need collectors already
+// joined: runtime telemetry, and OOM log scanning (which needs both JVMs and
+// process LogFiles). Kept out of Build to hold Build's cyclomatic complexity
+// under the gate.
+func finalizeJVMData(ctx context.Context, s *Snapshot, opts Options) {
+	if opts.SkipJVMs {
+		return
+	}
+	s.RuntimeTelemetry = append(s.RuntimeTelemetry, collectJVMTelemetry(ctx, s.JVMs, opts)...)
+	if !opts.SkipProcesses {
+		s.OOMReports = collectOOMReports(s.JVMs, s.Processes)
+	}
 }
 
 func snapshotCollectorCount(opts Options) int {


### PR DESCRIPTION
Closes #434.

## What

Nothing in spectra detected that a JVM had actually hit an `OutOfMemoryError` — the single most important memory event, whose **variant** determines the fix (heap leak vs classloader leak vs off-heap buffers vs native-thread exhaustion are unrelated problems). Deep-mode process collection already discovers each process's open log-shaped files (`process.Info.LogFiles`); this reads them.

- **`internal/oom`** — pure, dependency-free `Scan(io.Reader)` / `ScanFile(path, maxBytes)` + `Classify`, covering all standard HotSpot OOM variants, with per-variant `Human()` / `Remediation()`. `ScanFile` scans only a bounded tail of large logs.
- **`snapshot`** — `OOMReport` + `collectOOMReports`, run in the **post-`wg.Wait()`** phase of `Build` where both JVMs and process `LogFiles` are available (no new collector slot, no `snapshotCollectorCount` change). Matches JVM→process by PID; bounded to a tail of a bounded number of files; does **no I/O outside deep mode** (LogFiles empty). Extracted `finalizeJVMData` to keep `Build` under the gocyclo gate.
- **`rules`** — `jvm-oom-detected` (high severity), one finding per `(PID, variant)` with a distinct subject (issue-catalog identity) and a variant-specific fix.

## Tests

- `internal/oom`: table-driven variant classification (incl. compressed-class-space-before-metaspace ordering), multi-occurrence scan with line numbers, no-false-positive, missing-file, and tail-bound scanning.
- `snapshot`: `collectOOMReports` with a temp log; nil when LogFiles empty (non-deep mode); nil on no PID match; skips unreadable/clean logs.
- `rules`: fires per variant with dedup + distinct subjects; no-fire when empty.

Docs: rule listed in `recommendations-engine.md`; capability added to `inspection/jvm.md`.

## Out of scope (follow-ups)

Parsing `hs_err_pid*.log` fatal-error logs; detecting an orphaned `.hprof` left by HeapDumpOnOutOfMemoryError; recency/de-staling of historical OOM lines.