### PR TITLE
Linux/OS-aware phase 3: netstate + sysinfo/power + toolchain backends

### DIFF
--- a/internal/netstate/linux.go
+++ b/internal/netstate/linux.go
@@ -1,0 +1,234 @@
+package netstate
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// collectLinux gathers network state on Linux from /proc, /sys, and the
+// iproute2 tools. Every source is best-effort; a missing file or absent
+// tool leaves its field empty rather than failing the snapshot.
+func collectLinux(run CmdRunner) State {
+	var s State
+	if data, err := os.ReadFile("/proc/net/route"); err == nil {
+		s.DefaultRouteIface, s.DefaultRouteGW = parseProcNetRoute(data)
+	}
+	if data, err := os.ReadFile("/etc/resolv.conf"); err == nil {
+		s.DNSServers = parseResolvConf(data)
+	}
+	s.Proxy = proxyFromEnv()
+	s.HostsOverrides = readHostsOverrides("/etc/hosts", hostsDefaultsLinux)
+	s.ListeningPorts = collectLinuxListeners(run)
+	s.VPNInterfaces = linuxVPNInterfaces("/sys/class/net")
+	s.VPNActive = len(s.VPNInterfaces) > 0
+	if out, err := run("ss", "-tan"); err == nil {
+		s.EstablishedConnectionsCount = countSSEstablished(string(out))
+	}
+	// Per-process throughput has no unprivileged, dependency-free source on
+	// Linux (nettop is macOS-only), so it is left empty.
+	return s
+}
+
+// parseProcNetRoute extracts the default route's interface and gateway from
+// /proc/net/route. The default route is the row whose Destination is all
+// zeros; Gateway is a little-endian hex IPv4 address.
+func parseProcNetRoute(data []byte) (iface, gw string) {
+	for i, line := range strings.Split(string(data), "\n") {
+		if i == 0 { // header
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[1] != "00000000" { // Destination
+			continue
+		}
+		return fields[0], hexLEToIPv4(fields[2])
+	}
+	return "", ""
+}
+
+// hexLEToIPv4 converts an 8-char little-endian hex string (as found in
+// /proc/net/route, where addresses are stored in host/little-endian byte
+// order) to dotted-decimal. The decoded bytes are the IP octets reversed.
+// Returns "" on malformed input or the unspecified address.
+func hexLEToIPv4(h string) string {
+	b, err := hex.DecodeString(h)
+	if err != nil || len(b) != 4 {
+		return ""
+	}
+	if b[0] == 0 && b[1] == 0 && b[2] == 0 && b[3] == 0 {
+		return ""
+	}
+	return strconv.Itoa(int(b[3])) + "." + strconv.Itoa(int(b[2])) + "." +
+		strconv.Itoa(int(b[1])) + "." + strconv.Itoa(int(b[0]))
+}
+
+// parseResolvConf returns the unique nameserver addresses from
+// resolv.conf content.
+func parseResolvConf(data []byte) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		rest, ok := strings.CutPrefix(line, "nameserver")
+		if !ok {
+			continue
+		}
+		ip := strings.TrimSpace(rest)
+		if ip != "" && !seen[ip] {
+			seen[ip] = true
+			out = append(out, ip)
+		}
+	}
+	return out
+}
+
+// proxyFromEnv reads the conventional Linux proxy environment variables.
+// Linux has no system-wide proxy store; these are the de-facto standard.
+func proxyFromEnv() ProxyConfig {
+	first := func(keys ...string) string {
+		for _, k := range keys {
+			if v := os.Getenv(k); v != "" {
+				return v
+			}
+		}
+		return ""
+	}
+	return ProxyConfig{
+		HTTP:  first("http_proxy", "HTTP_PROXY"),
+		HTTPS: first("https_proxy", "HTTPS_PROXY"),
+		SOCKS: first("all_proxy", "ALL_PROXY"),
+	}
+}
+
+// hostsDefaultsLinux are the stock /etc/hosts IPs on common distributions,
+// excluded from the "overrides" list.
+var hostsDefaultsLinux = map[string]bool{
+	"127.0.0.1": true,
+	"127.0.1.1": true, // Debian/Ubuntu hostname mapping
+	"::1":       true,
+	"ff02::1":   true,
+	"ff02::2":   true,
+	"fe00::0":   true,
+}
+
+func collectLinuxListeners(run CmdRunner) []ListeningPort {
+	var ports []ListeningPort
+	if out, err := run("ss", "-tlnp"); err == nil {
+		ports = append(ports, parseSSListen(string(out), "tcp")...)
+	}
+	if out, err := run("ss", "-ulnp"); err == nil {
+		ports = append(ports, parseSSListen(string(out), "udp")...)
+	}
+	return ports
+}
+
+var ssProcessRe = regexp.MustCompile(`"([^"]+)",pid=(\d+)`)
+
+// parseSSListen parses `ss -tlnp` / `ss -ulnp` output. Columns:
+// State Recv-Q Send-Q Local-Address:Port Peer-Address:Port [Process].
+func parseSSListen(out, proto string) []ListeningPort {
+	var ports []ListeningPort
+	for i, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		if i == 0 && strings.EqualFold(fields[0], "State") {
+			continue // header
+		}
+		local, port, ok := splitHostPort(fields[3])
+		if !ok {
+			continue
+		}
+		lp := ListeningPort{Port: port, Proto: proto, LocalAddr: local}
+		if len(fields) >= 6 {
+			if m := ssProcessRe.FindStringSubmatch(strings.Join(fields[5:], " ")); m != nil {
+				lp.Command = m[1]
+				lp.PID, _ = strconv.Atoi(m[2])
+			}
+		}
+		ports = append(ports, lp)
+	}
+	return ports
+}
+
+// splitHostPort splits an "addr:port" token (ss uses the last ':' as the
+// port separator, so bracketed/implicit IPv6 hosts work).
+func splitHostPort(s string) (host string, port int, ok bool) {
+	idx := strings.LastIndex(s, ":")
+	if idx < 0 || idx == len(s)-1 {
+		return "", 0, false
+	}
+	p, err := strconv.Atoi(s[idx+1:])
+	if err != nil || p <= 0 {
+		return "", 0, false
+	}
+	host = s[:idx]
+	if host == "" || host == "*" {
+		host = "*"
+	}
+	return host, p, true
+}
+
+// countSSEstablished counts ESTAB rows in `ss -tan` output.
+func countSSEstablished(out string) int {
+	count := 0
+	for i, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if i == 0 && strings.EqualFold(fields[0], "State") {
+			continue
+		}
+		if fields[0] == "ESTAB" {
+			count++
+		}
+	}
+	return count
+}
+
+// linuxVPNInterfaces scans sysClassNet (normally /sys/class/net) for tunnel
+// interfaces that are up. Linux names VPN tunnels tun*/tap*/wg*/ppp* and
+// Tailscale uses "tailscale0". tun devices frequently report operstate
+// "unknown" while up, so anything not explicitly "down" counts.
+func linuxVPNInterfaces(sysClassNet string) []string {
+	entries, err := os.ReadDir(sysClassNet)
+	if err != nil {
+		return nil
+	}
+	var active []string
+	for _, e := range entries {
+		name := e.Name()
+		if !isVPNIfaceName(name) {
+			continue
+		}
+		state := "unknown"
+		if b, err := os.ReadFile(filepath.Join(sysClassNet, name, "operstate")); err == nil {
+			state = strings.TrimSpace(string(b))
+		}
+		if state != "down" {
+			active = append(active, name)
+		}
+	}
+	return active
+}
+
+func isVPNIfaceName(name string) bool {
+	for _, p := range []string{"tun", "tap", "wg", "ppp", "tailscale"} {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return name == "utun"
+}

--- a/internal/netstate/linux_test.go
+++ b/internal/netstate/linux_test.go
@@ -1,0 +1,138 @@
+package netstate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kaeawc/spectra/internal/hostos"
+)
+
+func TestParseProcNetRoute(t *testing.T) {
+	// Gateway 0102A8C0 little-endian = 192.168.2.1; default row has
+	// Destination 00000000. A non-default row precedes it.
+	data := []byte("Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\n" +
+		"eth0\t0000FEA9\t00000000\t0001\t0\t0\t1000\t0000FFFF\n" +
+		"eth0\t00000000\t0102A8C0\t0003\t0\t0\t100\t00000000\n")
+	iface, gw := parseProcNetRoute(data)
+	if iface != "eth0" {
+		t.Errorf("iface = %q, want eth0", iface)
+	}
+	if gw != "192.168.2.1" {
+		t.Errorf("gw = %q, want 192.168.2.1", gw)
+	}
+}
+
+func TestParseResolvConf(t *testing.T) {
+	dns := parseResolvConf([]byte("# comment\nnameserver 1.1.1.1\nsearch lan\nnameserver 8.8.8.8\nnameserver 1.1.1.1\n"))
+	if len(dns) != 2 || dns[0] != "1.1.1.1" || dns[1] != "8.8.8.8" {
+		t.Errorf("parseResolvConf = %v, want [1.1.1.1 8.8.8.8] (deduped)", dns)
+	}
+}
+
+func TestParseSSListen(t *testing.T) {
+	out := `State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process
+LISTEN 0      128    0.0.0.0:22         0.0.0.0:*         users:(("sshd",pid=789,fd=3))
+LISTEN 0      4096   [::]:443           [::]:*            users:(("nginx",pid=1011,fd=6))
+`
+	ports := parseSSListen(out, "tcp")
+	if len(ports) != 2 {
+		t.Fatalf("got %d ports, want 2: %+v", len(ports), ports)
+	}
+	if ports[0].Port != 22 || ports[0].Command != "sshd" || ports[0].PID != 789 {
+		t.Errorf("port[0] = %+v, want :22 sshd pid 789", ports[0])
+	}
+	if ports[0].Proto != "tcp" {
+		t.Errorf("proto = %q, want tcp", ports[0].Proto)
+	}
+	if ports[1].Port != 443 || ports[1].Command != "nginx" {
+		t.Errorf("port[1] = %+v, want :443 nginx", ports[1])
+	}
+}
+
+func TestCountSSEstablished(t *testing.T) {
+	out := `State  Recv-Q Send-Q Local Address:Port Peer Address:Port
+ESTAB  0      0      10.0.0.1:22        10.0.0.2:51000
+LISTEN 0      128    0.0.0.0:22         0.0.0.0:*
+ESTAB  0      0      10.0.0.1:443       10.0.0.9:51001
+TIME-WAIT 0   0      10.0.0.1:80        10.0.0.3:40000
+`
+	if got := countSSEstablished(out); got != 2 {
+		t.Errorf("countSSEstablished = %d, want 2", got)
+	}
+}
+
+func TestLinuxVPNInterfaces(t *testing.T) {
+	root := t.TempDir()
+	// tailscale0 up, wg0 up (operstate unknown), eth0 (not a VPN), tun9 down.
+	mk := func(name, state string) {
+		d := filepath.Join(root, name)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "operstate"), []byte(state+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("tailscale0", "unknown")
+	mk("wg0", "up")
+	mk("eth0", "up")
+	mk("tun9", "down")
+
+	got := linuxVPNInterfaces(root)
+	set := map[string]bool{}
+	for _, n := range got {
+		set[n] = true
+	}
+	if !set["tailscale0"] || !set["wg0"] {
+		t.Errorf("got %v, want tailscale0 and wg0 active", got)
+	}
+	if set["eth0"] {
+		t.Errorf("eth0 is not a VPN interface")
+	}
+	if set["tun9"] {
+		t.Errorf("tun9 is down and should be excluded")
+	}
+}
+
+func TestHostsDefaultsLinux(t *testing.T) {
+	content := "127.0.0.1 localhost\n127.0.1.1 myhost\n::1 localhost ip6-localhost\nff02::1 ip6-allnodes\n10.1.2.3 corp.internal\n"
+	path := filepath.Join(t.TempDir(), "hosts")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := readHostsOverrides(path, hostsDefaultsLinux)
+	if len(entries) != 1 || entries[0].IP != "10.1.2.3" {
+		t.Errorf("entries = %+v, want only 10.1.2.3 (distro defaults filtered)", entries)
+	}
+}
+
+func TestProxyFromEnv(t *testing.T) {
+	t.Setenv("http_proxy", "http://proxy:3128")
+	t.Setenv("HTTPS_PROXY", "http://sproxy:3129")
+	t.Setenv("all_proxy", "socks5://sox:1080")
+	pc := proxyFromEnv()
+	if pc.HTTP != "http://proxy:3128" || pc.HTTPS != "http://sproxy:3129" || pc.SOCKS != "socks5://sox:1080" {
+		t.Errorf("proxyFromEnv = %+v", pc)
+	}
+}
+
+func TestCollectLinuxUsesSS(t *testing.T) {
+	// With OS pinned to Linux, Collect should route to the Linux backend,
+	// which queries ss (not lsof/route/scutil).
+	defer hostos.SetForTest(hostos.Linux)()
+	var sawSS bool
+	stub := func(name string, args ...string) ([]byte, error) {
+		if name == "ss" {
+			sawSS = true
+		}
+		if name == "route" || name == "scutil" || name == "nettop" {
+			t.Errorf("Linux backend invoked macOS tool %q", name)
+		}
+		return nil, nil
+	}
+	_ = Collect(stub)
+	if !sawSS {
+		t.Error("Linux Collect should query ss")
+	}
+}

--- a/internal/netstate/netstate.go
+++ b/internal/netstate/netstate.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/kaeawc/spectra/internal/hostos"
 )
 
 // State is the NetworkState slice of a Spectra snapshot.
@@ -74,8 +76,17 @@ func DefaultRunner(name string, args ...string) ([]byte, error) {
 }
 
 // Collect gathers network state. Any sub-command failure is silently
-// absorbed; partial results are still valid.
+// absorbed; partial results are still valid. The backend is chosen by host
+// OS: macOS uses route/scutil/lsof/ifconfig/nettop; Linux reads /proc, /sys,
+// and the iproute2 tools.
 func Collect(run CmdRunner) State {
+	if hostos.Current() == hostos.Linux {
+		return collectLinux(run)
+	}
+	return collectDarwin(run)
+}
+
+func collectDarwin(run CmdRunner) State {
 	var s State
 	if out, err := run("route", "-n", "get", "default"); err == nil {
 		s.DefaultRouteIface, s.DefaultRouteGW = parseRoute(string(out))
@@ -86,7 +97,7 @@ func Collect(run CmdRunner) State {
 	if out, err := run("scutil", "--proxy"); err == nil {
 		s.Proxy = parseProxy(string(out))
 	}
-	s.HostsOverrides = readHostsOverrides("/etc/hosts")
+	s.HostsOverrides = readHostsOverrides("/etc/hosts", hostsDefaultsDarwin)
 	if out, err := run("lsof", "-i", "-P", "-n", "-sTCP:LISTEN"); err == nil {
 		s.ListeningPorts = parseLSOFListen(string(out))
 	}
@@ -293,17 +304,18 @@ func scutilKV(out string) map[string]string {
 	return m
 }
 
-// readHostsOverrides reads /etc/hosts and returns non-default, non-comment
-// lines. hostsPath is parameterised for testing.
-func readHostsOverrides(hostsPath string) []HostsEntry {
-	// Default macOS /etc/hosts entries — skip these.
-	defaults := map[string]bool{
-		"127.0.0.1":       true,
-		"255.255.255.255": true,
-		"::1":             true,
-		"fe80::1%lo0":     true,
-	}
+// hostsDefaultsDarwin are the stock macOS /etc/hosts IPs.
+var hostsDefaultsDarwin = map[string]bool{
+	"127.0.0.1":       true,
+	"255.255.255.255": true,
+	"::1":             true,
+	"fe80::1%lo0":     true,
+}
 
+// readHostsOverrides reads /etc/hosts and returns non-default, non-comment
+// lines. hostsPath and defaults are parameterised for testing and per-OS
+// default filtering.
+func readHostsOverrides(hostsPath string, defaults map[string]bool) []HostsEntry {
 	f, err := os.Open(hostsPath)
 	if err != nil {
 		return nil

--- a/internal/netstate/netstate_test.go
+++ b/internal/netstate/netstate_test.go
@@ -5,7 +5,19 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/kaeawc/spectra/internal/hostos"
 )
+
+// TestMain pins the host OS to Darwin so the macOS command-stub tests
+// (route/scutil/lsof/nettop) are host-independent. Linux parsers are
+// exercised directly in linux_test.go.
+func TestMain(m *testing.M) {
+	restore := hostos.SetForTest(hostos.Darwin)
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
 
 func TestParseRoute(t *testing.T) {
 	out := `   route to: default
@@ -88,7 +100,7 @@ func TestReadHostsOverrides(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "hosts")
 	os.WriteFile(path, []byte(content), 0o644)
 
-	entries := readHostsOverrides(path)
+	entries := readHostsOverrides(path, hostsDefaultsDarwin)
 	if len(entries) != 2 {
 		t.Fatalf("got %d entries, want 2: %+v", len(entries), entries)
 	}
@@ -104,7 +116,7 @@ func TestReadHostsOverrides(t *testing.T) {
 }
 
 func TestReadHostsOverridesMissing(t *testing.T) {
-	entries := readHostsOverrides("/nonexistent/hosts")
+	entries := readHostsOverrides("/nonexistent/hosts", hostsDefaultsDarwin)
 	if entries != nil {
 		t.Error("expected nil for missing hosts file")
 	}

--- a/internal/sysinfo/linux.go
+++ b/internal/sysinfo/linux.go
@@ -1,0 +1,86 @@
+package sysinfo
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// LinuxAllowedSysctls is the Linux counterpart to AllowedSysctls: a curated
+// set of tunables read from /proc/sys. Keys use the conventional
+// dotted-path form; the path is derived by replacing '.' with '/'.
+var LinuxAllowedSysctls = []string{
+	"fs.file-max",
+	"fs.nr_open",
+	"kernel.pid_max",
+	"kernel.threads-max",
+	"vm.swappiness",
+	"vm.max_map_count",
+	"net.core.somaxconn",
+}
+
+// collectSysctlsLinux reads the Linux allowlist from a /proc/sys tree
+// rooted at procSysRoot (normally "/proc/sys"). Missing keys are omitted.
+func collectSysctlsLinux(procSysRoot string) map[string]string {
+	out := make(map[string]string, len(LinuxAllowedSysctls))
+	for _, key := range LinuxAllowedSysctls {
+		rel := strings.ReplaceAll(key, ".", string(os.PathSeparator))
+		data, err := os.ReadFile(filepath.Join(procSysRoot, rel))
+		if err != nil {
+			continue
+		}
+		if v := strings.TrimSpace(string(data)); v != "" {
+			out[key] = v
+		}
+	}
+	return out
+}
+
+// collectPowerLinux reads battery and AC state from a power-supply tree
+// rooted at root (normally "/sys/class/power_supply"). Thermal pressure has
+// no standard Linux equivalent, so those fields are left zero. Best-effort:
+// a missing or unreadable tree yields a zero PowerState.
+func collectPowerLinux(root string) PowerState {
+	var ps PowerState
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return ps
+	}
+	acOnline := false
+	acSeen := false
+	batterySeen := false
+	discharging := false
+
+	readField := func(supply, field string) string {
+		b, err := os.ReadFile(filepath.Join(root, supply, field))
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(b))
+	}
+
+	for _, e := range entries {
+		name := e.Name()
+		switch readField(name, "type") {
+		case "Mains", "USB", "UPS":
+			acSeen = true
+			if readField(name, "online") == "1" {
+				acOnline = true
+			}
+		case "Battery":
+			batterySeen = true
+			if pct, err := strconv.Atoi(readField(name, "capacity")); err == nil {
+				ps.BatteryPct = pct
+			}
+			if strings.EqualFold(readField(name, "status"), "Discharging") {
+				discharging = true
+			}
+		}
+	}
+
+	// On battery when discharging, or when an AC supply exists but none is
+	// online. A machine with no battery at all stays OnBattery=false.
+	ps.OnBattery = discharging || (batterySeen && acSeen && !acOnline)
+	return ps
+}

--- a/internal/sysinfo/linux_test.go
+++ b/internal/sysinfo/linux_test.go
@@ -1,0 +1,92 @@
+package sysinfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCollectSysctlsLinux(t *testing.T) {
+	root := t.TempDir()
+	// Mirror /proc/sys layout: fs/file-max, kernel/pid_max, vm/swappiness.
+	write := func(rel, val string) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(val), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("fs/file-max", "9223372036854775807\n")
+	write("kernel/pid_max", "4194304\n")
+	write("vm/swappiness", "60\n")
+
+	got := collectSysctlsLinux(root)
+	if got["fs.file-max"] != "9223372036854775807" {
+		t.Errorf("fs.file-max = %q", got["fs.file-max"])
+	}
+	if got["kernel.pid_max"] != "4194304" {
+		t.Errorf("kernel.pid_max = %q", got["kernel.pid_max"])
+	}
+	if got["vm.swappiness"] != "60" {
+		t.Errorf("vm.swappiness = %q", got["vm.swappiness"])
+	}
+	if _, ok := got["net.core.somaxconn"]; ok {
+		t.Error("absent key should be omitted, not empty")
+	}
+}
+
+func TestCollectPowerLinuxOnBattery(t *testing.T) {
+	root := t.TempDir()
+	mk := func(name string, fields map[string]string) {
+		d := filepath.Join(root, name)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for k, v := range fields {
+			if err := os.WriteFile(filepath.Join(d, k), []byte(v+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	mk("AC", map[string]string{"type": "Mains", "online": "0"})
+	mk("BAT0", map[string]string{"type": "Battery", "capacity": "72", "status": "Discharging"})
+
+	ps := collectPowerLinux(root)
+	if !ps.OnBattery {
+		t.Error("OnBattery should be true when discharging and AC offline")
+	}
+	if ps.BatteryPct != 72 {
+		t.Errorf("BatteryPct = %d, want 72", ps.BatteryPct)
+	}
+}
+
+func TestCollectPowerLinuxOnAC(t *testing.T) {
+	root := t.TempDir()
+	mkField := func(name, field, val string) {
+		d := filepath.Join(root, name)
+		os.MkdirAll(d, 0o755)
+		os.WriteFile(filepath.Join(d, field), []byte(val+"\n"), 0o644)
+	}
+	mkField("AC", "type", "Mains")
+	mkField("AC", "online", "1")
+	mkField("BAT0", "type", "Battery")
+	mkField("BAT0", "capacity", "100")
+	mkField("BAT0", "status", "Full")
+
+	ps := collectPowerLinux(root)
+	if ps.OnBattery {
+		t.Error("OnBattery should be false when AC is online")
+	}
+	if ps.BatteryPct != 100 {
+		t.Errorf("BatteryPct = %d, want 100", ps.BatteryPct)
+	}
+}
+
+func TestCollectPowerLinuxMissingTree(t *testing.T) {
+	ps := collectPowerLinux(filepath.Join(t.TempDir(), "nope"))
+	if ps.OnBattery || ps.BatteryPct != 0 {
+		t.Errorf("missing tree should yield zero PowerState, got %+v", ps)
+	}
+}

--- a/internal/sysinfo/power.go
+++ b/internal/sysinfo/power.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/kaeawc/spectra/internal/hostos"
 )
 
 // PowerState captures battery and thermal facts.
@@ -77,9 +79,13 @@ type PowerCollector struct {
 	Source PowerSource
 }
 
-// CollectPower gathers PowerState from pmset. Any sub-command failure is
-// silently absorbed; partial results are still valid.
+// CollectPower gathers PowerState. On macOS it parses pmset; on Linux it
+// reads /sys/class/power_supply (thermal pressure has no Linux equivalent,
+// so those fields stay zero). Any sub-source failure is silently absorbed.
 func CollectPower(run CmdRunner) PowerState {
+	if hostos.Current() == hostos.Linux {
+		return collectPowerLinux("/sys/class/power_supply")
+	}
 	return PowerCollector{Source: CommandPowerSource{Run: run}}.Collect()
 }
 

--- a/internal/sysinfo/sysctls.go
+++ b/internal/sysinfo/sysctls.go
@@ -5,6 +5,8 @@ package sysinfo
 
 import (
 	"strings"
+
+	"github.com/kaeawc/spectra/internal/hostos"
 )
 
 // AllowedSysctls is the allowlist of kernel tunables Spectra captures.
@@ -20,9 +22,13 @@ var AllowedSysctls = []string{
 	"hw.memsize",
 }
 
-// CollectSysctls returns the allowed sysctl key→value map.
-// Keys absent from the output (not present on this kernel) are omitted.
+// CollectSysctls returns the allowed sysctl key→value map. On Linux the
+// values come from /proc/sys using the Linux allowlist; on macOS they come
+// from sysctl(8). Keys absent on this kernel are omitted.
 func CollectSysctls(run CmdRunner) map[string]string {
+	if hostos.Current() == hostos.Linux {
+		return collectSysctlsLinux("/proc/sys")
+	}
 	out := make(map[string]string, len(AllowedSysctls))
 	for _, key := range AllowedSysctls {
 		val, err := run("sysctl", "-n", key)

--- a/internal/sysinfo/sysctls_test.go
+++ b/internal/sysinfo/sysctls_test.go
@@ -2,9 +2,21 @@ package sysinfo
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/kaeawc/spectra/internal/hostos"
 )
+
+// TestMain pins the host OS to Darwin so the pmset/sysctl stub tests are
+// host-independent. Linux backends are tested directly in linux_test.go.
+func TestMain(m *testing.M) {
+	restore := hostos.SetForTest(hostos.Darwin)
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
 
 func stubSysctl(responses map[string]string) CmdRunner {
 	return func(name string, args ...string) ([]byte, error) {

--- a/internal/toolchain/collect.go
+++ b/internal/toolchain/collect.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/kaeawc/spectra/internal/hostos"
 )
 
 // CollectOptions parameterises the collector. All path fields have sane
@@ -153,13 +155,22 @@ func withDefaults(o CollectOptions) CollectOptions {
 		h, _ := os.UserHomeDir()
 		o.Home = h
 	}
+	linux := hostos.Current() == hostos.Linux
 	if len(o.BrewCellars) == 0 {
-		o.BrewCellars = []string{"/opt/homebrew/Cellar", "/usr/local/Cellar"}
+		if linux {
+			o.BrewCellars = []string{"/home/linuxbrew/.linuxbrew/Cellar", filepath.Join(o.Home, ".linuxbrew", "Cellar")}
+		} else {
+			o.BrewCellars = []string{"/opt/homebrew/Cellar", "/usr/local/Cellar"}
+		}
 	}
 	if o.SystemJVMRoot == "" {
-		o.SystemJVMRoot = "/Library/Java/JavaVirtualMachines"
+		if linux {
+			o.SystemJVMRoot = "/usr/lib/jvm"
+		} else {
+			o.SystemJVMRoot = "/Library/Java/JavaVirtualMachines"
+		}
 	}
-	if o.UserJVMRoot == "" {
+	if o.UserJVMRoot == "" && !linux {
 		o.UserJVMRoot = filepath.Join(o.Home, "Library", "Java", "JavaVirtualMachines")
 	}
 	if o.CmdRunner == nil {

--- a/internal/toolchain/collect_test.go
+++ b/internal/toolchain/collect_test.go
@@ -5,7 +5,32 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/kaeawc/spectra/internal/hostos"
 )
+
+// TestMain pins the host OS to Darwin so default BrewCellar / JVM-root
+// selection and the xcrun-vs-make branch are host-independent in tests.
+func TestMain(m *testing.M) {
+	restore := hostos.SetForTest(hostos.Darwin)
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
+
+func TestWithDefaultsLinux(t *testing.T) {
+	defer hostos.SetForTest(hostos.Linux)()
+	o := withDefaults(CollectOptions{Home: "/home/u"})
+	if len(o.BrewCellars) == 0 || o.BrewCellars[0] != "/home/linuxbrew/.linuxbrew/Cellar" {
+		t.Errorf("BrewCellars = %v, want linuxbrew cellar first", o.BrewCellars)
+	}
+	if o.SystemJVMRoot != "/usr/lib/jvm" {
+		t.Errorf("SystemJVMRoot = %q, want /usr/lib/jvm", o.SystemJVMRoot)
+	}
+	if o.UserJVMRoot != "" {
+		t.Errorf("UserJVMRoot = %q, want empty on Linux", o.UserJVMRoot)
+	}
+}
 
 func TestCollectIntegration(t *testing.T) {
 	home := t.TempDir()

--- a/internal/toolchain/runtime.go
+++ b/internal/toolchain/runtime.go
@@ -4,8 +4,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
+
+	"github.com/kaeawc/spectra/internal/hostos"
 )
 
 // discoverNode enumerates Node.js installations from all common managers.
@@ -115,9 +118,10 @@ func discoverGo(opts CollectOptions) ([]RuntimeInstall, error) {
 	for _, v := range listDirs(filepath.Join(opts.Home, ".local", "share", "mise", "installs", "go")) {
 		out = append(out, runtimeInstall("mise", v, filepath.Join(opts.Home, ".local", "share", "mise", "installs", "go", v, "bin", "go"), active))
 	}
-	// asdf
+	// asdf — the go packages tool dir is named <GOOS>_<GOARCH>.
+	goPlatform := runtime.GOOS + "_" + runtime.GOARCH
 	for _, v := range listDirs(filepath.Join(opts.Home, ".asdf", "installs", "golang")) {
-		out = append(out, runtimeInstall("asdf", v, filepath.Join(opts.Home, ".asdf", "installs", "golang", v, "packages", "pkg", "tool", "darwin_arm64", "go"), active))
+		out = append(out, runtimeInstall("asdf", v, filepath.Join(opts.Home, ".asdf", "installs", "golang", v, "packages", "pkg", "tool", goPlatform, "go"), active))
 	}
 	// brew
 	for _, cellar := range opts.BrewCellars {
@@ -361,11 +365,19 @@ func discoverBuildTools(opts CollectOptions) []BuildTool {
 		add("bazel", v, "system")
 	}
 
-	// Make — check brew cellar first, then Xcode command line tools.
+	// Make — brew cellar first, then the system make. On macOS make ships
+	// via the Xcode command line tools and is invoked through xcrun; other
+	// OSes call make directly (xcrun does not exist there).
 	if v := brewVersion(opts.BrewCellars, "make"); v != "" {
 		add("make", v, "brew")
-	} else if v := versionFromCmd(opts.CmdRunner, "xcrun", "make", "--version"); v != "" {
-		add("make", v, "system")
+	} else {
+		makeName, makeArgs := "make", []string{"--version"}
+		if hostos.Current() == hostos.Darwin {
+			makeName, makeArgs = "xcrun", []string{"make", "--version"}
+		}
+		if v := versionFromCmd(opts.CmdRunner, makeName, makeArgs...); v != "" {
+			add("make", v, "system")
+		}
 	}
 
 	// CMake — check brew cellar first.


### PR DESCRIPTION
## Summary

Phase 3 of host-OS awareness: Linux backends for the remaining cross-platform collectors — network state, sysctls/power, and toolchain discovery. Stacked on #477.

## What's here

- **Network state** (`internal/netstate`). Linux `Collect` reads the default route from `/proc/net/route` (little-endian hex gateway decode), DNS from `/etc/resolv.conf`, proxy from the conventional `*_proxy` env vars, listening ports + established-connection count from `ss`, VPN tunnels from `/sys/class/net` (tun/tap/wg/ppp/tailscale), and applies per-OS `/etc/hosts` default filtering. Per-process throughput (macOS `nettop`) has no unprivileged, dependency-free Linux equivalent, so it's left empty.
- **Sysctls + power** (`internal/sysinfo`). `CollectSysctls` reads a Linux allowlist from `/proc/sys`; `CollectPower` reads battery/AC state from `/sys/class/power_supply`. Thermal pressure has no standard Linux equivalent and stays zero.
- **Toolchain discovery** (`internal/toolchain`). The asdf Go packages tool dir is derived from `runtime.GOOS/GOARCH` instead of a hardcoded `darwin_arm64`; `make` is invoked directly on Linux instead of via `xcrun`; `BrewCellars` defaults to the Linuxbrew roots and the system JVM root to `/usr/lib/jvm` on Linux.

## Testing

- Full Darwin suite green (`go test ./...`, 40 packages); Darwin + Linux `go build`/`go vet` green; `golangci-lint` clean on all three packages.
- Linux parsers are unit-tested on the macOS box via injected roots/fixtures: `/proc/net/route` gateway decode, `resolv.conf`, `ss -tlnp`/`-tan` parsing, `/sys/class/net` VPN detection, Linux `/etc/hosts` defaults, proxy env, `/proc/sys` sysctls, and `/sys/class/power_supply` battery/AC logic. Each affected package pins Darwin in `TestMain` so the existing macOS-stub tests stay host-independent.

## Notes

- Backends are selected via `hostos.Current()`/`Resolve`, so the daemon and snapshot pick the Linux path automatically on a Linux host.
- This completes the cross-platform **collector** work (PRs 1–3). Remaining: daemon/helper install and packaging/CI (PRs 4–5).
