### PR TITLE
Linux/OS-aware phase 4b: systemd privileged helper + SO_PEERCRED peer auth

### DIFF
--- a/cmd/spectra-helper/main.go
+++ b/cmd/spectra-helper/main.go
@@ -26,13 +26,24 @@ import (
 	"time"
 
 	"github.com/kaeawc/spectra/internal/helper"
+	"github.com/kaeawc/spectra/internal/hostos"
 )
 
 var version = "dev"
 var lookupGroup = user.LookupGroup
 
 const sockPath = "/var/run/spectra-helper.sock"
-const helperGroup = "_spectra"
+
+// helperGroup is the Unix group that owns the helper socket. macOS uses the
+// underscore-prefixed service-account convention; Linux does not.
+var helperGroup = defaultHelperGroup()
+
+func defaultHelperGroup() string {
+	if hostos.Current() == hostos.Linux {
+		return "spectra"
+	}
+	return "_spectra"
+}
 
 func main() {
 	os.Exit(runWithArgs(os.Args[1:]))

--- a/cmd/spectra/helper.go
+++ b/cmd/spectra/helper.go
@@ -358,9 +358,11 @@ func sudoCommandAllowed(name string) bool {
 
 // installHelperCmd dispatches install-helper subcommands.
 func runInstallHelperCmd(args []string) int {
-	if hostos.Current() != hostos.Darwin {
+	switch hostos.Current() {
+	case hostos.Darwin, hostos.Linux:
+		// supported below
+	default:
 		fmt.Fprintf(os.Stderr, "spectra install-helper: %v\n", hostos.Unsupported("privileged helper install"))
-		fmt.Fprintln(os.Stderr, "The privileged helper targets macOS launchd + TCC; a systemd-based Linux helper is not yet available.")
 		return 1
 	}
 	if len(args) > 0 {
@@ -368,8 +370,14 @@ func runInstallHelperCmd(args []string) int {
 		case "--status", "status":
 			return runHelperStatus(args[1:])
 		case "uninstall":
+			if hostos.Current() == hostos.Linux {
+				return runUninstallHelperLinux(args[1:])
+			}
 			return runUninstallHelper(args[1:])
 		}
+	}
+	if hostos.Current() == hostos.Linux {
+		return runInstallHelperLinux(args)
 	}
 	return runInstallHelper(args)
 }

--- a/cmd/spectra/helper_systemd.go
+++ b/cmd/spectra/helper_systemd.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kaeawc/spectra/internal/helperclient"
+)
+
+// runInstallHelperLinux parses flags and installs the helper via systemd.
+func runInstallHelperLinux(args []string) int {
+	fs := flag.NewFlagSet("spectra install-helper", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	requireSigned := fs.Bool("require-signed", false, "macOS-only; ignored on Linux")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if err := installHelperLinux(defaultHelperInstallDepsLinux(), helperInstallOptions{RequireSigned: *requireSigned}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+// runUninstallHelperLinux uninstalls the systemd helper.
+func runUninstallHelperLinux(args []string) int {
+	fs := flag.NewFlagSet("spectra uninstall-helper", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if err := uninstallHelperLinux(defaultHelperInstallDepsLinux()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+// Linux privileged-helper install locations and identity.
+const (
+	helperBinaryDestLinux = "/usr/local/lib/spectra/spectra-helper"
+	helperSystemdUnitPath = "/etc/systemd/system/spectra-helper.service"
+	helperGroupLinux      = "spectra"
+)
+
+// helperSystemdUnitContent runs the helper as root at boot and keeps it
+// alive. It logs to journald (StandardError/Output default), so no separate
+// logfile or rotation config is needed as on macOS.
+const helperSystemdUnitContent = `[Unit]
+Description=Spectra privileged helper
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=` + helperBinaryDestLinux + `
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+`
+
+func installHelperLinux(deps helperInstallDeps, opts helperInstallOptions) error {
+	self, err := deps.executable()
+	if err != nil {
+		return fmt.Errorf("install-helper: could not find executable path: %w", err)
+	}
+	helperSrc := filepath.Join(filepath.Dir(self), "spectra-helper")
+	if _, err := deps.stat(helperSrc); err != nil {
+		return fmt.Errorf("install-helper: spectra-helper binary not found at %s\nBuild it with: go build ./cmd/spectra-helper", helperSrc)
+	}
+	if opts.RequireSigned || truthyEnv(deps.getenv("SPECTRA_REQUIRE_SIGNED_HELPER")) {
+		fmt.Fprintln(os.Stderr, "install-helper: --require-signed is a macOS (codesign) option and is ignored on Linux.")
+	}
+
+	fmt.Fprintf(os.Stderr, "This requires administrator privilege. You may be prompted for your password.\n\n")
+
+	steps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"Create spectra group", func() error {
+			return deps.runRoot("groupadd", "-f", helperGroupLinux)
+		}},
+		{"Add current user to spectra group", func() error {
+			user := helperInstallUser(deps.getenv)
+			if user == "" || user == "root" {
+				return nil
+			}
+			return deps.runRoot("usermod", "-aG", helperGroupLinux, user)
+		}},
+		{"Create /usr/local/lib/spectra/", func() error {
+			return deps.runRoot("mkdir", "-p", filepath.Dir(helperBinaryDestLinux))
+		}},
+		{"Copy spectra-helper binary", func() error {
+			return deps.runRoot("cp", helperSrc, helperBinaryDestLinux)
+		}},
+		{"Set ownership and permissions", func() error {
+			if err := deps.runRoot("chown", "root:root", helperBinaryDestLinux); err != nil {
+				return err
+			}
+			return deps.runRoot("chmod", "755", helperBinaryDestLinux)
+		}},
+		{"Install systemd unit", func() error {
+			return installRootTextFile(helperSystemdUnitPath, helperSystemdUnitContent, deps.runRoot, deps.writeTemp)
+		}},
+		{"Reload systemd", func() error {
+			return deps.runRoot("systemctl", "daemon-reload")
+		}},
+		{"Enable and start helper", func() error {
+			return deps.runRoot("systemctl", "enable", "--now", "spectra-helper.service")
+		}},
+	}
+
+	for _, step := range steps {
+		fmt.Printf("  • %s… ", step.name)
+		if err := step.fn(); err != nil {
+			fmt.Println("FAILED")
+			return err
+		}
+		fmt.Println("done")
+	}
+
+	fmt.Println()
+	fmt.Println("spectra-helper installed successfully.")
+	fmt.Println()
+	fmt.Println("If this is the first install, log out and back in so group membership is refreshed.")
+	fmt.Println()
+	fmt.Println("Verify with: spectra install-helper --status")
+	return nil
+}
+
+func uninstallHelperLinux(deps helperInstallDeps) error {
+	steps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"Disable and stop helper", func() error {
+			return deps.runRoot("systemctl", "disable", "--now", "spectra-helper.service")
+		}},
+		{"Remove systemd unit", func() error {
+			return deps.runRoot("rm", "-f", helperSystemdUnitPath)
+		}},
+		{"Reload systemd", func() error {
+			return deps.runRoot("systemctl", "daemon-reload")
+		}},
+		{"Remove binary", func() error {
+			return deps.runRoot("rm", "-f", helperBinaryDestLinux)
+		}},
+	}
+	for _, step := range steps {
+		fmt.Printf("  • %s… ", step.name)
+		if err := step.fn(); err != nil {
+			fmt.Println("FAILED")
+			return err
+		}
+		fmt.Println("done")
+	}
+	fmt.Println("\nspectra-helper uninstalled.")
+	return nil
+}
+
+func defaultHelperInstallDepsLinux() helperInstallDeps {
+	return helperInstallDeps{
+		executable: os.Executable,
+		stat:       os.Stat,
+		getenv:     os.Getenv,
+		runCheck:   runCommand,
+		runRoot:    sudoRunLinux,
+		writeTemp:  writeTempText,
+		client: func() helperStatusClient {
+			return helperclient.New()
+		},
+	}
+}
+
+func sudoRunLinux(name string, args ...string) error {
+	if !sudoCommandAllowedLinux(name) {
+		return fmt.Errorf("sudo command %q is not allowlisted", name)
+	}
+	// #nosec G204 -- sudo is invoked only for the fixed helper management commands.
+	cmd := exec.Command("sudo", append([]string{name}, args...)...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}
+
+func sudoCommandAllowedLinux(name string) bool {
+	switch name {
+	case "chmod", "chown", "cp", "groupadd", "mkdir", "rm", "systemctl", "usermod":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/spectra/helper_systemd_test.go
+++ b/cmd/spectra/helper_systemd_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestInstallHelperLinuxRunsExpectedRootOperations(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.env["SUDO_USER"] = "alice"
+	if err := installHelperLinux(fake.deps(), helperInstallOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	helperSrc := filepath.Join(filepath.Dir(fake.executablePath), "spectra-helper")
+	wantRuns := [][]string{
+		{"groupadd", "-f", helperGroupLinux},
+		{"usermod", "-aG", helperGroupLinux, "alice"},
+		{"mkdir", "-p", filepath.Dir(helperBinaryDestLinux)},
+		{"cp", helperSrc, helperBinaryDestLinux},
+		{"chown", "root:root", helperBinaryDestLinux},
+		{"chmod", "755", helperBinaryDestLinux},
+		{"cp", "/tmp/spectra-helper-1", helperSystemdUnitPath},
+		{"systemctl", "daemon-reload"},
+		{"systemctl", "enable", "--now", "spectra-helper.service"},
+	}
+	if !reflect.DeepEqual(fake.runs, wantRuns) {
+		t.Fatalf("runs = %v,\nwant %v", fake.runs, wantRuns)
+	}
+	if !slices.Equal(fake.tempContents, []string{helperSystemdUnitContent}) {
+		t.Fatalf("temp contents = %q", fake.tempContents)
+	}
+}
+
+func TestInstallHelperLinuxSkipsRootUser(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	fake.env["SUDO_USER"] = "root"
+	if err := installHelperLinux(fake.deps(), helperInstallOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range fake.runs {
+		if len(r) > 0 && r[0] == "usermod" {
+			t.Errorf("should not usermod the root user; runs=%v", fake.runs)
+		}
+	}
+}
+
+func TestUninstallHelperLinux(t *testing.T) {
+	fake := newFakeHelperInstallDeps(t)
+	if err := uninstallHelperLinux(fake.deps()); err != nil {
+		t.Fatal(err)
+	}
+	wantRuns := [][]string{
+		{"systemctl", "disable", "--now", "spectra-helper.service"},
+		{"rm", "-f", helperSystemdUnitPath},
+		{"systemctl", "daemon-reload"},
+		{"rm", "-f", helperBinaryDestLinux},
+	}
+	if !reflect.DeepEqual(fake.runs, wantRuns) {
+		t.Fatalf("runs = %v,\nwant %v", fake.runs, wantRuns)
+	}
+}
+
+func TestSudoCommandAllowedLinux(t *testing.T) {
+	for _, ok := range []string{"groupadd", "usermod", "systemctl", "cp", "chown", "chmod", "mkdir", "rm"} {
+		if !sudoCommandAllowedLinux(ok) {
+			t.Errorf("%q should be allowlisted", ok)
+		}
+	}
+	for _, bad := range []string{"dseditgroup", "launchctl", "bash", "sh", "rm -rf"} {
+		if sudoCommandAllowedLinux(bad) {
+			t.Errorf("%q must not be allowlisted", bad)
+		}
+	}
+}

--- a/internal/helper/peeruid_linux.go
+++ b/internal/helper/peeruid_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package helper
+
+import (
+	"net"
+	"syscall"
+)
+
+// peerUID returns the real UID of the process on the other end of a Unix
+// socket connection, read from the kernel via SO_PEERCRED. The value is
+// authenticated by the kernel and cannot be forged by the client, so it is
+// safe to use for per-caller rate limiting, audit, and ownership of
+// caller-scoped artifacts.
+//
+// On any failure it falls back to 0, matching the socket's 0660 root:spectra
+// permission model (only root or the spectra group can connect at all).
+func peerUID(conn net.Conn) uint32 {
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return 0
+	}
+	raw, err := uc.SyscallConn()
+	if err != nil {
+		return 0
+	}
+	var ucred *syscall.Ucred
+	var credErr error
+	if ctrlErr := raw.Control(func(fd uintptr) {
+		ucred, credErr = syscall.GetsockoptUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+	}); ctrlErr != nil || credErr != nil || ucred == nil {
+		return 0
+	}
+	return ucred.Uid
+}

--- a/internal/helper/peeruid_linux_test.go
+++ b/internal/helper/peeruid_linux_test.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package helper
+
+import (
+	"net"
+	"os"
+	"testing"
+)
+
+// TestPeerUIDReadsSocketpairCredentials verifies SO_PEERCRED returns the
+// real UID of the connected peer. Both ends are this process, so the
+// expected UID is the test process's own. Runs only on Linux.
+func TestPeerUIDReadsSocketpairCredentials(t *testing.T) {
+	// Real Unix socket via a listener/dialer; both ends are this process.
+	dir := t.TempDir()
+	sock := dir + "/peer.sock"
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	type res struct {
+		conn net.Conn
+		err  error
+	}
+	accepted := make(chan res, 1)
+	go func() {
+		conn, err := ln.Accept()
+		accepted <- res{conn, err}
+	}()
+
+	client, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	a := <-accepted
+	if a.err != nil {
+		t.Fatalf("accept: %v", a.err)
+	}
+	defer a.conn.Close()
+
+	got := peerUID(a.conn)
+	if got != uint32(os.Getuid()) {
+		t.Fatalf("peerUID = %d, want %d (own uid)", got, os.Getuid())
+	}
+}

--- a/internal/helper/peeruid_other.go
+++ b/internal/helper/peeruid_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package helper
 


### PR DESCRIPTION
## Summary

Phase 4b: the privileged helper on Linux — systemd system unit, group management, and **real peer-credential authentication**. Stacked on #479. Root-level and security-sensitive, kept small and isolated for review.

## What's here

- **`SO_PEERCRED` peer authentication** (`internal/helper/peeruid_linux.go`). `peerUID` now reads the kernel-authenticated real UID of each connecting client via `SO_PEERCRED`, replacing the previous `return 0` stub. The dispatcher already consumes this UID for per-caller rate limiting, audit logging, and ownership of caller-scoped capture artifacts (`net_capture.go` chowns capture files to the caller) — so real credentials make all three correct rather than pinning everything to root. Falls back to 0 only on the unexpected syscall-error path, matching the `0660 root:spectra` socket permission model. The `!darwin` stub is retagged `!darwin && !linux`.
- **systemd helper install** (`cmd/spectra`). `install-helper` dispatches to a systemd implementation on Linux: `groupadd` the `spectra` group, `usermod` the installing user into it, copy the binary to `/usr/local/lib/spectra`, write `/etc/systemd/system/spectra-helper.service`, then `systemctl daemon-reload` + `enable --now`. Logs go to journald (no newsyslog/logrotate). A Linux-specific sudo allowlist (`groupadd`/`usermod`/`systemctl`/…) replaces the launchctl/dseditgroup one; `codesign` verification is macOS-only and skipped with a notice.
- **OS-aware helper group** (`cmd/spectra-helper`). The socket-owning group is `spectra` on Linux (no underscore-prefixed service-account convention).

## Security notes

- This is a genuine hardening: the helper previously treated every peer as UID 0 on both OSes. The change is safe because no handler *denies* on UID — it's used for rate-limit bucketing, audit, and chowning artifacts to the caller — so switching from fake-0 to the real UID only improves correctness. Verified by reading every `uid` consumer in `internal/helper`.
- The sudo allowlist is a fixed, closed set; no shell, no user-supplied command names.

## Testing

- Full Darwin suite green (`go test ./...`, 40 packages); Darwin + Linux `go build`/`go vet` green; `golangci-lint` clean on the changed packages under both `GOOS=darwin` and `GOOS=linux`.
- Linux install/uninstall run-sequences and the sudo allowlist are tested via the existing `newFakeHelperInstallDeps` harness. `peeruid_linux_test.go` (build-tagged `linux`) exercises `SO_PEERCRED` over a real Unix socket and runs on the PR5 Linux test lane.
