### PR TITLE
flamegraph: fold branching sample stacks (+/!/: tree-drawing indentation)

### DIFF
--- a/internal/flamegraph/flamegraph_test.go
+++ b/internal/flamegraph/flamegraph_test.go
@@ -91,3 +91,41 @@ func TestRenderSVGEscapesXML(t *testing.T) {
 		t.Errorf("symbol angle brackets not escaped:\n%s", svg)
 	}
 }
+
+// realBranchGraph mirrors the tree-drawing indentation `sample` emits for a
+// branching thread: leading spaces plus +, !, and : characters.
+const realBranchGraph = `Analysis of sampling ...
+
+Call graph:
+    100 Thread_1   DispatchQueue_1: com.apple.main-thread  (serial)
+    + 60 main.workerA  (in burn) + 92  [0x1]
+    + ! 60 hashLoop  (in burn) + 10  [0x2]
+    + 40 main.workerB  (in burn) + 80  [0x3]
+    +   40 sortLoop  (in burn) + 8  [0x4]
+    100 Thread_2
+    + 100 runtime.usleep  (in burn) + 20  [0x5]
+    + ! 100 __semwait_signal  (in libsystem_kernel.dylib) + 8  [0x6]
+
+Total number in stack:
+      100 something
+`
+
+func TestFoldBranchingSampleFormat(t *testing.T) {
+	folded := Fold(realBranchGraph)
+	if len(folded) < 3 {
+		t.Fatalf("expected multiple folded stacks from a branching sample, got %d: %+v", len(folded), folded)
+	}
+	byLeaf := map[string]Folded{}
+	for _, f := range folded {
+		byLeaf[f.Frames[len(f.Frames)-1]] = f
+	}
+	if got := byLeaf["hashLoop"]; got.Count != 60 || strings.Join(got.Frames, ";") != "Thread_1;main.workerA;hashLoop" {
+		t.Errorf("hashLoop branch = %+v", got)
+	}
+	if got := byLeaf["sortLoop"]; got.Count != 40 || strings.Join(got.Frames, ";") != "Thread_1;main.workerB;sortLoop" {
+		t.Errorf("sortLoop branch = %+v", got)
+	}
+	if got := byLeaf["__semwait_signal"]; got.Count != 100 || got.Frames[0] != "Thread_2" {
+		t.Errorf("thread-2 leaf = %+v", got)
+	}
+}

--- a/internal/flamegraph/fold.go
+++ b/internal/flamegraph/fold.go
@@ -17,8 +17,10 @@ type Folded struct {
 var (
 	// callGraphStart marks the beginning of sample's call-tree section.
 	callGraphStart = "Call graph:"
-	// frameLine matches an indented "<count> <symbol...>" call-graph line.
-	frameLine  = regexp.MustCompile(`^(\s+)(\d+)\s+(.*\S)\s*$`)
+	// frameLine matches an indented "<count> <symbol...>" call-graph line. When a
+	// thread's stack branches, `sample` draws the indentation with +, !, :, and |
+	// tree characters rather than plain spaces, so the indent run includes them.
+	frameLine  = regexp.MustCompile(`^([\s+!:|]+)(\d+)\s+(.*\S)\s*$`)
 	offsetTail = regexp.MustCompile(`\s+\+\s+\d+$`)
 )
 


### PR DESCRIPTION
## What

Fixes a real bug in `spectra flamegraph` (#455): on any **branching** `sample` capture, the flamegraph collapsed to a single bar.

## Root cause

`sample` draws a *branching* thread's call tree with the tree-drawing characters `+`, `!`, `:`, `|` in the indentation:

```
    100 Thread_1
    + 60 main.workerA  (in burn) + 92  [0x1]
    + ! 60 hashLoop  (in burn) + 10  [0x2]
    + 40 main.workerB  (in burn) + 80  [0x3]
```

`Fold`'s frame-line regex only accepted **whitespace** indentation (``^(\s+)(\d+)…``), so those `+`-prefixed lines never matched — only the plain-space thread-header lines did — and the whole graph folded to one stack. The unit tests missed it because the fixtures were all *linear*, space-indented stacks (which `sample` emits for a non-branching thread, so the idle-shell smoke test looked fine).

## Fix

Widen the indent run to include the tree characters: ``^([\s+!:|]+)(\d+)\s+(.*\S)\s*$``. Depth is still the prefix length (these characters occupy indent columns like spaces), so the existing fold logic is unchanged.

## Testing

New `TestFoldBranchingSampleFormat` uses the real `+`/`!`/`:` sample format (two threads, a branch) and asserts the per-branch paths (`Thread_1;main.workerA;hashLoop` @60, `Thread_1;main.workerB;sortLoop` @40) and the second thread's leaf. The existing linear-fixture tests still pass (the wider class is a superset). **Verified on a live 6-thread process: `Fold` went from 1 folded stack to 46**, rendering the real worker/runtime branches. `make vet complexity lint security docs-validate test` green (74 pkgs).

Closes #470
