### PR TITLE
cli: spectra jvm heap-hprof — analyze and diff .hprof heap dumps from disk

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -92,6 +92,7 @@ func resolveJVMSubcommand(args []string) (func([]string) int, bool) {
 	handlers := map[string]func([]string) int{
 		"thread-dump":    runJVMThreadDump,
 		"heap-histogram": runJVMHeapHistogram,
+		"heap-hprof":     runJVMHeapHPROF,
 		"heap-dump":      runJVMHeapDump,
 		"jfr":            runJVMJFR,
 		"gc-stats":       runJVMGCStats,
@@ -304,12 +305,106 @@ func runJVMHeapHistogramCompare(args []string) int {
 	return 0
 }
 
+// runJVMHeapHPROF analyzes a saved binary .hprof heap dump: it ranks the
+// largest classes, or (with the "compare" subcommand) diffs two dumps to rank
+// growth suspects. This is the on-disk counterpart to heap-histogram.
+func runJVMHeapHPROF(args []string) int {
+	if len(args) > 0 && args[0] == "compare" {
+		return runJVMHeapHPROFCompare(args[1:])
+	}
+
+	fs := flag.NewFlagSet("spectra jvm heap-hprof", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit the parsed histogram and ranked suspects as JSON")
+	suspects := fs.Int("suspects", 20, "Number of largest classes (leak suspects) to rank")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm heap-hprof [--json] [--suspects N] <file.hprof>")
+		fmt.Fprintln(os.Stderr, "       spectra jvm heap-hprof compare [--json] [--suspects N] <before.hprof> <after.hprof>")
+		return 2
+	}
+	path := fs.Arg(0)
+	hist, err := heap.ParseHPROFFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parsing %q: %v\n", path, err)
+		return 1
+	}
+	limit := *suspects
+	if limit <= 0 {
+		limit = 20
+	}
+	ranked := heap.RankHistogramSuspects(hist, limit)
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(heapHistogramReport{Histogram: hist, Suspects: ranked})
+		return 0
+	}
+	printHeapSuspectsFor(os.Stdout, path, ranked, hist.Total)
+	return 0
+}
+
+// runJVMHeapHPROFCompare diffs two .hprof dumps and ranks the classes that grew
+// the most between them — the leak-suspect shortlist.
+func runJVMHeapHPROFCompare(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm heap-hprof compare", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit deltas and growth suspects as JSON")
+	limit := fs.Int("suspects", 20, "Number of growth suspects to rank")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm heap-hprof compare [--json] [--suspects N] <before.hprof> <after.hprof>")
+		return 2
+	}
+	before, err := heap.ParseHPROFFile(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parsing %q: %v\n", fs.Arg(0), err)
+		return 1
+	}
+	after, err := heap.ParseHPROFFile(fs.Arg(1))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parsing %q: %v\n", fs.Arg(1), err)
+		return 1
+	}
+	growth := heap.RankGrowthSuspects(before, after, *limit)
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(heapCompareReport{Deltas: heap.CompareHistograms(before, after), Growth: growth})
+		return 0
+	}
+	printGrowthSuspects(os.Stdout, growth)
+	return 0
+}
+
+// readHistogramFile parses a saved heap capture, auto-detecting a binary
+// `.hprof` dump (magic "JAVA PROFILE") versus a text `GC.class_histogram`. HPROF
+// is stream-parsed so a multi-GiB dump is not loaded whole into memory.
 func readHistogramFile(path string) (heap.Histogram, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return heap.Histogram{}, err
 	}
-	return heap.ParseHistogram(string(data))
+	defer f.Close()
+
+	const magic = "JAVA PROFILE"
+	head := make([]byte, len(magic))
+	n, _ := io.ReadFull(f, head)
+	if string(head[:n]) == magic {
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return heap.Histogram{}, err
+		}
+		return heap.ParseHPROF(f)
+	}
+	rest, err := io.ReadAll(f)
+	if err != nil {
+		return heap.Histogram{}, err
+	}
+	return heap.ParseHistogram(string(head[:n]) + string(rest))
 }
 
 // heapHistogramReport is the JSON shape emitted by `heap-histogram --json`.
@@ -325,7 +420,13 @@ type heapCompareReport struct {
 }
 
 func printHeapSuspects(w io.Writer, pid int, suspects []heap.Suspect, total heap.ClassEntry) {
-	fmt.Fprintf(w, "Heap histogram for PID %d — %d classes, %d bytes total live\n", pid, total.Instances, total.Bytes)
+	printHeapSuspectsFor(w, fmt.Sprintf("PID %d", pid), suspects, total)
+}
+
+// printHeapSuspectsFor renders the largest-classes table for any histogram
+// source label (a live PID or an .hprof file path).
+func printHeapSuspectsFor(w io.Writer, source string, suspects []heap.Suspect, total heap.ClassEntry) {
+	fmt.Fprintf(w, "Heap histogram for %s — %d instances, %d bytes total live\n", source, total.Instances, total.Bytes)
 	fmt.Fprintf(w, "Top %d largest classes:\n", len(suspects))
 	for i, s := range suspects {
 		fmt.Fprintf(w, "  %2d. %-50s %12d bytes  %10d instances\n", i+1, s.ClassName, s.Bytes, s.Instances)

--- a/cmd/spectra/jvm_heap_hprof_test.go
+++ b/cmd/spectra/jvm_heap_hprof_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/heap"
+)
+
+// writeHPROF writes a minimal but spec-valid 8-byte-id .hprof containing
+// `count` instances of com.acme.Widget (24 bytes each) and returns its path.
+func writeHPROF(t *testing.T, name string, count int) string {
+	t.Helper()
+	var buf bytes.Buffer
+	buf.WriteString("JAVA PROFILE 1.0.2")
+	buf.WriteByte(0)
+	be := func(v any) { _ = binary.Write(&buf, binary.BigEndian, v) }
+	be(uint32(8)) // id size
+	be(uint64(0)) // timestamp
+
+	record := func(tag byte, body []byte) {
+		buf.WriteByte(tag)
+		be(uint32(0))
+		be(uint32(len(body)))
+		buf.Write(body)
+	}
+
+	// STRING id=1 "com/acme/Widget"
+	var s bytes.Buffer
+	_ = binary.Write(&s, binary.BigEndian, uint64(1))
+	s.WriteString("com/acme/Widget")
+	record(0x01, s.Bytes())
+
+	// LOAD_CLASS serial=1 classId=7 nameId=1
+	var lc bytes.Buffer
+	_ = binary.Write(&lc, binary.BigEndian, uint32(1))
+	_ = binary.Write(&lc, binary.BigEndian, uint64(7))
+	_ = binary.Write(&lc, binary.BigEndian, uint32(0))
+	_ = binary.Write(&lc, binary.BigEndian, uint64(1))
+	record(0x02, lc.Bytes())
+
+	// HEAP DUMP SEGMENT: CLASS_DUMP(classId=7, instSize=24) + count instances.
+	var seg bytes.Buffer
+	seg.WriteByte(0x20)
+	_ = binary.Write(&seg, binary.BigEndian, uint64(7)) // class obj id
+	_ = binary.Write(&seg, binary.BigEndian, uint32(0)) // stack serial
+	for i := 0; i < 6; i++ {
+		_ = binary.Write(&seg, binary.BigEndian, uint64(0)) // super/loader/... reserved
+	}
+	_ = binary.Write(&seg, binary.BigEndian, uint32(24)) // instance size
+	_ = binary.Write(&seg, binary.BigEndian, uint16(0))  // const pool
+	_ = binary.Write(&seg, binary.BigEndian, uint16(0))  // static fields
+	_ = binary.Write(&seg, binary.BigEndian, uint16(0))  // instance fields
+	for i := 0; i < count; i++ {
+		seg.WriteByte(0x21)
+		_ = binary.Write(&seg, binary.BigEndian, uint64(1000+i)) // obj id
+		_ = binary.Write(&seg, binary.BigEndian, uint32(0))      // stack serial
+		_ = binary.Write(&seg, binary.BigEndian, uint64(7))      // class id
+		_ = binary.Write(&seg, binary.BigEndian, uint32(0))      // nbytes following
+	}
+	record(0x1C, seg.Bytes())
+	record(0x2C, nil) // heap dump end
+
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+func TestReadHistogramFileAutoDetectsHPROF(t *testing.T) {
+	hist, err := readHistogramFile(writeHPROF(t, "dump.hprof", 5))
+	if err != nil {
+		t.Fatalf("readHistogramFile: %v", err)
+	}
+	var widget heap.ClassEntry
+	for _, e := range hist.Entries {
+		if e.ClassName == "com.acme.Widget" {
+			widget = e
+		}
+	}
+	if widget.Instances != 5 || widget.Bytes != 120 {
+		t.Fatalf("Widget = %+v, want 5 instances / 120 bytes", widget)
+	}
+}
+
+func TestHeapHPROFCompareRanksGrowth(t *testing.T) {
+	before, err := heap.ParseHPROFFile(writeHPROF(t, "before.hprof", 5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := heap.ParseHPROFFile(writeHPROF(t, "after.hprof", 105))
+	if err != nil {
+		t.Fatal(err)
+	}
+	growth := heap.RankGrowthSuspects(before, after, 10)
+	if len(growth) == 0 || growth[0].ClassName != "com.acme.Widget" {
+		t.Fatalf("top growth suspect = %+v, want com.acme.Widget", growth)
+	}
+	if growth[0].DeltaCount != 100 {
+		t.Fatalf("delta count = %d, want 100", growth[0].DeltaCount)
+	}
+
+	var buf bytes.Buffer
+	printHeapSuspectsFor(&buf, "after.hprof", heap.RankHistogramSuspects(after, 5), after.Total)
+	if !strings.Contains(buf.String(), "after.hprof") || !strings.Contains(buf.String(), "largest classes") {
+		t.Fatalf("render missing header:\n%s", buf.String())
+	}
+}

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -37,6 +37,8 @@ spectra jvm explain [--samples 1] [--interval 1s] <pid>
 spectra jvm thread-dump [--json] [--summary] <pid>
 spectra jvm heap-histogram [--json] [--suspects N] <pid>
 spectra jvm heap-histogram compare [--json] [--suspects N] <before-file> <after-file>
+spectra jvm heap-hprof [--json] [--suspects N] <file.hprof>
+spectra jvm heap-hprof compare [--json] [--suspects N] <before.hprof> <after.hprof>
 spectra jvm heap-dump [--out <path>] <pid>
 spectra jvm gc-stats [--json] <pid>
 spectra jvm vm-memory [--json] <pid>
@@ -55,6 +57,12 @@ spectra jvm jfr summary [--json] <recording.jfr>
 spectra jvm jfr view [--json] <view> <recording.jfr>
 spectra jvm jfr analyze [--json] [--view <name>]... <recording.jfr>
 ```
+
+`heap-hprof` reads binary `.hprof` dumps (`jcmd GC.heap_dump` / `jmap -dump`)
+into the same class histogram the live `heap-histogram` produces, so a dump can
+be ranked for its largest classes or diffed against another dump to shortlist
+leak suspects. `heap-histogram compare` auto-detects its inputs, so each file may
+be a text `GC.class_histogram` capture or a binary `.hprof`.
 
 Daemon methods:
 


### PR DESCRIPTION
Closes #439.

## What

Stage A (#437) added a binary `.hprof` parser to `internal/heap`, but it was only reachable from Go — no way to point spectra at a heap dump on disk. This makes it usable:

- **`spectra jvm heap-hprof [--json] [--suspects N] <file.hprof>`** — parse a dump and rank its largest classes (the common MAT question).
- **`spectra jvm heap-hprof compare [--json] [--suspects N] <a.hprof> <b.hprof>`** — diff two dumps and rank growth suspects (the leak shortlist).
- **`readHistogramFile` now auto-detects** the HPROF magic (`JAVA PROFILE`) and stream-parses it, so `jvm heap-histogram compare` transparently accepts a text `GC.class_histogram` capture, a binary `.hprof`, or a mix — without loading a whole dump into memory.

Reuses the existing `RankHistogramSuspects` / `RankGrowthSuspects` / `CompareHistograms` and report/printer helpers (`printHeapSuspects` refactored to a source-labeled variant).

## Tests

`jvm_heap_hprof_test.go` builds minimal spec-valid hprof fixtures and asserts auto-detection through `readHistogramFile`, dump-vs-dump growth ranking, and the rendered output. Docs updated with the new subcommands and the auto-detect note.

## Scope

Local-file analysis, so CLI-only (like `heap-histogram compare`) — no RPC/MCP surfacing. Dominator tree / retained sizes / paths-to-GC-roots remain Stage B/C.