### PR TITLE
storage: spectra storage growth — rank what grew between two snapshots (bytes/day)

### DIFF
--- a/cmd/spectra/storage.go
+++ b/cmd/spectra/storage.go
@@ -18,6 +18,9 @@ func runStorage(args []string) int {
 	if len(args) > 0 && args[0] == "db-check" {
 		return runStorageDBCheck(args[1:], os.Stdout, os.Stderr)
 	}
+	if len(args) > 0 && args[0] == "growth" {
+		return runStorageGrowth(args[1:], os.Stdout, os.Stderr)
+	}
 	if len(args) > 0 && args[0] == "cache-triage" {
 		return runStorageCacheTriage(args[1:], os.Stdout, os.Stderr, os.UserHomeDir)
 	}

--- a/cmd/spectra/storage_growth.go
+++ b/cmd/spectra/storage_growth.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/storagegrowth"
+	"github.com/kaeawc/spectra/internal/storagestate"
+)
+
+// snapshotStorage is the subset of a snapshot JSON the growth report needs.
+type snapshotStorage struct {
+	TakenAt time.Time          `json:"taken_at"`
+	Storage storagestate.State `json:"storage"`
+}
+
+func runStorageGrowth(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("spectra storage growth", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	top := fs.Int("top", 10, "Show the top N growing areas (0 for all)")
+	asJSON := fs.Bool("json", false, "Emit JSON instead of a human summary")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *top < 0 {
+		fmt.Fprintln(stderr, "storage growth: --top must be >= 0")
+		return 2
+	}
+	if fs.NArg() != 2 {
+		fmt.Fprintln(stderr, "usage: spectra storage growth [--top N] [--json] <before-snapshot.json> <after-snapshot.json>")
+		return 2
+	}
+
+	before, err := readSnapshotStorage(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(stderr, "storage growth: %v\n", err)
+		return 1
+	}
+	after, err := readSnapshotStorage(fs.Arg(1))
+	if err != nil {
+		fmt.Fprintf(stderr, "storage growth: %v\n", err)
+		return 1
+	}
+
+	rep := storagegrowth.Compute(before.Storage, after.Storage, before.TakenAt, after.TakenAt, *top)
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			fmt.Fprintf(stderr, "storage growth: write output: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printStorageGrowth(stdout, rep)
+	return 0
+}
+
+func readSnapshotStorage(path string) (snapshotStorage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return snapshotStorage{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var s snapshotStorage
+	if err := json.Unmarshal(data, &s); err != nil {
+		return snapshotStorage{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if s.TakenAt.IsZero() {
+		return snapshotStorage{}, fmt.Errorf("%s: no taken_at timestamp (not a snapshot?)", path)
+	}
+	return s, nil
+}
+
+func printStorageGrowth(w io.Writer, rep storagegrowth.Report) {
+	fmt.Fprintf(w, "=== storage growth (%s → %s, %.1f days) ===\n",
+		rep.BeforeAt.Local().Format("2006-01-02 15:04"),
+		rep.AfterAt.Local().Format("2006-01-02 15:04"), rep.Days)
+	fmt.Fprintf(w, "total growth: %s\n", humanSize(rep.TotalGrowthBytes))
+	if rep.Note != "" {
+		fmt.Fprintf(w, "note: %s\n", rep.Note)
+	}
+	if len(rep.Deltas) == 0 {
+		fmt.Fprintln(w, "  (nothing grew)")
+		return
+	}
+	fmt.Fprintf(w, "  %12s  %12s  %-10s  %s\n", "GROWTH", "PER DAY", "CATEGORY", "AREA")
+	for _, d := range rep.Deltas {
+		fmt.Fprintf(w, "  %12s  %12s  %-10s  %s\n",
+			humanSize(d.GrowthBytes), humanSize(int64(d.BytesPerDay))+"/d",
+			truncate(d.Category, 10), truncate(d.Label, 42))
+	}
+}

--- a/cmd/spectra/storage_growth_test.go
+++ b/cmd/spectra/storage_growth_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const snapA = `{"taken_at":"2026-01-01T00:00:00Z","storage":{"volumes":[{"mount_point":"/","used_bytes":1000}],"user_library_bytes":500,"app_caches_bytes":200,"largest_apps":[{"path":"/Applications/Foo.app","on_disk_bytes":100}]}}`
+const snapB = `{"taken_at":"2026-01-03T00:00:00Z","storage":{"volumes":[{"mount_point":"/","used_bytes":1600}],"user_library_bytes":520,"app_caches_bytes":900,"largest_apps":[{"path":"/Applications/Foo.app","on_disk_bytes":100},{"path":"/Applications/Bar.app","on_disk_bytes":300}]}}`
+
+func writeSnap(t *testing.T, name, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestRunStorageGrowthHuman(t *testing.T) {
+	a, b := writeSnap(t, "a.json", snapA), writeSnap(t, "b.json", snapB)
+	var out, errBuf bytes.Buffer
+	if code := runStorageGrowth([]string{a, b}, &out, &errBuf); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, errBuf.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "app-caches") || !strings.Contains(s, "Bar.app") || !strings.Contains(s, "days") {
+		t.Errorf("expected growth summary, got:\n%s", s)
+	}
+}
+
+func TestRunStorageGrowthJSON(t *testing.T) {
+	a, b := writeSnap(t, "a.json", snapA), writeSnap(t, "b.json", snapB)
+	var out, errBuf bytes.Buffer
+	if code := runStorageGrowth([]string{"--json", a, b}, &out, &errBuf); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(out.String(), `"deltas"`) || !strings.Contains(out.String(), `"bytes_per_day"`) {
+		t.Errorf("expected JSON, got:\n%s", out.String())
+	}
+}
+
+func TestRunStorageGrowthArgValidation(t *testing.T) {
+	a := writeSnap(t, "a.json", snapA)
+	for _, args := range [][]string{{}, {a}, {a, a, a}, {"--top", "-1", a, a}} {
+		var out, errBuf bytes.Buffer
+		if code := runStorageGrowth(args, &out, &errBuf); code != 2 {
+			t.Errorf("args %v: exit = %d, want 2", args, code)
+		}
+	}
+}
+
+func TestRunStorageGrowthBadInputs(t *testing.T) {
+	a := writeSnap(t, "a.json", snapA)
+	missing := filepath.Join(t.TempDir(), "nope.json")
+	bad := writeSnap(t, "bad.json", "not json")
+	noTS := writeSnap(t, "nots.json", `{"storage":{}}`)
+	for _, args := range [][]string{{missing, a}, {a, bad}, {a, noTS}} {
+		var out, errBuf bytes.Buffer
+		if code := runStorageGrowth(args, &out, &errBuf); code != 1 {
+			t.Errorf("args %v: exit = %d, want 1", args, code)
+		}
+	}
+}

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -732,6 +732,29 @@ spectra storage cache-triage --json
 spectra storage cache-triage "$HOME/Library/Containers/com.example.App/Data/Library/Caches"
 ```
 
+## `spectra storage growth`
+
+Diffs the storage sections of two snapshots to find what grew over time, and how
+fast. Every snapshot stamps `taken_at` and records storage state (volume usage,
+`~/Library` and app-caches footprint, per-app on-disk sizes); this ranks the
+areas that grew between two of them by growth size, each with a **bytes/day**
+rate computed from the timestamps. It compares per volume (by mount point), the
+user-library and app-caches footprints, and per app (by path; a newly appeared
+app counts from zero). Shrinking areas are excluded from the ranking but still
+count toward the reported total. `--top` bounds the list (default 10); a
+non-positive interval yields zero rates with a note rather than an error;
+`--json` emits the structured result.
+
+### Examples
+
+```bash
+spectra snapshot capture --out /tmp/before.json
+# ... time passes ...
+spectra snapshot capture --out /tmp/after.json
+spectra storage growth /tmp/before.json /tmp/after.json
+spectra storage growth --top 20 --json /tmp/before.json /tmp/after.json
+```
+
 ## `spectra crash readiness`
 
 Audits whether the machine can produce a debuggable crash *before* one

--- a/internal/storagegrowth/storagegrowth.go
+++ b/internal/storagegrowth/storagegrowth.go
@@ -1,0 +1,106 @@
+// Package storagegrowth diffs the storage sections of two snapshots to find
+// what grew over time, and how fast (bytes/day). It reads only.
+package storagegrowth
+
+import (
+	"sort"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/storagestate"
+)
+
+// Delta is the change in one storage area between two captures.
+type Delta struct {
+	Category    string  `json:"category"` // volume | user-library | app-caches | app
+	Label       string  `json:"label"`    // mount point, app path, or a fixed name
+	BeforeBytes int64   `json:"before_bytes"`
+	AfterBytes  int64   `json:"after_bytes"`
+	GrowthBytes int64   `json:"growth_bytes"`
+	BytesPerDay float64 `json:"bytes_per_day"`
+}
+
+// Report ranks the storage areas that grew between two captures.
+type Report struct {
+	BeforeAt         time.Time `json:"before_at"`
+	AfterAt          time.Time `json:"after_at"`
+	Days             float64   `json:"days"`
+	TotalGrowthBytes int64     `json:"total_growth_bytes"`
+	Deltas           []Delta   `json:"deltas"`
+	Note             string    `json:"note,omitempty"`
+}
+
+// Compute diffs two storage states and ranks growth descending, keeping the top
+// N growers (topN <= 0 keeps all growers). Shrinking areas are excluded from
+// the ranking but still count toward TotalGrowthBytes.
+func Compute(before, after storagestate.State, beforeAt, afterAt time.Time, topN int) Report {
+	rep := Report{BeforeAt: beforeAt, AfterAt: afterAt}
+	rep.Days = afterAt.Sub(beforeAt).Hours() / 24
+	if rep.Days <= 0 {
+		rep.Note = "non-positive interval between snapshots; rates are zero"
+	}
+
+	var deltas []Delta
+	add := func(cat, label string, b, a int64) {
+		g := a - b
+		rep.TotalGrowthBytes += g
+		deltas = append(deltas, Delta{
+			Category: cat, Label: label,
+			BeforeBytes: b, AfterBytes: a, GrowthBytes: g,
+			BytesPerDay: perDay(g, rep.Days),
+		})
+	}
+
+	beforeVols := indexVolumes(before.Volumes)
+	for _, v := range after.Volumes {
+		add("volume", v.MountPoint, beforeVols[v.MountPoint], v.UsedBytes)
+	}
+	add("user-library", "~/Library", before.UserLibraryBytes, after.UserLibraryBytes)
+	add("app-caches", "~/Library/Caches", before.AppCachesBytes, after.AppCachesBytes)
+
+	beforeApps := indexApps(before.LargestApps)
+	for _, app := range after.LargestApps {
+		add("app", app.Path, beforeApps[app.Path], app.OnDiskBytes)
+	}
+
+	// Rank only growers, largest first.
+	growers := make([]Delta, 0, len(deltas))
+	for _, d := range deltas {
+		if d.GrowthBytes > 0 {
+			growers = append(growers, d)
+		}
+	}
+	sort.SliceStable(growers, func(i, j int) bool {
+		if growers[i].GrowthBytes != growers[j].GrowthBytes {
+			return growers[i].GrowthBytes > growers[j].GrowthBytes
+		}
+		return growers[i].Label < growers[j].Label
+	})
+	if topN > 0 && len(growers) > topN {
+		growers = growers[:topN]
+	}
+	rep.Deltas = growers
+	return rep
+}
+
+func perDay(growth int64, days float64) float64 {
+	if days <= 0 {
+		return 0
+	}
+	return float64(growth) / days
+}
+
+func indexVolumes(vols []storagestate.Volume) map[string]int64 {
+	m := make(map[string]int64, len(vols))
+	for _, v := range vols {
+		m[v.MountPoint] = v.UsedBytes
+	}
+	return m
+}
+
+func indexApps(apps []storagestate.AppSize) map[string]int64 {
+	m := make(map[string]int64, len(apps))
+	for _, a := range apps {
+		m[a.Path] = a.OnDiskBytes
+	}
+	return m
+}

--- a/internal/storagegrowth/storagegrowth_test.go
+++ b/internal/storagegrowth/storagegrowth_test.go
@@ -1,0 +1,99 @@
+package storagegrowth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kaeawc/spectra/internal/storagestate"
+)
+
+func state(vols map[string]int64, lib, caches int64, apps map[string]int64) storagestate.State {
+	s := storagestate.State{UserLibraryBytes: lib, AppCachesBytes: caches}
+	for mp, used := range vols {
+		s.Volumes = append(s.Volumes, storagestate.Volume{MountPoint: mp, UsedBytes: used})
+	}
+	for p, b := range apps {
+		s.LargestApps = append(s.LargestApps, storagestate.AppSize{Path: p, OnDiskBytes: b})
+	}
+	return s
+}
+
+func deltaFor(rep Report, cat, label string) (Delta, bool) {
+	for _, d := range rep.Deltas {
+		if d.Category == cat && d.Label == label {
+			return d, true
+		}
+	}
+	return Delta{}, false
+}
+
+func TestComputeRanksGrowthAndRate(t *testing.T) {
+	before := state(map[string]int64{"/": 1000}, 500, 200, map[string]int64{"/Applications/Foo.app": 100})
+	// caches +800 (biggest), volume +600, new app Bar +300, library +20; Foo unchanged.
+	after := state(map[string]int64{"/": 1600}, 520, 1000, map[string]int64{
+		"/Applications/Foo.app": 100, "/Applications/Bar.app": 300,
+	})
+	b := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	a := b.Add(2 * 24 * time.Hour)
+
+	rep := Compute(before, after, b, a, 0)
+	if rep.Days != 2 {
+		t.Errorf("days = %v, want 2", rep.Days)
+	}
+	// Ranked by growth desc: app-caches(800) first.
+	if rep.Deltas[0].Category != "app-caches" || rep.Deltas[0].GrowthBytes != 800 {
+		t.Errorf("top grower = %+v, want app-caches +800", rep.Deltas[0])
+	}
+	// Rate = growth / days: 800 / 2 = 400/day.
+	if rep.Deltas[0].BytesPerDay != 400 {
+		t.Errorf("rate = %v, want 400/day", rep.Deltas[0].BytesPerDay)
+	}
+	// New app counted from zero.
+	if d, ok := deltaFor(rep, "app", "/Applications/Bar.app"); !ok || d.BeforeBytes != 0 || d.GrowthBytes != 300 {
+		t.Errorf("new app delta = %+v (ok=%v)", d, ok)
+	}
+	// Unchanged app must not appear among growers.
+	if _, ok := deltaFor(rep, "app", "/Applications/Foo.app"); ok {
+		t.Error("unchanged Foo.app should not be a grower")
+	}
+}
+
+func TestComputeExcludesShrinkersFromRankingButCountsTotal(t *testing.T) {
+	before := state(map[string]int64{"/": 2000}, 0, 0, nil)
+	after := state(map[string]int64{"/": 1500}, 0, 0, nil) // volume shrank 500
+	b := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rep := Compute(before, after, b, b.Add(24*time.Hour), 0)
+	if len(rep.Deltas) != 0 {
+		t.Errorf("a shrinking volume should not rank as a grower: %+v", rep.Deltas)
+	}
+	// Total growth reflects the net change (library/caches 0 delta, volume -500).
+	if rep.TotalGrowthBytes != -500 {
+		t.Errorf("total growth = %d, want -500", rep.TotalGrowthBytes)
+	}
+}
+
+func TestComputeTopN(t *testing.T) {
+	before := state(map[string]int64{"/": 100, "/data": 100}, 100, 100, nil)
+	after := state(map[string]int64{"/": 400, "/data": 300}, 250, 600, nil)
+	rep := Compute(before, after, time.Unix(0, 0), time.Unix(0, 0).Add(24*time.Hour), 2)
+	if len(rep.Deltas) != 2 {
+		t.Fatalf("topN=2 gave %d", len(rep.Deltas))
+	}
+	// The two biggest growers: caches(+500), volume /(+300)? data +200, library +150.
+	if rep.Deltas[0].GrowthBytes != 500 || rep.Deltas[1].GrowthBytes != 300 {
+		t.Errorf("top-2 growth = %d,%d want 500,300", rep.Deltas[0].GrowthBytes, rep.Deltas[1].GrowthBytes)
+	}
+}
+
+func TestComputeNonPositiveInterval(t *testing.T) {
+	before := state(map[string]int64{"/": 100}, 0, 0, nil)
+	after := state(map[string]int64{"/": 500}, 0, 0, nil)
+	same := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rep := Compute(before, after, same, same, 0) // zero interval
+	if rep.Note == "" {
+		t.Error("expected a note about the non-positive interval")
+	}
+	if d, _ := deltaFor(rep, "volume", "/"); d.BytesPerDay != 0 {
+		t.Errorf("rate should be 0 for a zero interval, got %v", d.BytesPerDay)
+	}
+}


### PR DESCRIPTION
## What

`spectra storage growth <before.json> <after.json>` — diffs the storage sections of two snapshots to answer the question that actually finds a disk leak: **what grew over time, and how fast?** **The final item (11) of the campaign.**

## How

- **`internal/storagegrowth`** — a pure `Compute(before, after storagestate.State, beforeAt, afterAt, topN)`:
  - diffs per **volume** (matched by mount point), the **user-library** and **app-caches** footprints, and per **app** (matched by path; a newly appeared app counts from zero);
  - each delta carries before / after / growth and a **bytes/day** rate from the two `taken_at` timestamps;
  - ranks growers descending (top `--top`), **excludes shrinking areas** from the ranking but still counts them toward the reported total; a **non-positive interval** yields zero rates and a note rather than a divide error.
- **`spectra storage growth [--top N] [--json] <before.json> <after.json>`** — reads the `taken_at` + `storage` sections of two snapshot JSON files (self-contained; no snapshot-store coupling) and prints the ranked report.

## Testing

Engine tests with constructed states: growth ranking + rate math (caches +800 over 2 days → 400/day, ranked first), a **new app counted from zero**, an **unchanged app excluded**, **shrinkers excluded from the ranking but counted in the total**, top-N, and the **non-positive-interval** note/zero-rate path. CLI tests: human + JSON output, arg validation (incl. negative `--top`), and bad inputs (missing file, non-JSON, missing `taken_at`). **Smoke-tested end-to-end** against two hand-written snapshot JSONs (ranked growers with per-day rates over a 2-day interval). `make vet complexity lint security docs-validate test` green (74 pkgs). `make licenses` fails only on the known local go-licenses/Go 1.26 quirk.

Closes #468
