### PR TITLE
heap: parse .hprof heap dumps into a class histogram (MAT gap, Stage A)

### DIFF
--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -15,11 +15,13 @@ Heap forensics beyond capture is intentionally split into reusable
 application-runtime interfaces before it grows a command surface.
 `internal/heap` defines generic heap records, snapshots, parsers, and
 analyzers that JVM, native, Node, Python, WebKit, and future collectors can
-adapt to. The JVM adapter parses `jcmd GC.class_histogram` output into
-structured rows, compares histogram snapshots, and ranks shallow-size and
-growth suspects. It does not parse `.hprof` object graphs yet, so dominator
-trees, retained sizes, paths-to-GC-roots, object queries, and heap-dump
-diffing remain future work.
+adapt to. The JVM adapter parses both `jcmd GC.class_histogram` output and
+binary `.hprof` heap dumps (`ParseHPROF` / `HPROFParser`) into structured
+per-class histograms, compares histogram snapshots, and ranks shallow-size and
+growth suspects — so an `.hprof` can be diffed against a live histogram or
+against another dump to shortlist leak suspects. It does not yet parse the
+`.hprof` object *reference graph*, so dominator trees, retained sizes,
+paths-to-GC-roots, and object queries remain future work.
 
 Spectra is intended to **supplant VisualVM** for the day-to-day
 "what's this Java process doing" question. JVM inspection is a

--- a/internal/heap/hprof.go
+++ b/internal/heap/hprof.go
@@ -2,6 +2,7 @@ package heap
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -72,6 +73,12 @@ const (
 // header with compressed oops. Diffs — the primary use — are robust to it.
 const hprofArrayHeaderBytes = 16
 
+// maxHPROFStringBytes bounds a single STRING_IN_UTF8 record body. HPROF string
+// records hold symbol names (classes, fields, threads), which are small; the
+// cap guards against a corrupt or hostile length field driving a multi-GiB
+// allocation before the body is even read (CWE-400).
+const maxHPROFStringBytes = 64 << 20 // 64 MiB
+
 // HPROFParser implements heap.Parser for JVM .hprof dumps.
 type HPROFParser struct{}
 
@@ -81,7 +88,7 @@ func (HPROFParser) Runtime() Runtime { return RuntimeJVM }
 // ParseSnapshot parses an in-memory .hprof dump. For large dumps prefer
 // ParseHPROF (streaming) or ParseHPROFFile.
 func (HPROFParser) ParseSnapshot(out []byte) (Snapshot, error) {
-	return ParseHPROF(strings.NewReader(string(out)))
+	return ParseHPROF(bytes.NewReader(out))
 }
 
 // ParseHPROFFile streams and parses the .hprof file at path.
@@ -236,6 +243,9 @@ func readStringRecord(hr *hprofReader, st *hprofState, length int64) error {
 	if n < 0 {
 		return fmt.Errorf("hprof: negative string length %d", n)
 	}
+	if n > maxHPROFStringBytes {
+		return fmt.Errorf("hprof: string record too large (%d bytes, max %d)", n, maxHPROFStringBytes)
+	}
 	body := make([]byte, n)
 	if _, err := io.ReadFull(hr.r, body); err != nil {
 		return fmt.Errorf("hprof: string body: %w", err)
@@ -264,13 +274,18 @@ func readLoadClassRecord(hr *hprofReader, st *hprofState) error {
 }
 
 // readHeapDump parses the sub-records inside a HEAP DUMP / HEAP DUMP SEGMENT,
-// consuming exactly length bytes via a limited reader.
+// consuming exactly length bytes via a limited reader. If the underlying stream
+// ends before the declared length is consumed (a truncated dump), it returns
+// io.ErrUnexpectedEOF rather than a silently-partial histogram.
 func readHeapDump(hr *hprofReader, st *hprofState, length int64) error {
-	limited := io.LimitReader(hr.r, length)
-	sub := &hprofReader{r: bufio.NewReader(limited), idSize: hr.idSize}
+	lr := &io.LimitedReader{R: hr.r, N: length}
+	sub := &hprofReader{r: bufio.NewReader(lr), idSize: hr.idSize}
 	for {
 		tag, err := sub.u1()
 		if errors.Is(err, io.EOF) {
+			if lr.N != 0 {
+				return fmt.Errorf("hprof: truncated heap dump (%d of %d bytes missing): %w", lr.N, length, io.ErrUnexpectedEOF)
+			}
 			return nil
 		}
 		if err != nil {

--- a/internal/heap/hprof.go
+++ b/internal/heap/hprof.go
@@ -1,0 +1,567 @@
+package heap
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// HPROF binary format support: parse a JVM .hprof heap dump into a class
+// histogram (instance counts + shallow bytes per class). This is the reusable
+// building block behind dump-vs-live and dump-vs-dump comparison via the
+// existing DefaultAnalyzer — the object reference graph (dominator tree,
+// retained sizes, paths-to-GC-roots) is a later stage.
+//
+// Reference: the HPROF binary format as emitted by HotSpot
+// (jcmd GC.heap_dump / jmap -dump), versions JAVA PROFILE 1.0.1/1.0.2/1.0.3.
+
+// Top-level record tags.
+const (
+	hprofTagString          = 0x01
+	hprofTagLoadClass       = 0x02
+	hprofTagHeapDump        = 0x0C
+	hprofTagHeapDumpSegment = 0x1C
+	hprofTagHeapDumpEnd     = 0x2C
+)
+
+// Heap-dump sub-record tags.
+const (
+	hprofRootJNIGlobal    = 0x01
+	hprofRootJNILocal     = 0x02
+	hprofRootJavaFrame    = 0x03
+	hprofRootNativeStack  = 0x04
+	hprofRootStickyClass  = 0x05
+	hprofRootThreadBlock  = 0x06
+	hprofRootMonitorUsed  = 0x07
+	hprofRootThreadObject = 0x08
+	hprofClassDump        = 0x20
+	hprofInstanceDump     = 0x21
+	hprofObjectArrayDump  = 0x22
+	hprofPrimArrayDump    = 0x23
+	hprofRootInterned     = 0x89
+	hprofRootFinalizing   = 0x8A
+	hprofRootDebugger     = 0x8B
+	hprofRootRefCleanup   = 0x8C
+	hprofRootVMInternal   = 0x8D
+	hprofRootJNIMonitor   = 0x8E
+	hprofHeapDumpInfo     = 0xFE
+	hprofRootUnknown      = 0xFF
+)
+
+// Basic-type tags used by CLASS_DUMP fields and PRIMITIVE_ARRAY_DUMP.
+const (
+	hprofTypeObject  = 2
+	hprofTypeBoolean = 4
+	hprofTypeChar    = 5
+	hprofTypeFloat   = 6
+	hprofTypeDouble  = 7
+	hprofTypeByte    = 8
+	hprofTypeShort   = 9
+	hprofTypeInt     = 10
+	hprofTypeLong    = 11
+)
+
+// hprofArrayHeaderBytes is the fixed per-array object-header estimate added to
+// array shallow sizes. Unlike instance sizes (authoritative, from CLASS_DUMP),
+// array headers are not in the dump; this constant is close to HotSpot's array
+// header with compressed oops. Diffs — the primary use — are robust to it.
+const hprofArrayHeaderBytes = 16
+
+// HPROFParser implements heap.Parser for JVM .hprof dumps.
+type HPROFParser struct{}
+
+// Runtime returns the parser's supported runtime.
+func (HPROFParser) Runtime() Runtime { return RuntimeJVM }
+
+// ParseSnapshot parses an in-memory .hprof dump. For large dumps prefer
+// ParseHPROF (streaming) or ParseHPROFFile.
+func (HPROFParser) ParseSnapshot(out []byte) (Snapshot, error) {
+	return ParseHPROF(strings.NewReader(string(out)))
+}
+
+// ParseHPROFFile streams and parses the .hprof file at path.
+func ParseHPROFFile(path string) (Histogram, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Histogram{}, err
+	}
+	defer f.Close()
+	return ParseHPROF(f)
+}
+
+type hprofReader struct {
+	r      *bufio.Reader
+	idSize int
+	buf    [8]byte
+}
+
+func (h *hprofReader) u1() (byte, error) { return h.r.ReadByte() }
+func (h *hprofReader) u2() (uint16, error) {
+	if _, err := io.ReadFull(h.r, h.buf[:2]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint16(h.buf[:2]), nil
+}
+func (h *hprofReader) u4() (uint32, error) {
+	if _, err := io.ReadFull(h.r, h.buf[:4]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(h.buf[:4]), nil
+}
+func (h *hprofReader) u8() (uint64, error) {
+	if _, err := io.ReadFull(h.r, h.buf[:8]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(h.buf[:8]), nil
+}
+func (h *hprofReader) id() (uint64, error) {
+	if _, err := io.ReadFull(h.r, h.buf[:h.idSize]); err != nil {
+		return 0, err
+	}
+	if h.idSize == 4 {
+		return uint64(binary.BigEndian.Uint32(h.buf[:4])), nil
+	}
+	return binary.BigEndian.Uint64(h.buf[:8]), nil
+}
+func (h *hprofReader) skip(n int64) error {
+	_, err := io.CopyN(io.Discard, h.r, n)
+	return err
+}
+
+// hprofState accumulates the data needed to build a histogram.
+type hprofState struct {
+	strings       map[uint64]string
+	classNameID   map[uint64]uint64 // class object id -> class name string id
+	classInstSize map[uint64]uint32 // class object id -> per-instance shallow size
+	instCount     map[uint64]int64  // class object id -> instance count
+	arrayCount    map[uint64]int64  // array class id -> array count (object arrays)
+	arrayBytes    map[uint64]int64  // array class id -> total shallow bytes
+	primCount     map[byte]int64    // element type -> primitive-array count
+	primBytes     map[byte]int64    // element type -> total shallow bytes
+}
+
+func newHPROFState() *hprofState {
+	return &hprofState{
+		strings:       map[uint64]string{},
+		classNameID:   map[uint64]uint64{},
+		classInstSize: map[uint64]uint32{},
+		instCount:     map[uint64]int64{},
+		arrayCount:    map[uint64]int64{},
+		arrayBytes:    map[uint64]int64{},
+		primCount:     map[byte]int64{},
+		primBytes:     map[byte]int64{},
+	}
+}
+
+// ParseHPROF streams a .hprof dump and returns a class Histogram.
+func ParseHPROF(r io.Reader) (Histogram, error) {
+	br := bufio.NewReaderSize(r, 64*1024)
+	hr := &hprofReader{r: br}
+
+	if err := readHPROFHeader(hr); err != nil {
+		return Histogram{}, err
+	}
+
+	st := newHPROFState()
+	for {
+		tag, err := hr.u1()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return Histogram{}, fmt.Errorf("hprof: read record tag: %w", err)
+		}
+		if _, err := hr.u4(); err != nil { // record timestamp (relative micros); unused
+			return Histogram{}, fmt.Errorf("hprof: read record time: %w", err)
+		}
+		length, err := hr.u4()
+		if err != nil {
+			return Histogram{}, fmt.Errorf("hprof: read record length: %w", err)
+		}
+		if err := readHPROFRecord(hr, st, tag, int64(length)); err != nil {
+			return Histogram{}, err
+		}
+	}
+	return buildHistogram(st), nil
+}
+
+func readHPROFHeader(hr *hprofReader) error {
+	// Null-terminated format-name string, e.g. "JAVA PROFILE 1.0.2".
+	name, err := hr.r.ReadString(0x00)
+	if err != nil {
+		return fmt.Errorf("hprof: read header name: %w", err)
+	}
+	if !strings.HasPrefix(name, "JAVA PROFILE") {
+		return fmt.Errorf("hprof: not a JAVA PROFILE dump (got %q)", strings.TrimRight(name, "\x00"))
+	}
+	idSize, err := hr.u4()
+	if err != nil {
+		return fmt.Errorf("hprof: read id size: %w", err)
+	}
+	if idSize != 4 && idSize != 8 {
+		return fmt.Errorf("hprof: unsupported identifier size %d", idSize)
+	}
+	hr.idSize = int(idSize)
+	if _, err := hr.u8(); err != nil { // timestamp
+		return fmt.Errorf("hprof: read timestamp: %w", err)
+	}
+	return nil
+}
+
+func readHPROFRecord(hr *hprofReader, st *hprofState, tag byte, length int64) error {
+	switch tag {
+	case hprofTagString:
+		return readStringRecord(hr, st, length)
+	case hprofTagLoadClass:
+		return readLoadClassRecord(hr, st)
+	case hprofTagHeapDump, hprofTagHeapDumpSegment:
+		return readHeapDump(hr, st, length)
+	default:
+		// hprofTagHeapDumpEnd has length 0; everything else we skip wholesale.
+		return hr.skip(length)
+	}
+}
+
+func readStringRecord(hr *hprofReader, st *hprofState, length int64) error {
+	id, err := hr.id()
+	if err != nil {
+		return fmt.Errorf("hprof: string id: %w", err)
+	}
+	n := length - int64(hr.idSize)
+	if n < 0 {
+		return fmt.Errorf("hprof: negative string length %d", n)
+	}
+	body := make([]byte, n)
+	if _, err := io.ReadFull(hr.r, body); err != nil {
+		return fmt.Errorf("hprof: string body: %w", err)
+	}
+	st.strings[id] = string(body)
+	return nil
+}
+
+func readLoadClassRecord(hr *hprofReader, st *hprofState) error {
+	if _, err := hr.u4(); err != nil { // class serial number
+		return err
+	}
+	classObjID, err := hr.id()
+	if err != nil {
+		return err
+	}
+	if _, err := hr.u4(); err != nil { // stack trace serial
+		return err
+	}
+	nameID, err := hr.id()
+	if err != nil {
+		return err
+	}
+	st.classNameID[classObjID] = nameID
+	return nil
+}
+
+// readHeapDump parses the sub-records inside a HEAP DUMP / HEAP DUMP SEGMENT,
+// consuming exactly length bytes via a limited reader.
+func readHeapDump(hr *hprofReader, st *hprofState, length int64) error {
+	limited := io.LimitReader(hr.r, length)
+	sub := &hprofReader{r: bufio.NewReader(limited), idSize: hr.idSize}
+	for {
+		tag, err := sub.u1()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("hprof: heap-dump sub-tag: %w", err)
+		}
+		if err := readHeapSubRecord(sub, st, tag); err != nil {
+			return err
+		}
+	}
+}
+
+func readHeapSubRecord(sub *hprofReader, st *hprofState, tag byte) error {
+	if fixed, ok := hprofRootSkipBytes(sub.idSize, tag); ok {
+		return sub.skip(fixed)
+	}
+	switch tag {
+	case hprofClassDump:
+		return readClassDump(sub, st)
+	case hprofInstanceDump:
+		return readInstanceDump(sub, st)
+	case hprofObjectArrayDump:
+		return readObjectArrayDump(sub, st)
+	case hprofPrimArrayDump:
+		return readPrimArrayDump(sub, st)
+	default:
+		return fmt.Errorf("hprof: unknown heap-dump sub-record tag 0x%02x", tag)
+	}
+}
+
+// hprofRootSkipBytes returns the fixed body size (after the sub-tag) of the
+// root / info sub-records that carry no histogram data, so they can be skipped
+// without desyncing the stream.
+func hprofRootSkipBytes(idSize int, tag byte) (int64, bool) {
+	id := int64(idSize)
+	switch tag {
+	case hprofRootUnknown, hprofRootStickyClass, hprofRootMonitorUsed,
+		hprofRootInterned, hprofRootFinalizing, hprofRootDebugger,
+		hprofRootRefCleanup, hprofRootVMInternal:
+		return id, true
+	case hprofRootJNIGlobal:
+		return id + id, true // object id + JNI global ref id
+	case hprofRootNativeStack, hprofRootThreadBlock:
+		return id + 4, true // object id + u4
+	case hprofRootJNILocal, hprofRootJavaFrame, hprofRootThreadObject, hprofRootJNIMonitor:
+		return id + 8, true // object id + two u4
+	case hprofHeapDumpInfo:
+		return 4 + id, true // u4 heap id + heap name string id
+	default:
+		return 0, false
+	}
+}
+
+func readClassDump(sub *hprofReader, st *hprofState) error {
+	classObjID, err := sub.id()
+	if err != nil {
+		return err
+	}
+	// stack trace serial, then 6 ids (super, loader, signers, protection
+	// domain, reserved1, reserved2).
+	if _, err := sub.u4(); err != nil {
+		return err
+	}
+	for i := 0; i < 6; i++ {
+		if _, err := sub.id(); err != nil {
+			return err
+		}
+	}
+	instSize, err := sub.u4()
+	if err != nil {
+		return err
+	}
+	st.classInstSize[classObjID] = instSize
+
+	// Constant pool: u2 count, each {u2 index, u1 type, value}.
+	if err := skipClassPool(sub); err != nil {
+		return err
+	}
+	// Static fields: u2 count, each {id name, u1 type, value}.
+	if err := skipStaticFields(sub); err != nil {
+		return err
+	}
+	// Instance fields: u2 count, each {id name, u1 type} (no value).
+	return skipInstanceFields(sub)
+}
+
+func skipClassPool(sub *hprofReader) error {
+	count, err := sub.u2()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < int(count); i++ {
+		if _, err := sub.u2(); err != nil { // constant pool index
+			return err
+		}
+		typ, err := sub.u1()
+		if err != nil {
+			return err
+		}
+		if err := sub.skip(hprofTypeSize(typ, sub.idSize)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func skipStaticFields(sub *hprofReader) error {
+	count, err := sub.u2()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < int(count); i++ {
+		if _, err := sub.id(); err != nil { // field name string id
+			return err
+		}
+		typ, err := sub.u1()
+		if err != nil {
+			return err
+		}
+		if err := sub.skip(hprofTypeSize(typ, sub.idSize)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func skipInstanceFields(sub *hprofReader) error {
+	count, err := sub.u2()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < int(count); i++ {
+		if _, err := sub.id(); err != nil { // field name string id
+			return err
+		}
+		if _, err := sub.u1(); err != nil { // type
+			return err
+		}
+	}
+	return nil
+}
+
+func readInstanceDump(sub *hprofReader, st *hprofState) error {
+	if _, err := sub.id(); err != nil { // object id
+		return err
+	}
+	if _, err := sub.u4(); err != nil { // stack trace serial
+		return err
+	}
+	classID, err := sub.id()
+	if err != nil {
+		return err
+	}
+	nbytes, err := sub.u4()
+	if err != nil {
+		return err
+	}
+	st.instCount[classID]++
+	return sub.skip(int64(nbytes))
+}
+
+func readObjectArrayDump(sub *hprofReader, st *hprofState) error {
+	if _, err := sub.id(); err != nil { // array object id
+		return err
+	}
+	if _, err := sub.u4(); err != nil { // stack trace serial
+		return err
+	}
+	numElems, err := sub.u4()
+	if err != nil {
+		return err
+	}
+	arrayClassID, err := sub.id()
+	if err != nil {
+		return err
+	}
+	st.arrayCount[arrayClassID]++
+	st.arrayBytes[arrayClassID] += hprofArrayHeaderBytes + int64(numElems)*int64(sub.idSize)
+	return sub.skip(int64(numElems) * int64(sub.idSize))
+}
+
+func readPrimArrayDump(sub *hprofReader, st *hprofState) error {
+	if _, err := sub.id(); err != nil { // array object id
+		return err
+	}
+	if _, err := sub.u4(); err != nil { // stack trace serial
+		return err
+	}
+	numElems, err := sub.u4()
+	if err != nil {
+		return err
+	}
+	elemType, err := sub.u1()
+	if err != nil {
+		return err
+	}
+	elemSize := hprofTypeSize(elemType, sub.idSize)
+	st.primCount[elemType]++
+	st.primBytes[elemType] += hprofArrayHeaderBytes + int64(numElems)*elemSize
+	return sub.skip(int64(numElems) * elemSize)
+}
+
+func hprofTypeSize(typ byte, idSize int) int64 {
+	switch typ {
+	case hprofTypeObject:
+		return int64(idSize)
+	case hprofTypeBoolean, hprofTypeByte:
+		return 1
+	case hprofTypeChar, hprofTypeShort:
+		return 2
+	case hprofTypeFloat, hprofTypeInt:
+		return 4
+	case hprofTypeDouble, hprofTypeLong:
+		return 8
+	default:
+		return 0
+	}
+}
+
+func (st *hprofState) className(classObjID uint64) string {
+	nameID, ok := st.classNameID[classObjID]
+	if !ok {
+		return fmt.Sprintf("unknown-0x%x", classObjID)
+	}
+	name := st.strings[nameID]
+	if name == "" {
+		return fmt.Sprintf("unknown-0x%x", classObjID)
+	}
+	return strings.ReplaceAll(name, "/", ".")
+}
+
+func primArrayName(elemType byte) string {
+	switch elemType {
+	case hprofTypeBoolean:
+		return "[Z"
+	case hprofTypeChar:
+		return "[C"
+	case hprofTypeFloat:
+		return "[F"
+	case hprofTypeDouble:
+		return "[D"
+	case hprofTypeByte:
+		return "[B"
+	case hprofTypeShort:
+		return "[S"
+	case hprofTypeInt:
+		return "[I"
+	case hprofTypeLong:
+		return "[J"
+	default:
+		return "[?"
+	}
+}
+
+func buildHistogram(st *hprofState) Histogram {
+	var entries []ClassEntry
+	for classID, count := range st.instCount {
+		size := int64(st.classInstSize[classID])
+		entries = append(entries, ClassEntry{
+			Instances: count,
+			Bytes:     count * size,
+			ClassName: st.className(classID),
+		})
+	}
+	for arrayClassID, count := range st.arrayCount {
+		entries = append(entries, ClassEntry{
+			Instances: count,
+			Bytes:     st.arrayBytes[arrayClassID],
+			ClassName: st.className(arrayClassID),
+		})
+	}
+	for elemType, count := range st.primCount {
+		entries = append(entries, ClassEntry{
+			Instances: count,
+			Bytes:     st.primBytes[elemType],
+			ClassName: primArrayName(elemType),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Bytes != entries[j].Bytes {
+			return entries[i].Bytes > entries[j].Bytes
+		}
+		return entries[i].ClassName < entries[j].ClassName
+	})
+
+	var total ClassEntry
+	total.ClassName = "Total"
+	for i := range entries {
+		entries[i].Rank = i + 1
+		total.Instances += entries[i].Instances
+		total.Bytes += entries[i].Bytes
+	}
+	return Histogram{Entries: entries, Total: total}
+}

--- a/internal/heap/hprof_test.go
+++ b/internal/heap/hprof_test.go
@@ -3,6 +3,8 @@ package heap
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -200,6 +202,34 @@ func TestParseHPROFRejectsUnknownSubTag(t *testing.T) {
 	b.heapDumpSegment(seg.Bytes())
 	if _, err := ParseHPROF(bytes.NewReader(b.buf.Bytes())); err == nil {
 		t.Fatal("expected error on unknown sub-record tag")
+	}
+}
+
+func TestParseHPROFRejectsTruncatedSegment(t *testing.T) {
+	b := newHPROFBuilder(8)
+	// Emit a heap-dump segment header claiming more bytes than we provide, then
+	// stop the stream mid-segment (after one valid sub-record).
+	b.u1(0x1C)
+	b.u4(0)  // time
+	b.u4(64) // declared length, larger than the body below
+	var seg bytes.Buffer
+	b.rootStickyClass(&seg, 1) // 1 + 8 bytes, well under 64
+	b.buf.Write(seg.Bytes())
+	if _, err := ParseHPROF(bytes.NewReader(b.buf.Bytes())); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected io.ErrUnexpectedEOF on truncated segment, got %v", err)
+	}
+}
+
+func TestParseHPROFRejectsOversizedStringRecord(t *testing.T) {
+	b := newHPROFBuilder(8)
+	// A STRING record header claiming a body far beyond the allocation cap must
+	// be rejected before allocating (guards against corrupt/hostile lengths).
+	b.u1(0x01)
+	b.u4(0)                                 // time
+	b.u4(uint32(maxHPROFStringBytes) + 100) // declared record length
+	b.writeIDTo(&b.buf, 1)                  // string id; body would follow but never does
+	if _, err := ParseHPROF(bytes.NewReader(b.buf.Bytes())); err == nil {
+		t.Fatal("expected error on oversized string record")
 	}
 }
 

--- a/internal/heap/hprof_test.go
+++ b/internal/heap/hprof_test.go
@@ -1,0 +1,236 @@
+package heap
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// hprofBuilder constructs a spec-valid .hprof byte stream for tests. It doubles
+// as executable documentation of the record layout the parser consumes.
+type hprofBuilder struct {
+	buf    bytes.Buffer
+	idSize int
+}
+
+func newHPROFBuilder(idSize int) *hprofBuilder {
+	b := &hprofBuilder{idSize: idSize}
+	b.buf.WriteString("JAVA PROFILE 1.0.2")
+	b.buf.WriteByte(0x00)
+	b.u4(uint32(idSize))
+	b.u8(0) // timestamp
+	return b
+}
+
+func (b *hprofBuilder) u1(v byte)   { b.buf.WriteByte(v) }
+func (b *hprofBuilder) u4(v uint32) { _ = binary.Write(&b.buf, binary.BigEndian, v) }
+func (b *hprofBuilder) u8(v uint64) { _ = binary.Write(&b.buf, binary.BigEndian, v) }
+
+// writeIDTo writes an id (idSize bytes, big-endian) into a sub-record body.
+func (b *hprofBuilder) writeIDTo(w *bytes.Buffer, v uint64) {
+	if b.idSize == 4 {
+		_ = binary.Write(w, binary.BigEndian, uint32(v))
+		return
+	}
+	_ = binary.Write(w, binary.BigEndian, v)
+}
+
+func (b *hprofBuilder) record(tag byte, body []byte) {
+	b.u1(tag)
+	b.u4(0) // time
+	b.u4(uint32(len(body)))
+	b.buf.Write(body)
+}
+
+func (b *hprofBuilder) stringRecord(id uint64, s string) {
+	var body bytes.Buffer
+	b.writeIDTo(&body, id)
+	body.WriteString(s)
+	b.record(0x01, body.Bytes())
+}
+
+func (b *hprofBuilder) loadClass(serial uint32, classObjID uint64, nameID uint64) {
+	var body bytes.Buffer
+	_ = binary.Write(&body, binary.BigEndian, serial)
+	b.writeIDTo(&body, classObjID)
+	_ = binary.Write(&body, binary.BigEndian, uint32(0)) // stack serial
+	b.writeIDTo(&body, nameID)
+	b.record(0x02, body.Bytes())
+}
+
+// heap-dump sub-record builders (written into one segment body).
+
+func (b *hprofBuilder) classDump(w *bytes.Buffer, classObjID uint64, instSize uint32) {
+	w.WriteByte(0x20)
+	b.writeIDTo(w, classObjID)
+	_ = binary.Write(w, binary.BigEndian, uint32(0)) // stack serial
+	for i := 0; i < 6; i++ {
+		b.writeIDTo(w, 0) // super, loader, signers, protdomain, reserved x2
+	}
+	_ = binary.Write(w, binary.BigEndian, instSize)
+	_ = binary.Write(w, binary.BigEndian, uint16(0)) // const pool
+	_ = binary.Write(w, binary.BigEndian, uint16(0)) // static fields
+	_ = binary.Write(w, binary.BigEndian, uint16(0)) // instance fields
+}
+
+func (b *hprofBuilder) instanceDump(w *bytes.Buffer, objID, classID uint64, nbytes uint32) {
+	w.WriteByte(0x21)
+	b.writeIDTo(w, objID)
+	_ = binary.Write(w, binary.BigEndian, uint32(0)) // stack serial
+	b.writeIDTo(w, classID)
+	_ = binary.Write(w, binary.BigEndian, nbytes)
+	w.Write(make([]byte, nbytes))
+}
+
+func (b *hprofBuilder) objectArrayDump(w *bytes.Buffer, objID uint64, numElems uint32, arrayClassID uint64) {
+	w.WriteByte(0x22)
+	b.writeIDTo(w, objID)
+	_ = binary.Write(w, binary.BigEndian, uint32(0)) // stack serial
+	_ = binary.Write(w, binary.BigEndian, numElems)
+	b.writeIDTo(w, arrayClassID)
+	w.Write(make([]byte, int(numElems)*b.idSize))
+}
+
+func (b *hprofBuilder) primArrayDump(w *bytes.Buffer, objID uint64, numElems uint32, elemType byte, elemSize int) {
+	w.WriteByte(0x23)
+	b.writeIDTo(w, objID)
+	_ = binary.Write(w, binary.BigEndian, uint32(0)) // stack serial
+	_ = binary.Write(w, binary.BigEndian, numElems)
+	w.WriteByte(elemType)
+	w.Write(make([]byte, int(numElems)*elemSize))
+}
+
+func (b *hprofBuilder) rootStickyClass(w *bytes.Buffer, classID uint64) {
+	w.WriteByte(0x05)
+	b.writeIDTo(w, classID)
+}
+
+func (b *hprofBuilder) heapDumpInfo(w *bytes.Buffer, heapID uint32, nameID uint64) {
+	w.WriteByte(0xFE)
+	_ = binary.Write(w, binary.BigEndian, heapID)
+	b.writeIDTo(w, nameID)
+}
+
+func (b *hprofBuilder) heapDumpSegment(body []byte) { b.record(0x1C, body) }
+func (b *hprofBuilder) heapDumpEnd()                { b.record(0x2C, nil) }
+
+// buildStandardDump builds a dump with 3 A + 2 B instances, one object array of
+// A (4 elems), one int primitive array (10 elems), plus a root and a heap-dump
+// info record to exercise skip logic. aExtra adds more A instances (for diffs).
+func buildStandardDump(idSize int, aExtra int) []byte {
+	b := newHPROFBuilder(idSize)
+	b.stringRecord(100, "com/acme/A")
+	b.stringRecord(101, "com/acme/B")
+	b.stringRecord(102, "[Lcom/acme/A;")
+	b.loadClass(1, 1, 100)
+	b.loadClass(2, 2, 101)
+	b.loadClass(3, 3, 102)
+
+	var seg bytes.Buffer
+	b.heapDumpInfo(&seg, 1, 100)
+	b.rootStickyClass(&seg, 1)
+	b.classDump(&seg, 1, 24)
+	b.classDump(&seg, 2, 16)
+	b.classDump(&seg, 3, 0)
+	for i := 0; i < 3+aExtra; i++ {
+		b.instanceDump(&seg, uint64(1000+i), 1, 16)
+	}
+	b.instanceDump(&seg, 2000, 2, 8)
+	b.instanceDump(&seg, 2001, 2, 8)
+	b.objectArrayDump(&seg, 3000, 4, 3)
+	b.primArrayDump(&seg, 4000, 10, 10, 4) // int[], 10 elems, 4 bytes each
+	b.heapDumpSegment(seg.Bytes())
+	b.heapDumpEnd()
+	return b.buf.Bytes()
+}
+
+func entryByName(h Histogram, name string) (ClassEntry, bool) {
+	for _, e := range h.Entries {
+		if e.ClassName == name {
+			return e, true
+		}
+	}
+	return ClassEntry{}, false
+}
+
+func TestParseHPROFHistogram(t *testing.T) {
+	for _, idSize := range []int{8, 4} {
+		h, err := ParseHPROF(bytes.NewReader(buildStandardDump(idSize, 0)))
+		if err != nil {
+			t.Fatalf("idSize %d: ParseHPROF error: %v", idSize, err)
+		}
+		a, ok := entryByName(h, "com.acme.A")
+		if !ok || a.Instances != 3 || a.Bytes != 72 {
+			t.Errorf("idSize %d: A = %+v, want instances 3 bytes 72", idSize, a)
+		}
+		b, ok := entryByName(h, "com.acme.B")
+		if !ok || b.Instances != 2 || b.Bytes != 32 {
+			t.Errorf("idSize %d: B = %+v, want instances 2 bytes 32", idSize, b)
+		}
+		oa, ok := entryByName(h, "[Lcom.acme.A;")
+		if !ok || oa.Instances != 1 || oa.Bytes != int64(hprofArrayHeaderBytes+4*idSize) {
+			t.Errorf("idSize %d: obj array = %+v", idSize, oa)
+		}
+		pa, ok := entryByName(h, "[I")
+		if !ok || pa.Instances != 1 || pa.Bytes != int64(hprofArrayHeaderBytes+10*4) {
+			t.Errorf("idSize %d: int array = %+v", idSize, pa)
+		}
+		wantTotal := int64(72 + 32 + (hprofArrayHeaderBytes + 4*idSize) + (hprofArrayHeaderBytes + 40))
+		if h.Total.Bytes != wantTotal || h.Total.Instances != 7 {
+			t.Errorf("idSize %d: total = %+v, want bytes %d instances 7", idSize, h.Total, wantTotal)
+		}
+		// Entries sorted by bytes desc: A is largest.
+		if h.Entries[0].ClassName != "com.acme.A" || h.Entries[0].Rank != 1 {
+			t.Errorf("idSize %d: top entry = %+v, want com.acme.A rank 1", idSize, h.Entries[0])
+		}
+	}
+}
+
+func TestParseHPROFRejectsBadHeader(t *testing.T) {
+	if _, err := ParseHPROF(strings.NewReader("NOT AN HPROF FILE")); err == nil {
+		t.Fatal("expected error on bad header")
+	}
+}
+
+func TestParseHPROFRejectsUnknownSubTag(t *testing.T) {
+	b := newHPROFBuilder(8)
+	var seg bytes.Buffer
+	seg.WriteByte(0x7A) // not a valid heap-dump sub-record tag
+	b.heapDumpSegment(seg.Bytes())
+	if _, err := ParseHPROF(bytes.NewReader(b.buf.Bytes())); err == nil {
+		t.Fatal("expected error on unknown sub-record tag")
+	}
+}
+
+func TestParseHPROFComposesWithAnalyzer(t *testing.T) {
+	before, err := ParseHPROF(bytes.NewReader(buildStandardDump(8, 0)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := ParseHPROF(bytes.NewReader(buildStandardDump(8, 100))) // 100 extra A instances
+	if err != nil {
+		t.Fatal(err)
+	}
+	suspects, err := DefaultAnalyzer{}.RankGrowth(before, after, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(suspects) == 0 || suspects[0].Name != "com.acme.A" {
+		t.Fatalf("top growth suspect = %+v, want com.acme.A", suspects)
+	}
+	if suspects[0].DeltaCount != 100 {
+		t.Errorf("A delta count = %d, want 100", suspects[0].DeltaCount)
+	}
+}
+
+func TestHPROFParserImplementsParser(t *testing.T) {
+	var _ Parser = HPROFParser{}
+	snap, err := HPROFParser{}.ParseSnapshot(buildStandardDump(8, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Runtime() != RuntimeJVM || len(snap.Records()) == 0 {
+		t.Fatalf("snapshot = %+v", snap)
+	}
+}


### PR DESCRIPTION
Closes #436.

## What

The single biggest documented JVM gap (`docs/inspection/jvm.md`): spectra captured `.hprof` heap dumps (`jcmd GC.heap_dump`) but **nothing read them back** — `internal/heap` only understood the *text* of `GC.class_histogram`. This is the Eclipse MAT gap.

**Stage A** adds a streaming binary HPROF parser producing a per-class histogram (instance counts + shallow bytes). It reuses the existing `ClassEntry`/`Histogram` types, so the result **is** a `heap.Snapshot` and composes with `DefaultAnalyzer` for free:

- **dump vs live** — compare an `.hprof` against a live `GC.class_histogram`.
- **dump vs dump** — diff two dumps to shortlist the growing classes (the leak-suspect list).

## Implementation

- `ParseHPROF(io.Reader)`, `ParseHPROFFile(path)`, and `HPROFParser` (implements `heap.Parser`).
- Handles 4- and 8-byte identifiers; `HEAP DUMP` and `HEAP DUMP SEGMENT`; all root / class / instance / object-array / primitive-array sub-records plus heap-dump-info. An **unknown sub-tag is a hard error** — never a silent desync.
- Instance shallow sizes are authoritative (from `CLASS_DUMP`); array sizes use a documented fixed header estimate (diffs, the primary use, are robust to it). Streaming, so multi-GB dumps don't OOM the tool.

Dominator tree, retained sizes, and paths-to-GC-roots (the object *reference graph*) are later stages.

## Tests

`hprof_test.go` builds spec-valid dumps via a documented builder and asserts per-class counts/bytes/total for **both** 4- and 8-byte id sizes, rejects a bad header and an unknown sub-tag, drives `DefaultAnalyzer.RankGrowth` across two dumps to find the grown class, and checks the `heap.Parser` conformance. Passes under `-race`. Docs gap statement updated.