### PR TITLE
malloc-history: spectra malloc-history — attribute allocations to call stacks (MallocStackLogging)

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -74,6 +74,7 @@ func subcommandList() []subcommand {
 		{"spindump", "Capture and summarize a per-thread stack report (heaviest stacks)", runSpindump},
 		{"vmmap", "Summarize a process's memory composition by region (dirty/resident/swapped)", runVmmap},
 		{"lsmp", "Summarize a process's Mach port table (right counts, leak detection)", runLsmp},
+		{"malloc-history", "Attribute allocations to call stacks (requires MallocStackLogging)", runMallocHistory},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/cmd/spectra/malloc_history.go
+++ b/cmd/spectra/malloc_history.go
@@ -62,12 +62,15 @@ func runMallocHistoryWithIO(args []string, stdout, stderr io.Writer, runner mall
 		return 2
 	}
 
+	// malloc_history takes the pid first, then the mode/address:
+	//   malloc_history <pid> -allBySize
+	//   malloc_history <pid> <address>
 	name := mallocHistoryBin
-	var cmdArgs []string
+	cmdArgs := []string{strconv.Itoa(pid)}
 	if *address != "" {
-		cmdArgs = []string{strconv.Itoa(pid), *address}
+		cmdArgs = append(cmdArgs, *address)
 	} else {
-		cmdArgs = []string{"-allBySize", strconv.Itoa(pid)}
+		cmdArgs = append(cmdArgs, "-allBySize")
 	}
 	if *sudo {
 		cmdArgs = append([]string{name}, cmdArgs...)

--- a/cmd/spectra/malloc_history.go
+++ b/cmd/spectra/malloc_history.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/mallochistory"
+)
+
+const (
+	mallocHistoryBin = "/usr/bin/malloc_history"
+	mallocSudoBin    = "/usr/bin/sudo"
+)
+
+// mallocHistoryRunner runs a command and returns its combined output.
+type mallocHistoryRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// mallocHistoryResult is the JSON shape for the command.
+type mallocHistoryResult struct {
+	PID     int                       `json:"pid"`
+	Address string                    `json:"address,omitempty"`
+	Sites   []mallochistory.AllocSite `json:"sites,omitempty"`
+	Traces  []mallochistory.Backtrace `json:"traces,omitempty"`
+}
+
+func runMallocHistory(args []string) int {
+	return runMallocHistoryWithIO(args, os.Stdout, os.Stderr, defaultMallocHistoryRunner)
+}
+
+func runMallocHistoryWithIO(args []string, stdout, stderr io.Writer, runner mallocHistoryRunner) int {
+	fs := flag.NewFlagSet("spectra malloc-history", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	address := fs.String("address", "", "Report the allocation backtrace for this heap address (hex)")
+	top := fs.Int("top", 10, "Show the top N allocation sites by bytes (0 for all)")
+	sudo := fs.Bool("sudo", false, "Prepend sudo (malloc_history needs root for another user's process)")
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *top < 0 {
+		fmt.Fprintln(stderr, "malloc-history: --top must be >= 0")
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "usage: spectra malloc-history [--address <hex>] [--top <n>] [--sudo] [--json] <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil || pid <= 0 {
+		fmt.Fprintf(stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+	if *address != "" && !isHexAddr(*address) {
+		fmt.Fprintf(stderr, "malloc-history: invalid address %q (want hex like 0x600000abcdef)\n", *address)
+		return 2
+	}
+
+	name := mallocHistoryBin
+	var cmdArgs []string
+	if *address != "" {
+		cmdArgs = []string{strconv.Itoa(pid), *address}
+	} else {
+		cmdArgs = []string{"-allBySize", strconv.Itoa(pid)}
+	}
+	if *sudo {
+		cmdArgs = append([]string{name}, cmdArgs...)
+		name = mallocSudoBin
+	}
+
+	out, runErr := runner(context.Background(), name, cmdArgs...)
+	if mallochistory.StackLoggingDisabled(string(out)) {
+		fmt.Fprintf(stderr, "malloc-history: PID %d has no malloc stack logging — relaunch the target with MallocStackLogging=1 in its environment\n", pid)
+		return 1
+	}
+	if runErr != nil {
+		fmt.Fprintf(stderr, "malloc-history failed for PID %d: %v\n", pid, runErr)
+		return 1
+	}
+
+	result := mallocHistoryResult{PID: pid, Address: *address}
+	if *address != "" {
+		result.Traces = mallochistory.ParseAddress(string(out))
+	} else {
+		result.Sites = mallochistory.ParseAllBySize(string(out), *top)
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+		return 0
+	}
+	printMallocHistory(stdout, result)
+	return 0
+}
+
+func printMallocHistory(w io.Writer, r mallocHistoryResult) {
+	if r.Address != "" {
+		fmt.Fprintf(w, "=== malloc-history pid %d @ %s ===\n", r.PID, r.Address)
+		if len(r.Traces) == 0 {
+			fmt.Fprintln(w, "  (no backtraces for this address)")
+		}
+		for _, t := range r.Traces {
+			fmt.Fprintf(w, "  %s: %s\n", t.Kind, strings.Join(t.Frames, " ← "))
+		}
+		return
+	}
+	fmt.Fprintf(w, "=== malloc-history pid %d — top allocation sites ===\n", r.PID)
+	if len(r.Sites) == 0 {
+		fmt.Fprintln(w, "  (no allocation sites parsed)")
+	}
+	for _, s := range r.Sites {
+		fmt.Fprintf(w, "  %s in %d calls  %s\n", humanSize(s.Bytes), s.Calls, truncate(leaf(s.Stack), 64))
+	}
+}
+
+func leaf(stack []string) string {
+	if len(stack) == 0 {
+		return ""
+	}
+	return stack[len(stack)-1]
+}
+
+func isHexAddr(s string) bool {
+	s = strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
+	if s == "" {
+		return false
+	}
+	_, err := strconv.ParseUint(s, 16, 64)
+	return err == nil
+}
+
+func defaultMallocHistoryRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	if err != nil {
+		// Return out too: the caller inspects it for the stack-logging notice.
+		return out, fmt.Errorf("malloc_history: %w", err)
+	}
+	return out, nil
+}

--- a/cmd/spectra/malloc_history_test.go
+++ b/cmd/spectra/malloc_history_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const mhAllBySize = `Malloc stack logging: recording
+16 calls for 262144 bytes: start | main | bar | operator new
+8 calls for 131072 bytes: start | main | foo | malloc
+`
+
+func mhRunner(out string, err error) mallocHistoryRunner {
+	return func(context.Context, string, ...string) ([]byte, error) { return []byte(out), err }
+}
+
+func TestRunMallocHistoryAllBySize(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runMallocHistoryWithIO([]string{"4012"}, &out, &errBuf, mhRunner(mhAllBySize, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "operator new") || !strings.Contains(out.String(), "256 KB") {
+		t.Errorf("expected top-site summary, got:\n%s", out.String())
+	}
+}
+
+func TestRunMallocHistoryAddress(t *testing.T) {
+	runner := mhRunner("ALLOC 0x600000abcdef [size=17]: start | main | leak | malloc\n", nil)
+	var out, errBuf bytes.Buffer
+	code := runMallocHistoryWithIO([]string{"--address", "0x600000abcdef", "4012"}, &out, &errBuf, runner)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "ALLOC") || !strings.Contains(out.String(), "malloc") {
+		t.Errorf("expected address backtrace, got:\n%s", out.String())
+	}
+}
+
+func TestRunMallocHistoryStackLoggingDisabled(t *testing.T) {
+	runner := mhRunner("malloc_history: stack logging not enabled for this process\n", errors.New("exit status 1"))
+	var out, errBuf bytes.Buffer
+	code := runMallocHistoryWithIO([]string{"4012"}, &out, &errBuf, runner)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "MallocStackLogging") {
+		t.Errorf("expected the precondition message, got: %q", errBuf.String())
+	}
+}
+
+func TestRunMallocHistoryJSON(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runMallocHistoryWithIO([]string{"--json", "4012"}, &out, &errBuf, mhRunner(mhAllBySize, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"sites"`) || !strings.Contains(out.String(), `"bytes"`) {
+		t.Errorf("expected JSON, got:\n%s", out.String())
+	}
+}
+
+func TestRunMallocHistorySudoAbsolutePaths(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	runner := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		gotName, gotArgs = name, args
+		return []byte(mhAllBySize), nil
+	}
+	var out, errBuf bytes.Buffer
+	if code := runMallocHistoryWithIO([]string{"--sudo", "4012"}, &out, &errBuf, runner); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if gotName != mallocSudoBin || len(gotArgs) == 0 || gotArgs[0] != mallocHistoryBin {
+		t.Errorf("expected `%s %s ...`, got name=%q args=%v", mallocSudoBin, mallocHistoryBin, gotName, gotArgs)
+	}
+}
+
+func TestRunMallocHistoryArgValidation(t *testing.T) {
+	runner := mhRunner(mhAllBySize, nil)
+	for _, args := range [][]string{
+		{},                              // no pid
+		{"notapid"},                     // bad pid
+		{"1", "2"},                      // too many
+		{"--address", "nothex", "4012"}, // bad address
+		{"--top", "-1", "4012"},         // bad top
+	} {
+		var out, errBuf bytes.Buffer
+		if code := runMallocHistoryWithIO(args, &out, &errBuf, runner); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}

--- a/cmd/spectra/malloc_history_test.go
+++ b/cmd/spectra/malloc_history_test.go
@@ -18,13 +18,37 @@ func mhRunner(out string, err error) mallocHistoryRunner {
 }
 
 func TestRunMallocHistoryAllBySize(t *testing.T) {
+	var gotArgs []string
+	runner := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte(mhAllBySize), nil
+	}
 	var out, errBuf bytes.Buffer
-	code := runMallocHistoryWithIO([]string{"4012"}, &out, &errBuf, mhRunner(mhAllBySize, nil))
+	code := runMallocHistoryWithIO([]string{"4012"}, &out, &errBuf, runner)
 	if code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
 	}
+	// malloc_history requires the pid before the mode: `<pid> -allBySize`.
+	if len(gotArgs) != 2 || gotArgs[0] != "4012" || gotArgs[1] != "-allBySize" {
+		t.Errorf("arg order = %v, want [4012 -allBySize]", gotArgs)
+	}
 	if !strings.Contains(out.String(), "operator new") || !strings.Contains(out.String(), "256 KB") {
 		t.Errorf("expected top-site summary, got:\n%s", out.String())
+	}
+}
+
+func TestRunMallocHistoryAddressArgOrder(t *testing.T) {
+	var gotArgs []string
+	runner := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte("ALLOC 0x1: a | b\n"), nil
+	}
+	var out, errBuf bytes.Buffer
+	if code := runMallocHistoryWithIO([]string{"--address", "0x1", "4012"}, &out, &errBuf, runner); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if len(gotArgs) != 2 || gotArgs[0] != "4012" || gotArgs[1] != "0x1" {
+		t.Errorf("arg order = %v, want [4012 0x1]", gotArgs)
 	}
 }
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -478,6 +478,27 @@ spectra lsmp --sudo 4012
 spectra lsmp --json --sudo 4012
 ```
 
+## `spectra malloc-history`
+
+Attributes heap allocations to the call stacks that made them, from
+`malloc_history` — useful when a leak reproduces under `MallocStackLogging`.
+By default it runs `malloc_history -allBySize` and summarizes the top allocation
+sites (bytes, call count, leaf frame) ranked by bytes (`--top`, default 10);
+with `--address <hex>` it reports the ALLOC/FREE backtraces for one heap
+address. `malloc_history` needs the target launched with `MallocStackLogging=1`,
+so when logging isn't enabled the command says so and explains the precondition
+rather than returning empty. It needs root for another user's process, so
+`--sudo` prepends `sudo`; backtrace addresses can be fed through
+`spectra symbolicate`. `--json` emits the structured result.
+
+### Examples
+
+```bash
+spectra malloc-history --sudo 4012
+spectra malloc-history --address 0x600000abcdef --sudo 4012
+spectra malloc-history --top 20 --json --sudo 4012
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/mallochistory/mallochistory.go
+++ b/internal/mallochistory/mallochistory.go
@@ -1,0 +1,113 @@
+// Package mallochistory summarizes `malloc_history` output — allocation
+// backtraces recorded when a process runs under MallocStackLogging. It groups
+// the heaviest allocation sites and extracts per-address backtraces so a leak
+// can be attributed to the call stacks that made it. It reads only.
+package mallochistory
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// AllocSite is one unique allocation stack and its total footprint, from
+// `malloc_history -allBySize`.
+type AllocSite struct {
+	Bytes int64    `json:"bytes"`
+	Calls int      `json:"calls"`
+	Stack []string `json:"stack"`
+}
+
+// Backtrace is one recorded event (ALLOC or FREE) for a specific address, from
+// `malloc_history <pid> <address>`.
+type Backtrace struct {
+	Kind   string   `json:"kind"`
+	Frames []string `json:"frames"`
+}
+
+var (
+	// allBySizeLine matches "16 calls for 262144 bytes: <stack>".
+	allBySizeLine = regexp.MustCompile(`^\s*(\d+)\s+calls?\s+for\s+(\d+)\s+bytes:\s*(.*\S)\s*$`)
+	// eventLine matches a per-address backtrace line beginning ALLOC/FREE.
+	eventLine = regexp.MustCompile(`^\s*(ALLOC|FREE)\b.*?:\s*(.*\S)\s*$`)
+)
+
+// StackLoggingDisabled reports whether the output says MallocStackLogging was
+// not enabled in the target — the precondition everyone trips over.
+func StackLoggingDisabled(out string) bool {
+	l := strings.ToLower(out)
+	if !strings.Contains(l, "stack logging") {
+		return false
+	}
+	return strings.Contains(l, "not enabled") ||
+		strings.Contains(l, "was not enabled") ||
+		strings.Contains(l, "not being recorded") ||
+		strings.Contains(l, "no malloc") ||
+		strings.Contains(l, "not recording")
+}
+
+// ParseAllBySize parses `malloc_history -allBySize` into allocation sites
+// ranked by total bytes, keeping the top n (0 keeps all).
+func ParseAllBySize(out string, n int) []AllocSite {
+	var sites []AllocSite
+	for _, line := range strings.Split(out, "\n") {
+		m := allBySizeLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		calls, _ := strconv.Atoi(m[1])
+		bytes, _ := strconv.ParseInt(m[2], 10, 64)
+		sites = append(sites, AllocSite{Bytes: bytes, Calls: calls, Stack: splitStack(m[3])})
+	}
+	sort.SliceStable(sites, func(i, j int) bool {
+		if sites[i].Bytes != sites[j].Bytes {
+			return sites[i].Bytes > sites[j].Bytes
+		}
+		return sites[i].Calls > sites[j].Calls
+	})
+	if n > 0 && len(sites) > n {
+		sites = sites[:n]
+	}
+	return sites
+}
+
+// ParseAddress parses `malloc_history <pid> <address>` into its ALLOC/FREE
+// backtraces.
+func ParseAddress(out string) []Backtrace {
+	var traces []Backtrace
+	for _, line := range strings.Split(out, "\n") {
+		m := eventLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		traces = append(traces, Backtrace{Kind: m[1], Frames: splitStack(m[2])})
+	}
+	return traces
+}
+
+// splitStack turns a "a | b | c" backtrace into frames, sanitizing each and
+// dropping empties.
+func splitStack(s string) []string {
+	var frames []string
+	for _, f := range strings.Split(s, "|") {
+		if t := sanitize(strings.TrimSpace(f)); t != "" {
+			frames = append(frames, t)
+		}
+	}
+	return frames
+}
+
+// sanitize strips terminal control bytes from text taken from the tool output.
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t':
+			return ' '
+		case r < 0x20 || r == 0x7f:
+			return -1
+		default:
+			return r
+		}
+	}, s)
+}

--- a/internal/mallochistory/mallochistory_test.go
+++ b/internal/mallochistory/mallochistory_test.go
@@ -1,0 +1,76 @@
+package mallochistory
+
+import "testing"
+
+const allBySizeOut = `Malloc stack logging: recording malloc and VM allocation stacks
+8 calls for 131072 bytes: thread_7fff | start | main | foo | malloc
+16 calls for 262144 bytes: thread_7fff | start | main | bar | operator new
+2 calls for 4096 bytes: thread_7fff | start | helper | calloc
+`
+
+func TestParseAllBySizeRankedByBytes(t *testing.T) {
+	sites := ParseAllBySize(allBySizeOut, 0)
+	if len(sites) != 3 {
+		t.Fatalf("sites = %d, want 3", len(sites))
+	}
+	// Ranked by bytes: 262144 first.
+	if sites[0].Bytes != 262144 || sites[0].Calls != 16 {
+		t.Errorf("top site = %+v", sites[0])
+	}
+	if sites[0].Stack[len(sites[0].Stack)-1] != "operator new" {
+		t.Errorf("leaf frame = %q", sites[0].Stack[len(sites[0].Stack)-1])
+	}
+}
+
+func TestParseAllBySizeTopN(t *testing.T) {
+	if sites := ParseAllBySize(allBySizeOut, 2); len(sites) != 2 {
+		t.Errorf("topN=2 gave %d", len(sites))
+	}
+}
+
+func TestParseAddress(t *testing.T) {
+	out := `ALLOC 0x600000abcdef-0x600000abce00 [size=17]: thread_1 | start | main | leak | malloc
+FREE  0x600000abcdef: thread_1 | start | teardown | free
+`
+	traces := ParseAddress(out)
+	if len(traces) != 2 {
+		t.Fatalf("traces = %d, want 2", len(traces))
+	}
+	if traces[0].Kind != "ALLOC" || traces[0].Frames[len(traces[0].Frames)-1] != "malloc" {
+		t.Errorf("alloc trace = %+v", traces[0])
+	}
+	if traces[1].Kind != "FREE" {
+		t.Errorf("free trace kind = %q", traces[1].Kind)
+	}
+}
+
+func TestStackLoggingDisabled(t *testing.T) {
+	disabled := []string{
+		"malloc_history: stack logging not enabled for this process",
+		"Malloc stack logging was not enabled",
+		"error: no malloc stack logging",
+	}
+	for _, s := range disabled {
+		if !StackLoggingDisabled(s) {
+			t.Errorf("expected disabled for %q", s)
+		}
+	}
+	if StackLoggingDisabled(allBySizeOut) {
+		t.Error("a real recording must not be flagged disabled")
+	}
+}
+
+func TestSplitStackSanitizes(t *testing.T) {
+	frames := splitStack("start | ma\x1bin |  | leak\x07 ")
+	// Empty segment dropped; control bytes stripped.
+	if len(frames) != 3 {
+		t.Fatalf("frames = %v", frames)
+	}
+	for _, f := range frames {
+		for _, r := range f {
+			if r < 0x20 {
+				t.Errorf("control byte survived in %q", f)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

`spectra malloc-history <pid>` — attributes heap allocations to the **call stacks** that made them, from `malloc_history`, for leak-hunting under `MallocStackLogging`. **Final Phase-A item** of the native-capture line.

## How

- **`internal/mallochistory`** parses two modes: `-allBySize` into allocation **sites** (bytes, call count, `|`-separated backtrace) ranked by bytes; and `<pid> <address>` into the **ALLOC/FREE backtraces** for one heap address. It also detects the `MallocStackLogging`-not-enabled notice, and sanitizes control bytes out of frames.
- **`spectra malloc-history [--address <hex>] [--top n] [--sudo] [--json] <pid>`** — invokes `/usr/bin/malloc_history` (absolute path) through an injected runner; validates the address is hex and `--top >= 0`. When stack logging isn't enabled it **explains the precondition** (`relaunch the target with MallocStackLogging=1`) rather than returning empty — the #1 thing users hit; `--sudo` for another user's process; addresses can feed `spectra symbolicate`.

## Testing

Parser tests: `-allBySize` ranked by bytes with leaf frame, top-N, address-mode ALLOC/FREE parsing, the not-enabled detector (three phrasings, and a real recording not flagged), and control-byte sanitization. CLI tests: all-by-size + address modes, the stack-logging-disabled message, JSON, `sudo` absolute-path prefixing, and arg validation (pid, address hex, `--top`). `make vet complexity lint security docs-validate test` green (69 pkgs).

## Honest limitation

Requires the target launched with `MallocStackLogging` (and root for other users), so the **live path can't be exercised in CI**; the parser is validated against the documented `malloc_history` output format. `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #451
