### PR TITLE
jvm: parse -Xlog:gc* unified GC logs into a pause summary (spectra jvm gc-log)

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kaeawc/spectra/internal/artifact"
 	"github.com/kaeawc/spectra/internal/cache"
 	"github.com/kaeawc/spectra/internal/diag"
+	"github.com/kaeawc/spectra/internal/gclog"
 	"github.com/kaeawc/spectra/internal/heap"
 	"github.com/kaeawc/spectra/internal/jvm"
 	"github.com/kaeawc/spectra/internal/toolchain"
@@ -94,6 +95,7 @@ func resolveJVMSubcommand(args []string) (func([]string) int, bool) {
 		"heap-histogram": runJVMHeapHistogram,
 		"heap-hprof":     runJVMHeapHPROF,
 		"heap-dump":      runJVMHeapDump,
+		"gc-log":         runJVMGCLog,
 		"jfr":            runJVMJFR,
 		"gc-stats":       runJVMGCStats,
 		"vm-memory":      runJVMVMMemory,
@@ -303,6 +305,65 @@ func runJVMHeapHistogramCompare(args []string) int {
 	}
 	printGrowthSuspects(os.Stdout, growth)
 	return 0
+}
+
+// runJVMGCLog parses a JDK unified-logging (`-Xlog:gc*`) GC log file and prints
+// an aggregate pause summary — the per-pause view jstat counters cannot give.
+func runJVMGCLog(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm gc-log", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit the parsed GC pause summary as JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm gc-log [--json] <file>")
+		return 2
+	}
+	summary, err := gclog.ParseFile(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading %q: %v\n", fs.Arg(0), err)
+		return 1
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(summary)
+		return 0
+	}
+	printGCLogSummary(os.Stdout, fs.Arg(0), summary)
+	return 0
+}
+
+func printGCLogSummary(w io.Writer, source string, s gclog.Summary) {
+	fmt.Fprintf(w, "GC log %s — %d pauses, %.1fms total, %.1fms max, %.2fms avg\n",
+		source, s.Pauses, s.TotalPauseMs, s.MaxPauseMs, s.AvgPauseMs)
+	fmt.Fprintf(w, "  Young/Mixed: %d   Full: %d   System.gc(): %d   evacuation failures: %d\n",
+		s.YoungGCCount, s.FullGCCount, s.SystemGCCount, s.EvacuationFailures)
+	if s.LongestPause != nil {
+		p := s.LongestPause
+		fmt.Fprintf(w, "  Longest: GC(%d) Pause %s %s %.3fms\n", p.ID, p.Kind, p.Cause, p.PauseMs)
+	}
+	if len(s.Causes) > 0 {
+		type causeCount struct {
+			cause string
+			n     int
+		}
+		list := make([]causeCount, 0, len(s.Causes))
+		for c, n := range s.Causes {
+			list = append(list, causeCount{c, n})
+		}
+		sort.Slice(list, func(i, j int) bool {
+			if list[i].n != list[j].n {
+				return list[i].n > list[j].n
+			}
+			return list[i].cause < list[j].cause
+		})
+		fmt.Fprintln(w, "  Causes:")
+		for _, c := range list {
+			fmt.Fprintf(w, "    %4d  %s\n", c.n, c.cause)
+		}
+	}
 }
 
 // runJVMHeapHPROF analyzes a saved binary .hprof heap dump: it ranks the

--- a/cmd/spectra/jvm_gclog_test.go
+++ b/cmd/spectra/jvm_gclog_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/gclog"
+)
+
+func TestGCLogSummaryRenders(t *testing.T) {
+	log := "[0.1s][info][gc] GC(0) Pause Young (G1 Evacuation Pause) 25M->5M(256M) 4.0ms\n" +
+		"[1.0s][info][gc] GC(1) Pause Full (System.gc()) 100M->40M(256M) 45.0ms\n"
+	p := filepath.Join(t.TempDir(), "gc.log")
+	if err := os.WriteFile(p, []byte(log), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	summary, err := gclog.ParseFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Pauses != 2 || summary.FullGCCount != 1 {
+		t.Fatalf("summary = %+v", summary)
+	}
+	var buf bytes.Buffer
+	printGCLogSummary(&buf, p, summary)
+	out := buf.String()
+	if !strings.Contains(out, "2 pauses") || !strings.Contains(out, "Longest: GC(1) Pause Full") {
+		t.Fatalf("render:\n%s", out)
+	}
+	if !strings.Contains(out, "Causes:") {
+		t.Fatalf("missing causes section:\n%s", out)
+	}
+}

--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -41,6 +41,7 @@ spectra jvm heap-hprof [--json] [--suspects N] <file.hprof>
 spectra jvm heap-hprof compare [--json] [--suspects N] <before.hprof> <after.hprof>
 spectra jvm heap-dump [--out <path>] <pid>
 spectra jvm gc-stats [--json] <pid>
+spectra jvm gc-log [--json] <file>
 spectra jvm vm-memory [--json] <pid>
 spectra jvm jmx status [--json] <pid>
 spectra jvm jmx start-local [--json] <pid>
@@ -57,6 +58,12 @@ spectra jvm jfr summary [--json] <recording.jfr>
 spectra jvm jfr view [--json] <view> <recording.jfr>
 spectra jvm jfr analyze [--json] [--view <name>]... <recording.jfr>
 ```
+
+`gc-log` parses a JDK unified-logging (`-Xlog:gc*`) GC log file into an aggregate
+pause summary — pause count, total/max/avg pause, Full vs young/mixed counts,
+`System.gc()` calls, evacuation failures, and the longest pause — the per-pause
+view the jstat-counter GC-pressure rule cannot provide. ZGC/Shenandoah
+concurrent-cycle formats and the legacy pre-JDK9 log format are out of scope.
 
 `heap-hprof` reads binary `.hprof` dumps (`jcmd GC.heap_dump` / `jmap -dump`)
 into the same class histogram the live `heap-histogram` produces, so a dump can

--- a/internal/gclog/gclog.go
+++ b/internal/gclog/gclog.go
@@ -1,0 +1,168 @@
+// Package gclog parses JDK unified-logging garbage-collection output
+// (`-Xlog:gc` and the `[gc]` summary lines of `-Xlog:gc*`) into per-pause
+// records and an aggregate summary. It is the authoritative per-pause view the
+// jstat-counter GC-pressure rule cannot provide.
+//
+// Scope: G1/Parallel/Serial "Pause ..." lines. ZGC/Shenandoah concurrent-cycle
+// formats and the legacy pre-JDK9 -XX:+PrintGCDetails format are out of scope.
+package gclog
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Pause is one stop-the-world GC pause parsed from a log line.
+type Pause struct {
+	ID       int     `json:"id"`
+	Kind     string  `json:"kind"`  // Young, Full, Mixed, Remark, Cleanup, Other
+	Cause    string  `json:"cause"` // e.g. "(G1 Evacuation Pause)", "(System.gc())"
+	PauseMs  float64 `json:"pause_ms"`
+	BeforeMB int64   `json:"before_mb"`
+	AfterMB  int64   `json:"after_mb"`
+	HeapMB   int64   `json:"heap_mb"`
+}
+
+// Summary aggregates all pauses in a log.
+type Summary struct {
+	Pauses             int            `json:"pauses"`
+	TotalPauseMs       float64        `json:"total_pause_ms"`
+	MaxPauseMs         float64        `json:"max_pause_ms"`
+	AvgPauseMs         float64        `json:"avg_pause_ms"`
+	FullGCCount        int            `json:"full_gc_count"`
+	YoungGCCount       int            `json:"young_gc_count"`
+	SystemGCCount      int            `json:"system_gc_count"`
+	EvacuationFailures int            `json:"evacuation_failures"`
+	Causes             map[string]int `json:"causes"`
+	LongestPause       *Pause         `json:"longest_pause,omitempty"`
+}
+
+var (
+	// idKindRe captures the GC id and pause kind: "GC(12) Pause Young".
+	idKindRe = regexp.MustCompile(`GC\((\d+)\)\s+Pause\s+([A-Za-z]+)`)
+	// durationRe captures a duration in ms; the LAST match on a line is the
+	// total pause (sub-phase times, if any, precede it).
+	durationRe = regexp.MustCompile(`([0-9]+(?:\.[0-9]+)?)ms`)
+	// heapRe captures "25M->5M(256M)" with K/M/G/B units.
+	heapRe = regexp.MustCompile(`(\d+)([BKMG])->(\d+)([BKMG])\((\d+)([BKMG])\)`)
+)
+
+// ParseFile parses the GC log at path.
+func ParseFile(path string) (Summary, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Summary{}, err
+	}
+	defer f.Close()
+	return Parse(f), nil
+}
+
+// Parse reads unified GC-log text and returns an aggregate Summary. It never
+// errors; unrecognized lines are ignored.
+func Parse(r io.Reader) Summary {
+	s := Summary{Causes: map[string]int{}}
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		line := sc.Text()
+		p, ok := parsePause(line)
+		if !ok {
+			continue
+		}
+		accumulate(&s, p, line)
+	}
+	if s.Pauses > 0 {
+		s.AvgPauseMs = s.TotalPauseMs / float64(s.Pauses)
+	}
+	return s
+}
+
+func accumulate(s *Summary, p Pause, raw string) {
+	s.Pauses++
+	s.TotalPauseMs += p.PauseMs
+	if p.PauseMs > s.MaxPauseMs {
+		s.MaxPauseMs = p.PauseMs
+		lp := p
+		s.LongestPause = &lp
+	}
+	switch p.Kind {
+	case "Full":
+		s.FullGCCount++
+	case "Young", "Mixed":
+		s.YoungGCCount++
+	}
+	if p.Cause != "" {
+		s.Causes[p.Cause]++
+	}
+	if strings.Contains(p.Cause, "System.gc") {
+		s.SystemGCCount++
+	}
+	if strings.Contains(raw, "Evacuation Failure") || strings.Contains(raw, "to-space exhausted") {
+		s.EvacuationFailures++
+	}
+}
+
+func parsePause(line string) (Pause, bool) {
+	m := idKindRe.FindStringSubmatchIndex(line)
+	if m == nil {
+		return Pause{}, false
+	}
+	id, _ := strconv.Atoi(line[m[2]:m[3]])
+	kindWord := line[m[4]:m[5]]
+
+	dur := durationRe.FindAllStringSubmatch(line, -1)
+	if len(dur) == 0 {
+		return Pause{}, false // a "Pause" line with no duration isn't a completed pause
+	}
+	pauseMs, err := strconv.ParseFloat(dur[len(dur)-1][1], 64)
+	if err != nil {
+		return Pause{}, false
+	}
+
+	p := Pause{ID: id, Kind: normalizeKind(kindWord), PauseMs: pauseMs}
+
+	heapStart := len(line)
+	if h := heapRe.FindStringSubmatchIndex(line); h != nil {
+		heapStart = h[0]
+		p.BeforeMB = toMB(line[h[2]:h[3]], line[h[4]:h[5]])
+		p.AfterMB = toMB(line[h[6]:h[7]], line[h[8]:h[9]])
+		p.HeapMB = toMB(line[h[10]:h[11]], line[h[12]:h[13]])
+	}
+	// Cause is the text between the kind word and the heap/duration region.
+	if m[5] < heapStart {
+		p.Cause = strings.TrimSpace(line[m[5]:heapStart])
+	}
+	return p, true
+}
+
+func normalizeKind(word string) string {
+	switch word {
+	case "Young", "Full", "Mixed", "Remark", "Cleanup":
+		return word
+	default:
+		return "Other"
+	}
+}
+
+func toMB(numStr, unit string) int64 {
+	n, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	switch unit {
+	case "B":
+		return n / (1024 * 1024)
+	case "K":
+		return n / 1024
+	case "M":
+		return n
+	case "G":
+		return n * 1024
+	default:
+		return n
+	}
+}

--- a/internal/gclog/gclog_test.go
+++ b/internal/gclog/gclog_test.go
@@ -1,0 +1,79 @@
+package gclog
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+const sampleLog = `[0.100s][info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 25M->5M(256M) 4.123ms
+[0.050s][info][gc,start] GC(0) Pause Young (Normal)
+[0.100s][info][gc,phases] GC(0)   Evacuate Collection Set: 3.0ms
+[0.200s][info][gc] GC(1) Pause Young (Concurrent Start) (G1 Humongous Allocation) 60M->30M(256M) 6.500ms
+[1.000s][info][gc] GC(2) Pause Full (System.gc()) 100M->40M(256M) 45.678ms
+[2.000s][info][gc] GC(3) Pause Young (Allocation Failure) 200M->190M(256M) 12.000ms to-space exhausted
+random unrelated line
+`
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 0.001 }
+
+func TestParseGCLog(t *testing.T) {
+	s := Parse(strings.NewReader(sampleLog))
+	if s.Pauses != 4 {
+		t.Fatalf("pauses = %d, want 4", s.Pauses)
+	}
+	if s.YoungGCCount != 3 || s.FullGCCount != 1 {
+		t.Errorf("young/full = %d/%d, want 3/1", s.YoungGCCount, s.FullGCCount)
+	}
+	if s.SystemGCCount != 1 {
+		t.Errorf("system.gc count = %d, want 1", s.SystemGCCount)
+	}
+	if s.EvacuationFailures != 1 {
+		t.Errorf("evacuation failures = %d, want 1", s.EvacuationFailures)
+	}
+	if !approx(s.TotalPauseMs, 68.301) {
+		t.Errorf("total pause = %v, want ~68.301", s.TotalPauseMs)
+	}
+	if !approx(s.MaxPauseMs, 45.678) {
+		t.Errorf("max pause = %v, want 45.678", s.MaxPauseMs)
+	}
+	if !approx(s.AvgPauseMs, 68.301/4) {
+		t.Errorf("avg pause = %v", s.AvgPauseMs)
+	}
+	if s.LongestPause == nil || s.LongestPause.Kind != "Full" || s.LongestPause.ID != 2 {
+		t.Errorf("longest pause = %+v, want the Full GC(2)", s.LongestPause)
+	}
+	if s.Causes["(System.gc())"] != 1 {
+		t.Errorf("causes = %+v, want a System.gc() entry", s.Causes)
+	}
+}
+
+func TestParsePauseDetail(t *testing.T) {
+	s := Parse(strings.NewReader("[info][gc] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 25M->5M(256M) 4.123ms\n"))
+	if s.LongestPause == nil {
+		t.Fatal("expected a pause")
+	}
+	p := *s.LongestPause
+	if p.BeforeMB != 25 || p.AfterMB != 5 || p.HeapMB != 256 {
+		t.Errorf("heap transition = %d->%d(%d), want 25->5(256)", p.BeforeMB, p.AfterMB, p.HeapMB)
+	}
+	if p.Cause != "(Normal) (G1 Evacuation Pause)" {
+		t.Errorf("cause = %q", p.Cause)
+	}
+}
+
+func TestParseHeapUnits(t *testing.T) {
+	// Gigabyte and kilobyte units normalize to MiB.
+	s := Parse(strings.NewReader("[info][gc] GC(0) Pause Full (System.gc()) 2G->512M(4G) 100.0ms\n"))
+	p := s.LongestPause
+	if p == nil || p.BeforeMB != 2048 || p.HeapMB != 4096 {
+		t.Fatalf("unit conversion = %+v, want before 2048 / heap 4096", p)
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	s := Parse(strings.NewReader("no gc lines here\n"))
+	if s.Pauses != 0 || s.LongestPause != nil || s.AvgPauseMs != 0 {
+		t.Fatalf("empty log summary = %+v", s)
+	}
+}


### PR DESCRIPTION
Closes #441.

## What

GC-log handling was **entirely absent** — `jvm-gc-pressure` reasons only from cumulative `jstat` FGC/FGCT counters, with no per-pause, per-cause, or pause-distribution view.

- **`internal/gclog`** — `Parse(io.Reader)` / `ParseFile(path)` parse JDK unified-logging `Pause ...` lines (G1/Parallel/Serial) into per-pause records and an aggregate `Summary`: pause count, total/max/avg pause ms, Full vs young/mixed counts, `System.gc()` calls, evacuation failures, a causes histogram, and the longest pause. Lenient — non-pause and concurrent-phase lines are ignored.
- **`spectra jvm gc-log [--json] <file>`** prints the summary, on-demand like `jvm jfr summary` / `jvm heap-hprof` (GC logs can be large, so this is deliberately not an every-snapshot collector).

## Tests

Parser over a mixed fixture (young + full pauses, `System.gc()`, `to-space exhausted`, K/M/G size units, and lines that must be ignored) asserting all aggregates and the longest pause; plus a CLI renderer test. Docs updated with the subcommand and a capability note.

## Scope

G1/Parallel/Serial `Pause` lines. ZGC/Shenandoah concurrent-cycle formats and the legacy pre-JDK9 `-XX:+PrintGCDetails` format are documented out of scope. A snapshot rule / GC-log auto-discovery is a possible follow-up.