### PR TITLE
heap: dominator tree + retained sizes + leak-suspects (spectra jvm dominators)

### DIFF
--- a/cmd/spectra/jvm.go
+++ b/cmd/spectra/jvm.go
@@ -94,6 +94,7 @@ func resolveJVMSubcommand(args []string) (func([]string) int, bool) {
 		"thread-dump":    runJVMThreadDump,
 		"heap-histogram": runJVMHeapHistogram,
 		"heap-hprof":     runJVMHeapHPROF,
+		"dominators":     runJVMDominators,
 		"heap-dump":      runJVMHeapDump,
 		"gc-log":         runJVMGCLog,
 		"jfr":            runJVMJFR,

--- a/cmd/spectra/jvm_dominators.go
+++ b/cmd/spectra/jvm_dominators.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kaeawc/spectra/internal/heap"
+)
+
+// runJVMDominators computes retained sizes over a saved .hprof heap dump and
+// ranks the objects retaining the most memory — the leak suspects a class
+// histogram (shallow size) cannot find.
+func runJVMDominators(args []string) int {
+	fs := flag.NewFlagSet("spectra jvm dominators", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	asJSON := fs.Bool("json", false, "Emit the retained-size analysis as JSON")
+	top := fs.Int("top", 20, "Number of top retained-size objects (leak suspects) to rank")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *top < 0 {
+		fmt.Fprintln(os.Stderr, "dominators: --top must be >= 0")
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: spectra jvm dominators [--top N] [--json] <file.hprof>")
+		return 2
+	}
+	path := fs.Arg(0)
+	graph, err := heap.ParseObjectGraphFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parsing %q: %v\n", path, err)
+		return 1
+	}
+	res := heap.Dominators(graph, *top)
+	if graph.Unresolved > 0 {
+		fmt.Fprintf(os.Stderr, "note: %d instance(s) had no class layout; their references were not walked\n", graph.Unresolved)
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(res)
+		return 0
+	}
+	printDominators(os.Stdout, path, res)
+	return 0
+}
+
+func printDominators(w io.Writer, path string, res heap.DominatorResult) {
+	fmt.Fprintf(w, "=== retained-size analysis: %s ===\n", path)
+	fmt.Fprintf(w, "total heap (shallow): %s | reachable: %s across %d objects\n",
+		humanSize(res.TotalShallowBytes), humanSize(res.ReachableBytes), res.ReachableObjects)
+	fmt.Fprintf(w, "  %12s  %7s  %-40s\n", "RETAINED", "%HEAP", "CLASS (object id)")
+	for _, s := range res.Suspects {
+		fmt.Fprintf(w, "  %12s  %6.1f%%  %s\n",
+			humanSize(s.RetainedBytes), s.PercentOfHeap,
+			truncate(fmt.Sprintf("%s (0x%x)", s.ClassName, s.ID), 48))
+	}
+}

--- a/cmd/spectra/jvm_dominators_test.go
+++ b/cmd/spectra/jvm_dominators_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunJVMDominatorsArgValidation(t *testing.T) {
+	for _, args := range [][]string{
+		{},                     // no file
+		{"a.hprof", "b.hprof"}, // too many
+		{"--top", "-1", "a.hprof"},
+	} {
+		if code := runJVMDominators(args); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}
+
+func TestRunJVMDominatorsBadFile(t *testing.T) {
+	if code := runJVMDominators([]string{filepath.Join(t.TempDir(), "missing.hprof")}); code != 1 {
+		t.Errorf("missing file: exit = %d, want 1", code)
+	}
+}
+
+func TestRunJVMDominatorsInvalidHPROF(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.hprof")
+	if err := os.WriteFile(path, []byte("not an hprof file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if code := runJVMDominators([]string{path}); code != 1 {
+		t.Errorf("invalid hprof: exit = %d, want 1", code)
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -305,6 +305,13 @@ spectra issues update --status fixed issue-123
 
 Lists or inspects running JVM processes and exposes JDK-tool diagnostics.
 
+`spectra jvm dominators <file.hprof>` goes beyond the class histogram (shallow
+sizes): it parses the heap dump's object reference graph, builds the dominator
+tree over the GC roots, and ranks objects by **retained size** — the memory that
+would actually be freed if the object were collected. The object retaining the
+largest share of the reachable heap is the leak suspect a histogram cannot
+surface. `--top` bounds the ranking; `--json` emits the structured result.
+
 ### Examples
 
 ```bash
@@ -315,6 +322,8 @@ spectra jvm explain --samples 6 --interval 10s 4012
 spectra jvm thread-dump --summary 4012
 spectra jvm heap-histogram --suspects 20 4012
 spectra jvm heap-dump --out /tmp/app.hprof 4012
+spectra jvm dominators --top 20 /tmp/app.hprof
+spectra jvm dominators --json /tmp/app.hprof
 spectra jvm gc-stats --json 4012
 spectra jvm vm-memory --json 4012
 spectra jvm jmx status 4012

--- a/internal/heap/dominators.go
+++ b/internal/heap/dominators.go
@@ -1,0 +1,247 @@
+package heap
+
+import (
+	"bufio"
+	"os"
+	"sort"
+)
+
+// RetainedSuspect is one object ranked by retained size — the memory that would
+// be freed if it were collected.
+type RetainedSuspect struct {
+	ID            uint64  `json:"id"`
+	ClassName     string  `json:"class_name"`
+	ShallowBytes  int64   `json:"shallow_bytes"`
+	RetainedBytes int64   `json:"retained_bytes"`
+	PercentOfHeap float64 `json:"percent_of_heap"`
+}
+
+// DominatorResult is the retained-size analysis of an object graph.
+type DominatorResult struct {
+	TotalShallowBytes int64             `json:"total_shallow_bytes"`
+	ReachableObjects  int               `json:"reachable_objects"`
+	ReachableBytes    int64             `json:"reachable_bytes"`
+	Suspects          []RetainedSuspect `json:"suspects"`
+}
+
+// Dominators computes the dominator tree of g (rooted at a synthetic super-root
+// over all GC roots), each reachable object's retained size, and the top N
+// objects by retained size. Cooper-Harvey-Kennedy iterative dominators; cost is
+// roughly O(nodes × edges) worst case, adequate for moderate heaps.
+func Dominators(g *ObjectGraph, topN int) DominatorResult {
+	var res DominatorResult
+	for _, n := range g.Nodes {
+		res.TotalShallowBytes += n.ShallowSize
+	}
+
+	// Index the reachable subgraph. Node 0 is the synthetic super-root, whose
+	// successors are the GC roots.
+	idx := map[uint64]int{}
+	var ids []uint64     // dense index (>=1) -> object id
+	succ := [][]int{nil} // succ[0] filled after roots are indexed
+	ids = append(ids, 0) // placeholder for the super-root at index 0
+	var visit func(id uint64) int
+	visit = func(id uint64) int {
+		if i, ok := idx[id]; ok {
+			return i
+		}
+		node, ok := g.Nodes[id]
+		if !ok {
+			return -1
+		}
+		i := len(ids)
+		idx[id] = i
+		ids = append(ids, id)
+		succ = append(succ, nil)
+		for _, o := range node.Out {
+			if child := visit(o); child >= 0 {
+				succ[i] = append(succ[i], child)
+			}
+		}
+		return i
+	}
+	for _, r := range g.Roots {
+		if child := visit(r); child >= 0 {
+			succ[0] = append(succ[0], child)
+		}
+	}
+
+	n := len(ids)
+	res.ReachableObjects = n - 1
+	if n == 1 {
+		return res // no reachable objects
+	}
+	for i := 1; i < n; i++ {
+		res.ReachableBytes += g.Nodes[ids[i]].ShallowSize
+	}
+
+	idom := computeIdom(n, succ)
+	retained := computeRetained(n, idom, ids, g)
+
+	suspects := make([]RetainedSuspect, 0, n-1)
+	for i := 1; i < n; i++ {
+		node := g.Nodes[ids[i]]
+		pct := 0.0
+		if res.ReachableBytes > 0 {
+			pct = 100 * float64(retained[i]) / float64(res.ReachableBytes)
+		}
+		suspects = append(suspects, RetainedSuspect{
+			ID: node.ID, ClassName: node.ClassName,
+			ShallowBytes: node.ShallowSize, RetainedBytes: retained[i], PercentOfHeap: pct,
+		})
+	}
+	sort.SliceStable(suspects, func(a, b int) bool {
+		if suspects[a].RetainedBytes != suspects[b].RetainedBytes {
+			return suspects[a].RetainedBytes > suspects[b].RetainedBytes
+		}
+		return suspects[a].ID < suspects[b].ID
+	})
+	if topN > 0 && len(suspects) > topN {
+		suspects = suspects[:topN]
+	}
+	res.Suspects = suspects
+	return res
+}
+
+// computeIdom returns the immediate dominator index of each node (idom[0]=0 for
+// the super-root), using the CHK iterative algorithm over a reverse-postorder.
+func computeIdom(n int, succ [][]int) []int {
+	order, post := reversePostorder(n, succ)
+	pred := make([][]int, n)
+	for u := 0; u < n; u++ {
+		for _, v := range succ[u] {
+			pred[v] = append(pred[v], u)
+		}
+	}
+
+	idom := make([]int, n)
+	for i := range idom {
+		idom[i] = -1
+	}
+	idom[0] = 0
+
+	changed := true
+	for changed {
+		changed = false
+		for _, b := range order {
+			if b == 0 {
+				continue
+			}
+			newIdom := -1
+			for _, p := range pred[b] {
+				if idom[p] == -1 {
+					continue
+				}
+				if newIdom == -1 {
+					newIdom = p
+				} else {
+					newIdom = intersect(p, newIdom, idom, post)
+				}
+			}
+			if newIdom != -1 && idom[b] != newIdom {
+				idom[b] = newIdom
+				changed = true
+			}
+		}
+	}
+	return idom
+}
+
+func intersect(a, b int, idom, post []int) int {
+	for a != b {
+		for post[a] < post[b] {
+			a = idom[a]
+		}
+		for post[b] < post[a] {
+			b = idom[b]
+		}
+	}
+	return a
+}
+
+// reversePostorder returns node indices in reverse postorder (root first) and a
+// postorder-number array (higher = later in postorder; the root is highest).
+func reversePostorder(n int, succ [][]int) (order, post []int) {
+	post = make([]int, n)
+	for i := range post {
+		post[i] = -1
+	}
+	visited := make([]bool, n)
+	counter := 0
+	// Iterative DFS postorder from the super-root (0).
+	type frame struct {
+		node int
+		next int
+	}
+	stack := []frame{{0, 0}}
+	visited[0] = true
+	var postList []int
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		if top.next < len(succ[top.node]) {
+			child := succ[top.node][top.next]
+			top.next++
+			if !visited[child] {
+				visited[child] = true
+				stack = append(stack, frame{child, 0})
+			}
+			continue
+		}
+		post[top.node] = counter
+		postList = append(postList, top.node)
+		counter++
+		stack = stack[:len(stack)-1]
+	}
+	// Reverse postorder.
+	order = make([]int, 0, len(postList))
+	for i := len(postList) - 1; i >= 0; i-- {
+		order = append(order, postList[i])
+	}
+	return order, post
+}
+
+// computeRetained sums shallow sizes over the dominator tree: retained[n] =
+// shallow[n] + sum(retained[children]).
+func computeRetained(n int, idom []int, ids []uint64, g *ObjectGraph) []int64 {
+	children := make([][]int, n)
+	for i := 1; i < n; i++ {
+		if idom[i] >= 0 && idom[i] != i {
+			children[idom[i]] = append(children[idom[i]], i)
+		}
+	}
+	retained := make([]int64, n)
+	for i := 1; i < n; i++ {
+		retained[i] = g.Nodes[ids[i]].ShallowSize
+	}
+	// Post-order over the dominator tree (root 0), iterative.
+	type frame struct {
+		node int
+		next int
+	}
+	stack := []frame{{0, 0}}
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		if top.next < len(children[top.node]) {
+			c := children[top.node][top.next]
+			top.next++
+			stack = append(stack, frame{c, 0})
+			continue
+		}
+		if p := idom[top.node]; top.node != 0 && p >= 0 {
+			retained[p] += retained[top.node]
+		}
+		stack = stack[:len(stack)-1]
+	}
+	return retained
+}
+
+// ParseObjectGraphFile streams and parses the object reference graph of the
+// .hprof file at path.
+func ParseObjectGraphFile(path string) (*ObjectGraph, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return ParseObjectGraph(bufio.NewReaderSize(f, 1<<20))
+}

--- a/internal/heap/dominators_test.go
+++ b/internal/heap/dominators_test.go
@@ -1,0 +1,134 @@
+package heap
+
+import (
+	"bytes"
+	"testing"
+)
+
+func bytesReader(b []byte) *bytes.Reader { return bytes.NewReader(b) }
+
+func node(id uint64, class string, shallow int64, out ...uint64) *ObjectNode {
+	return &ObjectNode{ID: id, ClassName: class, ShallowSize: shallow, Out: out}
+}
+
+func graph(roots []uint64, nodes ...*ObjectNode) *ObjectGraph {
+	m := map[uint64]*ObjectNode{}
+	for _, n := range nodes {
+		m[n.ID] = n
+	}
+	return &ObjectGraph{Nodes: m, Roots: roots, IDSize: 8}
+}
+
+func retainedByID(res DominatorResult, id uint64) int64 {
+	for _, s := range res.Suspects {
+		if s.ID == id {
+			return s.RetainedBytes
+		}
+	}
+	return -1
+}
+
+func TestDominatorsDiamond(t *testing.T) {
+	// R -> a; a -> b, a -> c; b -> d; c -> d. idom(d) = a, so a retains all.
+	g := graph([]uint64{1},
+		node(1, "A", 10, 2, 3),
+		node(2, "B", 10, 4),
+		node(3, "C", 10, 4),
+		node(4, "D", 10),
+	)
+	res := Dominators(g, 0)
+	if res.ReachableObjects != 4 || res.ReachableBytes != 40 {
+		t.Fatalf("reachable = %d objs / %d bytes", res.ReachableObjects, res.ReachableBytes)
+	}
+	if got := retainedByID(res, 1); got != 40 {
+		t.Errorf("retained(a) = %d, want 40 (a dominates the whole graph)", got)
+	}
+	for _, id := range []uint64{2, 3, 4} {
+		if got := retainedByID(res, id); got != 10 {
+			t.Errorf("retained(%d) = %d, want 10", id, got)
+		}
+	}
+	if res.Suspects[0].ID != 1 || res.Suspects[0].PercentOfHeap != 100 {
+		t.Errorf("top suspect = %+v, want id 1 at 100%%", res.Suspects[0])
+	}
+}
+
+func TestDominatorsCycle(t *testing.T) {
+	// R -> a; a <-> b. a retains a+b; b retains itself.
+	g := graph([]uint64{1},
+		node(1, "A", 10, 2),
+		node(2, "B", 10, 1),
+	)
+	res := Dominators(g, 0)
+	if got := retainedByID(res, 1); got != 20 {
+		t.Errorf("retained(a) = %d, want 20", got)
+	}
+	if got := retainedByID(res, 2); got != 10 {
+		t.Errorf("retained(b) = %d, want 10", got)
+	}
+}
+
+func TestDominatorsUnreachable(t *testing.T) {
+	// orphan (5) is neither a root nor referenced; it counts toward total heap
+	// but not the reachable set or the suspects.
+	g := graph([]uint64{1},
+		node(1, "A", 10),
+		node(5, "Orphan", 7),
+	)
+	res := Dominators(g, 0)
+	if res.TotalShallowBytes != 17 {
+		t.Errorf("total = %d, want 17", res.TotalShallowBytes)
+	}
+	if res.ReachableObjects != 1 || res.ReachableBytes != 10 {
+		t.Errorf("reachable = %d/%d, want 1/10", res.ReachableObjects, res.ReachableBytes)
+	}
+	if retainedByID(res, 5) != -1 {
+		t.Error("orphan must not appear in suspects")
+	}
+}
+
+func TestDominatorsTopN(t *testing.T) {
+	g := graph([]uint64{1, 2, 3},
+		node(1, "A", 30),
+		node(2, "B", 20),
+		node(3, "C", 10),
+	)
+	res := Dominators(g, 2)
+	if len(res.Suspects) != 2 {
+		t.Fatalf("topN=2 gave %d", len(res.Suspects))
+	}
+	if res.Suspects[0].ID != 1 || res.Suspects[1].ID != 2 {
+		t.Errorf("top-2 by retained = %d,%d want 1,2", res.Suspects[0].ID, res.Suspects[1].ID)
+	}
+}
+
+func TestDominatorsEmpty(t *testing.T) {
+	res := Dominators(&ObjectGraph{Nodes: map[uint64]*ObjectNode{}, IDSize: 8}, 5)
+	if res.ReachableObjects != 0 || len(res.Suspects) != 0 {
+		t.Errorf("empty graph = %+v", res)
+	}
+}
+
+func TestDominatorsEndToEndFromHPROF(t *testing.T) {
+	// Parse the graph the 9a builder emits, then run retained-size analysis.
+	// Reachable from the root (a): a and b form a cycle; the arrays are neither
+	// rooted nor referenced, so they are unreachable.
+	g, err := ParseObjectGraph(bytesReader(buildGraphDump(8)))
+	if err != nil {
+		t.Fatalf("ParseObjectGraph: %v", err)
+	}
+	res := Dominators(g, 5)
+	if res.ReachableObjects != 2 {
+		t.Fatalf("reachable = %d, want 2 (a,b)", res.ReachableObjects)
+	}
+	// a shallow = idSize(8); b shallow = instSize(idSize+4=12). a retains both.
+	if got := retainedByID(res, 1000); got != 20 {
+		t.Errorf("retained(a) = %d, want 20", got)
+	}
+	if got := retainedByID(res, 1001); got != 12 {
+		t.Errorf("retained(b) = %d, want 12", got)
+	}
+	if res.Suspects[0].ID != 1000 {
+		t.Errorf("top suspect = 0x%x, want a(0x3e8)", res.Suspects[0].ID)
+	}
+}


### PR DESCRIPTION
## What

`spectra jvm dominators <file.hprof>` — computes **retained sizes** over the heap-dump object graph and ranks the objects retaining the most memory: the leak suspects a class histogram (shallow size) cannot find. **Item 9b — completes the hprof-dominator keystone** (9a #461 parsed the graph).

## How

`internal/heap/dominators.go`:
- index the subgraph reachable from a **synthetic super-root** over all GC roots;
- compute each object's **immediate dominator** via the Cooper-Harvey-Kennedy iterative algorithm over a reverse-postorder (correct on cycles);
- compute **retained size** by a post-order walk of the dominator tree — an object's shallow size plus the retained size of everything it dominates;
- rank the top-N by retained size with **% of the reachable heap**; unreachable objects count toward the total but are excluded from the reachable set and suspects.
- `ParseObjectGraphFile` reads a dump from disk.

CLI `spectra jvm dominators [--top N] [--json] <file.hprof>` parses, analyzes, prints. Worst-case cost ≈ O(nodes × edges) — noted as adequate for moderate heaps.

## Testing

Algorithm tests on **hand-verifiable** graphs built directly (no HPROF bytes): a **diamond** (`R→a; a→b; a→c; b→d; c→d` ⇒ `idom(d)=a`, `retained(a)=whole graph at 100%`), a **cycle** (`a↔b` ⇒ a retains both), **unreachable** objects (count toward total, excluded from reachable/suspects), top-N truncation, and an empty graph. An **end-to-end** test parses the 9a builder's HPROF bytes and runs the analysis (a↔b cycle reachable, arrays unreachable; retained(a)=20, retained(b)=12). CLI tests: arg validation (incl. negative `--top`), missing file, and invalid HPROF. `make vet complexity lint security docs-validate test` green (72 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #462
