### PR TITLE
timeline: unified incident timeline engine + process-start source (spectra timeline)

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -78,6 +78,7 @@ func subcommandList() []subcommand {
 		{"malloc-history", "Attribute allocations to call stacks (requires MallocStackLogging)", runMallocHistory},
 		{"flamegraph", "Render a native CPU flamegraph (SVG) from a process sample", runFlamegraph},
 		{"hang", "Classify why a process's main thread is hung (lock/I-O/spin/idle)", runHang},
+		{"timeline", "Merge process/log/update events into one chronological incident timeline", runTimeline},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -78,7 +78,7 @@ func subcommandList() []subcommand {
 		{"malloc-history", "Attribute allocations to call stacks (requires MallocStackLogging)", runMallocHistory},
 		{"flamegraph", "Render a native CPU flamegraph (SVG) from a process sample", runFlamegraph},
 		{"hang", "Classify why a process's main thread is hung (lock/I-O/spin/idle)", runHang},
-		{"timeline", "Merge process/log/update events into one chronological incident timeline", runTimeline},
+		{"timeline", "Chronological incident timeline of recently started processes (log/update sources coming)", runTimeline},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/cmd/spectra/timeline.go
+++ b/cmd/spectra/timeline.go
@@ -46,10 +46,16 @@ func runTimelineWithIO(args []string, stdout, stderr io.Writer, now func() time.
 	if *asJSON {
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(tl)
+		if err := enc.Encode(tl); err != nil {
+			fmt.Fprintf(stderr, "timeline: write output: %v\n", err)
+			return 1
+		}
 		return 0
 	}
-	tl.Render(stdout)
+	if err := tl.Render(stdout); err != nil {
+		fmt.Fprintf(stderr, "timeline: write output: %v\n", err)
+		return 1
+	}
 	return 0
 }
 

--- a/cmd/spectra/timeline.go
+++ b/cmd/spectra/timeline.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/timeline"
+)
+
+// processLister returns the currently running processes; injected for testing.
+type processLister func() []process.Info
+
+func runTimeline(args []string) int {
+	return runTimelineWithIO(args, os.Stdout, os.Stderr, time.Now, defaultProcessLister)
+}
+
+func runTimelineWithIO(args []string, stdout, stderr io.Writer, now func() time.Time, procs processLister) int {
+	fs := flag.NewFlagSet("spectra timeline", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	since := fs.Duration("since", time.Hour, "Only show events within this window (e.g. 30m, 2h)")
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a text timeline")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *since <= 0 {
+		fmt.Fprintln(stderr, "timeline: --since must be positive")
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: spectra timeline [--since <dur>] [--json]")
+		return 2
+	}
+
+	cutoff := now().Add(-*since)
+	tl, errs := timeline.Collect(cutoff, processStartSource{procs: procs})
+	for _, e := range errs {
+		fmt.Fprintf(stderr, "timeline: %v\n", e)
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(tl)
+		return 0
+	}
+	tl.Render(stdout)
+	return 0
+}
+
+// processStartSource turns each running process's start time into an event.
+type processStartSource struct {
+	procs processLister
+}
+
+func (processStartSource) Name() string { return "process" }
+
+func (s processStartSource) Events(since time.Time) ([]timeline.Event, error) {
+	var out []timeline.Event
+	for _, p := range s.procs() {
+		if p.StartTime.IsZero() || p.StartTime.Before(since) {
+			continue
+		}
+		name := p.Command
+		if name == "" {
+			name = p.BSDName
+		}
+		out = append(out, timeline.Event{
+			Time:     p.StartTime,
+			Source:   "process",
+			Severity: timeline.SeverityInfo,
+			Summary:  fmt.Sprintf("%s [%d] started", name, p.PID),
+		})
+	}
+	return out, nil
+}
+
+func defaultProcessLister() []process.Info {
+	return process.CollectAll(context.Background(), process.CollectOptions{})
+}

--- a/cmd/spectra/timeline_test.go
+++ b/cmd/spectra/timeline_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/process"
+)
+
+func fixedNow() time.Time { return time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC) }
+
+func fakeTimelineProcs() []process.Info {
+	return []process.Info{
+		{PID: 10, Command: "recent", StartTime: time.Date(2026, 1, 1, 11, 30, 0, 0, time.UTC)},
+		{PID: 20, Command: "old", StartTime: time.Date(2026, 1, 1, 8, 0, 0, 0, time.UTC)},
+		{PID: 30, Command: "nostart"}, // zero StartTime -> excluded
+	}
+}
+
+func TestRunTimelineWindowsAndSummary(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := runTimelineWithIO([]string{"--since", "1h"}, &out, &errBuf, fixedNow, fakeTimelineProcs)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "recent [10] started") {
+		t.Errorf("expected the recent process event, got:\n%s", s)
+	}
+	if strings.Contains(s, "old [20]") || strings.Contains(s, "nostart") {
+		t.Errorf("out-of-window / zero-start processes should be excluded:\n%s", s)
+	}
+}
+
+func TestRunTimelineJSON(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := runTimelineWithIO([]string{"--since", "6h", "--json"}, &out, &errBuf, fixedNow, fakeTimelineProcs); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"events"`) || !strings.Contains(out.String(), `"source"`) {
+		t.Errorf("expected JSON, got:\n%s", out.String())
+	}
+}
+
+func TestRunTimelineArgValidation(t *testing.T) {
+	for _, args := range [][]string{{"--since", "0"}, {"extra"}, {"--since", "-5m"}} {
+		var out, errBuf bytes.Buffer
+		if code := runTimelineWithIO(args, &out, &errBuf, fixedNow, fakeTimelineProcs); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -566,6 +566,25 @@ spectra hang --duration 3 4012
 spectra hang --input /tmp/beachball.sample.txt --json
 ```
 
+## `spectra timeline`
+
+Merges timestamped events from independent sources into one chronological
+incident view, so "what happened around 14:03?" has a single answer instead of
+being scattered across `process`, `logs`, and `updates`. Events carry a time,
+source, severity, and summary; the timeline is sorted ascending and filtered to
+a `--since` window (default 1h). Collection is best-effort — one failing source
+does not drop the others. `--json` emits the structured result. This first
+release wires the **process-start** source (each recently started process);
+the unified-log and install-history sources follow.
+
+### Examples
+
+```bash
+spectra timeline
+spectra timeline --since 30m
+spectra timeline --since 6h --json
+```
+
 ## `spectra power`
 
 Shows current host power and thermal state: AC/battery source, battery

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -79,17 +80,36 @@ func Collect(since time.Time, sources ...Source) (Timeline, []error) {
 	return Merge(groups...).Since(since), errs
 }
 
-// Render writes the timeline as aligned text.
-func (t Timeline) Render(w io.Writer) {
+// Render writes the timeline as aligned text, sanitizing event fields so a
+// control byte in a source's data cannot inject terminal escape sequences. It
+// returns the first write error (e.g. a broken pipe).
+func (t Timeline) Render(w io.Writer) error {
 	if len(t.Events) == 0 {
-		fmt.Fprintln(w, "(no events in the window)")
-		return
+		_, err := fmt.Fprintln(w, "(no events in the window)")
+		return err
 	}
 	for _, e := range t.Events {
-		fmt.Fprintf(w, "%s  %-5s  %-8s  %s\n",
+		if _, err := fmt.Fprintf(w, "%s  %-5s  %-8s  %s\n",
 			e.Time.Local().Format("2006-01-02 15:04:05"),
-			e.Severity, truncateField(e.Source, 8), e.Summary)
+			e.Severity, truncateField(sanitize(e.Source), 8), sanitize(e.Summary)); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+// sanitize strips C0/C1 control bytes from text taken from a source.
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t':
+			return ' '
+		case r < 0x20 || (r >= 0x7f && r <= 0x9f):
+			return -1
+		default:
+			return r
+		}
+	}, s)
 }
 
 func sortEvents(evs []Event) {

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -1,0 +1,112 @@
+// Package timeline merges timestamped events from independent sources — process
+// starts, unified-log entries, install/update events, and more — into one
+// chronological incident view. It reads only.
+package timeline
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"time"
+)
+
+// Severity ranks an event's importance.
+type Severity string
+
+const (
+	SeverityInfo  Severity = "info"
+	SeverityWarn  Severity = "warn"
+	SeverityError Severity = "error"
+)
+
+// Event is one thing that happened at a point in time.
+type Event struct {
+	Time     time.Time `json:"time"`
+	Source   string    `json:"source"`
+	Severity Severity  `json:"severity"`
+	Summary  string    `json:"summary"`
+}
+
+// Source produces events at or after the given cutoff.
+type Source interface {
+	// Name identifies the source (e.g. "process", "log").
+	Name() string
+	// Events returns this source's events no earlier than since.
+	Events(since time.Time) ([]Event, error)
+}
+
+// Timeline is a chronologically ordered set of events.
+type Timeline struct {
+	Events []Event `json:"events"`
+}
+
+// Merge combines event groups into one timeline sorted ascending by time
+// (ties broken by source then summary for stable output).
+func Merge(groups ...[]Event) Timeline {
+	var all []Event
+	for _, g := range groups {
+		all = append(all, g...)
+	}
+	sortEvents(all)
+	return Timeline{Events: all}
+}
+
+// Since returns the events at or after cutoff (the input is assumed sorted).
+func (t Timeline) Since(cutoff time.Time) Timeline {
+	out := make([]Event, 0, len(t.Events))
+	for _, e := range t.Events {
+		if !e.Time.Before(cutoff) {
+			out = append(out, e)
+		}
+	}
+	return Timeline{Events: out}
+}
+
+// Collect gathers events from all sources within the window [since, ∞), merges
+// them, and returns the timeline plus any per-source errors (collection is best
+// effort: one failing source does not drop the others).
+func Collect(since time.Time, sources ...Source) (Timeline, []error) {
+	var groups [][]Event
+	var errs []error
+	for _, s := range sources {
+		evs, err := s.Events(since)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", s.Name(), err))
+			continue
+		}
+		groups = append(groups, evs)
+	}
+	return Merge(groups...).Since(since), errs
+}
+
+// Render writes the timeline as aligned text.
+func (t Timeline) Render(w io.Writer) {
+	if len(t.Events) == 0 {
+		fmt.Fprintln(w, "(no events in the window)")
+		return
+	}
+	for _, e := range t.Events {
+		fmt.Fprintf(w, "%s  %-5s  %-8s  %s\n",
+			e.Time.Local().Format("2006-01-02 15:04:05"),
+			e.Severity, truncateField(e.Source, 8), e.Summary)
+	}
+}
+
+func sortEvents(evs []Event) {
+	sort.SliceStable(evs, func(i, j int) bool {
+		if !evs[i].Time.Equal(evs[j].Time) {
+			return evs[i].Time.Before(evs[j].Time)
+		}
+		if evs[i].Source != evs[j].Source {
+			return evs[i].Source < evs[j].Source
+		}
+		return evs[i].Summary < evs[j].Summary
+	})
+}
+
+func truncateField(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -90,13 +90,35 @@ func TestCollectAppliesWindow(t *testing.T) {
 
 func TestRenderEmptyAndPopulated(t *testing.T) {
 	var empty bytes.Buffer
-	Timeline{}.Render(&empty)
+	if err := (Timeline{}).Render(&empty); err != nil {
+		t.Fatalf("render: %v", err)
+	}
 	if !strings.Contains(empty.String(), "no events") {
 		t.Errorf("empty render = %q", empty.String())
 	}
 	var buf bytes.Buffer
-	Merge([]Event{{Time: at("2026-01-01T10:00:00Z"), Source: "process", Severity: SeverityWarn, Summary: "hello"}}).Render(&buf)
+	_ = Merge([]Event{{Time: at("2026-01-01T10:00:00Z"), Source: "process", Severity: SeverityWarn, Summary: "hello"}}).Render(&buf)
 	if !strings.Contains(buf.String(), "warn") || !strings.Contains(buf.String(), "hello") {
 		t.Errorf("render = %q", buf.String())
 	}
 }
+
+func TestRenderSanitizesControlBytes(t *testing.T) {
+	var buf bytes.Buffer
+	_ = Merge([]Event{{Time: at("2026-01-01T10:00:00Z"), Source: "pro\x1bcess", Summary: "ev\x07il\x1b[31m"}}).Render(&buf)
+	out := buf.String()
+	if strings.ContainsAny(out, "\x1b\x07") {
+		t.Errorf("control bytes not stripped: %q", out)
+	}
+}
+
+func TestRenderPropagatesWriteError(t *testing.T) {
+	tl := Merge([]Event{{Time: at("2026-01-01T10:00:00Z"), Source: "s", Summary: "x"}})
+	if err := tl.Render(failWriter{}); err == nil {
+		t.Error("expected a write error to propagate")
+	}
+}
+
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, errors.New("broken pipe") }

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -1,0 +1,102 @@
+package timeline
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func at(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestMergeSortsByTime(t *testing.T) {
+	a := []Event{{Time: at("2026-01-01T10:00:03Z"), Source: "log", Summary: "c"}}
+	b := []Event{
+		{Time: at("2026-01-01T10:00:01Z"), Source: "process", Summary: "a"},
+		{Time: at("2026-01-01T10:00:02Z"), Source: "update", Summary: "b"},
+	}
+	tl := Merge(a, b)
+	got := []string{tl.Events[0].Summary, tl.Events[1].Summary, tl.Events[2].Summary}
+	if strings.Join(got, "") != "abc" {
+		t.Errorf("order = %v, want a,b,c", got)
+	}
+}
+
+func TestMergeTieBreak(t *testing.T) {
+	ts := at("2026-01-01T10:00:00Z")
+	tl := Merge([]Event{
+		{Time: ts, Source: "process", Summary: "z"},
+		{Time: ts, Source: "log", Summary: "a"},
+		{Time: ts, Source: "process", Summary: "y"},
+	})
+	// Same time → by source then summary: log/a, process/y, process/z.
+	if tl.Events[0].Source != "log" || tl.Events[1].Summary != "y" || tl.Events[2].Summary != "z" {
+		t.Errorf("tie-break wrong: %+v", tl.Events)
+	}
+}
+
+func TestSinceFilters(t *testing.T) {
+	tl := Merge([]Event{
+		{Time: at("2026-01-01T09:00:00Z"), Summary: "old"},
+		{Time: at("2026-01-01T10:00:00Z"), Summary: "edge"},
+		{Time: at("2026-01-01T11:00:00Z"), Summary: "new"},
+	})
+	got := tl.Since(at("2026-01-01T10:00:00Z"))
+	if len(got.Events) != 2 || got.Events[0].Summary != "edge" {
+		t.Errorf("since filter = %+v", got.Events)
+	}
+}
+
+type fakeSource struct {
+	name string
+	evs  []Event
+	err  error
+}
+
+func (f fakeSource) Name() string                      { return f.name }
+func (f fakeSource) Events(time.Time) ([]Event, error) { return f.evs, f.err }
+
+func TestCollectBestEffort(t *testing.T) {
+	since := at("2026-01-01T00:00:00Z")
+	good := fakeSource{name: "good", evs: []Event{{Time: at("2026-01-01T10:00:00Z"), Source: "good", Summary: "ok"}}}
+	bad := fakeSource{name: "bad", err: errors.New("boom")}
+	tl, errs := Collect(since, good, bad)
+	if len(tl.Events) != 1 || tl.Events[0].Summary != "ok" {
+		t.Errorf("a failing source must not drop the others: %+v", tl.Events)
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0].Error(), "bad:") {
+		t.Errorf("expected a per-source error, got %v", errs)
+	}
+}
+
+func TestCollectAppliesWindow(t *testing.T) {
+	since := at("2026-01-01T10:00:00Z")
+	src := fakeSource{name: "s", evs: []Event{
+		{Time: at("2026-01-01T09:00:00Z"), Summary: "old"},
+		{Time: at("2026-01-01T11:00:00Z"), Summary: "new"},
+	}}
+	tl, _ := Collect(since, src)
+	if len(tl.Events) != 1 || tl.Events[0].Summary != "new" {
+		t.Errorf("Collect should drop pre-window events: %+v", tl.Events)
+	}
+}
+
+func TestRenderEmptyAndPopulated(t *testing.T) {
+	var empty bytes.Buffer
+	Timeline{}.Render(&empty)
+	if !strings.Contains(empty.String(), "no events") {
+		t.Errorf("empty render = %q", empty.String())
+	}
+	var buf bytes.Buffer
+	Merge([]Event{{Time: at("2026-01-01T10:00:00Z"), Source: "process", Severity: SeverityWarn, Summary: "hello"}}).Render(&buf)
+	if !strings.Contains(buf.String(), "warn") || !strings.Contains(buf.String(), "hello") {
+		t.Errorf("render = %q", buf.String())
+	}
+}


### PR DESCRIPTION
## What

A source-agnostic **incident-timeline engine** plus `spectra timeline` — merging scattered timestamped signals into one chronological "what happened around then?" view. **Item 10a of the unified-incident-timeline keystone** (10b wires the log and install-history sources).

## How

- **`internal/timeline`**: `Event{ Time, Source, Severity, Summary }` and a `Source` interface (`Name`, `Events(since)`).
  - `Merge` combines event groups sorted ascending by time, ties broken by source then summary (stable output);
  - `Since` filters to a window;
  - `Collect` gathers from all sources **best-effort** — a failing source returns a per-source error but does not drop the others — then applies the window;
  - text render (aligned `time  severity  source  summary`) + JSON.
- **`spectra timeline [--since <dur>] [--json]`** (default window 1h) wires the **process-start** source: each running process whose start time is in the window becomes an `info` event. The process lister and the clock are injected, so the command is deterministic in tests.

## Testing

Engine tests with fixed timestamps (no wall clock): merge ordering, tie-break by source/summary, `Since` boundary (inclusive), `Collect` best-effort (a failing source doesn't drop others; emits a per-source error) and window application, and empty/populated render. CLI tests: window filtering + summary text, zero-start and out-of-window processes excluded, `--json`, and arg validation (non-positive `--since`, extra args). **Smoke-tested live** — produced a real chronological process-start timeline. `make vet complexity lint security docs-validate test` green (73 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

## Scope

The engine is source-agnostic by design; **10b** adds the unified-log (`logquery.LogEntry`) and install-history (`internal/updates`) sources into the same command.

Closes #464
