### PR TITLE
Fix daemon crash from typed-nil spawn failure watcher

### DIFF
--- a/internal/serve/churn.go
+++ b/internal/serve/churn.go
@@ -328,6 +328,11 @@ func (w *spawnFailureWatcher) Start(ctx context.Context) {
 }
 
 func (w *spawnFailureWatcher) CountsSince(cutoff time.Time) map[string]int {
+	// Survive a typed-nil watcher stored in the spawnFailureCounter
+	// interface, which slips past the caller's interface nil check.
+	if w == nil {
+		return nil
+	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.trimLocked(cutoff.Add(-time.Minute))

--- a/internal/serve/churn_test.go
+++ b/internal/serve/churn_test.go
@@ -132,3 +132,17 @@ func BenchmarkChurnTick(b *testing.B) {
 func procInfo(pid, ppid int, app string, start time.Time) process.Info {
 	return process.Info{PID: pid, PPID: ppid, AppPath: app, StartTime: start}
 }
+
+func TestChurnTrackerSurvivesTypedNilWatcher(t *testing.T) {
+	// Regression: runDaemon once stored a typed-nil *spawnFailureWatcher in
+	// the spawnFailureCounter interface, which passed the interface nil check
+	// and crashed the churn loop's first failureCounts call.
+	var watcher *spawnFailureWatcher
+	if got := watcher.CountsSince(time.Now()); got != nil {
+		t.Fatalf("nil watcher CountsSince = %v, want nil", got)
+	}
+	tracker := newChurnTracker(watcher)
+	if got := tracker.failureCounts(time.Now()); got != nil {
+		t.Fatalf("failureCounts with typed-nil watcher = %v, want nil", got)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -213,13 +213,15 @@ func runDaemon(ctx context.Context, log logger.Logger, opts Options, listeners [
 	log.Info("daemon storage ready", "db", dbPath)
 
 	collector := metrics.NewCollector()
-	var failures *spawnFailureWatcher
+	// Assign the watcher into the interface only when it exists: a typed-nil
+	// *spawnFailureWatcher would defeat the interface nil checks downstream.
+	churn := newChurnTracker(nil)
 	if opts.TrackSpawnFailures {
-		failures = newSpawnFailureWatcher()
+		failures := newSpawnFailureWatcher()
 		go failures.Start(ctx)
 		log.Info("daemon spawn failure watcher enabled", "source", "log stream")
+		churn = newChurnTracker(failures)
 	}
-	churn := newChurnTracker(failures)
 	liveTelemetry := telemetry.NewLiveCollector()
 	history := livehistory.NewRing(livehistory.DefaultCapacity)
 	sampler := metrics.NewSampler(collector, time.Second, nil)


### PR DESCRIPTION
## Summary

Every plain `spectra serve` (without `--track-spawn-failures`) crashes with a nil-pointer SIGSEGV within seconds of any process exiting: `runDaemon` stored a typed-nil `*spawnFailureWatcher` in the `spawnFailureCounter` interface, so `failureCounts`' interface nil check passed and the churn loop's first `CountsSince` call dereferenced a nil receiver.

Found by running the daemon during manual smoke testing on current `main`; the panic is in the churn loop (`churn.go:331` via `churn.go:238`), untouched by any open branch.

**Fix**: assign the watcher into the interface only when it exists, and make `CountsSince` nil-receiver safe as a backstop. Regression test included.

## Type

- [x] Bug fix

## Testing

- [x] Added unit test `TestChurnTrackerSurvivesTypedNilWatcher`
- [x] Reproduced the crash on a live daemon before the fix; daemon runs stably after
- [x] `go build ./...", `go vet`, `go test ./internal/serve/` pass

## Checklist

- [x] No new `go vet` warnings
- [x] `gofmt -s` clean
- [x] No new `gocyclo` violations
- [x] No new `gosec` findings
- [x] `go mod tidy` untouched

## Notes

The same commit is also on `work/mesh-transport` (#472), which needs a running daemon; whichever merges second resolves trivially.