### PR TITLE
vmregions: spectra vmregions — memory composition by sharing/protection/backing, with RWX flagging

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -73,6 +73,7 @@ func subcommandList() []subcommand {
 		{"symbolicate", "Resolve raw stack addresses to symbol + file:line via atos", runSymbolicate},
 		{"spindump", "Capture and summarize a per-thread stack report (heaviest stacks)", runSpindump},
 		{"vmmap", "Summarize a process's memory composition by region (dirty/resident/swapped)", runVmmap},
+		{"vmregions", "Composition by sharing/protection/backing, with RWX (W^X) flagging", runVmregions},
 		{"lsmp", "Summarize a process's Mach port table (right counts, leak detection)", runLsmp},
 		{"malloc-history", "Attribute allocations to call stacks (requires MallocStackLogging)", runMallocHistory},
 		{"flamegraph", "Render a native CPU flamegraph (SVG) from a process sample", runFlamegraph},

--- a/cmd/spectra/vmregions.go
+++ b/cmd/spectra/vmregions.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/kaeawc/spectra/internal/vmregions"
+)
+
+const vmregionsBin = "/usr/bin/vmmap"
+
+// vmregionsRunner runs a command and returns its combined output.
+type vmregionsRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+func runVmregions(args []string) int {
+	return runVmregionsWithIO(args, os.Stdout, os.Stderr, defaultVmregionsRunner)
+}
+
+func runVmregionsWithIO(args []string, stdout, stderr io.Writer, runner vmregionsRunner) int {
+	fs := flag.NewFlagSet("spectra vmregions", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	top := fs.Int("top", 8, "Show the top N regions by dirty size (0 for all)")
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *top < 0 {
+		fmt.Fprintln(stderr, "vmregions: --top must be >= 0")
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "usage: spectra vmregions [--top <n>] [--json] <pid>")
+		return 2
+	}
+	pid, err := strconv.Atoi(fs.Arg(0))
+	if err != nil || pid <= 0 {
+		fmt.Fprintf(stderr, "invalid PID %q\n", fs.Arg(0))
+		return 2
+	}
+
+	out, runErr := runner(context.Background(), vmregionsBin, strconv.Itoa(pid))
+	if isVmregionsPermission(string(out)) {
+		fmt.Fprintf(stderr, "vmregions: not permitted for PID %d — it likely belongs to another user; re-run as root (sudo)\n", pid)
+		return 1
+	}
+	if runErr != nil {
+		fmt.Fprintf(stderr, "vmregions failed for PID %d: %v\n", pid, runErr)
+		return 1
+	}
+
+	comp := vmregions.Parse(string(out), *top)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(comp)
+		return 0
+	}
+	printVmregions(stdout, pid, comp)
+	return 0
+}
+
+func isVmregionsPermission(out string) bool {
+	l := strings.ToLower(out)
+	return strings.Contains(l, "not permitted") || strings.Contains(l, "unable to access") ||
+		strings.Contains(l, "resource must be") || strings.Contains(l, "only root")
+}
+
+func printVmregions(w io.Writer, pid int, c vmregions.Composition) {
+	fmt.Fprintf(w, "=== vmregions composition (pid %d) ===\n", pid)
+	fmt.Fprintf(w, "  resident: %s   dirty: %s\n", humanSize(c.TotalResidentBytes), humanSize(c.TotalDirtyBytes))
+	fmt.Fprintf(w, "  shared-resident: %s\n", humanSize(c.SharedResidentBytes))
+	fmt.Fprintf(w, "  dirty: file-backed %s | anonymous %s\n", humanSize(c.FileBackedDirtyBytes), humanSize(c.AnonymousDirtyBytes))
+	fmt.Fprintf(w, "  resident: writable %s | executable %s\n", humanSize(c.WritableResidentBytes), humanSize(c.ExecutableResidentBytes))
+	if len(c.RWXRegions) > 0 {
+		fmt.Fprintf(w, "  ! %d RWX region(s) (writable + executable — W^X violation):\n", len(c.RWXRegions))
+		for _, r := range c.RWXRegions {
+			fmt.Fprintf(w, "      %s %s-%s %s %s\n", truncate(r.Type, 22), r.AddrStart, r.AddrEnd, r.Prot, truncate(r.Detail, 30))
+		}
+	}
+	fmt.Fprintln(w, "  top regions by dirty:")
+	for _, r := range c.TopDirty {
+		fmt.Fprintf(w, "    %10s  %-22s %s %s\n", humanSize(r.DirtyBytes), truncate(r.Type, 22), r.Prot, truncate(r.Detail, 28))
+	}
+}
+
+func defaultVmregionsRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	if err != nil {
+		// Return out too: the caller inspects it for a permission failure.
+		return out, fmt.Errorf("vmmap: %w", err)
+	}
+	return out, nil
+}

--- a/cmd/spectra/vmregions_test.go
+++ b/cmd/spectra/vmregions_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const vrCLIOut = `REGION TYPE                    START - END         [ VSIZE  RSDNT  DIRTY   SWAP] PRT/MAX SHRMOD PURGE    REGION DETAIL
+__TEXT                      102300000-102388000    [  544K   528K     0K     0K] r-x/r-x SM=COW          /bin/zsh
+JIT region                  400000000-400100000    [ 1024K   512K   512K     0K] rwx/rwx SM=PRV
+`
+
+func vrRunnerReturning(out string, err error) vmregionsRunner {
+	return func(context.Context, string, ...string) ([]byte, error) { return []byte(out), err }
+}
+
+func TestRunVmregionsHuman(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runVmregionsWithIO([]string{"4012"}, &out, &errBuf, vrRunnerReturning(vrCLIOut, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "RWX region") || !strings.Contains(s, "JIT region") {
+		t.Errorf("expected RWX flag, got:\n%s", s)
+	}
+}
+
+func TestRunVmregionsJSON(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runVmregionsWithIO([]string{"--json", "4012"}, &out, &errBuf, vrRunnerReturning(vrCLIOut, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"rwx_regions"`) || !strings.Contains(out.String(), `"total_dirty_bytes"`) {
+		t.Errorf("expected JSON, got:\n%s", out.String())
+	}
+}
+
+func TestRunVmregionsPermission(t *testing.T) {
+	runner := vrRunnerReturning("vmmap: Unable to access process. Not permitted.\n", errors.New("exit status 1"))
+	var out, errBuf bytes.Buffer
+	if code := runVmregionsWithIO([]string{"4012"}, &out, &errBuf, runner); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(errBuf.String(), "root") {
+		t.Errorf("expected a root hint, got: %q", errBuf.String())
+	}
+}
+
+func TestRunVmregionsArgValidation(t *testing.T) {
+	runner := vrRunnerReturning(vrCLIOut, nil)
+	for _, args := range [][]string{{}, {"notapid"}, {"0"}, {"1", "2"}, {"--top", "-1", "4012"}} {
+		var out, errBuf bytes.Buffer
+		if code := runVmregionsWithIO(args, &out, &errBuf, runner); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -517,6 +517,25 @@ spectra flamegraph --duration 5 4012
 spectra flamegraph --input /tmp/app.sample.txt --out /tmp/app.svg
 ```
 
+## `spectra vmregions`
+
+Aggregates a process's full `vmmap` region list by **sharing, protection, and
+backing** — the lens `spectra vmmap` (region-type summary) does not give. It
+reports total resident/dirty, shared-resident (SM=SHM), file-backed vs anonymous
+dirty, and writable vs executable resident, then lists every **RWX region**
+(current protection writable *and* executable — a W^X violation / JIT-or-exploit
+smell) and the top `--top` regions by dirty size. `vmmap` works without root for
+a same-user process; another user's process needs root, surfaced as "re-run as
+root (sudo)". `--json` emits the structured result.
+
+### Examples
+
+```bash
+spectra vmregions 4012
+spectra vmregions --top 20 4012
+spectra vmregions --json 4012
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/vmregions/vmregions.go
+++ b/internal/vmregions/vmregions.go
@@ -1,0 +1,145 @@
+// Package vmregions aggregates a process's full `vmmap` region list by sharing,
+// protection, and backing — answering how much of the footprint is private
+// dirty vs shared, file-backed vs anonymous, and whether any region is RWX
+// (writable and executable at once). It reads only.
+package vmregions
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Region is one parsed vmmap region.
+type Region struct {
+	Type          string `json:"type"`
+	AddrStart     string `json:"addr_start"`
+	AddrEnd       string `json:"addr_end"`
+	Prot          string `json:"prot"`
+	MaxProt       string `json:"max_prot"`
+	Share         string `json:"share"`
+	Detail        string `json:"detail,omitempty"`
+	ResidentBytes int64  `json:"resident_bytes"`
+	DirtyBytes    int64  `json:"dirty_bytes"`
+}
+
+// Composition is the aggregated memory picture of a process.
+type Composition struct {
+	TotalResidentBytes      int64    `json:"total_resident_bytes"`
+	TotalDirtyBytes         int64    `json:"total_dirty_bytes"`
+	SharedResidentBytes     int64    `json:"shared_resident_bytes"`
+	FileBackedDirtyBytes    int64    `json:"file_backed_dirty_bytes"`
+	AnonymousDirtyBytes     int64    `json:"anonymous_dirty_bytes"`
+	WritableResidentBytes   int64    `json:"writable_resident_bytes"`
+	ExecutableResidentBytes int64    `json:"executable_resident_bytes"`
+	RWXRegions              []Region `json:"rwx_regions,omitempty"`
+	TopDirty                []Region `json:"top_dirty,omitempty"`
+}
+
+// regionLine matches "TYPE start-end [ VSIZE RSDNT DIRTY SWAP] PRT/MAX SM=xx DETAIL".
+var regionLine = regexp.MustCompile(
+	`^(.*?\S)\s+([0-9a-f]+)-([0-9a-f]+)\s+\[\s*(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*\]\s+(\S+)/(\S+)\s+SM=(\S+)\s*(.*)$`)
+
+// Parse aggregates full `vmmap` output. topN keeps that many top-dirty regions.
+func Parse(out string, topN int) Composition {
+	var c Composition
+	var all []Region
+	for _, line := range strings.Split(out, "\n") {
+		m := regionLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		r := Region{
+			Type: strings.TrimSpace(m[1]), AddrStart: m[2], AddrEnd: m[3],
+			ResidentBytes: parseSize(m[5]), DirtyBytes: parseSize(m[6]),
+			Prot: m[8], MaxProt: m[9], Share: m[10], Detail: sanitize(strings.TrimSpace(m[11])),
+		}
+		all = append(all, r)
+		accumulate(&c, r)
+	}
+
+	for _, r := range all {
+		if isRWX(r.Prot) {
+			c.RWXRegions = append(c.RWXRegions, r)
+		}
+	}
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].DirtyBytes != all[j].DirtyBytes {
+			return all[i].DirtyBytes > all[j].DirtyBytes
+		}
+		return all[i].AddrStart < all[j].AddrStart
+	})
+	if topN > 0 && len(all) > topN {
+		all = all[:topN]
+	}
+	c.TopDirty = all
+	return c
+}
+
+func accumulate(c *Composition, r Region) {
+	c.TotalResidentBytes += r.ResidentBytes
+	c.TotalDirtyBytes += r.DirtyBytes
+	if r.Share == "SHM" || r.Share == "ALI" {
+		c.SharedResidentBytes += r.ResidentBytes
+	}
+	if r.Detail != "" && strings.HasPrefix(r.Detail, "/") {
+		c.FileBackedDirtyBytes += r.DirtyBytes
+	} else {
+		c.AnonymousDirtyBytes += r.DirtyBytes
+	}
+	if strings.Contains(r.Prot, "w") {
+		c.WritableResidentBytes += r.ResidentBytes
+	}
+	if strings.Contains(r.Prot, "x") {
+		c.ExecutableResidentBytes += r.ResidentBytes
+	}
+}
+
+// isRWX reports whether a current protection string is writable and executable
+// at once (a W^X violation).
+func isRWX(prot string) bool {
+	return strings.Contains(prot, "w") && strings.Contains(prot, "x")
+}
+
+// parseSize converts a vmmap size token like "544K" or "1.2M" into bytes.
+func parseSize(s string) int64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	mult := int64(1)
+	switch s[len(s)-1] {
+	case 'K':
+		mult = 1 << 10
+	case 'M':
+		mult = 1 << 20
+	case 'G':
+		mult = 1 << 30
+	case 'T':
+		mult = 1 << 40
+	case 'B':
+		mult = 1
+	}
+	if mult != 1 || s[len(s)-1] == 'B' {
+		s = s[:len(s)-1]
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return int64(v * float64(mult))
+}
+
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t':
+			return ' '
+		case r < 0x20 || r == 0x7f:
+			return -1
+		default:
+			return r
+		}
+	}, s)
+}

--- a/internal/vmregions/vmregions_test.go
+++ b/internal/vmregions/vmregions_test.go
@@ -1,0 +1,72 @@
+package vmregions
+
+import "testing"
+
+const sampleVmmap = `==== Non-writable regions for process 47118
+REGION TYPE                    START - END         [ VSIZE  RSDNT  DIRTY   SWAP] PRT/MAX SHRMOD PURGE    REGION DETAIL
+__TEXT                      102300000-102388000    [  544K   528K     0K     0K] r-x/r-x SM=COW          /bin/zsh
+shared memory               1023b8000-1023c0000    [   32K    32K    32K     0K] r--/r-- SM=SHM
+MALLOC_TINY                 300000000-300100000    [ 1024K   256K   200K     0K] rw-/rwx SM=PRV
+JIT region                  400000000-400100000    [ 1024K   512K   512K     0K] rwx/rwx SM=PRV
+__DATA                      500000000-500010000    [   64K    64K    40K     0K] rw-/rw- SM=COW          /usr/lib/foo.dylib
+`
+
+func TestParseComposition(t *testing.T) {
+	c := Parse(sampleVmmap, 0)
+	// Dirty totals: 0 + 32 + 200 + 512 + 40 = 784K
+	if c.TotalDirtyBytes != 784*1024 {
+		t.Errorf("total dirty = %d, want %d", c.TotalDirtyBytes, 784*1024)
+	}
+	// Shared-resident: only the SM=SHM region (32K).
+	if c.SharedResidentBytes != 32*1024 {
+		t.Errorf("shared resident = %d, want 32K", c.SharedResidentBytes)
+	}
+	// File-backed dirty: __TEXT (0K) + __DATA (40K) = 40K; anonymous = 32+200+512 = 744K.
+	if c.FileBackedDirtyBytes != 40*1024 {
+		t.Errorf("file-backed dirty = %d, want 40K", c.FileBackedDirtyBytes)
+	}
+	if c.AnonymousDirtyBytes != 744*1024 {
+		t.Errorf("anonymous dirty = %d, want 744K", c.AnonymousDirtyBytes)
+	}
+	// Executable resident: __TEXT (528K, r-x) + JIT (512K, rwx) = 1040K.
+	if c.ExecutableResidentBytes != 1040*1024 {
+		t.Errorf("executable resident = %d, want 1040K", c.ExecutableResidentBytes)
+	}
+}
+
+func TestParseRWXFlagged(t *testing.T) {
+	c := Parse(sampleVmmap, 0)
+	// Only the JIT region has current protection rwx (MALLOC_TINY is rw-/rwx — max only).
+	if len(c.RWXRegions) != 1 {
+		t.Fatalf("rwx regions = %d, want 1 (%+v)", len(c.RWXRegions), c.RWXRegions)
+	}
+	if c.RWXRegions[0].Type != "JIT region" || c.RWXRegions[0].Prot != "rwx" {
+		t.Errorf("rwx region = %+v", c.RWXRegions[0])
+	}
+}
+
+func TestParseTopDirty(t *testing.T) {
+	c := Parse(sampleVmmap, 2)
+	if len(c.TopDirty) != 2 {
+		t.Fatalf("top = %d", len(c.TopDirty))
+	}
+	// Ranked by dirty: JIT (512K) then MALLOC_TINY (200K).
+	if c.TopDirty[0].Type != "JIT region" || c.TopDirty[1].Type != "MALLOC_TINY" {
+		t.Errorf("top order = %q, %q", c.TopDirty[0].Type, c.TopDirty[1].Type)
+	}
+}
+
+func TestIsRWX(t *testing.T) {
+	if !isRWX("rwx") || isRWX("rw-") || isRWX("r-x") || isRWX("---") {
+		t.Error("isRWX classification wrong")
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	cases := map[string]int64{"0K": 0, "544K": 544 * 1024, "1.5M": int64(1.5 * float64(1<<20)), "2G": 2 << 30, "": 0}
+	for in, want := range cases {
+		if got := parseSize(in); got != want {
+			t.Errorf("parseSize(%q) = %d, want %d", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

`spectra vmregions <pid>` — aggregates a process's **full** `vmmap` region list by **sharing, protection, and backing**: the lens `spectra vmmap` (region-*type* summary, #409) does not provide. **Phase-B item 2.**

## How

- **`internal/vmregions`** parses full `vmmap` region lines (`TYPE start-end [ VSIZE RSDNT DIRTY SWAP] PRT/MAX SM=xx DETAIL`) and aggregates:
  - total resident / dirty; **shared-resident** (`SM=SHM`); **file-backed vs anonymous** dirty (by whether the region has a mapped-file path); **writable vs executable** resident (from the current protection);
  - every **RWX region** — current protection writable *and* executable at once, a W^X violation / JIT-or-exploit smell — listed explicitly (note: `rw-/rwx` is *max* rwx only and is correctly **not** flagged; only current `rwx` is);
  - the top `--top` (default 8) regions by dirty size.
- **`spectra vmregions [--top n] [--json] <pid>`** — runs `/usr/bin/vmmap` (absolute path) through an injected runner. Works unprivileged for a same-user process; another user's needs root, surfaced as "re-run as root (sudo)".

## Testing

Parser tests against canned full `vmmap` output: dirty/shared/file-backed/anonymous/executable aggregation across COW/SHM/PRV regions, **RWX flagged for the `rwx/rwx` region but not the `rw-/rwx` max-only one**, top-by-dirty ranking, `isRWX`, and size parsing. CLI tests: human (RWX flag) + JSON, permission message, and arg validation (incl. negative `--top`). **Smoke-tested live** against a same-user process (correct writable/executable/anonymous-vs-file-backed split). `make vet complexity lint security docs-validate test` green (71 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

## Distinct from `spectra vmmap`

`vmmap` aggregates by region *type* (`--summary`); `vmregions` aggregates the full per-region detail by *sharing/protection/backing* and flags RWX. Different question, different output.

Closes #456
