### PR TITLE
Linux/OS-aware phase 5: Linux release archives, CI test lane, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,14 @@ jobs:
           ./spectra /System/Applications/Calculator.app
           ./spectra --json /System/Applications/Chess.app | python3 -m json.tool
 
-  # Cross-compile + vet for Linux. Spectra targets macOS first, but is
-  # being made host-OS-aware; this lane keeps the Linux build honest so
-  # OS-specific breakage (build-tag collisions, macOS-only literals) is
-  # caught immediately rather than at release time. CGO is disabled to
-  # match the static Linux build (the cgo thread collector is darwin-only).
-  build-linux:
+  # Native Linux build + test. Spectra targets macOS first but is host-OS-
+  # aware; this lane runs the suite on Linux (CGO off, matching the static
+  # Linux binary) and smoke-tests the OS-aware commands against real /proc
+  # and /sys. Linux has no .app model, so app inspection is expected to be
+  # refused rather than exercised.
+  test-linux:
     runs-on: ubuntu-latest
     env:
-      GOOS: linux
       CGO_ENABLED: '0'
     steps:
       - uses: actions/checkout@v6
@@ -69,10 +68,39 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: go build (linux)
-        run: go build ./...
-      - name: go vet (linux)
+      - name: go vet
         run: go vet ./...
+      - name: go build
+        run: go build -o spectra ./cmd/spectra/
+      # Run the suite for packages with real Linux backends and injected /
+      # faked dependencies. The detect engine and its downstream consumers
+      # shell out to macOS-only tools (plutil/otool/codesign) in their tests
+      # and are macOS-only by design; vet+build above still cover them for
+      # Linux compilation, and the smoke test exercises the end-to-end path.
+      - name: go test (Linux backends)
+        run: |
+          go test -count=1 \
+            ./internal/hostos/... \
+            ./internal/process/... \
+            ./internal/metrics/... \
+            ./internal/storagestate/... \
+            ./internal/netstate/... \
+            ./internal/sysinfo/... \
+            ./internal/toolchain/... \
+            ./internal/helper/...
+      - name: Smoke test OS-aware commands
+        run: |
+          set -x
+          # Cross-platform collectors must run and exit cleanly on Linux.
+          ./spectra process | head -5
+          ./spectra storage | head -5
+          ./spectra snapshot > /dev/null
+          # App inspection has no Linux equivalent and must be refused clearly.
+          if ./spectra inspect /nonexistent.app 2>&1 | grep -qi 'unsupported'; then
+            echo "app inspection correctly refused on Linux"
+          else
+            echo "expected inspect to report unsupported on Linux"; exit 1
+          fi
 
   complexity:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,20 @@ product framing.
 - Internal packages (not part of any public API) live under `internal/`.
 - Filesystem writes that must survive crashes go through
   `internal/fsutil.WriteFileAtomic`.
-- macOS-only utilities (`plutil`, `otool`, `codesign`, `file`, `sqlite3`) are
-  invoked via `os/exec`. CLI is a Mac-only tool today; cross-compilation is
-  preserved for future platform expansion via build-tagged files like
-  `internal/detect/syscall_darwin.go`.
+- Spectra runs on macOS and Linux and is **host-OS-aware**: anything that
+  invokes or shells out to another tool must select the right binary, path,
+  and parser per OS through `internal/hostos` (the OS-selection layer), while
+  `internal/proc.Runner` stays the execution seam. Collectors take an
+  `OS hostos.Kind` option whose zero value resolves to the host; prefer a
+  runtime `Kind` switch in shared files over new `_linux.go` build-tag files
+  wherever the code is pure Go (so Linux paths are testable on a macOS box).
+- macOS-only concepts — `.app`/Mach-O inspection (`plutil`, `otool`,
+  `codesign`, `spctl`, `file`), the TCC privacy DB, and launchd — have no
+  Linux equivalent: gate them with `hostos.Unsupported(...)` off Darwin
+  rather than shelling out to tools that do not exist. Cross-platform
+  subsystems (host facts, processes, network, storage, sysinfo, toolchain)
+  have real Linux backends reading `/proc`, `/sys`, `/etc/os-release`, and
+  `ip`/`ss`/`df`.
 
 ## Build & Validate
 
@@ -81,6 +91,9 @@ Living docs in `docs/`. mkdocs nav at `mkdocs.yml`. Validation:
 
 - `test` — macOS runner; `go vet`, `go build`, `gotestsum -race`, smoke
   tests against `/System/Applications/Calculator.app` etc.
+- `test-linux` — ubuntu runner; `go vet`/`go build` for all packages plus
+  `go test` for the Linux-backend collector packages (`CGO_ENABLED=0`), and a
+  smoke test of the OS-aware commands against real `/proc` and `/sys`.
 - `complexity` — `gocyclo -over 15`.
 - `static-analysis` — `golangci-lint v2`.
 - `check-licenses` — `go-licenses report`.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ make docs-serve     # http://127.0.0.1:8080
 
 ## Requirements
 
-- macOS (detection shells out to `plutil`, `otool`, `codesign`, `file`,
-  `sqlite3` — all preinstalled)
+- macOS or Linux. Spectra is host-OS-aware: on Linux it uses native
+  sources (`/etc/os-release`, `/proc`, `/sys`, `ip`/`ss`, `df`) and installs
+  the daemon/helper via systemd. App-bundle inspection is macOS-only — it
+  shells out to `plutil`, `otool`, `codesign`, `file`, and `sqlite3`, and is
+  refused with a clear message on Linux.
 - Go 1.26+ for source builds
 
 ## License

--- a/docs/design/distribution.md
+++ b/docs/design/distribution.md
@@ -6,6 +6,14 @@ Spectra can do. This page captures the analysis behind the current
 release packaging now present in-tree, and why the Mac App Store is out
 of scope for the full product.
 
+Spectra also ships Linux archives. `scripts/dist.sh` cross-builds
+`linux_amd64` and `linux_arm64` tarballs (static, `CGO_ENABLED=0`)
+alongside the macOS ones, and each Linux archive includes the systemd unit
+templates in `packaging/systemd/`. On Linux the daemon installs as a
+`systemctl --user` unit and the privileged helper as a systemd system unit
+(`spectra install-daemon` / `spectra install-helper`); there is no launchd,
+notarization, or Mac App Store consideration.
+
 Today the supported path is:
 
 ```bash

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -37,19 +37,26 @@ make build-all
 | `make ci` | vet + test + complexity + lint + security + licenses + docs |
 | `make clean` | Remove build artifacts |
 
-## Cross-compiling
+## Cross-compiling and Linux
 
-The Go module has no CGo dependencies, so it cross-compiles cleanly:
+Spectra builds and runs on Linux as well as macOS. The Linux build is
+pure Go (`CGO_ENABLED=0`); the one cgo dependency —
+`internal/process/thread_darwin.go`, which links `libproc` for per-process
+thread counts — is **darwin-only**, so macOS builds keep `CGO_ENABLED=1`
+while Linux disables it and reads thread counts from `/proc` instead.
 
 ```bash
-GOOS=linux GOARCH=arm64 go build ./...
+# Linux (static, pure Go)
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./...
 ```
 
-Note that the resulting Linux binary won't actually do anything useful
-(every collector shells out to a macOS tool that doesn't exist on
-Linux), but the build succeeds. This is what enables future Linux
-detection: the `syscall_other.go` build-tagged file ensures the
-non-darwin path doesn't reference `syscall.Stat_t.Blocks`.
+On Linux, the host-aware collectors use native sources — `/etc/os-release`
+and `/proc` for host facts, `/proc` for processes, `ip`/`ss`/`/proc/net`
+for network state, `df`/`/proc/mounts` for storage, `/sys` for power — and
+the daemon/helper install via systemd. App-bundle inspection
+(`.app`/Mach-O/`codesign`/TCC) has no Linux equivalent and is refused with
+a clear message. The `internal/hostos` package is the OS-selection layer
+every collector consults.
 
 ## Build version stamping
 

--- a/packaging/homebrew/spectra.rb
+++ b/packaging/homebrew/spectra.rb
@@ -1,5 +1,5 @@
 class Spectra < Formula
-  desc "macOS app diagnostics and JVM-aware remote debugging"
+  desc "Host-aware app/JVM diagnostics and remote debugging (macOS + Linux)"
   homepage "https://github.com/kaeawc/spectra"
   url "https://github.com/kaeawc/spectra/archive/refs/tags/v0.0.0.tar.gz"
   sha256 "REPLACE_WITH_SOURCE_ARCHIVE_SHA256"

--- a/packaging/systemd/spectra-daemon.service
+++ b/packaging/systemd/spectra-daemon.service
@@ -1,0 +1,21 @@
+# Spectra daemon — systemd --user unit template.
+#
+# Install per user (no root):
+#   spectra install-daemon
+# which writes ~/.config/systemd/user/spectra-daemon.service and enables it.
+#
+# This template is for reference / distro packaging. Adjust ExecStart to the
+# installed spectra path if packaging system-wide.
+[Unit]
+Description=Spectra daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/spectra serve
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target

--- a/packaging/systemd/spectra-helper.service
+++ b/packaging/systemd/spectra-helper.service
@@ -1,0 +1,22 @@
+# Spectra privileged helper — systemd system unit template.
+#
+# Install (root):
+#   sudo spectra install-helper
+# which creates the 'spectra' group, installs the binary to
+# /usr/local/lib/spectra/spectra-helper, writes this unit, and enables it.
+#
+# The helper exposes a narrow root-only JSON-RPC surface over
+# /var/run/spectra-helper.sock (0660 root:spectra); connecting clients are
+# authenticated by SO_PEERCRED.
+[Unit]
+Description=Spectra privileged helper
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/lib/spectra/spectra-helper
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build macOS release archives for Spectra.
+# Build release archives for Spectra (macOS and Linux).
 #
 # Outputs:
 #   dist/spectra_${VERSION}_darwin_arm64.tar.gz
 #   dist/spectra_${VERSION}_darwin_amd64.tar.gz
+#   dist/spectra_${VERSION}_linux_amd64.tar.gz
+#   dist/spectra_${VERSION}_linux_arm64.tar.gz
 #   dist/checksums.txt
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -20,7 +22,7 @@ Usage: VERSION=vX.Y.Z $0
 Environment:
   VERSION       Release version. Defaults to git describe.
   DIST_DIR      Output directory. Defaults to ./dist.
-  CODESIGN_ID   Optional Developer ID Application identity.
+  CODESIGN_ID   Optional Developer ID Application identity (darwin only).
 EOF
 }
 
@@ -29,19 +31,29 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     exit 0
 fi
 
+# build_one <goos> <arch>
 build_one() {
-    local arch="$1"
-    local stage="$DIST_DIR/stage/spectra_${VERSION}_darwin_${arch}"
-    local archive="$DIST_DIR/spectra_${VERSION}_darwin_${arch}.tar.gz"
+    local goos="$1"
+    local arch="$2"
+    local stage="$DIST_DIR/stage/spectra_${VERSION}_${goos}_${arch}"
+    local archive="$DIST_DIR/spectra_${VERSION}_${goos}_${arch}.tar.gz"
 
     rm -rf "$stage"
     mkdir -p "$stage/bin" "$stage/docs" "$stage/licenses"
 
+    # Linux ships a static, pure-Go binary (CGO off; the cgo libproc thread
+    # collector is darwin-only and the Linux path reads procfs). Darwin keeps
+    # the toolchain default so its native cgo thread collector links.
+    local cgo_env=()
+    if [[ "$goos" == "linux" ]]; then
+        cgo_env=(CGO_ENABLED=0)
+    fi
+
     (
         cd "$ROOT"
-        GOOS=darwin GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" -o "$stage/bin/spectra" ./cmd/spectra/
-        GOOS=darwin GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" -o "$stage/bin/spectra-mcp" ./cmd/spectra-mcp/
-        GOOS=darwin GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" -o "$stage/bin/spectra-helper" ./cmd/spectra-helper/
+        env "${cgo_env[@]}" GOOS="$goos" GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" -o "$stage/bin/spectra" ./cmd/spectra/
+        env "${cgo_env[@]}" GOOS="$goos" GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" -o "$stage/bin/spectra-mcp" ./cmd/spectra-mcp/
+        env "${cgo_env[@]}" GOOS="$goos" GOARCH="$arch" go build -trimpath -ldflags "$LDFLAGS" -o "$stage/bin/spectra-helper" ./cmd/spectra-helper/
     )
 
     cp "$ROOT/README.md" "$stage/"
@@ -53,8 +65,13 @@ build_one() {
         mkdir -p "$stage/agent"
         cp "$ROOT/agent/spectra-agent.jar" "$stage/agent/"
     fi
+    # Linux archives ship the systemd unit templates.
+    if [[ "$goos" == "linux" && -d "$ROOT/packaging/systemd" ]]; then
+        mkdir -p "$stage/systemd"
+        cp "$ROOT"/packaging/systemd/*.service "$stage/systemd/"
+    fi
 
-    if [[ -n "${CODESIGN_ID:-}" ]]; then
+    if [[ "$goos" == "darwin" && -n "${CODESIGN_ID:-}" ]]; then
         codesign --force --timestamp --options runtime --sign "$CODESIGN_ID" \
             "$stage/bin/spectra" "$stage/bin/spectra-mcp" "$stage/bin/spectra-helper"
     fi
@@ -65,12 +82,18 @@ build_one() {
 rm -rf "$DIST_DIR/stage"
 mkdir -p "$DIST_DIR"
 
-build_one arm64
-build_one amd64
+build_one darwin arm64
+build_one darwin amd64
+build_one linux amd64
+build_one linux arm64
 
 (
     cd "$DIST_DIR"
-    shasum -a 256 spectra_"${VERSION}"_darwin_*.tar.gz > checksums.txt
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 spectra_"${VERSION}"_*.tar.gz > checksums.txt
+    else
+        sha256sum spectra_"${VERSION}"_*.tar.gz > checksums.txt
+    fi
 )
 
 rm -rf "$DIST_DIR/stage"


### PR DESCRIPTION
## Summary

Phase 5 (final): Linux release archives, a native Linux CI test lane, and docs. Stacked on #480. Completes the host-OS-awareness effort.

## What's here

- **Linux release archives** (`scripts/dist.sh`). Cross-builds `linux_amd64` and `linux_arm64` tarballs (static, `CGO_ENABLED=0`) alongside the macOS archives, bundling the systemd unit templates from the new `packaging/systemd/`. macOS builds are unchanged (their native cgo thread collector still links); checksums fall back to `sha256sum` when `shasum` is absent.
- **Linux CI test lane** (`.github/workflows/ci.yml`). Replaces the earlier build/vet-only Linux lane with a native test lane on ubuntu: `go vet`/`go build` for **all** packages, `go test` for the Linux-backend collector packages (`hostos`, `process`, `metrics`, `storagestate`, `netstate`, `sysinfo`, `toolchain`, `helper` — `CGO_ENABLED=0`), and a smoke test that runs `process`/`storage`/`snapshot` against real `/proc` and `/sys` and asserts `inspect` is refused as unsupported. The detect engine and its consumers remain macOS-only (their tests shell out to `plutil`/`otool`), so they're covered by vet+build on Linux and by the full suite on the macOS lane.
- **Docs**. README requirements now say macOS **or** Linux; AGENTS.md documents the `hostos` selection layer and per-OS gating rule; `docs/development/building.md` corrects the stale "no CGo dependencies" claim (the darwin thread collector uses cgo; Linux is `CGO_ENABLED=0`); the distribution doc and Homebrew description mention Linux + systemd.

## Testing

- Full Darwin suite green (`go test ./...`, 40 packages); Darwin + Linux build/vet green; `scripts/validate-workflows.sh` (shellcheck + YAML) and the mkdocs nav validator pass.
- The Linux CI lane is the first place the `peeruid_linux` `SO_PEERCRED` test and the end-to-end OS-aware commands run against a real kernel.

## The full stack

This is the last of six stacked PRs (#476 → #477 → #478 → #479 → #480 → this) taking Spectra from macOS-only to host-OS-aware with real Linux backends for every cross-platform collector, systemd daemon/helper install, and Linux release + CI.
