### PR TITLE
hang: spectra hang — classify why a process's main thread is hung (lock / I/O / spin / idle)

### DIFF
--- a/cmd/spectra/hang.go
+++ b/cmd/spectra/hang.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/hangcapture"
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+// hangCapturer captures a `sample` report for a pid over a duration.
+type hangCapturer func(ctx context.Context, pid, durationSec int) (string, error)
+
+// hangDeps injects capture and filesystem access for testing.
+type hangDeps struct {
+	capture  hangCapturer
+	readFile func(string) ([]byte, error)
+}
+
+func runHang(args []string) int {
+	deps := hangDeps{capture: defaultHangCapture, readFile: os.ReadFile}
+	return runHangWithIO(args, os.Stdout, os.Stderr, deps)
+}
+
+func runHangWithIO(args []string, stdout, stderr io.Writer, deps hangDeps) int {
+	fs := flag.NewFlagSet("spectra hang", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	input := fs.String("input", "", "Analyze an existing sample report file instead of capturing")
+	duration := fs.Int("duration", 2, "Capture duration in seconds")
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	var report string
+	if *input != "" {
+		if fs.NArg() != 0 {
+			fmt.Fprintln(stderr, "hang: pass either --input or a pid, not both")
+			return 2
+		}
+		data, err := deps.readFile(*input)
+		if err != nil {
+			fmt.Fprintf(stderr, "hang: read %s: %v\n", *input, err)
+			return 1
+		}
+		report = string(data)
+	} else {
+		if fs.NArg() != 1 {
+			fmt.Fprintln(stderr, "usage: spectra hang [--duration <s>] [--json] <pid>   (or --input <file>)")
+			return 2
+		}
+		pid, err := strconv.Atoi(fs.Arg(0))
+		if err != nil || pid <= 0 {
+			fmt.Fprintf(stderr, "invalid PID %q\n", fs.Arg(0))
+			return 2
+		}
+		report, err = deps.capture(context.Background(), pid, *duration)
+		if err != nil {
+			fmt.Fprintf(stderr, "hang: capture failed for PID %d: %v\n", pid, err)
+			return 1
+		}
+	}
+
+	analysis := hangcapture.Analyze(report)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(analysis)
+		return exitForVerdict(analysis)
+	}
+	printHang(stdout, analysis)
+	return exitForVerdict(analysis)
+}
+
+// exitForVerdict returns non-zero when the main thread is genuinely hung, so a
+// script can gate on it; idle/unknown return 0.
+func exitForVerdict(a hangcapture.Analysis) int {
+	switch a.MainThread.Verdict {
+	case hangcapture.VerdictLockBlocked, hangcapture.VerdictIOBlocked, hangcapture.VerdictSpinning:
+		return 3
+	default:
+		return 0
+	}
+}
+
+func printHang(w io.Writer, a hangcapture.Analysis) {
+	mt := a.MainThread
+	fmt.Fprintf(w, "=== hang analysis ===\n")
+	fmt.Fprintf(w, "  main thread: %s\n", mt.Verdict)
+	fmt.Fprintf(w, "  %s\n", mt.Reason)
+	if len(mt.TopFrames) > 0 {
+		fmt.Fprintln(w, "  stack (leaf last):")
+		for _, f := range mt.TopFrames {
+			fmt.Fprintf(w, "    %s\n", truncate(f, 76))
+		}
+	}
+}
+
+func defaultHangCapture(ctx context.Context, pid, durationSec int) (string, error) {
+	sampler := process.NewSampler(nil, nil)
+	res, err := sampler.Capture(ctx, process.SampleOptions{
+		PID:      pid,
+		Duration: time.Duration(durationSec) * time.Second,
+	})
+	if err != nil {
+		return "", err
+	}
+	return res.Output, nil
+}

--- a/cmd/spectra/hang_test.go
+++ b/cmd/spectra/hang_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const hangLockSample = `Call graph:
+    900 Thread_2   DispatchQueue_1: com.apple.main-thread  (serial)
+      900 main  (in App) + 1  [0x1]
+        900 __psynch_mutexwait  (in libsystem_kernel.dylib) + 1  [0x2]
+`
+
+const hangIdleSample = `Call graph:
+    900 Thread_2   DispatchQueue_1: com.apple.main-thread  (serial)
+      900 CFRunLoopRunSpecific  (in CoreFoundation) + 1  [0x1]
+        900 mach_msg2_trap  (in libsystem_kernel.dylib) + 1  [0x2]
+`
+
+func hangDepsFor(report string, capErr error, files map[string]string) hangDeps {
+	return hangDeps{
+		capture: func(context.Context, int, int) (string, error) { return report, capErr },
+		readFile: func(p string) ([]byte, error) {
+			if v, ok := files[p]; ok {
+				return []byte(v), nil
+			}
+			return nil, errors.New("no such file")
+		},
+	}
+}
+
+func TestRunHangLockedExit3(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runHangWithIO([]string{"4012"}, &out, &errBuf, hangDepsFor(hangLockSample, nil, nil))
+	if code != 3 {
+		t.Fatalf("exit = %d, want 3 for a hung main thread", code)
+	}
+	if !strings.Contains(out.String(), "lock-blocked") {
+		t.Errorf("expected lock-blocked verdict, got:\n%s", out.String())
+	}
+}
+
+func TestRunHangIdleExit0(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runHangWithIO([]string{"4012"}, &out, &errBuf, hangDepsFor(hangIdleSample, nil, nil))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 for an idle main thread", code)
+	}
+	if !strings.Contains(out.String(), "idle") {
+		t.Errorf("expected idle verdict, got:\n%s", out.String())
+	}
+}
+
+func TestRunHangInput(t *testing.T) {
+	deps := hangDepsFor("", nil, map[string]string{"/s.txt": hangLockSample})
+	var out, errBuf bytes.Buffer
+	if code := runHangWithIO([]string{"--input", "/s.txt"}, &out, &errBuf, deps); code != 3 {
+		t.Fatalf("exit = %d, want 3", code)
+	}
+}
+
+func TestRunHangJSON(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runHangWithIO([]string{"--json", "4012"}, &out, &errBuf, hangDepsFor(hangIdleSample, nil, nil)); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"main_thread"`) || !strings.Contains(out.String(), `"verdict"`) {
+		t.Errorf("expected JSON, got:\n%s", out.String())
+	}
+}
+
+func TestRunHangCaptureError(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runHangWithIO([]string{"4012"}, &out, &errBuf, hangDepsFor("", errors.New("boom"), nil)); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestRunHangArgValidation(t *testing.T) {
+	deps := hangDepsFor(hangIdleSample, nil, map[string]string{"/s.txt": hangIdleSample})
+	for _, args := range [][]string{{}, {"notapid"}, {"1", "2"}, {"--input", "/s.txt", "9"}} {
+		var out, errBuf bytes.Buffer
+		if code := runHangWithIO(args, &out, &errBuf, deps); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -77,6 +77,7 @@ func subcommandList() []subcommand {
 		{"lsmp", "Summarize a process's Mach port table (right counts, leak detection)", runLsmp},
 		{"malloc-history", "Attribute allocations to call stacks (requires MallocStackLogging)", runMallocHistory},
 		{"flamegraph", "Render a native CPU flamegraph (SVG) from a process sample", runFlamegraph},
+		{"hang", "Classify why a process's main thread is hung (lock/I-O/spin/idle)", runHang},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -536,6 +536,27 @@ spectra vmregions --top 20 4012
 spectra vmregions --json 4012
 ```
 
+## `spectra hang`
+
+Captures a `sample` and classifies why a process's **main thread** is hung —
+answering the question a raw sample can't. It finds the `com.apple.main-thread`,
+follows its hottest stack to the leaf, and reports a verdict: **idle** (parked in
+`mach_msg` under a CFRunLoop, healthy — waiting for events), **lock-blocked**
+(leaf is a mutex/condvar/ulock wait, or a synchronous `mach_msg` IPC outside the
+run loop — the main thread should never wait on a lock), **io-blocked** (leaf is
+a synchronous syscall such as `read`/`select`/`open`), **spinning** (leaf is
+application code on-CPU — a compute hang), or **unknown**. It exits non-zero when
+the main thread is genuinely hung (lock/I-O/spin) so scripts can gate on it.
+`--input` analyzes an existing sample file; `--json` emits the structured result.
+
+### Examples
+
+```bash
+spectra hang 4012
+spectra hang --duration 3 4012
+spectra hang --input /tmp/beachball.sample.txt --json
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/hangcapture/hangcapture.go
+++ b/internal/hangcapture/hangcapture.go
@@ -1,0 +1,200 @@
+// Package hangcapture analyzes a native `sample` report to decide whether a
+// process's main thread is genuinely hung — and why (a lock, synchronous I/O,
+// or a CPU spin) — or merely idle waiting for events. It reads only.
+package hangcapture
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Verdict is the classification of a main thread's state.
+type Verdict string
+
+const (
+	VerdictIdle        Verdict = "idle"
+	VerdictLockBlocked Verdict = "lock-blocked"
+	VerdictIOBlocked   Verdict = "io-blocked"
+	VerdictSpinning    Verdict = "spinning"
+	VerdictUnknown     Verdict = "unknown"
+)
+
+// MainThread is the analysis of a process's main thread.
+type MainThread struct {
+	Found     bool     `json:"found"`
+	Verdict   Verdict  `json:"verdict"`
+	Reason    string   `json:"reason"`
+	Leaf      string   `json:"leaf,omitempty"`
+	TopFrames []string `json:"top_frames,omitempty"`
+}
+
+// Analysis is the whole hang analysis of a sample.
+type Analysis struct {
+	MainThread MainThread `json:"main_thread"`
+}
+
+var frameLine = regexp.MustCompile(`^(\s+)(\d+)\s+(.*\S)\s*$`)
+
+// lockWaits are leaf symbols that mean the thread is blocked on a lock.
+var lockWaits = map[string]bool{
+	"__psynch_mutexwait": true, "__psynch_cvwait": true,
+	"__ulock_wait": true, "__ulock_wait2": true,
+	"pthread_mutex_lock": true, "pthread_cond_wait": true,
+	"pthread_rwlock_wrlock": true, "pthread_rwlock_rdlock": true,
+	"os_unfair_lock_lock_slow": true,
+}
+
+// ioWaits are leaf symbols that mean the thread is blocked in a syscall.
+var ioWaits = map[string]bool{
+	"read": true, "__read_nocancel": true, "write": true, "__write_nocancel": true,
+	"__semwait_signal": true, "select": true, "poll": true, "__select": true,
+	"open": true, "__open_nocancel": true, "stat64": true, "fstat64": true, "lstat64": true,
+	"connect": true, "__connect_nocancel": true, "recvfrom": true, "recvmsg": true,
+	"sendto": true, "fcntl": true, "__getdirentries64": true, "fsync": true, "flock": true,
+	"waitpid": true, "__wait4": true, "kevent": true, "kevent_id": true, "kevent_qos": true,
+}
+
+// machMsg leaf symbols mean the thread is parked in the Mach messaging layer;
+// under a CFRunLoop that is a healthy idle wait for events.
+var machMsg = map[string]bool{
+	"mach_msg_trap": true, "mach_msg2_trap": true, "mach_msg": true, "mach_msg2_internal": true,
+}
+
+// Analyze classifies the main thread found in a `sample` call graph.
+func Analyze(sampleOutput string) Analysis {
+	chain, ok := mainThreadChain(sampleOutput)
+	if !ok {
+		return Analysis{MainThread: MainThread{Found: false, Verdict: VerdictUnknown, Reason: "no main thread (com.apple.main-thread) found in the sample"}}
+	}
+	leaf := ""
+	if len(chain) > 0 {
+		leaf = chain[len(chain)-1]
+	}
+	verdict, reason := classify(leaf, chain)
+	return Analysis{MainThread: MainThread{
+		Found:     true,
+		Verdict:   verdict,
+		Reason:    reason,
+		Leaf:      leaf,
+		TopFrames: topFrames(chain, 8),
+	}}
+}
+
+// classify decides the verdict from the leaf frame and the thread's stack.
+func classify(leaf string, chain []string) (Verdict, string) {
+	switch {
+	case lockWaits[leaf]:
+		return VerdictLockBlocked, "main thread is blocked acquiring a lock (" + leaf + ") — it should never wait on a lock"
+	case machMsg[leaf] && stackHasRunLoop(chain):
+		return VerdictIdle, "main thread is idle in its run loop waiting for events (" + leaf + ")"
+	case machMsg[leaf]:
+		return VerdictLockBlocked, "main thread is parked in mach_msg outside the run loop (" + leaf + ") — likely a synchronous IPC/wait"
+	case ioWaits[leaf]:
+		return VerdictIOBlocked, "main thread is blocked in a synchronous syscall (" + leaf + ")"
+	case leaf == "":
+		return VerdictUnknown, "main thread stack could not be read"
+	default:
+		return VerdictSpinning, "main thread is on-CPU in application code (" + leaf + ") — a compute hang"
+	}
+}
+
+func stackHasRunLoop(chain []string) bool {
+	for _, f := range chain {
+		if strings.Contains(f, "CFRunLoop") || strings.Contains(f, "__CFRunLoopServiceMachPort") {
+			return true
+		}
+	}
+	return false
+}
+
+// mainThreadChain returns the root→leaf frame chain of the main thread. It
+// follows the heaviest child at each level so a branching thread still yields
+// its hottest path.
+func mainThreadChain(out string) ([]string, bool) {
+	lines := strings.Split(out, "\n")
+	start, headerIndent := -1, 0
+	for i, line := range lines {
+		if !strings.Contains(line, "main-thread") {
+			continue
+		}
+		if m := frameLine.FindStringSubmatch(line); m != nil {
+			start, headerIndent = i, len(m[1])
+			break
+		}
+	}
+	if start < 0 {
+		return nil, false
+	}
+
+	chain := []string{cleanSymbol(lineText(lines[start]))}
+	// Walk deeper frames, at each depth taking the highest-count child.
+	curIndent := headerIndent
+	for i := start + 1; i < len(lines); i++ {
+		m := frameLine.FindStringSubmatch(lines[i])
+		if m == nil {
+			if strings.TrimSpace(lines[i]) == "" {
+				continue
+			}
+			break // left the call graph
+		}
+		indent := len(m[1])
+		if indent <= headerIndent {
+			break // next thread
+		}
+		if indent <= curIndent {
+			continue // sibling or shallower; keep the first (heaviest) chosen path
+		}
+		// First child one level deeper: take it and descend.
+		if indent == curIndent+2 || indent > curIndent {
+			chain = append(chain, cleanSymbol(m[3]))
+			curIndent = indent
+		}
+	}
+	return chain, true
+}
+
+func lineText(line string) string {
+	if m := frameLine.FindStringSubmatch(line); m != nil {
+		return m[3]
+	}
+	return strings.TrimSpace(line)
+}
+
+func topFrames(chain []string, n int) []string {
+	// The most relevant frames are the deepest (leaf-most).
+	if len(chain) <= n {
+		return chain
+	}
+	return chain[len(chain)-n:]
+}
+
+// cleanSymbol reduces a call-graph frame's text to a bare symbol name.
+func cleanSymbol(s string) string {
+	if i := strings.Index(s, "  (in "); i >= 0 {
+		s = s[:i]
+	} else if i := strings.Index(s, " (in "); i >= 0 {
+		s = s[:i]
+	} else if i := strings.Index(s, "   "); i >= 0 {
+		s = s[:i]
+	}
+	if i := strings.Index(s, "  ["); i >= 0 {
+		s = s[:i]
+	}
+	s = offsetTail.ReplaceAllString(s, "")
+	return sanitize(strings.TrimSpace(s))
+}
+
+var offsetTail = regexp.MustCompile(`\s+\+\s+\d+$`)
+
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t':
+			return ' '
+		case r < 0x20 || r == 0x7f:
+			return -1
+		default:
+			return r
+		}
+	}, s)
+}

--- a/internal/hangcapture/hangcapture_test.go
+++ b/internal/hangcapture/hangcapture_test.go
@@ -1,0 +1,107 @@
+package hangcapture
+
+import "testing"
+
+// buildSample wraps a main-thread call chain (leaf last) in a minimal sample
+// "Call graph" with the given deepest-leaf symbols, plus an unrelated thread.
+func idleSample() string {
+	return `Call graph:
+    500 Thread_1   DispatchQueue_2: com.apple.libdispatch  (serial)
+      500 worker  (in App) + 1  [0x1]
+    900 Thread_2   DispatchQueue_1: com.apple.main-thread  (serial)
+      900 start  (in dyld) + 1  [0x2]
+        900 CFRunLoopRunSpecific  (in CoreFoundation) + 1  [0x3]
+          900 __CFRunLoopServiceMachPort  (in CoreFoundation) + 1  [0x4]
+            900 mach_msg2_trap  (in libsystem_kernel.dylib) + 1  [0x5]
+`
+}
+
+func TestAnalyzeIdle(t *testing.T) {
+	a := Analyze(idleSample())
+	if !a.MainThread.Found {
+		t.Fatal("main thread not found")
+	}
+	if a.MainThread.Verdict != VerdictIdle {
+		t.Errorf("verdict = %s, want idle (leaf %q)", a.MainThread.Verdict, a.MainThread.Leaf)
+	}
+}
+
+func TestAnalyzeLockBlocked(t *testing.T) {
+	sample := `Call graph:
+    900 Thread_2   DispatchQueue_1: com.apple.main-thread  (serial)
+      900 main  (in App) + 1  [0x1]
+        900 -[Store save]  (in App) + 1  [0x2]
+          900 pthread_mutex_lock  (in libsystem_pthread.dylib) + 1  [0x3]
+            900 __psynch_mutexwait  (in libsystem_kernel.dylib) + 1  [0x4]
+`
+	a := Analyze(sample)
+	if a.MainThread.Verdict != VerdictLockBlocked {
+		t.Errorf("verdict = %s, want lock-blocked (leaf %q)", a.MainThread.Verdict, a.MainThread.Leaf)
+	}
+	if a.MainThread.Leaf != "__psynch_mutexwait" {
+		t.Errorf("leaf = %q", a.MainThread.Leaf)
+	}
+}
+
+func TestAnalyzeIOBlocked(t *testing.T) {
+	sample := `Call graph:
+    900 Thread_2   DispatchQueue_1: com.apple.main-thread  (serial)
+      900 main  (in App) + 1  [0x1]
+        900 -[Net fetch]  (in App) + 1  [0x2]
+          900 read  (in libsystem_kernel.dylib) + 1  [0x3]
+`
+	if v := Analyze(sample).MainThread.Verdict; v != VerdictIOBlocked {
+		t.Errorf("verdict = %s, want io-blocked", v)
+	}
+}
+
+func TestAnalyzeSpinning(t *testing.T) {
+	sample := `Call graph:
+    900 Thread_2   DispatchQueue_1: com.apple.main-thread  (serial)
+      900 main  (in App) + 1  [0x1]
+        900 -[Layout compute]  (in App) + 1  [0x2]
+          900 crunchNumbers  (in App) + 1  [0x3]
+`
+	a := Analyze(sample)
+	if a.MainThread.Verdict != VerdictSpinning {
+		t.Errorf("verdict = %s, want spinning", a.MainThread.Verdict)
+	}
+	if a.MainThread.Leaf != "crunchNumbers" {
+		t.Errorf("leaf = %q", a.MainThread.Leaf)
+	}
+}
+
+func TestAnalyzeMachMsgOutsideRunLoop(t *testing.T) {
+	// mach_msg without a CFRunLoop in the stack is a synchronous IPC wait, not idle.
+	sample := `Call graph:
+    900 Thread_2   DispatchQueue_1: com.apple.main-thread  (serial)
+      900 main  (in App) + 1  [0x1]
+        900 xpc_connection_send_message_with_reply_sync  (in libxpc) + 1  [0x2]
+          900 mach_msg2_trap  (in libsystem_kernel.dylib) + 1  [0x3]
+`
+	if v := Analyze(sample).MainThread.Verdict; v != VerdictLockBlocked {
+		t.Errorf("verdict = %s, want lock-blocked (synchronous IPC)", v)
+	}
+}
+
+func TestAnalyzeNoMainThread(t *testing.T) {
+	sample := `Call graph:
+    500 Thread_1   DispatchQueue_2: com.apple.libdispatch  (serial)
+      500 worker  (in App) + 1  [0x1]
+`
+	a := Analyze(sample)
+	if a.MainThread.Found {
+		t.Error("should not find a main thread")
+	}
+	if a.MainThread.Verdict != VerdictUnknown {
+		t.Errorf("verdict = %s, want unknown", a.MainThread.Verdict)
+	}
+}
+
+func TestTopFramesLeafLast(t *testing.T) {
+	a := Analyze(idleSample())
+	frames := a.MainThread.TopFrames
+	if len(frames) == 0 || frames[len(frames)-1] != "mach_msg2_trap" {
+		t.Errorf("leaf should be last, got %v", frames)
+	}
+}


### PR DESCRIPTION
## What

`spectra hang <pid>` — captures a `sample` and classifies why a process's **main thread** is hung, the question a raw sample/spindump can't answer. **Phase-B item 3 (final).**

## How

- **`internal/hangcapture`** finds the `com.apple.main-thread` in the sample call graph, follows its hottest stack to the leaf, and returns a verdict:
  - **idle** — leaf is `mach_msg*_trap` *and* a CFRunLoop is in the stack (healthy: waiting for events);
  - **lock-blocked** — leaf is a mutex/condvar/ulock wait (`__psynch_mutexwait`, `__psynch_cvwait`, `__ulock_wait`, `pthread_mutex_lock`, …), **or** a synchronous `mach_msg` IPC *outside* the run loop — the main thread should never wait on a lock;
  - **io-blocked** — leaf is a synchronous syscall (`read`, `__semwait_signal`, `select`, `poll`, `open`, `stat64`, …);
  - **spinning** — leaf is application code on-CPU (a compute hang);
  - **unknown** otherwise.
  It reports the verdict, a one-line reason, and the main thread's top frames (leaf last).
- **`spectra hang [--input <sample>] [--duration <s>] [--json] <pid>`** — captures via the existing sampler (injected for tests) or analyzes an existing `--input` sample. **Exits 3** when the main thread is genuinely hung (lock/I-O/spin), 0 for idle/unknown, so scripts can gate on it.

## Testing

Analyzer tests for every verdict: idle (mach_msg under CFRunLoop), lock-blocked (`__psynch_mutexwait`), io-blocked (`read`), spinning (app code), the mach_msg-outside-runloop → lock-blocked distinction, no-main-thread → unknown, and leaf-last frame ordering. CLI tests: locked → exit 3, idle → exit 0, `--input`, `--json`, capture error, and arg validation. `make vet complexity lint security docs-validate test` green (72 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #458
