### PR TITLE
Add Nebula peer discovery source for remote hosts and fan

### DIFF
--- a/cmd/spectra/discover_nebula.go
+++ b/cmd/spectra/discover_nebula.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// selectDiscoverProvider maps the --discover-via value to the peer source used
+// by `spectra hosts` and `spectra fan`. The default, "auto", attempts every
+// source and merges the results, so plain `--discover` finds peers whether the
+// host is on Tailscale, a Nebula mesh, or both. Tailscale queries a live
+// coordination server; Nebula has no such peer list, so its source of truth is
+// the set of signed host certs (see discoverNebulaPeers).
+func selectDiscoverProvider(via string) error {
+	switch strings.ToLower(strings.TrimSpace(via)) {
+	case "", "auto", "both", "all":
+		fanDiscoverPeers = discoverAllPeers
+	case "tailscale":
+		fanDiscoverPeers = discoverTailscalePeers
+	case "nebula":
+		fanDiscoverPeers = discoverNebulaPeers
+	default:
+		return fmt.Errorf("unknown --discover-via %q (want auto, tailscale, or nebula)", via)
+	}
+	return nil
+}
+
+// discoverAllPeers merges every discovery source, deduping by target string. A
+// source that fails (Tailscale not installed, no Nebula certs on disk) is
+// tolerated: its error is only surfaced when *every* source failed and no peers
+// were found, so a Tailscale-only or Nebula-only host still discovers cleanly.
+func discoverAllPeers() ([]string, error) {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	var errs []error
+	merge := func(peers []string, err error) {
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
+		for _, peer := range peers {
+			if _, ok := seen[peer]; ok {
+				continue
+			}
+			seen[peer] = struct{}{}
+			out = append(out, peer)
+		}
+	}
+	merge(discoverTailscalePeers())
+	merge(discoverNebulaPeers())
+	sort.Strings(out)
+	if len(out) == 0 && len(errs) > 0 {
+		return nil, fmt.Errorf("discover peers: all sources failed: %w", errors.Join(errs...))
+	}
+	return out, nil
+}
+
+// nebulaCertsDir is the directory scanned for signed Nebula host certs.
+// $SPECTRA_NEBULA_CERTS overrides the default of ~/.nebula.
+func nebulaCertsDir() (string, error) {
+	if dir := strings.TrimSpace(os.Getenv("SPECTRA_NEBULA_CERTS")); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".nebula"), nil
+}
+
+// discoverNebulaPeers enumerates signed host certs and returns their overlay
+// IPs. Nebula exposes no live peer list, so cert membership is the source of
+// truth: every host you can reach has a cert signed by the mesh CA. The
+// --discover-daemons probe then narrows this to hosts actually running a
+// Spectra daemon. Overlay IPs are returned rather than names because Nebula
+// has no MagicDNS; parseConnectTarget dials a bare IP directly.
+func discoverNebulaPeers() ([]string, error) {
+	dir, err := nebulaCertsDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read nebula certs %s: %w", dir, err)
+	}
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || name == "ca.crt" || !strings.HasSuffix(name, ".crt") {
+			continue
+		}
+		ip, err := nebulaCertIP(filepath.Join(dir, name))
+		if err != nil || ip == "" {
+			// Skip unreadable or CA certs rather than failing the whole listing.
+			continue
+		}
+		seen[ip] = struct{}{}
+	}
+	hosts := make([]string, 0, len(seen))
+	for ip := range seen {
+		hosts = append(hosts, ip)
+	}
+	sort.Strings(hosts)
+	return hosts, nil
+}
+
+// nebulaCertIP returns the bare overlay IP from a signed Nebula cert, dropping
+// the CIDR mask so parseConnectTarget can dial it. Empty string means the cert
+// carries no usable host IP (for example a CA cert).
+func nebulaCertIP(path string) (string, error) {
+	raw, err := runNebulaCertPrint(path)
+	if err != nil {
+		return "", err
+	}
+	var payload struct {
+		Details struct {
+			IsCa bool     `json:"isCa"`
+			Ips  []string `json:"ips"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return "", err
+	}
+	if payload.Details.IsCa || len(payload.Details.Ips) == 0 {
+		return "", nil
+	}
+	ip := strings.TrimSpace(payload.Details.Ips[0])
+	if idx := strings.IndexByte(ip, '/'); idx >= 0 {
+		ip = ip[:idx]
+	}
+	return ip, nil
+}
+
+// runNebulaCertPrint is the seam tests replace; production shells out to the
+// nebula-cert binary that ships with Nebula.
+var runNebulaCertPrint = func(path string) ([]byte, error) {
+	return exec.Command("nebula-cert", "print", "-json", "-path", path).Output()
+}

--- a/cmd/spectra/discover_nebula_test.go
+++ b/cmd/spectra/discover_nebula_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeNebulaCert(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("cert-"+name), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// fakeNebulaCertPrint returns a nebula-cert-shaped JSON payload keyed on the
+// cert filename so tests can control each cert's overlay IP independently.
+func fakeNebulaCertPrint(t *testing.T, byBase map[string]string, isCa map[string]bool) func(string) ([]byte, error) {
+	t.Helper()
+	return func(path string) ([]byte, error) {
+		base := filepath.Base(path)
+		ip, ok := byBase[base]
+		if !ok {
+			return nil, fmt.Errorf("no fake cert for %s", base)
+		}
+		payload := map[string]any{
+			"details": map[string]any{
+				"isCa": isCa[base],
+				"ips":  []string{ip},
+			},
+		}
+		return json.Marshal(payload)
+	}
+}
+
+func TestDiscoverNebulaPeersFromCertDir(t *testing.T) {
+	dir := t.TempDir()
+	writeNebulaCert(t, dir, "your-mac.crt")
+	writeNebulaCert(t, dir, "work-mac.crt")
+	writeNebulaCert(t, dir, "ca.crt")    // skipped by name
+	writeNebulaCert(t, dir, "notes.txt") // skipped: wrong suffix
+	writeNebulaCert(t, dir, "lighthouse.crt")
+
+	t.Setenv("SPECTRA_NEBULA_CERTS", dir)
+	orig := runNebulaCertPrint
+	runNebulaCertPrint = fakeNebulaCertPrint(t,
+		map[string]string{
+			"your-mac.crt":   "192.168.100.10/24",
+			"work-mac.crt":   "192.168.100.11/24",
+			"lighthouse.crt": "192.168.100.1/24",
+		},
+		nil,
+	)
+	t.Cleanup(func() { runNebulaCertPrint = orig })
+
+	peers, err := discoverNebulaPeers()
+	if err != nil {
+		t.Fatalf("discoverNebulaPeers = %v", err)
+	}
+	want := []string{"192.168.100.1", "192.168.100.10", "192.168.100.11"}
+	if !reflect.DeepEqual(peers, want) {
+		t.Fatalf("peers = %v, want %v", peers, want)
+	}
+}
+
+func TestDiscoverNebulaPeersSkipsCAAndUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	writeNebulaCert(t, dir, "self-ca.crt")
+	writeNebulaCert(t, dir, "broken.crt")
+	writeNebulaCert(t, dir, "work-mac.crt")
+
+	t.Setenv("SPECTRA_NEBULA_CERTS", dir)
+	orig := runNebulaCertPrint
+	runNebulaCertPrint = func(path string) ([]byte, error) {
+		switch filepath.Base(path) {
+		case "self-ca.crt":
+			return json.Marshal(map[string]any{"details": map[string]any{"isCa": true, "ips": []string{"192.168.100.1/24"}}})
+		case "broken.crt":
+			return nil, fmt.Errorf("boom")
+		case "work-mac.crt":
+			return json.Marshal(map[string]any{"details": map[string]any{"ips": []string{"192.168.100.11/24"}}})
+		}
+		return nil, fmt.Errorf("unexpected %s", path)
+	}
+	t.Cleanup(func() { runNebulaCertPrint = orig })
+
+	peers, err := discoverNebulaPeers()
+	if err != nil {
+		t.Fatalf("discoverNebulaPeers = %v", err)
+	}
+	want := []string{"192.168.100.11"}
+	if !reflect.DeepEqual(peers, want) {
+		t.Fatalf("peers = %v, want %v", peers, want)
+	}
+}
+
+func TestDiscoverNebulaPeersMissingDir(t *testing.T) {
+	t.Setenv("SPECTRA_NEBULA_CERTS", filepath.Join(t.TempDir(), "does-not-exist"))
+	if _, err := discoverNebulaPeers(); err == nil {
+		t.Fatal("expected error for missing cert dir")
+	}
+}
+
+func TestSelectDiscoverProvider(t *testing.T) {
+	orig := fanDiscoverPeers
+	t.Cleanup(func() { fanDiscoverPeers = orig })
+
+	cases := []struct {
+		via  string
+		want func() ([]string, error)
+	}{
+		{"nebula", discoverNebulaPeers},
+		{"tailscale", discoverTailscalePeers},
+		{"", discoverAllPeers},
+		{"auto", discoverAllPeers},
+		{"both", discoverAllPeers},
+	}
+	for _, tc := range cases {
+		if err := selectDiscoverProvider(tc.via); err != nil {
+			t.Fatalf("%q: %v", tc.via, err)
+		}
+		if reflect.ValueOf(fanDiscoverPeers).Pointer() != reflect.ValueOf(tc.want).Pointer() {
+			t.Fatalf("via %q selected the wrong provider", tc.via)
+		}
+	}
+
+	if err := selectDiscoverProvider("wireguard"); err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestDiscoverAllPeersMergesSources(t *testing.T) {
+	dir := t.TempDir()
+	writeNebulaCert(t, dir, "work-mac.crt")
+	t.Setenv("SPECTRA_NEBULA_CERTS", dir)
+
+	origCert := runNebulaCertPrint
+	runNebulaCertPrint = fakeNebulaCertPrint(t,
+		map[string]string{"work-mac.crt": "192.168.100.11/24"}, nil)
+	t.Cleanup(func() { runNebulaCertPrint = origCert })
+
+	origTS := runTailscaleStatus
+	runTailscaleStatus = func() ([]byte, error) {
+		return json.Marshal(map[string]any{
+			"Peers": map[string]map[string]string{
+				"a": {"DNSName": "alice.tailnet.example"},
+			},
+		})
+	}
+	t.Cleanup(func() { runTailscaleStatus = origTS })
+
+	peers, err := discoverAllPeers()
+	if err != nil {
+		t.Fatalf("discoverAllPeers = %v", err)
+	}
+	want := []string{"192.168.100.11", "alice.tailnet.example"}
+	if !reflect.DeepEqual(peers, want) {
+		t.Fatalf("peers = %v, want %v", peers, want)
+	}
+}
+
+func TestDiscoverAllPeersToleratesOneFailedSource(t *testing.T) {
+	// No Nebula certs on disk (dir missing) — that source errors, but Tailscale
+	// still yields a peer, so discoverAllPeers succeeds.
+	t.Setenv("SPECTRA_NEBULA_CERTS", filepath.Join(t.TempDir(), "absent"))
+
+	origTS := runTailscaleStatus
+	runTailscaleStatus = func() ([]byte, error) {
+		return json.Marshal(map[string]any{
+			"Peers": map[string]map[string]string{
+				"a": {"HostName": "work-mac"},
+			},
+		})
+	}
+	t.Cleanup(func() { runTailscaleStatus = origTS })
+
+	peers, err := discoverAllPeers()
+	if err != nil {
+		t.Fatalf("discoverAllPeers = %v", err)
+	}
+	if !reflect.DeepEqual(peers, []string{"work-mac"}) {
+		t.Fatalf("peers = %v, want [work-mac]", peers)
+	}
+}
+
+func TestDiscoverAllPeersErrorsWhenAllSourcesFail(t *testing.T) {
+	t.Setenv("SPECTRA_NEBULA_CERTS", filepath.Join(t.TempDir(), "absent"))
+
+	origTS := runTailscaleStatus
+	runTailscaleStatus = func() ([]byte, error) { return nil, fmt.Errorf("tailscale missing") }
+	t.Cleanup(func() { runTailscaleStatus = origTS })
+
+	if _, err := discoverAllPeers(); err == nil {
+		t.Fatal("expected error when every source fails")
+	}
+}

--- a/cmd/spectra/fan.go
+++ b/cmd/spectra/fan.go
@@ -45,9 +45,15 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 	timeout := fs.Duration("timeout", 3*time.Second, "Dial/read timeout per target")
 	hosts := fs.String("hosts", "", "Comma-separated daemon targets; defaults to discovered hosts")
 	probe := fs.Bool("probe", false, "When discovering hosts, skip entries that fail a health check")
-	discoverHosts := fs.Bool("discover", false, "Include tailscale peers from tailscale status --json")
-	discoverDaemons := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from Tailscale peers")
+	discoverHosts := fs.Bool("discover", false, "Include peers discovered from the --discover-via source")
+	discoverDaemons := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from discovered peers")
+	discoverVia := fs.String("discover-via", "auto", "Peer discovery source: auto (both), tailscale, or nebula")
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if err := selectDiscoverProvider(*discoverVia); err != nil {
+		fmt.Fprintln(stderr, err)
+		printFanUsage(stderr)
 		return 2
 	}
 
@@ -92,7 +98,7 @@ func runFanWith(args []string, stdout io.Writer, stderr io.Writer, caller fanRPC
 }
 
 func printFanUsage(w io.Writer) {
-	fmt.Fprintln(w, "usage: spectra fan [--hosts host-a,host-b] [--probe] [--discover|--discover-daemons] [status|host|jvm|processes|network|storage|power|rules]")
+	fmt.Fprintln(w, "usage: spectra fan [--hosts host-a,host-b] [--probe] [--discover|--discover-daemons] [--discover-via auto|tailscale|nebula] [status|host|jvm|processes|network|storage|power|rules]")
 	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] inspect <App.app>")
 	fmt.Fprintln(w, "   or: spectra fan [--hosts host-a,host-b] call <method> [json-params]")
 }

--- a/cmd/spectra/hosts.go
+++ b/cmd/spectra/hosts.go
@@ -39,13 +39,18 @@ func runHostsWith(args []string, stdout io.Writer, stderr io.Writer, list hostLi
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "Emit JSON")
 	probeFlag := fs.Bool("probe", false, "Probe each known host and report reachability")
-	discoverFlag := fs.Bool("discover", false, "Merge tailscale peer discovery from `tailscale status --json`")
-	discoverDaemonsFlag := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from Tailscale peers")
+	discoverFlag := fs.Bool("discover", false, "Merge peer discovery from the --discover-via source")
+	discoverDaemonsFlag := fs.Bool("discover-daemons", false, "Discover reachable Spectra daemons from discovered peers")
+	discoverViaFlag := fs.String("discover-via", "auto", "Peer discovery source: auto (both), tailscale, or nebula")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: spectra hosts [--json] [--probe] [--discover|--discover-daemons]")
+		fmt.Fprintln(stderr, "usage: spectra hosts [--json] [--probe] [--discover|--discover-daemons] [--discover-via auto|tailscale|nebula]")
+		return 2
+	}
+	if err := selectDiscoverProvider(*discoverViaFlag); err != nil {
+		fmt.Fprintln(stderr, err)
 		return 2
 	}
 

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -136,6 +136,30 @@ spectra fan --discover status
 spectra fan --discover-daemons status
 ```
 
+### Discovery source
+
+`--discover` and `--discover-daemons` default to `--discover-via auto`, which
+attempts every source and merges the results: a Tailscale-only host, a
+Nebula-only host, and a host on both all discover cleanly, and a source that is
+absent (no `tailscale`, no Nebula certs) is skipped rather than treated as an
+error. Pass `--discover-via tailscale` or `--discover-via nebula` to force a
+single source.
+
+- **Tailscale** reads peers from `tailscale status --json`.
+- **Nebula** has no live peer list, so the source of truth is the signed host
+  certs: Spectra enumerates `~/.nebula` (override with `SPECTRA_NEBULA_CERTS`),
+  runs `nebula-cert print -json` on each `*.crt`, and returns their overlay IPs.
+  Because Nebula has no MagicDNS, discovery yields IPs rather than names.
+
+`--discover-daemons` then narrows the merged set to hosts actually running a
+Spectra daemon.
+
+```bash
+spectra hosts --discover                        # auto: Tailscale + Nebula
+spectra hosts --discover-daemons --discover-via nebula
+spectra fan --discover-via tailscale jvm
+```
+
 The client makes parallel RPC calls to each daemon and aggregates
 results locally into one JSON envelope. The remaining intended shape is:
 


### PR DESCRIPTION
## Summary

Adds a **Nebula** peer-discovery source to `spectra hosts` and `spectra fan`, so
remote debugging works over a Nebula overlay, not just Tailscale.

- `--discover` / `--discover-daemons` gain a `--discover-via auto|tailscale|nebula`
  selector. The default, **`auto`**, attempts every source and merges the
  results — plain `--discover` now finds peers whether the host is on Tailscale,
  a Nebula mesh, or both. A source that is absent (no `tailscale` binary, no
  Nebula certs on disk) is skipped rather than treated as an error; an error
  surfaces only when *every* source fails.
- Nebula has no live peer list, so `discoverNebulaPeers` uses the signed host
  certs as the source of truth: it enumerates `~/.nebula` (override with
  `SPECTRA_NEBULA_CERTS`), runs `nebula-cert print -json` on each `*.crt`, and
  returns the overlay IPs. `--discover-daemons` then narrows the merged set to
  hosts actually running a Spectra daemon.

Because Nebula has no MagicDNS, discovery yields overlay **IPs** rather than
names, and cert presence means *membership*, not *liveness* — which is exactly
why it pairs with `--discover-daemons`. Both trade-offs are documented in
`docs/operations/remote.md`.

Usage:

```bash
spectra hosts --discover                          # auto: Tailscale + Nebula
spectra hosts --discover-daemons --discover-via nebula
spectra fan --discover-via nebula jvm
```

## Type

- [x] New feature

## Testing

- [x] Added unit tests (`discover_nebula_test.go`: cert-dir discovery, CA/unreadable
      skipping, missing-dir error, provider selection, multi-source merge,
      single-source-failure tolerance, all-sources-fail error)
- [x] `go build ./...`, `go vet ./...`, `go test ./cmd/spectra/...` pass on top of current `main`
- [ ] Manually exercised end-to-end against a live Nebula mesh (not yet — no mesh stood up)

## Checklist

- [x] No new `go vet` warnings
- [x] `gofmt -s` clean
- [x] No new `gocyclo` violations (checked against the CI gate, `-over 15`)
- [x] No new `gosec` findings (`Issues: 0`)
- [x] `go mod tidy` is clean (no new dependencies)

## Reviewer notes

- The discovery seam is the existing package-level `fanDiscoverPeers` var;
  `selectDiscoverProvider` swaps it per invocation, matching the codebase's
  existing global-var injection pattern (`runTailscaleStatus`, `fanProbeTarget`).
- `runNebulaCertPrint` is the injectable seam for `nebula-cert`; tests never
  shell out.
- Supersedes #425, which was opened from a stale branch that duplicated work
  already on `main`. This PR is that branch's one genuinely new commit,
  cherry-picked cleanly onto current `main` (5 files, no conflicts).
