### PR TITLE
flamegraph: spectra flamegraph — native CPU flamegraph from a sample (fold + self-contained SVG)

### DIFF
--- a/cmd/spectra/flamegraph.go
+++ b/cmd/spectra/flamegraph.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/flamegraph"
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+// sampleCapturer captures a `sample` report for a pid over a duration.
+type sampleCapturer func(ctx context.Context, pid, durationSec int) (string, error)
+
+// flamegraphDeps injects capture and filesystem access for testing.
+type flamegraphDeps struct {
+	capture   sampleCapturer
+	readFile  func(string) ([]byte, error)
+	writeFile func(string, []byte, os.FileMode) error
+}
+
+func runFlamegraph(args []string) int {
+	deps := flamegraphDeps{
+		capture:   defaultSampleCapture,
+		readFile:  os.ReadFile,
+		writeFile: os.WriteFile,
+	}
+	return runFlamegraphWithIO(args, os.Stdout, os.Stderr, deps)
+}
+
+func runFlamegraphWithIO(args []string, stdout, stderr io.Writer, deps flamegraphDeps) int {
+	fs := flag.NewFlagSet("spectra flamegraph", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	input := fs.String("input", "", "Fold an existing sample report file instead of capturing")
+	duration := fs.Int("duration", 2, "Capture duration in seconds")
+	out := fs.String("out", "", "Write the SVG here (default <pid>.flamegraph.svg)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	var report, title, outPath string
+	if *input != "" {
+		if fs.NArg() != 0 {
+			fmt.Fprintln(stderr, "flamegraph: pass either --input or a pid, not both")
+			return 2
+		}
+		data, err := deps.readFile(*input)
+		if err != nil {
+			fmt.Fprintf(stderr, "flamegraph: read %s: %v\n", *input, err)
+			return 1
+		}
+		report, title, outPath = string(data), "flamegraph: "+*input, *out
+		if outPath == "" {
+			outPath = *input + ".flamegraph.svg"
+		}
+	} else {
+		if fs.NArg() != 1 {
+			fmt.Fprintln(stderr, "usage: spectra flamegraph [--duration <s>] [--out <file>] <pid>   (or --input <file>)")
+			return 2
+		}
+		pid, err := strconv.Atoi(fs.Arg(0))
+		if err != nil || pid <= 0 {
+			fmt.Fprintf(stderr, "invalid PID %q\n", fs.Arg(0))
+			return 2
+		}
+		report, err = deps.capture(context.Background(), pid, *duration)
+		if err != nil {
+			fmt.Fprintf(stderr, "flamegraph: capture failed for PID %d: %v\n", pid, err)
+			return 1
+		}
+		title = fmt.Sprintf("flamegraph: pid %d (%ds)", pid, *duration)
+		outPath = *out
+		if outPath == "" {
+			outPath = fmt.Sprintf("%d.flamegraph.svg", pid)
+		}
+	}
+
+	folded := flamegraph.Fold(report)
+	if len(folded) == 0 {
+		fmt.Fprintln(stderr, "flamegraph: no stacks found in the sample (was it a Call graph report?)")
+		return 1
+	}
+	svg := flamegraph.RenderSVG(folded, title)
+	if err := deps.writeFile(outPath, []byte(svg), 0o644); err != nil {
+		fmt.Fprintf(stderr, "flamegraph: write %s: %v\n", outPath, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "wrote %s (%d folded stacks)\n", outPath, len(folded))
+	return 0
+}
+
+func defaultSampleCapture(ctx context.Context, pid, durationSec int) (string, error) {
+	sampler := process.NewSampler(nil, nil)
+	res, err := sampler.Capture(ctx, process.SampleOptions{
+		PID:      pid,
+		Duration: time.Duration(durationSec) * time.Second,
+	})
+	if err != nil {
+		return "", err
+	}
+	return res.Output, nil
+}

--- a/cmd/spectra/flamegraph_test.go
+++ b/cmd/spectra/flamegraph_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+const fgSample = `Call graph:
+    100 Thread_1   main-thread
+      100 start  (in dyld) + 1  [0x1]
+        100 main  (in App) + 2  [0x2]
+          100 work  (in App) + 3  [0x3]
+`
+
+func fgDeps(report string, captureErr error, files, written map[string]string) flamegraphDeps {
+	return flamegraphDeps{
+		capture: func(context.Context, int, int) (string, error) { return report, captureErr },
+		readFile: func(p string) ([]byte, error) {
+			if v, ok := files[p]; ok {
+				return []byte(v), nil
+			}
+			return nil, errors.New("no such file")
+		},
+		writeFile: func(p string, data []byte, _ os.FileMode) error {
+			if written != nil {
+				written[p] = string(data)
+			}
+			return nil
+		},
+	}
+}
+
+func TestRunFlamegraphCapture(t *testing.T) {
+	written := map[string]string{}
+	var out, errBuf bytes.Buffer
+	code := runFlamegraphWithIO([]string{"4012"}, &out, &errBuf, fgDeps(fgSample, nil, nil, written))
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	svg := written["4012.flamegraph.svg"]
+	if !strings.HasPrefix(svg, "<svg") || !strings.Contains(svg, "work") {
+		t.Errorf("expected an SVG with the work frame, got:\n%s", svg)
+	}
+	if !strings.Contains(out.String(), "folded stacks") {
+		t.Errorf("expected a summary line, got: %q", out.String())
+	}
+}
+
+func TestRunFlamegraphInput(t *testing.T) {
+	written := map[string]string{}
+	deps := fgDeps("", nil, map[string]string{"/s.txt": fgSample}, written)
+	var out, errBuf bytes.Buffer
+	code := runFlamegraphWithIO([]string{"--input", "/s.txt", "--out", "/g.svg"}, &out, &errBuf, deps)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	if !strings.HasPrefix(written["/g.svg"], "<svg") {
+		t.Errorf("expected SVG at /g.svg, got: %q", written["/g.svg"])
+	}
+}
+
+func TestRunFlamegraphCaptureError(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runFlamegraphWithIO([]string{"4012"}, &out, &errBuf, fgDeps("", errors.New("sample failed"), nil, nil))
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestRunFlamegraphNoStacks(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runFlamegraphWithIO([]string{"4012"}, &out, &errBuf, fgDeps("no call graph here\n", nil, nil, nil))
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for a sample with no stacks", code)
+	}
+	if !strings.Contains(errBuf.String(), "no stacks") {
+		t.Errorf("expected a no-stacks message, got: %q", errBuf.String())
+	}
+}
+
+func TestRunFlamegraphArgValidation(t *testing.T) {
+	deps := fgDeps(fgSample, nil, map[string]string{"/s.txt": fgSample}, map[string]string{})
+	for _, args := range [][]string{
+		{},                         // no pid, no input
+		{"notapid"},                // bad pid
+		{"1", "2"},                 // too many
+		{"--input", "/s.txt", "9"}, // both input and pid
+	} {
+		var out, errBuf bytes.Buffer
+		if code := runFlamegraphWithIO(args, &out, &errBuf, deps); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -75,6 +75,7 @@ func subcommandList() []subcommand {
 		{"vmmap", "Summarize a process's memory composition by region (dirty/resident/swapped)", runVmmap},
 		{"lsmp", "Summarize a process's Mach port table (right counts, leak detection)", runLsmp},
 		{"malloc-history", "Attribute allocations to call stacks (requires MallocStackLogging)", runMallocHistory},
+		{"flamegraph", "Render a native CPU flamegraph (SVG) from a process sample", runFlamegraph},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -499,6 +499,24 @@ spectra malloc-history --address 0x600000abcdef --sudo 4012
 spectra malloc-history --top 20 --json --sudo 4012
 ```
 
+## `spectra flamegraph`
+
+Renders a native CPU flamegraph (SVG) from a process sample — the counterpart to
+`spectra jvm flamegraph` for non-JVM processes. It captures a `sample` (or reads
+one with `--input`), folds the call graph into collapsed stacks with correct
+**self** sample counts (a frame's own time = its samples minus its children's),
+and draws a self-contained SVG: width proportional to samples, stacked by depth,
+a deterministic per-frame color, and native `<title>` hover tooltips — no
+external scripts or fonts. It writes to `--out` (default `<pid>.flamegraph.svg`).
+Frame addresses in the source sample can be resolved with `spectra symbolicate`.
+
+### Examples
+
+```bash
+spectra flamegraph --duration 5 4012
+spectra flamegraph --input /tmp/app.sample.txt --out /tmp/app.svg
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/flamegraph/flamegraph_test.go
+++ b/internal/flamegraph/flamegraph_test.go
@@ -1,0 +1,93 @@
+package flamegraph
+
+import (
+	"strings"
+	"testing"
+)
+
+// A small call graph: main splits into two leaves with different self time,
+// plus main has some self time of its own.
+const sampleGraph = `Analysis of sampling ...
+
+Call graph:
+    100 Thread_1   DispatchQueue_1: main-thread  (serial)
+      100 start  (in dyld) + 10  [0x1]
+        100 main  (in App) + 20  [0x2]
+          60 work  (in App) + 4  [0x3]
+          30 idle  (in App) + 8  [0x4]
+
+Total number in stack:
+      100 something else
+`
+
+func TestFoldSelfCounts(t *testing.T) {
+	folded := Fold(sampleGraph)
+	// Expect three folded stacks: work (60), idle (30), and main's self (10).
+	byLeaf := map[string]Folded{}
+	for _, f := range folded {
+		byLeaf[f.Frames[len(f.Frames)-1]] = f
+	}
+	if got := byLeaf["work"].Count; got != 60 {
+		t.Errorf("work self = %d, want 60", got)
+	}
+	if got := byLeaf["idle"].Count; got != 30 {
+		t.Errorf("idle self = %d, want 30", got)
+	}
+	if got := byLeaf["main"].Count; got != 10 {
+		t.Errorf("main self = %d, want 10 (100 - 60 - 30)", got)
+	}
+	// The full path to a leaf is root→leaf, symbols cleaned.
+	if strings.Join(byLeaf["work"].Frames, ";") != "Thread_1;start;main;work" {
+		t.Errorf("work path = %v", byLeaf["work"].Frames)
+	}
+}
+
+func TestFoldIgnoresNonGraph(t *testing.T) {
+	if f := Fold("no call graph here\njust text\n"); len(f) != 0 {
+		t.Errorf("expected no stacks, got %v", f)
+	}
+}
+
+func TestCleanSymbol(t *testing.T) {
+	cases := map[string]string{
+		"main  (in App) + 20  [0x2]":                               "main",
+		"start  (in dyld) + 6076  [0x19037eb98]":                   "start",
+		"???  (in zsh)  load address 0x1 + 0x2  [0x3]":             "???",
+		"Thread_75376767   DispatchQueue_1: com.apple.main-thread": "Thread_75376767",
+	}
+	for in, want := range cases {
+		if got := cleanSymbol(in); got != want {
+			t.Errorf("cleanSymbol(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRenderSVGDeterministicAndSafe(t *testing.T) {
+	folded := Fold(sampleGraph)
+	a := RenderSVG(folded, "t")
+	b := RenderSVG(folded, "t")
+	if a != b {
+		t.Error("RenderSVG is not deterministic")
+	}
+	if !strings.HasPrefix(a, "<svg") || !strings.Contains(a, "</svg>") {
+		t.Error("output is not an SVG")
+	}
+	if !strings.Contains(a, "<title>work (60 samples") {
+		t.Errorf("expected a work frame title, got:\n%s", a)
+	}
+	// No external references or scripts (CSP-safe). The xmlns namespace URI is
+	// a required, non-fetched identifier, so it is not a violation.
+	for _, bad := range []string{"href", "src=", "<script", "<image", "url(", "<foreignObject"} {
+		if strings.Contains(a, bad) {
+			t.Errorf("SVG contains external/script reference %q", bad)
+		}
+	}
+}
+
+func TestRenderSVGEscapesXML(t *testing.T) {
+	folded := []Folded{{Frames: []string{"a<b>&\"c"}, Count: 5}}
+	svg := RenderSVG(folded, "x")
+	if strings.Contains(svg, "<b>") {
+		t.Errorf("symbol angle brackets not escaped:\n%s", svg)
+	}
+}

--- a/internal/flamegraph/fold.go
+++ b/internal/flamegraph/fold.go
@@ -1,0 +1,117 @@
+// Package flamegraph turns a native `sample` call graph into folded stacks and
+// renders a self-contained SVG flamegraph. It reads only.
+package flamegraph
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Folded is one collapsed stack (root→leaf) and its self sample count.
+type Folded struct {
+	Frames []string `json:"frames"`
+	Count  int      `json:"count"`
+}
+
+var (
+	// callGraphStart marks the beginning of sample's call-tree section.
+	callGraphStart = "Call graph:"
+	// frameLine matches an indented "<count> <symbol...>" call-graph line.
+	frameLine  = regexp.MustCompile(`^(\s+)(\d+)\s+(.*\S)\s*$`)
+	offsetTail = regexp.MustCompile(`\s+\+\s+\d+$`)
+)
+
+// foldNode is one entry on the ancestry stack while folding.
+type foldNode struct {
+	indent   int
+	sym      string
+	count    int
+	childSum int
+}
+
+// Fold parses a `sample` report's call graph into folded stacks whose weight is
+// each frame's self time (its sample count minus the sum of its children).
+func Fold(sampleOutput string) []Folded {
+	var folded []Folded
+	var stack []foldNode
+
+	// path returns the symbols currently on the stack (a node's ancestors).
+	path := func() []string {
+		out := make([]string, len(stack))
+		for i, n := range stack {
+			out[i] = n.sym
+		}
+		return out
+	}
+	pop := func() {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if self := n.count - n.childSum; self > 0 {
+			folded = append(folded, Folded{Frames: append(path(), n.sym), Count: self})
+		}
+		if len(stack) > 0 {
+			stack[len(stack)-1].childSum += n.count
+		}
+	}
+
+	inGraph := false
+	for _, line := range strings.Split(sampleOutput, "\n") {
+		if !inGraph {
+			if strings.HasPrefix(strings.TrimSpace(line), callGraphStart) {
+				inGraph = true
+			}
+			continue
+		}
+		m := frameLine.FindStringSubmatch(line)
+		if m == nil {
+			// The call graph ends at the first non-frame line after it started.
+			if strings.TrimSpace(line) != "" {
+				break
+			}
+			continue
+		}
+		indent := len(m[1])
+		count, _ := strconv.Atoi(m[2])
+		sym := cleanSymbol(m[3])
+		for len(stack) > 0 && stack[len(stack)-1].indent >= indent {
+			pop()
+		}
+		stack = append(stack, foldNode{indent: indent, sym: sym, count: count})
+	}
+	for len(stack) > 0 {
+		pop()
+	}
+	return folded
+}
+
+// cleanSymbol reduces a call-graph frame's text to a bare symbol name.
+func cleanSymbol(s string) string {
+	if i := strings.Index(s, "  (in "); i >= 0 {
+		s = s[:i]
+	} else if i := strings.Index(s, " (in "); i >= 0 {
+		s = s[:i]
+	} else if i := strings.Index(s, "   "); i >= 0 {
+		// Thread header line ("Thread_123   DispatchQueue…"): keep the first col.
+		s = s[:i]
+	}
+	if i := strings.Index(s, "  ["); i >= 0 {
+		s = s[:i]
+	}
+	s = offsetTail.ReplaceAllString(s, "")
+	return sanitize(strings.TrimSpace(s))
+}
+
+// sanitize strips terminal control bytes from text taken from the sample.
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t':
+			return ' '
+		case r < 0x20 || r == 0x7f:
+			return -1
+		default:
+			return r
+		}
+	}, s)
+}

--- a/internal/flamegraph/render.go
+++ b/internal/flamegraph/render.go
@@ -1,0 +1,152 @@
+package flamegraph
+
+import (
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"strings"
+)
+
+const (
+	svgWidth  = 1200
+	rowHeight = 16
+	padding   = 12
+	minLabelW = 40
+)
+
+// node is a merged flamegraph tree node.
+type node struct {
+	sym      string
+	count    int
+	children map[string]*node
+	order    []string
+}
+
+func newNode(sym string) *node {
+	return &node{sym: sym, children: map[string]*node{}}
+}
+
+func (n *node) child(sym string) *node {
+	c, ok := n.children[sym]
+	if !ok {
+		c = newNode(sym)
+		n.children[sym] = c
+		n.order = append(n.order, sym)
+	}
+	return c
+}
+
+// RenderSVG builds a self-contained SVG flamegraph from folded stacks. Output is
+// deterministic: the same folded input always yields the same SVG.
+func RenderSVG(folded []Folded, title string) string {
+	root := newNode("root")
+	for _, f := range folded {
+		root.count += f.Count
+		cur := root
+		for _, frame := range f.Frames {
+			c := cur.child(frame)
+			c.count += f.Count
+			cur = c
+		}
+	}
+	if root.count == 0 {
+		root.count = 1 // avoid divide-by-zero on an empty graph
+	}
+
+	depth := treeDepth(root) // excludes the synthetic root
+	height := depth*rowHeight + 2*padding + rowHeight
+	var b strings.Builder
+	fmt.Fprintf(&b, `<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d" font-family="Menlo,Consolas,monospace" font-size="11">`,
+		svgWidth, height, svgWidth, height)
+	fmt.Fprintf(&b, `<rect width="%d" height="%d" fill="#ffffff"/>`, svgWidth, height)
+	fmt.Fprintf(&b, `<text x="%d" y="%d" font-size="13" fill="#111">%s</text>`, padding, padding+2, escapeXML(title))
+
+	usableW := float64(svgWidth - 2*padding)
+	// The synthetic root's children form the bottom row (depth 0).
+	renderRow(&b, root, float64(padding), usableW, 0, depth, root.count, height)
+	b.WriteString(`</svg>`)
+	return b.String()
+}
+
+// renderRow lays out a node's children left-to-right, widths proportional to
+// sample count, and recurses. depth grows upward from the bottom.
+func renderRow(b *strings.Builder, parent *node, x, width float64, depth, maxDepth, total, height int) {
+	if len(parent.order) == 0 {
+		return
+	}
+	childX := x
+	for _, sym := range sortedChildren(parent) {
+		c := parent.children[sym]
+		w := width * float64(c.count) / float64(parent.count)
+		y := float64(height-padding) - float64(depth+1)*float64(rowHeight)
+		drawFrame(b, c, childX, y, w, total)
+		renderRow(b, c, childX, w, depth+1, maxDepth, total, height)
+		childX += w
+	}
+}
+
+func drawFrame(b *strings.Builder, n *node, x, y, w float64, total int) {
+	if w < 0.4 {
+		return // too thin to see
+	}
+	pct := 100 * float64(n.count) / float64(total)
+	fmt.Fprintf(b, `<g><title>%s (%d samples, %.1f%%)</title><rect x="%.2f" y="%d" width="%.2f" height="%d" fill="%s" stroke="#ffffff" stroke-width="0.5"/>`,
+		escapeXML(n.sym), n.count, pct, x, int(y), w, rowHeight-1, warmColor(n.sym))
+	if w >= minLabelW {
+		fmt.Fprintf(b, `<text x="%.2f" y="%d" fill="#000">%s</text>`, x+2, int(y)+rowHeight-4, escapeXML(clip(n.sym, int(w/6))))
+	}
+	b.WriteString(`</g>`)
+}
+
+func sortedChildren(n *node) []string {
+	c := append([]string(nil), n.order...)
+	sort.SliceStable(c, func(i, j int) bool {
+		if n.children[c[i]].count != n.children[c[j]].count {
+			return n.children[c[i]].count > n.children[c[j]].count
+		}
+		return c[i] < c[j]
+	})
+	return c
+}
+
+func treeDepth(n *node) int {
+	deepest := 0
+	for _, c := range n.children {
+		if d := treeDepth(c); d > deepest {
+			deepest = d
+		}
+	}
+	if n.sym == "root" {
+		return deepest
+	}
+	return deepest + 1
+}
+
+// warmColor maps a symbol to a stable flamegraph-style warm color.
+func warmColor(sym string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(sym))
+	v := h.Sum32()
+	r := 205 + int(v%50)
+	g := int((v >> 8) % 230)
+	bl := int((v >> 16) % 55)
+	return fmt.Sprintf("#%02x%02x%02x", r, g, bl)
+}
+
+func clip(s string, n int) string {
+	if n < 1 {
+		return ""
+	}
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func escapeXML(s string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;")
+	return r.Replace(s)
+}


### PR DESCRIPTION
## What

`spectra flamegraph <pid>` — renders a **native CPU flamegraph (SVG)** from a process sample, the counterpart to `spectra jvm flamegraph` for non-JVM processes. `spectra sample` already captures the stacks; this makes them *visible*. **Phase-B item 1**, unblocked by Phase A.

## How

- **`internal/flamegraph`**:
  - `Fold()` parses the `sample` "Call graph" (indented `<count> <symbol> (in <image>) + <off> [addr]` lines) into collapsed stacks with correct **self** counts — a frame's own time = its samples minus the sum of its children — walking the indent tree with an ancestry stack.
  - `RenderSVG()` draws a **self-contained** SVG: width ∝ samples, stacked by depth, deterministic per-frame warm color (FNV hash), native `<title>` hover tooltips (symbol, samples, %). No external scripts, fonts, images, or `href`/`src` — CSP-safe; symbols are XML-escaped and stripped of control bytes.
- **`spectra flamegraph [--input <sample>] [--duration <s>] [--out <file>] <pid>`** — captures via the existing sampler (injected for tests) or folds an existing `--input` sample file, then writes the SVG (default `<pid>.flamegraph.svg`). Frame addresses can be resolved with `spectra symbolicate`.

## Testing

Folder tests: self-count correctness (main splits into work=60, idle=30, and main's own self=10 out of 100), full cleaned root→leaf paths, non-graph input ignored, and symbol cleaning (`(in image)`, `load address`, thread headers). Renderer tests: deterministic output, valid `<svg>`, expected `<title>`, **CSP-safety** (no script/href/image/url), and XML escaping of `<`/`>`/`&`/`"`. CLI tests: capture + `--input` modes writing an SVG, capture error, no-stacks handling, and arg validation. **Smoke-tested live** — folded a real `sample` of a process into a rendered SVG (attached in the session). `make vet complexity lint security docs-validate test` green (70 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #454
