### PR TITLE
Adapt connect read deadline to the method when --timeout is not set

### DIFF
--- a/cmd/spectra/connect.go
+++ b/cmd/spectra/connect.go
@@ -26,7 +26,7 @@ type connectTarget struct {
 func runConnect(args []string) int {
 	fs := flag.NewFlagSet("spectra connect", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
-	timeout := fs.Duration("timeout", 3*time.Second, "Dial/read timeout")
+	timeout := fs.Duration("timeout", 3*time.Second, "Dial timeout; also the read timeout when set explicitly (otherwise the read deadline adapts to the method)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -47,6 +47,19 @@ func runConnect(args []string) int {
 		return 2
 	}
 
+	explicitTimeout := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "timeout" {
+			explicitTimeout = true
+		}
+	})
+	readTimeout := *timeout
+	if !explicitTimeout {
+		readTimeout = connectReadTimeout(method, params)
+	}
+
+	// Dial stays on the short flag default so an unreachable host fails fast;
+	// only the read deadline stretches for slow collectors.
 	conn, err := dialConnectTarget(target, *timeout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "connect %s: %v\n", fs.Arg(0), err)
@@ -55,7 +68,7 @@ func runConnect(args []string) int {
 	defer conn.Close()
 
 	if d, ok := conn.(interface{ SetDeadline(time.Time) error }); ok {
-		_ = d.SetDeadline(time.Now().Add(*timeout))
+		_ = d.SetDeadline(time.Now().Add(readTimeout))
 	}
 
 	result, err := callRPC(conn, method, params)
@@ -96,7 +109,7 @@ func printConnectUsage(w io.Writer) {
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> issues check [snapshot-id]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> storage <App.app> [more.apps] | network [state|connections|firewall|by-app [App.app ...]] | network-by-app [App.app ...]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> job start <method> [json-params] | job get <id> | jobs")
-	fmt.Fprintln(w, "   or: spectra connect [--timeout 35s] <target> job wait <id> [seconds]   (use --timeout larger than the wait)")
+	fmt.Fprintln(w, "   or: spectra connect <target> job wait <id> [seconds]")
 	fmt.Fprintln(w, "   or: spectra connect [--timeout 3s] <target> call <method> [json-params]")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "targets: local, unix:/path/to/sock, /path/to/sock, host:port, host")
@@ -205,8 +218,8 @@ func parseConnectRules(args []string) (string, json.RawMessage, bool, error) {
 
 // parseConnectJob covers detached collector jobs: start a method without
 // holding the connection open, then fetch or wait on the result later from
-// any connection. `job wait` blocks daemon-side, so pass a --timeout larger
-// than the wait.
+// any connection. `job wait` blocks daemon-side; the client read deadline
+// stretches past the wait automatically unless --timeout is set explicitly.
 func parseConnectJob(args []string) (string, json.RawMessage, bool, error) {
 	if len(args) < 2 {
 		return "", nil, true, fmt.Errorf("connect job requires start|get|wait")
@@ -1055,6 +1068,63 @@ func parseConnectGenericCall(args []string) (string, json.RawMessage, error) {
 		return "", nil, fmt.Errorf("invalid json params: %w", err)
 	}
 	return args[1], params, nil
+}
+
+const (
+	connectBaseReadTimeout = 30 * time.Second
+	connectSlowReadTimeout = 120 * time.Second
+	connectReadMargin      = 30 * time.Second
+)
+
+// connectSlowMethodPrefixes are RPC families that run real collectors — process
+// sweeps, storage walks, bundle inspection, JVM attach — and routinely exceed a
+// short deadline on loaded machines.
+var connectSlowMethodPrefixes = []string{
+	"storage.",
+	"snapshot.",
+	"inspect.",
+	"process.",
+	"jvm.",
+	"rules.",
+	"toolchain.",
+	"network.capture.",
+	"helper.net_capture.",
+}
+
+// connectReadTimeout picks the read deadline when --timeout was not given
+// explicitly: methods that carry their own duration get that duration plus a
+// margin, slow collector families get a long deadline, and everything else a
+// moderate one. An explicit --timeout always wins over all of this.
+func connectReadTimeout(method string, params json.RawMessage) time.Duration {
+	switch method {
+	case "job.get":
+		var p struct {
+			WaitMS int `json:"wait_ms"`
+		}
+		if json.Unmarshal(params, &p) == nil && p.WaitMS > 0 {
+			return time.Duration(p.WaitMS)*time.Millisecond + connectReadMargin
+		}
+	case "process.sample":
+		var p struct {
+			Duration int `json:"duration"`
+		}
+		if json.Unmarshal(params, &p) == nil && p.Duration > 0 {
+			return time.Duration(p.Duration)*time.Second + connectReadMargin
+		}
+	case "helper.net_capture.start":
+		var p struct {
+			DurationMS int `json:"duration_ms"`
+		}
+		if json.Unmarshal(params, &p) == nil && p.DurationMS > 0 {
+			return time.Duration(p.DurationMS)*time.Millisecond + connectReadMargin
+		}
+	}
+	for _, prefix := range connectSlowMethodPrefixes {
+		if strings.HasPrefix(method, prefix) {
+			return connectSlowReadTimeout
+		}
+	}
+	return connectBaseReadTimeout
 }
 
 func dialConnectTarget(target connectTarget, timeout time.Duration) (io.ReadWriteCloser, error) {

--- a/cmd/spectra/connect_test.go
+++ b/cmd/spectra/connect_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/kaeawc/spectra/internal/rpc"
 )
@@ -331,5 +332,35 @@ func TestLoopbackListenAddr(t *testing.T) {
 		if isLoopbackListenAddr(addr) {
 			t.Fatalf("%s should not be loopback", addr)
 		}
+	}
+}
+
+func TestConnectReadTimeout(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		params string
+		want   time.Duration
+	}{
+		{name: "fast method gets base", method: "health", want: 30 * time.Second},
+		{name: "storage is slow", method: "storage.system", want: 120 * time.Second},
+		{name: "jvm attach is slow", method: "jvm.explain", want: 120 * time.Second},
+		{name: "snapshot is slow", method: "snapshot.create", want: 120 * time.Second},
+		{name: "job wait derives from wait_ms", method: "job.get", params: `{"id":"x","wait_ms":60000}`, want: 90 * time.Second},
+		{name: "job get without wait gets base", method: "job.get", params: `{"id":"x"}`, want: 30 * time.Second},
+		{name: "sample derives from duration", method: "process.sample", params: `{"pid":1,"duration":10}`, want: 40 * time.Second},
+		{name: "sample without duration falls to slow family", method: "process.sample", params: `{"pid":1}`, want: 120 * time.Second},
+		{name: "capture start derives from duration_ms", method: "helper.net_capture.start", params: `{"interface":"en0","duration_ms":5000}`, want: 35 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var params json.RawMessage
+			if tc.params != "" {
+				params = json.RawMessage(tc.params)
+			}
+			if got := connectReadTimeout(tc.method, params); got != tc.want {
+				t.Fatalf("connectReadTimeout(%s) = %v, want %v", tc.method, got, tc.want)
+			}
+		})
 	}
 }

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -145,9 +145,8 @@ spectra connect work-mac job start storage.system
 
 spectra connect work-mac jobs                       # list jobs, newest first
 spectra connect work-mac job get job-3-9f2c1a44     # poll: running|done|failed
-spectra connect --timeout 65s work-mac job wait job-3-9f2c1a44 60
-# → blocks daemon-side up to 60s for completion; pass a --timeout larger
-#   than the wait
+spectra connect work-mac job wait job-3-9f2c1a44 60
+# → blocks daemon-side up to 60s for completion
 ```
 
 Jobs run through the same method table as direct calls, so per-method policy
@@ -156,6 +155,14 @@ applies unchanged: sensitive artifact captures still require
 cannot themselves be started as jobs. Job state is held in daemon memory:
 finished results are kept for an hour (capped at 200 jobs, oldest finished
 pruned first) and do not survive a daemon restart.
+
+Client read deadlines adapt to the method: slow collector families
+(`storage.*`, `snapshot.*`, `inspect.*`, `process.*`, `jvm.*`, `rules.*`,
+`toolchain.*`, capture methods) get 120s, methods that carry their own
+duration (`job wait`, `sample`, capture starts) get that duration plus a
+margin, and everything else 30s. An explicit `--timeout` overrides all of
+this, and dialing an unreachable host still fails fast on the short dial
+timeout.
 
 The same typed surface is also available as a top-level client flag when you
 want the normal command shape:


### PR DESCRIPTION
## Summary

Makes `spectra connect`'s read deadline adapt to the method instead of the
flat 3s default that truncated every slow collector (the first paper cut hit
in real mesh testing: a `jvm` scan dying at 3s).

- **Dialing is unchanged**: the short `--timeout` default still bounds the
  dial, so an unreachable host fails fast.
- **When `--timeout` is not given explicitly**, the read deadline comes from
  the method: slow collector families (`storage.*`, `snapshot.*`,
  `inspect.*`, `process.*`, `jvm.*`, `rules.*`, `toolchain.*`, capture
  methods) get 120s; methods that carry their own duration — `job.get`
  (`wait_ms`), `process.sample` (`duration`), `helper.net_capture.start`
  (`duration_ms`) — get that duration plus a 30s margin; everything else 30s.
- **An explicit `--timeout` overrides all of it** (both dial and read),
  preserving current behavior for anyone who sets it.

This also removes the `job wait` footgun where the client had to remember to
pass a `--timeout` larger than the wait: `spectra connect work-mac job wait
<id> 60` now just works.

## Type

- [x] New feature

## Testing

- [x] Unit table test for the resolver: base, each slow family, wait_ms /
      duration / duration_ms derivation, and the fall-through when a
      duration-capable method omits its duration (9 cases)
- [x] Full `go test ./cmd/spectra/ ./internal/...` passes

## Checklist

- [x] No new `go vet` warnings
- [x] `gofmt -s` clean
- [x] No new `gocyclo` violations (CI gate `-over 15`)
- [x] No new `gosec` findings (`Issues: 0`)
- [x] `go mod tidy` is clean

## Reviewer notes

- Explicit-flag detection uses `fs.Visit`, so `--timeout 3s` passed
  explicitly behaves exactly as before (both dial and read at 3s).
- `docs/operations/remote.md` documents the policy and drops the stale
  "--timeout larger than the wait" guidance.
- `fan`'s per-target `--timeout` is untouched; if the same adaptation is
  wanted there it can reuse `connectReadTimeout` in a follow-up.
