### PR TITLE
jvm: parse NMT (VM.native_memory summary) into categories for native-memory attribution

### DIFF
--- a/docs/inspection/jvm.md
+++ b/docs/inspection/jvm.md
@@ -207,8 +207,9 @@ can be used for non-CPU profiles.
   native memory tracking, and soft-reference policy;
 - code-cache use, including nmethod/adaptor counts and `full_count`;
 - soft-reference evidence from the class histogram;
-- native-memory availability, including why fragmentation cannot be judged
-  when NMT is off;
+- native-memory attribution: when NMT is enabled, the summary is parsed into
+  categories and the largest committed ones (Java Heap, Class, Thread, Code, GC,
+  Internal) are reported; when NMT is off, why fragmentation cannot be judged;
 - optional repeated `jstat` samples via `--samples` and `--interval` for
   short-window old-gen/metaspace/full-GC trends.
 

--- a/internal/jvm/explain.go
+++ b/internal/jvm/explain.go
@@ -239,11 +239,40 @@ func explainMemorySections(e *Explanation, mem explainMemory) {
 			Recommendation: "Reproduce with `-XX:NativeMemoryTracking=summary` for category growth, or `detail` when fragmentation/location matters.",
 		})
 	} else if mem.NativeMemory.Output != "" {
-		e.Observations = append(e.Observations, Observation{
+		e.Observations = append(e.Observations, nativeMemoryObservation(mem.NativeMemory.Output))
+	}
+}
+
+// nativeMemoryObservation parses the NMT summary and reports total committed
+// native memory plus the largest categories, so a JVM whose RSS exceeds its heap
+// (see the jvm-rss-exceeds-heap rule) can be localized to Thread stacks, Class
+// metadata, Code cache, GC structures, or Internal/Other (direct buffers, JNI).
+func nativeMemoryObservation(output string) Observation {
+	nmt := ParseNMTSummary(output)
+	if len(nmt.Categories) == 0 {
+		return Observation{
 			ID:       "native-memory-available",
 			Severity: "info",
 			Summary:  "Native memory tracking output is available for category analysis.",
-		})
+		}
+	}
+	top := nmt.Categories
+	if len(top) > 5 {
+		top = top[:5]
+	}
+	var b strings.Builder
+	for i, c := range top {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%s %dMiB", c.Name, c.CommittedKiB/1024)
+	}
+	return Observation{
+		ID:             "native-memory-available",
+		Severity:       "info",
+		Summary:        fmt.Sprintf("Native memory committed %dMiB across %d categories.", nmt.TotalCommittedKiB/1024, len(nmt.Categories)),
+		Evidence:       "Top by committed size: " + b.String(),
+		Recommendation: "Compare category growth across two summaries to localize a native leak: Thread = stacks, Class = metaspace/classloaders, Code = JIT, Internal/Other = direct buffers & JNI.",
 	}
 }
 

--- a/internal/jvm/nmt.go
+++ b/internal/jvm/nmt.go
@@ -1,0 +1,62 @@
+package jvm
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// NMTCategory is one Native Memory Tracking category (Java Heap, Class, Thread,
+// Code, GC, Internal, …) with its reserved and committed sizes.
+type NMTCategory struct {
+	Name         string `json:"name"`
+	ReservedKiB  int64  `json:"reserved_kib"`
+	CommittedKiB int64  `json:"committed_kib"`
+}
+
+// NMTBreakdown is the parsed result of `jcmd VM.native_memory summary`.
+type NMTBreakdown struct {
+	Enabled           bool          `json:"enabled"`
+	TotalReservedKiB  int64         `json:"total_reserved_kib"`
+	TotalCommittedKiB int64         `json:"total_committed_kib"`
+	Categories        []NMTCategory `json:"categories,omitempty"`
+}
+
+var (
+	nmtTotalRe    = regexp.MustCompile(`Total: reserved=(\d+)KB, committed=(\d+)KB`)
+	nmtCategoryRe = regexp.MustCompile(`(?m)^-\s+(.+?)\s+\(reserved=(\d+)KB, committed=(\d+)KB\)`)
+)
+
+// ParseNMTSummary parses `VM.native_memory summary` output into a structured
+// breakdown, categories sorted by committed size (largest first). When NMT is
+// disabled or the output is empty, Enabled is false and there are no categories.
+func ParseNMTSummary(output string) NMTBreakdown {
+	if output == "" || strings.Contains(strings.ToLower(output), "not enabled") {
+		return NMTBreakdown{Enabled: false}
+	}
+	b := NMTBreakdown{Enabled: true}
+	if m := nmtTotalRe.FindStringSubmatch(output); m != nil {
+		b.TotalReservedKiB = atoi64(m[1])
+		b.TotalCommittedKiB = atoi64(m[2])
+	}
+	for _, m := range nmtCategoryRe.FindAllStringSubmatch(output, -1) {
+		b.Categories = append(b.Categories, NMTCategory{
+			Name:         strings.TrimSpace(m[1]),
+			ReservedKiB:  atoi64(m[2]),
+			CommittedKiB: atoi64(m[3]),
+		})
+	}
+	sort.SliceStable(b.Categories, func(i, j int) bool {
+		return b.Categories[i].CommittedKiB > b.Categories[j].CommittedKiB
+	})
+	return b
+}
+
+func atoi64(s string) int64 {
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/jvm/nmt_test.go
+++ b/internal/jvm/nmt_test.go
@@ -1,0 +1,87 @@
+package jvm
+
+import (
+	"strings"
+	"testing"
+)
+
+const nmtSample = `Native Memory Tracking:
+
+Total: reserved=6685554KB, committed=397490KB
+
+-                 Java Heap (reserved=4194304KB, committed=262144KB)
+                            (mmap: reserved=4194304KB, committed=262144KB)
+
+-                     Class (reserved=1048576KB, committed=81920KB)
+                            (classes #12345)
+
+-                    Thread (reserved=52428KB, committed=52428KB)
+                            (thread #51)
+
+-                      Code (reserved=249936KB, committed=45000KB)
+
+-                        GC (reserved=204800KB, committed=30000KB)
+
+-                  Internal (reserved=1024KB, committed=1024KB)
+`
+
+func TestParseNMTSummary(t *testing.T) {
+	b := ParseNMTSummary(nmtSample)
+	if !b.Enabled {
+		t.Fatal("expected Enabled")
+	}
+	if b.TotalReservedKiB != 6685554 || b.TotalCommittedKiB != 397490 {
+		t.Fatalf("totals = %d/%d", b.TotalReservedKiB, b.TotalCommittedKiB)
+	}
+	if len(b.Categories) != 6 {
+		t.Fatalf("categories = %d, want 6: %+v", len(b.Categories), b.Categories)
+	}
+	// Sorted by committed size, largest first.
+	if b.Categories[0].Name != "Java Heap" || b.Categories[0].CommittedKiB != 262144 {
+		t.Errorf("top category = %+v, want Java Heap 262144", b.Categories[0])
+	}
+	if b.Categories[1].Name != "Class" || b.Categories[1].CommittedKiB != 81920 {
+		t.Errorf("second = %+v, want Class 81920", b.Categories[1])
+	}
+	last := b.Categories[len(b.Categories)-1]
+	if last.Name != "Internal" || last.CommittedKiB != 1024 {
+		t.Errorf("last = %+v, want Internal 1024", last)
+	}
+	// Reserved is captured too.
+	if b.Categories[0].ReservedKiB != 4194304 {
+		t.Errorf("Java Heap reserved = %d, want 4194304", b.Categories[0].ReservedKiB)
+	}
+}
+
+func TestNativeMemoryObservationReportsCategories(t *testing.T) {
+	obs := nativeMemoryObservation(nmtSample)
+	if obs.ID != "native-memory-available" {
+		t.Fatalf("id = %q", obs.ID)
+	}
+	if !strings.Contains(obs.Summary, "committed 388MiB") {
+		t.Errorf("summary = %q, want total committed ~388MiB (397490KiB)", obs.Summary)
+	}
+	if !strings.Contains(obs.Evidence, "Java Heap 256MiB") {
+		t.Errorf("evidence should list top category: %q", obs.Evidence)
+	}
+	if obs.Recommendation == "" {
+		t.Error("expected remediation guidance")
+	}
+}
+
+func TestNativeMemoryObservationFallback(t *testing.T) {
+	// Output present but unparseable into categories -> generic observation.
+	obs := nativeMemoryObservation("Native Memory Tracking:\n(some unrecognized shape)\n")
+	if obs.Evidence != "" {
+		t.Fatalf("expected generic fallback observation, got %+v", obs)
+	}
+}
+
+func TestParseNMTSummaryDisabled(t *testing.T) {
+	for _, in := range []string{"", "Native memory tracking is not enabled\n"} {
+		b := ParseNMTSummary(in)
+		if b.Enabled || len(b.Categories) != 0 {
+			t.Fatalf("ParseNMTSummary(%q) = %+v, want disabled/empty", in, b)
+		}
+	}
+}


### PR DESCRIPTION
Closes #443.

## What

Spectra ran `jcmd VM.native_memory summary` (NMT) and kept the raw text but **never parsed it** — the `explain` `native-memory-available` observation only said "output is available". This is the other half of the off-heap story: `jvm-rss-exceeds-heap` (#431) says *"memory isn't in the heap — look at native"*, and NMT categories say **which** native.

- **`ParseNMTSummary(output) NMTBreakdown`** — parses the `Total: reserved=…KB, committed=…KB` line and each `- <Category> (reserved=…KB, committed=…KB)`, returning categories sorted by committed size; `Enabled=false` when NMT is off/empty.
- **Enriched observation** — reports total committed native memory and the top categories (Java Heap / Class / Thread / Code / GC / Internal), with guidance mapping each to a cause (Thread = stacks, Class = metaspace/classloaders, Internal/Other = direct buffers & JNI).

## Tests

`ParseNMTSummary` over a representative summary (totals, per-category reserved/committed, sort order) + the disabled/empty case; the enriched observation's summary/evidence/guidance; and the unparseable-output fallback. Docs explain section updated.

## Scope

NMT `detail` (per-callsite) and two-summary diffing are out of scope (possible follow-up, complementary to heap-histogram compare).