### PR TITLE
timeline: add unified-log and install-history sources to spectra timeline

### DIFF
--- a/cmd/spectra/main.go
+++ b/cmd/spectra/main.go
@@ -78,7 +78,7 @@ func subcommandList() []subcommand {
 		{"malloc-history", "Attribute allocations to call stacks (requires MallocStackLogging)", runMallocHistory},
 		{"flamegraph", "Render a native CPU flamegraph (SVG) from a process sample", runFlamegraph},
 		{"hang", "Classify why a process's main thread is hung (lock/I-O/spin/idle)", runHang},
-		{"timeline", "Chronological incident timeline of recently started processes (log/update sources coming)", runTimeline},
+		{"timeline", "Chronological incident timeline: process starts, unified-log errors, and installs", runTimeline},
 		{"runtime", "Identify a live PID's language runtime and the diagnostics available for it", runRuntime},
 		{"xattr-inspect", "Show quarantine, provenance, where-froms, and AppleDouble state of files", runXattrInspect},
 		{"core", "Inspect crashed-process core files and suggest offline analyzers", runCore},

--- a/cmd/spectra/timeline.go
+++ b/cmd/spectra/timeline.go
@@ -7,20 +7,28 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/logquery"
 	"github.com/kaeawc/spectra/internal/process"
 	"github.com/kaeawc/spectra/internal/timeline"
+	"github.com/kaeawc/spectra/internal/updates"
 )
 
 // processLister returns the currently running processes; injected for testing.
 type processLister func() []process.Info
 
 func runTimeline(args []string) int {
-	return runTimelineWithIO(args, os.Stdout, os.Stderr, time.Now, defaultProcessLister)
+	sources := []timeline.Source{
+		processStartSource{procs: defaultProcessLister},
+		logSource{run: logquery.Run},
+		installSource{fetch: defaultInstallFetch},
+	}
+	return runTimelineWithIO(args, os.Stdout, os.Stderr, time.Now, sources...)
 }
 
-func runTimelineWithIO(args []string, stdout, stderr io.Writer, now func() time.Time, procs processLister) int {
+func runTimelineWithIO(args []string, stdout, stderr io.Writer, now func() time.Time, sources ...timeline.Source) int {
 	fs := flag.NewFlagSet("spectra timeline", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	since := fs.Duration("since", time.Hour, "Only show events within this window (e.g. 30m, 2h)")
@@ -38,7 +46,7 @@ func runTimelineWithIO(args []string, stdout, stderr io.Writer, now func() time.
 	}
 
 	cutoff := now().Add(-*since)
-	tl, errs := timeline.Collect(cutoff, processStartSource{procs: procs})
+	tl, errs := timeline.Collect(cutoff, sources...)
 	for _, e := range errs {
 		fmt.Fprintf(stderr, "timeline: %v\n", e)
 	}
@@ -59,7 +67,8 @@ func runTimelineWithIO(args []string, stdout, stderr io.Writer, now func() time.
 	return 0
 }
 
-// processStartSource turns each running process's start time into an event.
+// --- process-start source ---------------------------------------------------
+
 type processStartSource struct {
 	procs processLister
 }
@@ -86,6 +95,95 @@ func (s processStartSource) Events(since time.Time) ([]timeline.Event, error) {
 	return out, nil
 }
 
+// --- unified-log source -----------------------------------------------------
+
+type logSource struct {
+	run func(ctx context.Context, q logquery.Query) (logquery.Result, error)
+}
+
+func (logSource) Name() string { return "log" }
+
+func (s logSource) Events(since time.Time) ([]timeline.Event, error) {
+	res, err := s.run(context.Background(), logquery.Query{
+		Start:           since,
+		MinLevel:        "error",
+		AllowLongWindow: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]timeline.Event, 0, len(res.Entries))
+	for _, e := range res.Entries {
+		msg := e.EventMessage
+		if e.Process != "" {
+			msg = e.Process + ": " + msg
+		}
+		out = append(out, timeline.Event{
+			Time:     e.Timestamp,
+			Source:   "log",
+			Severity: logSeverity(e),
+			Summary:  msg,
+		})
+	}
+	return out, nil
+}
+
+func logSeverity(e logquery.LogEntry) timeline.Severity {
+	kind := strings.ToLower(e.MessageType)
+	if kind == "" {
+		kind = strings.ToLower(e.LogType)
+	}
+	// Exact match: "default" contains "fault" as a substring, so Contains is wrong.
+	if kind == "fault" || kind == "error" {
+		return timeline.SeverityError
+	}
+	return timeline.SeverityWarn
+}
+
+// --- install-history source -------------------------------------------------
+
+type installFetch func(ctx context.Context) ([]updates.InstallEntry, error)
+
+type installSource struct {
+	fetch installFetch
+}
+
+func (installSource) Name() string { return "update" }
+
+func (s installSource) Events(since time.Time) ([]timeline.Event, error) {
+	entries, err := s.fetch(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	var out []timeline.Event
+	for _, e := range entries {
+		if e.InstallDate.IsZero() || e.InstallDate.Before(since) {
+			continue
+		}
+		summary := "installed " + e.Name
+		if e.Version != "" {
+			summary += " " + e.Version
+		}
+		out = append(out, timeline.Event{
+			Time:     e.InstallDate,
+			Source:   "update",
+			Severity: timeline.SeverityInfo,
+			Summary:  summary,
+		})
+	}
+	return out, nil
+}
+
+// --- default (production) dependencies --------------------------------------
+
 func defaultProcessLister() []process.Info {
 	return process.CollectAll(context.Background(), process.CollectOptions{})
+}
+
+func defaultInstallFetch(ctx context.Context) ([]updates.InstallEntry, error) {
+	history, err := updates.Collect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return history.Entries, nil
 }

--- a/cmd/spectra/timeline_test.go
+++ b/cmd/spectra/timeline_test.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/kaeawc/spectra/internal/logquery"
 	"github.com/kaeawc/spectra/internal/process"
+	"github.com/kaeawc/spectra/internal/timeline"
+	"github.com/kaeawc/spectra/internal/updates"
 )
 
 func fixedNow() time.Time { return time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC) }
@@ -19,9 +24,11 @@ func fakeTimelineProcs() []process.Info {
 	}
 }
 
+func procSource() timeline.Source { return processStartSource{procs: fakeTimelineProcs} }
+
 func TestRunTimelineWindowsAndSummary(t *testing.T) {
 	var out, errBuf bytes.Buffer
-	code := runTimelineWithIO([]string{"--since", "1h"}, &out, &errBuf, fixedNow, fakeTimelineProcs)
+	code := runTimelineWithIO([]string{"--since", "1h"}, &out, &errBuf, fixedNow, procSource())
 	if code != 0 {
 		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
 	}
@@ -36,7 +43,7 @@ func TestRunTimelineWindowsAndSummary(t *testing.T) {
 
 func TestRunTimelineJSON(t *testing.T) {
 	var out, errBuf bytes.Buffer
-	if code := runTimelineWithIO([]string{"--since", "6h", "--json"}, &out, &errBuf, fixedNow, fakeTimelineProcs); code != 0 {
+	if code := runTimelineWithIO([]string{"--since", "6h", "--json"}, &out, &errBuf, fixedNow, procSource()); code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
 	if !strings.Contains(out.String(), `"events"`) || !strings.Contains(out.String(), `"source"`) {
@@ -47,8 +54,95 @@ func TestRunTimelineJSON(t *testing.T) {
 func TestRunTimelineArgValidation(t *testing.T) {
 	for _, args := range [][]string{{"--since", "0"}, {"extra"}, {"--since", "-5m"}} {
 		var out, errBuf bytes.Buffer
-		if code := runTimelineWithIO(args, &out, &errBuf, fixedNow, fakeTimelineProcs); code != 2 {
+		if code := runTimelineWithIO(args, &out, &errBuf, fixedNow, procSource()); code != 2 {
 			t.Errorf("args %v: exit = %d, want 2", args, code)
 		}
+	}
+}
+
+func TestLogSourceMapsEntries(t *testing.T) {
+	var gotStart time.Time
+	src := logSource{run: func(_ context.Context, q logquery.Query) (logquery.Result, error) {
+		gotStart = q.Start
+		if q.MinLevel != "error" {
+			t.Errorf("expected MinLevel=error, got %q", q.MinLevel)
+		}
+		return logquery.Result{Entries: []logquery.LogEntry{
+			{Timestamp: fixedNow(), Process: "WindowServer", EventMessage: "boom", MessageType: "Fault"},
+			{Timestamp: fixedNow(), Process: "kernel", EventMessage: "warn", MessageType: "Default"},
+		}}, nil
+	}}
+	since := fixedNow().Add(-time.Hour)
+	evs, err := src.Events(since)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if !gotStart.Equal(since) {
+		t.Errorf("query start = %v, want %v", gotStart, since)
+	}
+	if len(evs) != 2 || evs[0].Summary != "WindowServer: boom" || evs[0].Severity != timeline.SeverityError {
+		t.Errorf("fault entry mapping wrong: %+v", evs[0])
+	}
+	if evs[1].Severity != timeline.SeverityWarn {
+		t.Errorf("non-error entry severity = %s, want warn", evs[1].Severity)
+	}
+}
+
+func TestInstallSourceFiltersAndMaps(t *testing.T) {
+	src := installSource{fetch: func(context.Context) ([]updates.InstallEntry, error) {
+		return []updates.InstallEntry{
+			{Name: "Xcode", Version: "16.2", InstallDate: fixedNow()},
+			{Name: "OldApp", Version: "1.0", InstallDate: fixedNow().Add(-48 * time.Hour)},
+		}, nil
+	}}
+	evs, err := src.Events(fixedNow().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(evs) != 1 || evs[0].Summary != "installed Xcode 16.2" || evs[0].Source != "update" {
+		t.Errorf("install mapping/filter wrong: %+v", evs)
+	}
+}
+
+func TestRunTimelineMergesAllSources(t *testing.T) {
+	logs := logSource{run: func(context.Context, logquery.Query) (logquery.Result, error) {
+		return logquery.Result{Entries: []logquery.LogEntry{
+			{Timestamp: time.Date(2026, 1, 1, 11, 45, 0, 0, time.UTC), Process: "kernel", EventMessage: "oops", MessageType: "Error"},
+		}}, nil
+	}}
+	installs := installSource{fetch: func(context.Context) ([]updates.InstallEntry, error) {
+		return []updates.InstallEntry{{Name: "App", InstallDate: time.Date(2026, 1, 1, 11, 50, 0, 0, time.UTC)}}, nil
+	}}
+	var out, errBuf bytes.Buffer
+	code := runTimelineWithIO([]string{"--since", "1h"}, &out, &errBuf, fixedNow, procSource(), logs, installs)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	for _, want := range []string{"recent [10] started", "kernel: oops", "installed App"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("merged timeline missing %q:\n%s", want, s)
+		}
+	}
+	// Chronological order: process(11:30) < log(11:45) < install(11:50).
+	if strings.Index(s, "started") >= strings.Index(s, "oops") || strings.Index(s, "oops") >= strings.Index(s, "installed") {
+		t.Errorf("events not in chronological order:\n%s", s)
+	}
+}
+
+func TestRunTimelineBestEffortOnSourceError(t *testing.T) {
+	failing := logSource{run: func(context.Context, logquery.Query) (logquery.Result, error) {
+		return logquery.Result{}, errors.New("log unavailable")
+	}}
+	var out, errBuf bytes.Buffer
+	code := runTimelineWithIO([]string{"--since", "1h"}, &out, &errBuf, fixedNow, procSource(), failing)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (best effort)", code)
+	}
+	if !strings.Contains(out.String(), "recent [10] started") {
+		t.Errorf("process events should survive a failing log source:\n%s", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "log:") {
+		t.Errorf("expected a per-source error on stderr, got: %q", errBuf.String())
 	}
 }

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -573,9 +573,10 @@ incident view, so "what happened around 14:03?" has a single answer instead of
 being scattered across `process`, `logs`, and `updates`. Events carry a time,
 source, severity, and summary; the timeline is sorted ascending and filtered to
 a `--since` window (default 1h). Collection is best-effort — one failing source
-does not drop the others. `--json` emits the structured result. This first
-release wires the **process-start** source (each recently started process);
-the unified-log and install-history sources follow.
+does not drop the others. `--json` emits the structured result. It merges three
+sources: **process starts** (each recently started process), **unified-log
+errors** (faults and errors from `log show`, bounded to the window), and
+**installs** (the system install/update history).
 
 ### Examples
 


### PR DESCRIPTION
## What

Adds the two richest incident sources to `spectra timeline` — **unified-log errors** and **install/update history** — so the timeline (10a shipped the engine + process starts) is genuinely useful for "what happened around then?". **Item 10b — completes the unified-incident-timeline keystone.**

## How

- **log source** — runs a bounded `logquery` query (`Start` = the window cutoff, `MinLevel` = error) via `logquery.Run` (injected), mapping each entry to an event: summary `"<process>: <message>"`, severity from the message type — **fault/error → error, else warn**. (Uses an *exact* match, because `"default"` contains the substring `"fault"` — caught by a test.)
- **install source** — reads the `updates` install history (fetch injected), filters to the window, mapping each install to an `info` event `"installed <name> <version>"`.
- `spectra timeline` now registers **process + log + install**, collected **best-effort** (a failing or slow source emits a per-source error but does not drop the others), still filtered to `--since` and rendered as text/JSON.

## Testing

Source tests with injected deps (no shelling out): log mapping (fault → error, non-error → warn, correct `Start`/`MinLevel` on the query), install filter + mapping. CLI tests: all three sources **merged in chronological order** (process 11:30 < log 11:45 < install 11:50), and **best-effort** (a failing log source doesn't drop process events, and emits a `log:` error on stderr). The pre-existing engine/process tests still pass. `make vet complexity lint security docs-validate test` green (73 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #466
